### PR TITLE
chore: introduce github actions CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,16 +27,22 @@ jobs:
             target: aarch64-apple-darwin
     timeout-minutes: 30
     runs-on: ${{ matrix.environments.runner }}
-    continue-on-error: ${{ matrix.environments.optional || false }}
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check format
         run: cargo fmt --all -- --check
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
       - run: rustup target add ${{ matrix.environments.target }}
       - name: Run tests
-        run: cargo test --locked --all-features --workspace --target ${{ matrix.environments.target }}
+        run: |
+          set +e
+          cargo test --locked --all-features --workspace --target ${{ matrix.environments.target }}
+          exitcode="$?"
+          if [[ "${{ matrix.environments.optional }}" == "true" && "$exitcode" != "0" ]] ; then
+            # Propagate failure as a warning
+            # but do not fail the job
+            echo "::warning::Tests failed with exit code $exitcode"
+            exit 0
+          fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,12 +33,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.environments.target }}
       - name: Check format
         run: cargo fmt --all -- --check
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+      - run: rustup target add ${{ matrix.environments.target }}
       - name: Run tests
         run: cargo test --locked --all-features --workspace --target ${{ matrix.environments.target }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
             target: wasm32-unknown-unknown
             optional: true
           - runner: macos-latest
-            target: x86_64-apple-darwin
+            target: aarch64-apple-darwin
     timeout-minutes: 30
     runs-on: ${{ matrix.environments.runner }}
     continue-on-error: ${{ matrix.environments.optional || false }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,44 @@
+name: Continuous Integration
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: ["*"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build on ${{ matrix.environments.runner }} with target ${{ matrix.environments.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        environments:
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-latest
+            target: wasm32-unknown-unknown
+            optional: true
+          - runner: macos-latest
+            target: x86_64-apple-darwin
+    timeout-minutes: 30
+    runs-on: ${{ matrix.environments.runner }}
+    continue-on-error: ${{ matrix.environments.optional || false }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.environments.target }}
+      - name: Check format
+        run: cargo fmt --all -- --check
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Run tests
+        run: cargo test --locked --all-features --workspace --target ${{ matrix.environments.target }}


### PR DESCRIPTION
Introduce a basic CI workflow.

New `environments` can be added by modifying the matrix `strategy`, e.g.:

```yaml
  - runner: ubuntu-latest
    target: wasm32-unknown-unknown
    optional: true
```

Note that `optional` environment failures won't cascade at the workflow level.

By default native `ubuntu` and `macos` are tested, and optionally wasm on `ubuntu`.

In a next step, a better integration with GitHub PR can be considered:
* https://github.com/actions-rust-lang/rustfmt
* https://github.com/actions-rust-lang/audit