### PR TITLE
Add a friendly panic hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,6 @@ dependencies = [
  "opentelemetry_sdk",
  "ouroboros",
  "ouroboros-praos",
- "owo-colors",
  "pallas-addresses",
  "pallas-codec",
  "pallas-crypto",
@@ -69,7 +68,6 @@ dependencies = [
  "proptest",
  "rocksdb",
  "serde",
- "strip-ansi-escapes",
  "thiserror 2.0.3",
  "tokio",
  "tokio-util",
@@ -330,17 +328,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -1356,15 +1343,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -1685,12 +1663,6 @@ name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
-
-[[package]]
-name = "is_ci"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2323,15 +2295,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "owo-colors"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
-dependencies = [
- "supports-color",
-]
 
 [[package]]
 name = "pallas-addresses"
@@ -3114,15 +3077,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "strip-ansi-escapes"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
-dependencies = [
- "vte",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3152,16 +3106,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "supports-color"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
-dependencies = [
- "atty",
- "is_ci",
-]
 
 [[package]]
 name = "syn"
@@ -3655,27 +3599,6 @@ dependencies = [
  "rand_core 0.5.1",
  "sha2 0.9.9",
  "thiserror 1.0.64",
-]
-
-[[package]]
-name = "vte"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
-dependencies = [
- "arrayvec",
- "utf8parse",
- "vte_generate_state_changes",
-]
-
-[[package]]
-name = "vte_generate_state_changes"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
-dependencies = [
- "proc-macro2",
- "quote",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,11 +44,13 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bech32 0.11.0",
+ "built",
  "clap",
  "envpath",
  "gasket",
  "hex",
  "indicatif",
+ "indoc",
  "insta",
  "miette 7.2.0",
  "opentelemetry",
@@ -56,6 +58,7 @@ dependencies = [
  "opentelemetry_sdk",
  "ouroboros",
  "ouroboros-praos",
+ "owo-colors",
  "pallas-addresses",
  "pallas-codec",
  "pallas-crypto",
@@ -66,6 +69,7 @@ dependencies = [
  "proptest",
  "rocksdb",
  "serde",
+ "strip-ansi-escapes",
  "thiserror 2.0.3",
  "tokio",
  "tokio-util",
@@ -328,6 +332,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +537,15 @@ dependencies = [
  "glob",
  "threadpool",
  "zeroize",
+]
+
+[[package]]
+name = "built"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
+dependencies = [
+ "git2",
 ]
 
 [[package]]
@@ -1227,6 +1251,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1353,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1616,6 +1662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
 name = "insta"
 version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,6 +1685,12 @@ name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1745,6 +1803,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1793,6 +1863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2252,6 +2323,15 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+dependencies = [
+ "supports-color",
+]
 
 [[package]]
 name = "pallas-addresses"
@@ -3034,6 +3114,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3063,6 +3152,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "supports-color"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba6faf2ca7ee42fdd458f4347ae0a9bd6bcc445ad7cb57ad82b383f18870d6f"
+dependencies = [
+ "atty",
+ "is_ci",
+]
 
 [[package]]
 name = "syn"
@@ -3556,6 +3655,27 @@ dependencies = [
  "rand_core 0.5.1",
  "sha2 0.9.9",
  "thiserror 1.0.64",
+]
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -19,8 +19,6 @@ gasket = { version = "0.8.0", features = ["derive"] }
 hex = "0.4.3"
 miette = "7.2.0"
 indoc = "2.0"
-strip-ansi-escapes = "0.1.1"
-owo-colors = { version = "3.5.0", features = ["supports-colors"] }
 ouroboros = { git = "https://github.com/pragma-org/ouroboros", rev = "ca1d447a6c106e421e6c2b1c7d9d59abf5ca9589" }
 ouroboros-praos = { git = "https://github.com/pragma-org/ouroboros", rev = "ca1d447a6c106e421e6c2b1c7d9d59abf5ca9589" }
 pallas-addresses = "0.31.0"

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/pragma-org/amaru"
 documentation = "https://docs.rs/amaru"
 readme = "README.md"
 rust-version = "1.81.0"
+build = "build.rs"
 
 [dependencies]
 async-trait = "0.1.83"
@@ -17,6 +18,9 @@ clap = { version = "4.5.20", features = ["derive"] }
 gasket = { version = "0.8.0", features = ["derive"] }
 hex = "0.4.3"
 miette = "7.2.0"
+indoc = "2.0"
+strip-ansi-escapes = "0.1.1"
+owo-colors = { version = "3.5.0", features = ["supports-colors"] }
 ouroboros = { git = "https://github.com/pragma-org/ouroboros", rev = "ca1d447a6c106e421e6c2b1c7d9d59abf5ca9589" }
 ouroboros-praos = { git = "https://github.com/pragma-org/ouroboros", rev = "ca1d447a6c106e421e6c2b1c7d9d59abf5ca9589" }
 pallas-addresses = "0.31.0"
@@ -39,10 +43,17 @@ serde = "1.0.215"
 bech32 = "0.11.0"
 opentelemetry = { version = "0.27.1" }
 opentelemetry_sdk = { version = "0.27.1", features = ["async-std", "rt-tokio"] }
-opentelemetry-otlp = { version = "0.27.0", features = ["grpc-tonic", "http-proto", "reqwest-client"] }
+opentelemetry-otlp = { version = "0.27.0", features = [
+    "grpc-tonic",
+    "http-proto",
+    "reqwest-client",
+] }
 tracing-opentelemetry = { version = "0.28.0" }
 
 [dev-dependencies]
 envpath = { version = "0.0.1-beta.3", features = ["rand"] }
 insta = { version = "1.41.1", features = ["json"] }
 proptest = "1.5.0"
+
+[build-dependencies]
+built = { version = "0.7.1", features = ["git2"] }

--- a/crates/amaru/build.rs
+++ b/crates/amaru/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    built::write_built_file().expect("Failed to acquire build-time information");
+}

--- a/crates/amaru/src/bin/amaru/cmd/daemon.rs
+++ b/crates/amaru/src/bin/amaru/cmd/daemon.rs
@@ -34,7 +34,6 @@ pub struct Args {
 }
 
 pub async fn run(args: Args, counter: Counter<u64>) -> miette::Result<()> {
-    panic!("sample panic for testing");
     let config = parse_args(args, counter)?;
 
     let client = Arc::new(Mutex::new(

--- a/crates/amaru/src/bin/amaru/cmd/daemon.rs
+++ b/crates/amaru/src/bin/amaru/cmd/daemon.rs
@@ -34,6 +34,7 @@ pub struct Args {
 }
 
 pub async fn run(args: Args, counter: Counter<u64>) -> miette::Result<()> {
+    panic!("sample panic for testing");
     let config = parse_args(args, counter)?;
 
     let client = Arc::new(Mutex::new(

--- a/crates/amaru/src/bin/amaru/main.rs
+++ b/crates/amaru/src/bin/amaru/main.rs
@@ -1,10 +1,12 @@
 use clap::{Parser, Subcommand};
 use opentelemetry::metrics::Counter;
+use panic::panic_handler;
 use std::env;
 
 mod cmd;
 mod config;
 mod exit;
+mod panic;
 
 pub const SERVICE_NAME: &str = "amaru";
 
@@ -28,6 +30,8 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> miette::Result<()> {
+    panic_handler();
+
     let counter = setup_tracing();
 
     let args = Cli::parse();

--- a/crates/amaru/src/bin/amaru/panic.rs
+++ b/crates/amaru/src/bin/amaru/panic.rs
@@ -1,0 +1,113 @@
+use owo_colors::OwoColorize;
+
+/// Installs a panic handler that prints some useful diagnostics and
+/// asks the user to report the issue.
+pub fn panic_handler() {
+    std::panic::set_hook(Box::new(move |info| {
+        let message = info
+            .payload()
+            .downcast_ref::<&str>()
+            .map(|s| (*s).to_string())
+            .or_else(|| {
+                info.payload()
+                    .downcast_ref::<String>()
+                    .map(|s| s.to_string())
+            })
+            .unwrap_or_else(|| "unknown error".to_string());
+
+        let location = info.location().map_or_else(
+            || "".into(),
+            |location| {
+                format!(
+                    "{}:{}:{}\n\n    ",
+                    location.file(),
+                    location.line(),
+                    location.column(),
+                )
+            },
+        );
+
+        // We present the user with a helpful and welcoming error message;
+        // Block producing nodes should be considered mission critical software, and so
+        // They should endeavor *never* to crash, and should always handle and recover from errors.
+        // So if the process panics, it should be treated as a bug, and we very much want the user to report it.
+        // TODO(pi): We could go a step further, and prefill some issue details like title, body, labels, etc.
+        //           using query parameters: https://github.com/sindresorhus/new-github-issue-url?tab=readme-ov-file#api
+        let error_message = indoc::formatdoc! {
+            r#"{fatal}
+                        Whoops! The Amaru process panicked, rather than handling the error it encountered gracefully.
+
+                        This is almost certainly a bug, and we'd appreciate a report so we can improve Amaru.
+
+                        Please report this error at https://github.com/pragma-org/amaru/issues/new.
+
+                        In your bug report please provide the information below and if possible the code
+                        that produced it.
+                        {info}
+
+                        {location}{message}"#,
+            info = node_info(),
+            fatal = "amaru::fatal::error".red().bold(),
+            location = location.purple(),
+        };
+
+        println!("\n{}", indent(&error_message, 3));
+    }));
+}
+
+// TODO: pulled from aiken; should we have our own utility crate for pretty printing?
+// https://github.com/aiken-lang/aiken/blob/main/crates/aiken-project/src/pretty.rs#L126C1-L134C2
+pub fn indent(lines: &str, n: usize) -> String {
+    let tab = pad_left(String::new(), n, " ");
+    lines
+        .lines()
+        .map(|line| format!("{tab}{line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn pad_left(mut text: String, n: usize, delimiter: &str) -> String {
+    let diff = n as i32 - ansi_len(&text) as i32;
+    if diff.is_positive() {
+        for _ in 0..diff {
+            text.insert_str(0, delimiter);
+        }
+    }
+    text
+}
+
+pub fn ansi_len(s: &str) -> usize {
+    String::from_utf8(strip_ansi_escapes::strip(s).unwrap())
+        .unwrap()
+        .chars()
+        .count()
+}
+
+// TODO: pulled from aiken; should we have our own config utility crate?
+// https://github.com/aiken-lang/aiken/blob/main/crates/aiken-project/src/config.rs#L382C1-L393C2
+mod built_info {
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+pub fn node_info() -> String {
+    format!(
+        r#"
+Operating System: {}
+Architecture:     {}
+Version:          {}"#,
+        built_info::CFG_OS,
+        built_info::CFG_TARGET_ARCH,
+        node_version(true),
+    )
+}
+pub fn node_version(include_commit_hash: bool) -> String {
+    let version = built_info::PKG_VERSION;
+    let suffix = if include_commit_hash {
+        format!(
+            "+{}",
+            built_info::GIT_COMMIT_HASH_SHORT.unwrap_or("unknown")
+        )
+    } else {
+        "".to_string()
+    };
+    format!("v{version}{suffix}")
+}

--- a/crates/amaru/src/bin/amaru/panic.rs
+++ b/crates/amaru/src/bin/amaru/panic.rs
@@ -1,5 +1,3 @@
-use owo_colors::OwoColorize;
-
 /// Installs a panic handler that prints some useful diagnostics and
 /// asks the user to report the issue.
 pub fn panic_handler() {
@@ -47,8 +45,8 @@ pub fn panic_handler() {
 
                         {location}{message}"#,
             info = node_info(),
-            fatal = "amaru::fatal::error".red().bold(),
-            location = location.purple(),
+            fatal = "amaru::fatal::error",
+            location = location,
         };
 
         println!("\n{}", indent(&error_message, 3));
@@ -67,7 +65,7 @@ pub fn indent(lines: &str, n: usize) -> String {
 }
 
 pub fn pad_left(mut text: String, n: usize, delimiter: &str) -> String {
-    let diff = n as i32 - ansi_len(&text) as i32;
+    let diff = n as i32 - text.len() as i32;
     if diff.is_positive() {
         for _ in 0..diff {
             text.insert_str(0, delimiter);
@@ -76,18 +74,12 @@ pub fn pad_left(mut text: String, n: usize, delimiter: &str) -> String {
     text
 }
 
-pub fn ansi_len(s: &str) -> usize {
-    String::from_utf8(strip_ansi_escapes::strip(s).unwrap())
-        .unwrap()
-        .chars()
-        .count()
-}
-
 // TODO: pulled from aiken; should we have our own config utility crate?
 // https://github.com/aiken-lang/aiken/blob/main/crates/aiken-project/src/config.rs#L382C1-L393C2
 mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
+
 pub fn node_info() -> String {
     format!(
         r#"
@@ -99,6 +91,7 @@ Version:          {}"#,
         node_version(true),
     )
 }
+
 pub fn node_version(include_commit_hash: bool) -> String {
     let version = built_info::PKG_VERSION;
     let suffix = if include_commit_hash {


### PR DESCRIPTION
A block producing node, and Amaru, is considered "mission critical" software, for the following reasons:
- The network is relying on the availability and correctness of each alternative implementation in proportion to its stake
- The stake pool operators are (i.e. eventually will be) relying on the continuing functioning of the block producer as a form of income

For that reason, the node should never just hard "crash"; even in error cases, the node should respond to these bad conditions in a more graceful way, perhaps eventually even including raising an alarm via any metrics / alerting systems built into the node.

Therefore, we install a panic hook; if a crash does arise in the wild, we'd *love* a bug report, so we can address it more appropriately. For that reason, we want to make the process to open the issue as welcoming as possible.

Here's what it looks like for an explicit panic:
![image](https://github.com/user-attachments/assets/1d6ff3fd-78f0-43cc-8a32-ae0c14549261)

Here's what it looks like for an implicit panic, like divide by zero:
![image](https://github.com/user-attachments/assets/4a14a7a1-ef74-41ea-bd89-4448faf3d66a)

Here's what it looks like for a contextual panic, like `.expect()`:
![image](https://github.com/user-attachments/assets/750c1862-235c-4178-895e-1d5a45d9ca5c)

I included a commit in the history with an explicit panic; if you want to test it yourself, you can checkout `e9bfdf5931ff6b093e830bf0252c6be29eaa7372` and run `cargo run daemon --peer-address 127.0.0.1`.

Note that I borrowed a lot of code from Aiken; For this PR, I just included the needed utility functions in the `panic.rs` file, but we might want to pull some of these into their own files / modules, as they are in Aiken.