### PR TITLE
First pass at tracking system metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,8 @@ dependencies = [
  "proptest",
  "rocksdb",
  "serde",
- "thiserror 2.0.9",
+ "sys_metrics",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-util",
  "tracing",
@@ -120,11 +121,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -216,7 +218,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener 5.4.0",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -234,7 +236,7 @@ dependencies = [
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.3.1",
+ "event-listener 5.4.0",
  "futures-lite",
  "rustix",
  "tracing",
@@ -304,7 +306,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -315,13 +317,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.84"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1244b10dcd56c92219da4e14caa97e312079e185f04ba3eea25061561dc0a0"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -399,6 +401,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,7 +462,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -471,9 +482,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bitvec"
@@ -579,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
 dependencies = [
  "jobserver",
  "libc",
@@ -616,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -626,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
 dependencies = [
  "anstream",
  "anstyle",
@@ -638,14 +649,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -687,6 +698,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -851,7 +868,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -923,7 +940,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1036,9 +1053,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1051,7 +1068,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener 5.4.0",
  "pin-project-lite",
 ]
 
@@ -1139,9 +1156,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -1158,7 +1175,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1214,7 +1231,7 @@ checksum = "d16f3b9da5c685c55178b9749f79bf6a6c62d1bd07656a0c8eeddadb80ef29c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1607,7 +1624,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1672,15 +1689,25 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "insta"
-version = "1.41.1"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8"
+checksum = "6513e4067e16e69ed1db5ab56048ed65db32d10ba5fc1217f5393f8f17d8b5a5"
 dependencies = [
  "console",
- "lazy_static",
  "linked-hash-map",
+ "once_cell",
  "serde",
  "similar",
+]
+
+[[package]]
+name = "io-kit-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2d4429acc1deff0fbdece0325b4997bdb02b2c245ab7023fd5deca0f6348de"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
 ]
 
 [[package]]
@@ -1688,6 +1715,12 @@ name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1748,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1865,9 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.20"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
+checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
 dependencies = [
  "cc",
  "libc",
@@ -1883,9 +1916,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
@@ -1895,9 +1928,9 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 dependencies = [
  "value-bag",
 ]
@@ -1909,6 +1942,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
+ "libc",
+]
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
  "libc",
 ]
 
@@ -1996,8 +2047,16 @@ version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "317f146e2eb7021892722af37cf1b971f0a70c8406f487e24952667616192c64"
 dependencies = [
+ "backtrace",
+ "backtrace-ext",
  "cfg-if",
  "miette-derive 7.4.0",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
  "thiserror 1.0.69",
  "unicode-width 0.1.14",
 ]
@@ -2010,7 +2069,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2021,7 +2080,7 @@ checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2048,7 +2107,7 @@ checksum = "bd2209fff77f705b00c737016a48e73733d7fbccb8b007194db148f03561fb70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2059,9 +2118,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -2100,7 +2159,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2333,7 +2392,7 @@ dependencies = [
  "pallas-codec",
  "pallas-crypto",
  "serde",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2348,7 +2407,7 @@ dependencies = [
  "pallas-crypto",
  "rand_core 0.6.4",
  "serde",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "vrf_dalek",
  "zeroize",
 ]
@@ -2373,6 +2432,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 
 [[package]]
 name = "pallas-addresses"
@@ -2528,29 +2593,29 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -2655,9 +2720,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -2702,7 +2767,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2929,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
  "bitflags",
  "errno",
@@ -3019,14 +3084,14 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3193,6 +3258,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f44ed3c63152de6a9f90acbea1a110441de43006ea51bcce8f436196a288b"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3205,9 +3291,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.94"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987bc0be1cdea8b10216bd06e2ca407d40b9543468fafd3ddfb02f36e77f71f3"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3231,7 +3317,22 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "sys_metrics"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b266b80f59f86e2e1e0a4938e316e32c3730d94a749f236305152279f77484"
+dependencies = [
+ "core-foundation-sys",
+ "glob",
+ "io-kit-sys",
+ "lazy_static",
+ "libc",
+ "mach",
+ "serde",
 ]
 
 [[package]]
@@ -3255,10 +3356,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.1.14",
+]
 
 [[package]]
 name = "thiserror"
@@ -3271,11 +3392,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.9",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -3286,18 +3407,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3331,9 +3452,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3348,13 +3469,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3477,7 +3598,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3566,6 +3687,12 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3722,34 +3849,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3760,9 +3888,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3770,28 +3898,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4048,7 +4179,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -4070,7 +4201,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4090,7 +4221,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
  "synstructure",
 ]
 
@@ -4111,7 +4242,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4133,7 +4264,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.94",
+ "syn 2.0.96",
 ]
 
 [[package]]

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -47,6 +47,8 @@ opentelemetry-otlp = { version = "0.27.0", features = [
     "reqwest-client",
 ] }
 tracing-opentelemetry = { version = "0.28.0" }
+
+[target.'cfg(not(windows))'.dependencies]
 sys_metrics = "0.2.7"
 
 [dev-dependencies]

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -47,6 +47,7 @@ opentelemetry-otlp = { version = "0.27.0", features = [
     "reqwest-client",
 ] }
 tracing-opentelemetry = { version = "0.28.0" }
+sys_metrics = "0.2.7"
 
 [dev-dependencies]
 envpath = { version = "0.0.1-beta.3", features = ["rand"] }

--- a/crates/amaru/src/bin/amaru/main.rs
+++ b/crates/amaru/src/bin/amaru/main.rs
@@ -8,6 +8,7 @@ use std::env;
 mod cmd;
 mod config;
 mod exit;
+mod metrics;
 mod panic;
 
 pub const SERVICE_NAME: &str = "amaru";
@@ -39,7 +40,7 @@ async fn main() -> miette::Result<()> {
     let args = Cli::parse();
 
     let result = match args.command {
-        Command::Daemon(args) => cmd::daemon::run(args, counter).await,
+        Command::Daemon(args) => cmd::daemon::run(args, counter, metrics.clone()).await,
         Command::Import(args) => cmd::import::run(args).await,
     };
 

--- a/crates/amaru/src/bin/amaru/metrics.rs
+++ b/crates/amaru/src/bin/amaru/metrics.rs
@@ -13,6 +13,7 @@ use sys_metrics::{
 use tokio::task::JoinHandle;
 use tracing::warn;
 
+#[cfg(not(windows))]
 pub fn track_system_metrics(metrics: SdkMeterProvider) -> JoinHandle<()> {
     tokio::spawn(async move {
         let counters = make_system_counters(metrics);
@@ -38,6 +39,13 @@ pub fn track_system_metrics(metrics: SdkMeterProvider) -> JoinHandle<()> {
             record_system_metrics(reading, &counters);
         }
     })
+}
+
+#[cfg(windows)]
+pub fn track_system_metrics(metrics: SdkMeterProvider) -> JoinHandle<()> {
+    use tracing::info;
+    info!("System metrics currently not supported on Windows");
+    tokio::spawn(async {})
 }
 
 struct SystemCounters {
@@ -88,6 +96,7 @@ fn make_system_counters(metrics: SdkMeterProvider) -> SystemCounters {
     }
 }
 
+#[cfg(not(windows))]
 fn get_reading() -> miette::Result<Reading> {
     use sys_metrics::*;
     let memory = memory::get_memory().into_diagnostic()?;

--- a/crates/amaru/src/bin/amaru/metrics.rs
+++ b/crates/amaru/src/bin/amaru/metrics.rs
@@ -1,0 +1,123 @@
+use std::time::Duration;
+
+use miette::IntoDiagnostic;
+use opentelemetry::{
+    metrics::{Counter, Gauge, MeterProvider},
+    KeyValue,
+};
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use sys_metrics::{
+    cpu::{CpuTimes, LoadAvg},
+    memory::Memory,
+};
+use tokio::task::JoinHandle;
+use tracing::warn;
+
+pub fn track_system_metrics(metrics: SdkMeterProvider) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let counters = make_system_counters(metrics);
+        let mut delay = Duration::from_secs(1);
+        loop {
+            // TODO(pi): configurable parameter?
+            tokio::time::sleep(delay).await;
+
+            let reading = match get_reading() {
+                Ok(sys) => sys,
+                Err(err) => {
+                    warn!("failed to read system metrics: {}", err);
+                    delay = delay * 2;
+                    if delay > Duration::from_secs(30) {
+                        delay = Duration::from_secs(30);
+                    }
+                    continue;
+                }
+            };
+            delay = Duration::from_secs(1);
+
+            record_system_metrics(reading, &counters);
+        }
+    })
+}
+
+struct SystemCounters {
+    total_memory: Gauge<u64>,
+    free_memory: Gauge<u64>,
+    cpu_load: Gauge<f64>,
+    user_time: Counter<u64>,
+}
+
+#[derive(Debug)]
+struct Reading {
+    memory: Memory,
+    cpu: CpuTimes,
+    load: LoadAvg,
+}
+
+fn make_system_counters(metrics: SdkMeterProvider) -> SystemCounters {
+    // TODO: standardize with the Haskell node somehow?
+    let meter = metrics.meter("system");
+    let total_memory = meter
+        .u64_gauge("memory.limit")
+        .with_description("The total system memory, updated once per second")
+        .with_unit("MB")
+        .build();
+
+    let free_memory = meter
+        .u64_gauge("memory.usage")
+        .with_description("The free system memory, measured once per second")
+        .with_unit("MB")
+        .build();
+
+    let cpu_load = meter
+        .f64_gauge("cpu.utilization")
+        .with_description("the 1m average load, measured once per second")
+        .build();
+
+    let user_time = meter
+        .u64_counter("cpu.time")
+        .with_description("the total cpu time spent in user processes")
+        .with_unit("ms")
+        .build();
+
+    SystemCounters {
+        total_memory,
+        free_memory,
+        cpu_load,
+        user_time,
+    }
+}
+
+fn get_reading() -> miette::Result<Reading> {
+    use sys_metrics::*;
+    let memory = memory::get_memory().into_diagnostic()?;
+    let cpu = cpu::get_cputimes().into_diagnostic()?;
+    let load = cpu::get_loadavg().into_diagnostic()?;
+
+    Ok(Reading { memory, cpu, load })
+}
+
+fn record_system_metrics(reading: Reading, counters: &SystemCounters) {
+    counters.total_memory.record(reading.memory.total, &[]);
+    counters.free_memory.record(reading.memory.free, &[]);
+    counters.cpu_load.record(reading.load.one, &[]);
+    counters
+        .user_time
+        .add(reading.cpu.user, &[KeyValue::new("state", "user")]);
+    counters
+        .user_time
+        .add(reading.cpu.system, &[KeyValue::new("state", "system")]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_read_system_metrics() {
+        let reading = get_reading().expect("failed to read system metrics");
+        assert!(reading.memory.free > 0, "failed to read free memory");
+        assert!(reading.memory.total > 0, "failed to read total memory");
+        assert!(reading.cpu.user > 0, "failed to read user cpu time");
+        assert!(reading.load.one > 0.0, "failed to read cpu load average");
+    }
+}

--- a/crates/amaru/src/bin/amaru/metrics.rs
+++ b/crates/amaru/src/bin/amaru/metrics.rs
@@ -25,7 +25,8 @@ pub fn track_system_metrics(metrics: SdkMeterProvider) -> JoinHandle<()> {
                 Ok(sys) => sys,
                 Err(err) => {
                     warn!("failed to read system metrics: {}", err);
-                    delay = delay * 2;
+                    // Back off slightly so the logs aren't as noisy
+                    delay *= 2;
                     if delay > Duration::from_secs(30) {
                         delay = Duration::from_secs(30);
                     }

--- a/crates/amaru/src/bin/amaru/metrics.rs
+++ b/crates/amaru/src/bin/amaru/metrics.rs
@@ -1,12 +1,9 @@
-use opentelemetry::{
-    metrics::{Counter, Gauge, MeterProvider},
-    KeyValue,
-};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use tokio::task::JoinHandle;
 
 #[cfg(not(windows))]
 pub fn track_system_metrics(metrics: SdkMeterProvider) -> JoinHandle<()> {
+    use internals::*;
     use std::time::Duration;
     use tracing::warn;
     tokio::spawn(async move {
@@ -42,89 +39,94 @@ pub fn track_system_metrics(_metrics: SdkMeterProvider) -> JoinHandle<()> {
     tokio::spawn(async {})
 }
 
-struct SystemCounters {
-    total_memory: Gauge<u64>,
-    free_memory: Gauge<u64>,
-    cpu_load: Gauge<f64>,
-    user_time: Counter<u64>,
-}
-
 #[cfg(not(windows))]
-#[derive(Debug)]
-struct Reading {
-    memory: sys_metrics::memory::Memory,
-    cpu: sys_metrics::cpu::CpuTimes,
-    load: sys_metrics::cpu::LoadAvg,
-}
-
-fn make_system_counters(metrics: SdkMeterProvider) -> SystemCounters {
-    // TODO: standardize with the Haskell node somehow?
-    let meter = metrics.meter("system");
-    let total_memory = meter
-        .u64_gauge("memory.limit")
-        .with_description("The total system memory, updated once per second")
-        .with_unit("MB")
-        .build();
-
-    let free_memory = meter
-        .u64_gauge("memory.usage")
-        .with_description("The free system memory, measured once per second")
-        .with_unit("MB")
-        .build();
-
-    let cpu_load = meter
-        .f64_gauge("cpu.utilization")
-        .with_description("the 1m average load, measured once per second")
-        .build();
-
-    let user_time = meter
-        .u64_counter("cpu.time")
-        .with_description("the total cpu time spent in user processes")
-        .with_unit("ms")
-        .build();
-
-    SystemCounters {
-        total_memory,
-        free_memory,
-        cpu_load,
-        user_time,
-    }
-}
-
-#[cfg(not(windows))]
-fn get_reading() -> miette::Result<Reading> {
+mod internals {
     use miette::IntoDiagnostic;
+    use opentelemetry::{
+        metrics::{Counter, Gauge, MeterProvider},
+        KeyValue,
+    };
+    use opentelemetry_sdk::metrics::SdkMeterProvider;
     use sys_metrics::*;
-    let memory = memory::get_memory().into_diagnostic()?;
-    let cpu = cpu::get_cputimes().into_diagnostic()?;
-    let load = cpu::get_loadavg().into_diagnostic()?;
 
-    Ok(Reading { memory, cpu, load })
-}
+    pub struct SystemCounters {
+        total_memory: Gauge<u64>,
+        free_memory: Gauge<u64>,
+        cpu_load: Gauge<f64>,
+        user_time: Counter<u64>,
+    }
 
-#[cfg(not(windows))]
-fn record_system_metrics(reading: Reading, counters: &SystemCounters) {
-    counters.total_memory.record(reading.memory.total, &[]);
-    counters.free_memory.record(reading.memory.free, &[]);
-    counters.cpu_load.record(reading.load.one, &[]);
-    counters
-        .user_time
-        .add(reading.cpu.user, &[KeyValue::new("state", "user")]);
-    counters
-        .user_time
-        .add(reading.cpu.system, &[KeyValue::new("state", "system")]);
-}
+    #[derive(Debug)]
+    pub struct Reading {
+        memory: sys_metrics::memory::Memory,
+        cpu: sys_metrics::cpu::CpuTimes,
+        load: sys_metrics::cpu::LoadAvg,
+    }
 
-#[cfg(all(test, not(windows)))]
-mod tests {
-    use super::*;
+    pub fn make_system_counters(metrics: SdkMeterProvider) -> SystemCounters {
+        // TODO: standardize with the Haskell node somehow?
+        let meter = metrics.meter("system");
+        let total_memory = meter
+            .u64_gauge("memory.limit")
+            .with_description("The total system memory, updated once per second")
+            .with_unit("MB")
+            .build();
 
-    #[test]
-    fn can_read_system_metrics() {
-        let reading = get_reading().expect("failed to read system metrics");
-        assert!(reading.memory.free > 0, "failed to read free memory");
-        assert!(reading.memory.total > 0, "failed to read total memory");
-        assert!(reading.cpu.user > 0, "failed to read user cpu time");
-        assert!(reading.load.one > 0.0, "failed to read cpu load average");
+        let free_memory = meter
+            .u64_gauge("memory.usage")
+            .with_description("The free system memory, measured once per second")
+            .with_unit("MB")
+            .build();
+
+        let cpu_load = meter
+            .f64_gauge("cpu.utilization")
+            .with_description("the 1m average load, measured once per second")
+            .build();
+
+        let user_time = meter
+            .u64_counter("cpu.time")
+            .with_description("the total cpu time spent in user processes")
+            .with_unit("ms")
+            .build();
+
+        SystemCounters {
+            total_memory,
+            free_memory,
+            cpu_load,
+            user_time,
+        }
+    }
+
+    pub fn get_reading() -> miette::Result<Reading> {
+        let memory = memory::get_memory().into_diagnostic()?;
+        let cpu = cpu::get_cputimes().into_diagnostic()?;
+        let load = cpu::get_loadavg().into_diagnostic()?;
+
+        Ok(Reading { memory, cpu, load })
+    }
+    pub fn record_system_metrics(reading: Reading, counters: &SystemCounters) {
+        counters.total_memory.record(reading.memory.total, &[]);
+        counters.free_memory.record(reading.memory.free, &[]);
+        counters.cpu_load.record(reading.load.one, &[]);
+        counters
+            .user_time
+            .add(reading.cpu.user, &[KeyValue::new("state", "user")]);
+        counters
+            .user_time
+            .add(reading.cpu.system, &[KeyValue::new("state", "system")]);
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn can_read_system_metrics() {
+            let reading = get_reading().expect("failed to read system metrics");
+            assert!(reading.memory.free > 0, "failed to read free memory");
+            assert!(reading.memory.total > 0, "failed to read total memory");
+            assert!(reading.cpu.user > 0, "failed to read user cpu time");
+            assert!(reading.load.one > 0.0, "failed to read cpu load average");
+        }
     }
 }


### PR DESCRIPTION
This spawns a background thread to track common system metrics; currently only tracks a few, but we can add more as needed.

I evaluated a few different metrics:
 - [opentelemetry-system-metrics](https://crates.io/crates/opentelemetry-system-metrics)
 - [sys_metrics](https://crates.io/crates/sys_metrics)
 - [heim](https://github.com/heim-rs/heim?tab=readme-ov-file)

Of these, sys_metrics doesn't support windows, but is the most actively maintained.

As a follow up, it might be useful to track Tokio runtime metrics as well:

https://docs.rs/tokio/latest/tokio/runtime/struct.RuntimeMetrics.html

Opening this as a draft PR, looking for feedback on the structure / organization before I write a few more tests and add a few more metrics.