### PR TITLE
Fixed Grafana / Tempo communication

### DIFF
--- a/monitoring/grafana-tempo/docker-compose.yml
+++ b/monitoring/grafana-tempo/docker-compose.yml
@@ -10,6 +10,17 @@ services:
       - "55679:55679"
       - "13133:13133"
 
+  prometheus:
+    image: prom/prometheus:v3.0.1
+    command:
+      [ "--web.enable-otlp-receiver"
+      , "--config.file=/etc/prometheus/prometheus.yml"
+      ]
+    volumes:
+      - "./prometheus.yml:/etc/prometheus/prometheus.yml"
+    ports:
+      - "9090:9090"
+
   tempo:
     image: grafana/tempo:latest
     ports:

--- a/monitoring/grafana-tempo/tempo.yml
+++ b/monitoring/grafana-tempo/tempo.yml
@@ -1,3 +1,4 @@
+stream_over_http_enabled: true
 server:
   http_listen_port: 3200
 


### PR DESCRIPTION
Grafana was no longer able to communicate with the Tempo backend after some config changes recently.

Checking the Grafana logs, I found

```
2024-12-27 04:52:35 logger=grafana-apiserver t=2024-12-27T09:52:35.291900754Z level=info msg="[core] [Channel #2 SubChannel #3]grpc: addrConn.createTransport failed to connect to {Addr: \"tempo:3200\", ServerName: \"tempo:3200\", }. Err: connection error: desc = \"error reading server preface: http2: frame too large\""
```

After some googling, this seemed to be an indicator that the client (Grafana) was trying to connect to the backend (Tempo) with http2, but the backend only supporting http1.1.

In particular, Tempo uses grpc for internal communication, but by default, exposes its grpc capabilities on the grpc port, 4317; However, we had Grafana connecting to the http port, 3200.

One option would be to expose the grpc port and use that, but it seems this is common enough that there's a built in [flag](https://github.com/grafana/tempo/blob/main/example/docker-compose/shared/tempo.yaml#L1) for it.

This causes tempo to expose its grpc API over http; in particular, this means that the http2 request to initiate the grpc connection now succeeds. I chose to go with this approach, since that's the way the [examples](https://github.com/grafana/tempo/blob/main/example/docker-compose/shared/tempo.yaml#L1) I saw were structured, and it's the first thing that worked.

See also this github discussion for context:
https://github.com/open-telemetry/opentelemetry-collector/issues/7680

Note: I don't have a cardano node currently, so I wasn't able to test it with Amaru running; instead, I tested the tempo data source connection within Grafana itself, and I am assuming this is sufficient.

Before:
![image](https://github.com/user-attachments/assets/c80e3d2a-9527-479b-a34d-447ae9334907)

After:
![image](https://github.com/user-attachments/assets/110318f3-4ca2-4a3b-8a13-ad01f123e7f3)
