### PR TITLE
fix: release mutex sooner

### DIFF
--- a/crates/amaru/src/consensus/mod.rs
+++ b/crates/amaru/src/consensus/mod.rs
@@ -94,6 +94,9 @@ impl gasket::framework::Worker<Stage> for Worker {
                 let ledger = stage.ledger.lock().await;
                 assert_header(&header, &stage.epoch_to_nonce, &*ledger)?;
 
+                // Make sure the Mutex is released as soon as possible
+                drop(ledger);
+
                 let block = {
                     let mut peer_session = stage.peer_session.lock().await;
                     let client = (*peer_session).blockfetch();


### PR DESCRIPTION
Release the `mutex` locking ledger access onc not needed anymore. On my machine this reduce `forward` time from couple hundreds ms to a couple hundreds μs.
Note that a better but more involved solution might be to reduce the need to interact with the lock per block. This fix allows to move forward while I investigate a potentially better option.

*Before*

<img width="1506" alt="Capture d’écran 2024-12-20 à 20 46 24" src="https://github.com/user-attachments/assets/3553d25c-72cb-478e-add7-fcd3d4db7f47" />


*After*

<img width="1496" alt="Capture d’écran 2024-12-20 à 20 45 18" src="https://github.com/user-attachments/assets/9b37e75a-622e-40bd-8d65-89da1a9ae2fc" />

