### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/crates/amaru/src/consensus/mod.rs
+++ b/crates/amaru/src/consensus/mod.rs
@@ -97,8 +97,7 @@ impl gasket::framework::Worker<Stage> for Worker {
                 let block = {
                     let mut peer_session = stage.peer_session.lock().await;
                     let client = (*peer_session).blockfetch();
-                    let block = client.fetch_single(point.clone()).await.or_restart()?;
-                    block
+                    client.fetch_single(point.clone()).await.or_restart()?
                 };
 
                 stage

--- a/crates/amaru/src/iter/borrow.rs
+++ b/crates/amaru/src/iter/borrow.rs
@@ -32,7 +32,7 @@ pub type RawIterator<'a> = Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a>
 
 pub type SharedVec<T> = Rc<RefCell<Vec<(Vec<u8>, T)>>>;
 
-impl<'a, const PREFIX: usize, K: Clone, V: Clone> KeyValueIterator<'a, PREFIX, K, V> {
+impl<const PREFIX: usize, K: Clone, V: Clone> KeyValueIterator<'_, PREFIX, K, V> {
     /// Obtain an iterator on the updates to be done. This takes ownership of the original
     /// iterator to ensure that it is correctly de-allocated as we now process updates.
     pub fn into_iter_updates(self) -> impl Iterator<Item = (Vec<u8>, Option<V>)> {

--- a/crates/amaru/src/ledger/kernel.rs
+++ b/crates/amaru/src/ledger/kernel.rs
@@ -136,7 +136,7 @@ impl serde::Serialize for PoolParams {
 
         struct WrapRelay<'a>(&'a Relay);
 
-        impl<'relay> serde::Serialize for WrapRelay<'relay> {
+        impl serde::Serialize for WrapRelay<'_> {
             fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
                 match self.0 {
                     Relay::SingleHostAddr(port, ipv4, ipv6) => {


### PR DESCRIPTION
Make sure clippy doesn't generate any warnings.
`cargo clippy --all-targets --all-features -- -D warnings` should not fail.