### PR TITLE
chore: add optional windows CI environment

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,9 @@ jobs:
             optional: true
           - runner: macos-latest
             target: aarch64-apple-darwin
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
+            optional: true
     timeout-minutes: 30
     runs-on: ${{ matrix.environments.runner }}
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,3 +49,4 @@ jobs:
             echo "::warning::Tests failed with exit code $exitcode"
             exit 0
           fi
+        shell: bash

--- a/crates/amaru/src/bin/amaru/exit.rs
+++ b/crates/amaru/src/bin/amaru/exit.rs
@@ -1,4 +1,7 @@
 use tokio_util::sync::CancellationToken;
+#[cfg(windows)]
+use tracing::debug;
+#[cfg(unix)]
 use tracing::{debug, warn};
 
 #[inline]


### PR DESCRIPTION
Add an optional windows CI `environment`. This will help keep track on the current state of amaru on windows.