### PR TITLE
Fix tracing on process exit; instrument Import command

### DIFF
--- a/crates/amaru/src/bin/amaru/cmd/import.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import.rs
@@ -14,9 +14,10 @@ use indicatif::{ProgressBar, ProgressStyle};
 use miette::{Diagnostic, IntoDiagnostic};
 use pallas_codec::minicbor as cbor;
 use std::{collections::HashMap, fs, iter, path::PathBuf};
-use tracing::info;
+use tracing::{info, info_span};
 
 const BATCH_SIZE: usize = 5000;
+const EVENT_TARGET: &str = "amaru::import";
 
 #[derive(Debug, Parser)]
 pub struct Args {
@@ -72,6 +73,18 @@ impl<T> From<StrictMaybe<T>> for Option<T> {
 
 pub async fn run(args: Args) -> miette::Result<()> {
     let point = super::parse_point(&args.date, Error::MalformedDate).into_diagnostic()?;
+    let import_span = info_span!(
+        target: EVENT_TARGET,
+        "import",
+        point.slot = point.slot_or_default(),
+        point.hash = tracing::field::Empty,
+        out_dir = &args.out.display().to_string(),
+        snapshot = &args.snapshot.display().to_string(),
+    )
+    .entered();
+    if let Point::Specific(_, ref header_hash) = point {
+        import_span.record("point.hash", hex::encode(header_hash));
+    }
 
     fs::create_dir_all(&args.out).into_diagnostic()?;
     let mut db = ledger::store::rocksdb::RocksDB::empty(&args.out).into_diagnostic()?;
@@ -81,202 +94,307 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
     // Epoch State
     {
-        let _epoch_state_len = d.array().into_diagnostic()?;
+        let epoch_span = info_span!(
+            target: EVENT_TARGET,
+            "epoch_state",
+            length = d.array().into_diagnostic()?,
+            current_epoch = tracing::field::Empty,
+        )
+        .entered();
 
         // Epoch State / Account State
-        d.skip().into_diagnostic()?;
+        {
+            let account_span = info_span!(
+                target: EVENT_TARGET,
+                "account_state",
+                skipped = true,
+            )
+            .entered();
+            d.skip().into_diagnostic()?;
+        }
 
         // Epoch State / Ledger State
-        let _ledger_state_len = d.array().into_diagnostic()?;
-
-        // Epoch State / Ledger State / Cert State
         {
-            let _cert_state_len = d.array().into_diagnostic()?;
+            let ledger_span = info_span!(
+                target: EVENT_TARGET,
+                "ledger_state",
+                length = d.array().into_diagnostic()?,
+            )
+            .entered();
 
-            // Epoch State / Ledger State / Cert State / Voting State
-            d.skip().into_diagnostic()?;
-
-            // Epoch State / Ledger State / Cert State / Pool State
+            // Epoch State / Ledger State / Cert State
             {
-                let _pool_state_len = d.array().into_diagnostic()?;
-
-                let pools: HashMap<PoolId, PoolParams> = d.decode().into_diagnostic()?;
-
-                let updates: HashMap<PoolId, PoolParams> = d.decode().into_diagnostic()?;
-
-                let retirements: HashMap<PoolId, Epoch> = d.decode().into_diagnostic()?;
-
-                // Deposits
-                d.skip().into_diagnostic()?;
-
-                let mut state = ledger::state::diff_epoch_reg::DiffEpochReg::default();
-                for (pool, params) in pools.into_iter() {
-                    state.register(pool, params);
-                }
-
-                for (pool, params) in updates.into_iter() {
-                    state.register(pool, params);
-                }
-
-                for (pool, epoch) in retirements.into_iter() {
-                    state.unregister(pool, epoch);
-                }
-
-                info!(
-                    what = "stake_pools",
-                    registered = state.registered.len(),
-                    retiring = state.unregistered.len(),
-                );
-
-                let current_epoch = epoch_from_slot(point.slot_or_default());
-
-                db.save(
-                    &Point::Origin,
-                    store::Columns {
-                        utxo: iter::empty(),
-                        pools: state
-                            .registered
-                            .into_iter()
-                            .flat_map(move |(_, registrations)| {
-                                registrations
-                                    .into_iter()
-                                    .map(|r| (r, current_epoch))
-                                    .collect::<Vec<_>>()
-                            }),
-                        accounts: iter::empty(),
-                    },
-                    store::Columns {
-                        pools: state.unregistered.into_iter(),
-                        utxo: iter::empty(),
-                        accounts: iter::empty(),
-                    },
+                let cert_span = info_span!(
+                    target: EVENT_TARGET,
+                    "cert_state",
+                    length = d.array().into_diagnostic()?,
                 )
-                .into_diagnostic()?;
-            }
+                .entered();
 
-            // Epoch State / Ledger State / Cert State / Delegation state
-            {
-                let _delegation_state_len = d.array().into_diagnostic()?;
-
-                // Epoch State / Ledger State / Cert State / Delegation state / dsUnified
+                // Epoch State / Ledger State / Cert State / Voting State
                 {
-                    let _stake_credentials_len = d.array().into_diagnostic()?;
+                    let vote_span = info_span!(
+                        target: EVENT_TARGET,
+                        "voting_state",
+                        skipped = true,
+                    )
+                    .entered();
+                    d.skip().into_diagnostic()?;
+                }
 
-                    // credentials
+                // Epoch State / Ledger State / Cert State / Pool State
+                {
+                    let pool_span = info_span!(
+                        target: EVENT_TARGET,
+                        "pool_state",
+                        length = d.array().into_diagnostic()?,
+                    )
+                    .entered();
+
+                    let pools: HashMap<PoolId, PoolParams> = d.decode().into_diagnostic()?;
+
+                    let updates: HashMap<PoolId, PoolParams> = d.decode().into_diagnostic()?;
+
+                    let retirements: HashMap<PoolId, Epoch> = d.decode().into_diagnostic()?;
+
+                    // Deposits
                     {
-                        let mut credentials =
-                            d.decode::<HashMap<
-                                StakeCredential,
-                                (
-                                    StrictMaybe<(Lovelace, Lovelace)>,
-                                    Set<()>,
-                                    StrictMaybe<PoolId>,
-                                    StrictMaybe<DRep>,
-                                ),
-                            >>()
-                            .into_diagnostic()?
-                            .into_iter()
-                            .map(
-                                |(credential, (rewards_and_deposit, _pointers, pool, _drep))| {
-                                    let (rewards, deposit) =
-                                        Option::<(Lovelace, Lovelace)>::from(rewards_and_deposit)
-                                            .unwrap_or((0, STAKE_CREDENTIAL_DEPOSIT as u64));
-
-                                    (
-                                        credential,
-                                        Option::<PoolId>::from(pool),
-                                        Some(deposit),
-                                        rewards,
-                                    )
-                                },
-                            )
-                            .collect::<Vec<(
-                                StakeCredential,
-                                Option<PoolId>,
-                                Option<Lovelace>,
-                                Lovelace,
-                            )>>();
-
-                        info!(what = "credentials", size = credentials.len());
-
-                        let progress = ProgressBar::new(credentials.len() as u64).with_style(
-                            ProgressStyle::with_template("  Accounts {bar:70} {pos:>7}/{len:7}")
-                                .unwrap(),
-                        );
-
-                        while !credentials.is_empty() {
-                            let n = std::cmp::min(BATCH_SIZE, credentials.len());
-                            let chunk = credentials.drain(0..n);
-
-                            db.save(
-                                &Point::Origin,
-                                store::Columns {
-                                    utxo: iter::empty(),
-                                    pools: iter::empty(),
-                                    accounts: chunk,
-                                },
-                                Default::default(),
-                            )
-                            .into_diagnostic()?;
-
-                            progress.inc(n as u64);
-                        }
-
-                        progress.finish();
-                    }
-
-                    // pointers
-                    {
+                        let deposit_span = info_span!(
+                            target: EVENT_TARGET,
+                            "deposits",
+                            skipped = true,
+                        )
+                        .entered();
                         d.skip().into_diagnostic()?;
                     }
-                }
 
-                // Epoch State / Ledger State / Cert State / Delegation state / dsFutureGenDelegs
-                d.skip().into_diagnostic()?;
+                    let mut state = ledger::state::diff_epoch_reg::DiffEpochReg::default();
+                    for (pool, params) in pools.into_iter() {
+                        state.register(pool, params);
+                    }
 
-                // Epoch State / Ledger State / Cert State / Delegation state / dsGenDelegs
-                d.skip().into_diagnostic()?;
+                    for (pool, params) in updates.into_iter() {
+                        state.register(pool, params);
+                    }
 
-                // Epoch State / Ledger State / Cert State / Delegation state / dsIRewards
-                d.skip().into_diagnostic()?;
-            }
+                    for (pool, epoch) in retirements.into_iter() {
+                        state.unregister(pool, epoch);
+                    }
 
-            // Epoch State / Ledger State / UTxO State
-            {
-                let _utxo_state_len = d.array().into_diagnostic()?;
+                    info!(
+                        what = "stake_pools",
+                        registered = state.registered.len(),
+                        retiring = state.unregistered.len(),
+                    );
 
-                let mut utxo: Vec<(TransactionInput, TransactionOutput)> = d
-                    .decode::<HashMap<TransactionInput, TransactionOutput>>()
-                    .into_diagnostic()?
-                    .into_iter()
-                    .collect::<Vec<(TransactionInput, TransactionOutput)>>();
-
-                info!(what = "utxo_entries", size = utxo.len());
-
-                let progress = ProgressBar::new(utxo.len() as u64).with_style(
-                    ProgressStyle::with_template("  UTxO entries {bar:70} {pos:>7}/{len:7}")
-                        .unwrap(),
-                );
-
-                while !utxo.is_empty() {
-                    let n = std::cmp::min(BATCH_SIZE, utxo.len());
-                    let chunk = utxo.drain(0..n);
+                    let current_epoch = epoch_from_slot(point.slot_or_default());
+                    epoch_span.record("current_epoch", current_epoch);
 
                     db.save(
                         &Point::Origin,
                         store::Columns {
-                            utxo: chunk,
-                            pools: iter::empty(),
+                            utxo: iter::empty(),
+                            pools: state.registered.into_iter().flat_map(
+                                move |(_, registrations)| {
+                                    registrations
+                                        .into_iter()
+                                        .map(|r| (r, current_epoch))
+                                        .collect::<Vec<_>>()
+                                },
+                            ),
                             accounts: iter::empty(),
                         },
-                        Default::default(),
+                        store::Columns {
+                            pools: state.unregistered.into_iter(),
+                            utxo: iter::empty(),
+                            accounts: iter::empty(),
+                        },
                     )
                     .into_diagnostic()?;
-
-                    progress.inc(n as u64);
                 }
 
-                progress.finish();
+                // Epoch State / Ledger State / Cert State / Delegation state
+                {
+                    let delegation_span = info_span!(
+                        target: EVENT_TARGET,
+                        "delegation_state",
+                        length = d.array().into_diagnostic()?,
+                    )
+                    .entered();
+
+                    // Epoch State / Ledger State / Cert State / Delegation state / dsUnified
+                    {
+                        let unified_span = info_span!(
+                            target: EVENT_TARGET,
+                            "unified",
+                            length = d.array().into_diagnostic()?,
+                        )
+                        .entered();
+
+                        // credentials
+                        {
+                            let credentials_span = info_span!(
+                                target: EVENT_TARGET,
+                                "credentials"
+                            )
+                            .entered();
+                            let mut credentials =
+                                d.decode::<HashMap<
+                                    StakeCredential,
+                                    (
+                                        StrictMaybe<(Lovelace, Lovelace)>,
+                                        Set<()>,
+                                        StrictMaybe<PoolId>,
+                                        StrictMaybe<DRep>,
+                                    ),
+                                >>()
+                                .into_diagnostic()?
+                                .into_iter()
+                                .map(
+                                    |(
+                                        credential,
+                                        (rewards_and_deposit, _pointers, pool, _drep),
+                                    )| {
+                                        let (rewards, deposit) =
+                                            Option::<(Lovelace, Lovelace)>::from(
+                                                rewards_and_deposit,
+                                            )
+                                            .unwrap_or((0, STAKE_CREDENTIAL_DEPOSIT as u64));
+
+                                        (
+                                            credential,
+                                            Option::<PoolId>::from(pool),
+                                            Some(deposit),
+                                            rewards,
+                                        )
+                                    },
+                                )
+                                .collect::<Vec<(
+                                    StakeCredential,
+                                    Option<PoolId>,
+                                    Option<Lovelace>,
+                                    Lovelace,
+                                )>>(
+                                );
+
+                            info!(what = "credentials", size = credentials.len());
+
+                            let progress = ProgressBar::new(credentials.len() as u64).with_style(
+                                ProgressStyle::with_template(
+                                    "  Accounts {bar:70} {pos:>7}/{len:7}",
+                                )
+                                .unwrap(),
+                            );
+
+                            while !credentials.is_empty() {
+                                let n = std::cmp::min(BATCH_SIZE, credentials.len());
+                                let chunk = credentials.drain(0..n);
+
+                                db.save(
+                                    &Point::Origin,
+                                    store::Columns {
+                                        utxo: iter::empty(),
+                                        pools: iter::empty(),
+                                        accounts: chunk,
+                                    },
+                                    Default::default(),
+                                )
+                                .into_diagnostic()?;
+
+                                progress.inc(n as u64);
+                            }
+
+                            progress.finish();
+                        }
+
+                        // pointers
+                        {
+                            let pointers_span = info_span!(
+                                target: EVENT_TARGET,
+                                "pointers",
+                                skipped = true,
+                            )
+                            .entered();
+                            d.skip().into_diagnostic()?;
+                        }
+                    }
+
+                    // Epoch State / Ledger State / Cert State / Delegation state / dsFutureGenDelegs
+                    {
+                        let future_gen_span = info_span!(
+                            target: EVENT_TARGET,
+                            "future_gen_delegations",
+                            skipped = true,
+                        )
+                        .entered();
+                        d.skip().into_diagnostic()?;
+                    }
+
+                    // Epoch State / Ledger State / Cert State / Delegation state / dsGenDelegs
+                    {
+                        let gen_delegs_span = info_span!(
+                            target: EVENT_TARGET,
+                            "gen_delegations",
+                            skipped = true,
+                        )
+                        .entered();
+                        d.skip().into_diagnostic()?;
+                    }
+
+                    // Epoch State / Ledger State / Cert State / Delegation state / dsIRewards
+                    {
+                        let rewards_span = info_span!(
+                            target: EVENT_TARGET,
+                            "rewards",
+                            skipped = true,
+                        )
+                        .entered();
+                        d.skip().into_diagnostic()?;
+                    }
+                }
+
+                // Epoch State / Ledger State / UTxO State
+                {
+                    let utxo_span = info_span!(
+                        target: EVENT_TARGET,
+                        "utxo_state",
+                        length = d.array().into_diagnostic()?,
+                    )
+                    .entered();
+
+                    let mut utxo: Vec<(TransactionInput, TransactionOutput)> = d
+                        .decode::<HashMap<TransactionInput, TransactionOutput>>()
+                        .into_diagnostic()?
+                        .into_iter()
+                        .collect::<Vec<(TransactionInput, TransactionOutput)>>();
+
+                    info!(what = "utxo_entries", size = utxo.len());
+
+                    let progress = ProgressBar::new(utxo.len() as u64).with_style(
+                        ProgressStyle::with_template("  UTxO entries {bar:70} {pos:>7}/{len:7}")
+                            .unwrap(),
+                    );
+
+                    while !utxo.is_empty() {
+                        let n = std::cmp::min(BATCH_SIZE, utxo.len());
+                        let chunk = utxo.drain(0..n);
+
+                        db.save(
+                            &Point::Origin,
+                            store::Columns {
+                                utxo: chunk,
+                                pools: iter::empty(),
+                                accounts: iter::empty(),
+                            },
+                            Default::default(),
+                        )
+                        .into_diagnostic()?;
+
+                        progress.inc(n as u64);
+                    }
+
+                    progress.finish();
+                }
             }
         }
     }
@@ -286,14 +404,28 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
     let epoch = epoch_from_slot(point.slot_or_default());
 
-    db.next_snapshot(epoch).into_diagnostic()?;
+    {
+        let snapshot_span = info_span!(
+            target: EVENT_TARGET,
+            "snapshot"
+        )
+        .entered();
+        db.next_snapshot(epoch).into_diagnostic()?;
+    }
 
-    db.with_pools(|iterator| {
-        for (_, pool) in iterator {
-            pools::Row::tick(pool, epoch + 1)
-        }
-    })
-    .into_diagnostic()?;
+    {
+        let pool_span = info_span!(
+            target: EVENT_TARGET,
+            "pools"
+        )
+        .entered();
+        db.with_pools(|iterator| {
+            for (_, pool) in iterator {
+                pools::Row::tick(pool, epoch + 1)
+            }
+        })
+        .into_diagnostic()?;
+    }
 
     Ok(())
 }

--- a/crates/amaru/src/bin/amaru/cmd/import.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import.rs
@@ -104,7 +104,7 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
         // Epoch State / Account State
         {
-            let account_span = info_span!(
+            let _account_span = info_span!(
                 target: EVENT_TARGET,
                 "account_state",
                 skipped = true,
@@ -115,7 +115,7 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
         // Epoch State / Ledger State
         {
-            let ledger_span = info_span!(
+            let _ledger_span = info_span!(
                 target: EVENT_TARGET,
                 "ledger_state",
                 length = d.array().into_diagnostic()?,
@@ -124,7 +124,7 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
             // Epoch State / Ledger State / Cert State
             {
-                let cert_span = info_span!(
+                let _cert_span = info_span!(
                     target: EVENT_TARGET,
                     "cert_state",
                     length = d.array().into_diagnostic()?,
@@ -133,7 +133,7 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
                 // Epoch State / Ledger State / Cert State / Voting State
                 {
-                    let vote_span = info_span!(
+                    let _vote_span = info_span!(
                         target: EVENT_TARGET,
                         "voting_state",
                         skipped = true,
@@ -144,7 +144,7 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
                 // Epoch State / Ledger State / Cert State / Pool State
                 {
-                    let pool_span = info_span!(
+                    let _pool_span = info_span!(
                         target: EVENT_TARGET,
                         "pool_state",
                         length = d.array().into_diagnostic()?,
@@ -159,7 +159,7 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
                     // Deposits
                     {
-                        let deposit_span = info_span!(
+                        let _deposit_span = info_span!(
                             target: EVENT_TARGET,
                             "deposits",
                             skipped = true,
@@ -215,7 +215,7 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
                 // Epoch State / Ledger State / Cert State / Delegation state
                 {
-                    let delegation_span = info_span!(
+                    let _delegation_span = info_span!(
                         target: EVENT_TARGET,
                         "delegation_state",
                         length = d.array().into_diagnostic()?,
@@ -224,7 +224,7 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
                     // Epoch State / Ledger State / Cert State / Delegation state / dsUnified
                     {
-                        let unified_span = info_span!(
+                        let _unified_span = info_span!(
                             target: EVENT_TARGET,
                             "unified",
                             length = d.array().into_diagnostic()?,
@@ -233,7 +233,7 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
                         // credentials
                         {
-                            let credentials_span = info_span!(
+                            let _credentials_span = info_span!(
                                 target: EVENT_TARGET,
                                 "credentials"
                             )
@@ -309,7 +309,7 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
                         // pointers
                         {
-                            let pointers_span = info_span!(
+                            let _pointers_span = info_span!(
                                 target: EVENT_TARGET,
                                 "pointers",
                                 skipped = true,
@@ -321,7 +321,7 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
                     // Epoch State / Ledger State / Cert State / Delegation state / dsFutureGenDelegs
                     {
-                        let future_gen_span = info_span!(
+                        let _future_gen_span = info_span!(
                             target: EVENT_TARGET,
                             "future_gen_delegations",
                             skipped = true,
@@ -332,7 +332,7 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
                     // Epoch State / Ledger State / Cert State / Delegation state / dsGenDelegs
                     {
-                        let gen_delegs_span = info_span!(
+                        let _gen_delegs_span = info_span!(
                             target: EVENT_TARGET,
                             "gen_delegations",
                             skipped = true,
@@ -343,7 +343,7 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
                     // Epoch State / Ledger State / Cert State / Delegation state / dsIRewards
                     {
-                        let rewards_span = info_span!(
+                        let _rewards_span = info_span!(
                             target: EVENT_TARGET,
                             "rewards",
                             skipped = true,
@@ -355,7 +355,7 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
                 // Epoch State / Ledger State / UTxO State
                 {
-                    let utxo_span = info_span!(
+                    let _utxo_span = info_span!(
                         target: EVENT_TARGET,
                         "utxo_state",
                         length = d.array().into_diagnostic()?,
@@ -405,7 +405,7 @@ pub async fn run(args: Args) -> miette::Result<()> {
     let epoch = epoch_from_slot(point.slot_or_default());
 
     {
-        let snapshot_span = info_span!(
+        let _snapshot_span = info_span!(
             target: EVENT_TARGET,
             "snapshot"
         )
@@ -414,7 +414,7 @@ pub async fn run(args: Args) -> miette::Result<()> {
     }
 
     {
-        let pool_span = info_span!(
+        let _pool_span = info_span!(
             target: EVENT_TARGET,
             "pools"
         )


### PR DESCRIPTION
I was playing around with instrumentation to get a feel for it, and test out my fix to the Grafana / tempo setup, and I wanted something that was a bit more nested than what we had in the sync, so I instrumented the import command.

This command is likely temporary, but served as a good test-bed / example for tracing. Indeed, it allowed me to discover a bug in capturing trace information when the process exits before the tracing provider has had a chance to export it from the process.

Now, Grafana consistently reports the full traces for an import, including in the presence of errors, etc.

![image](https://github.com/user-attachments/assets/a8006d9d-2189-43d1-8474-d2822c6921c6)

See the commit messages for more details; in particular, I'm not attached to this specific instrumentation, so feel free to suggest changes if you think it's overboard.

This branch is based on top of my pi/fix-tempo branch, so also includes that fix.