### PR TITLE
chore: rely on cargo aliases

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+# Find the full list of available options here: https://doc.rust-lang.org/cargo/reference/config.html
+
+[alias]
+acfmt = "fmt --all -- --check"
+aclippy = "clippy --workspace --all-targets --all-features -- -D warnings"
+atest = "test --workspace --all-targets --all-features "

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,14 +34,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - name: Check format
-        run: cargo fmt --all -- --check
+        run: cargo acfmt
       - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo aclippy
       - run: rustup target add ${{ matrix.environments.target }}
       - name: Run tests
         run: |
           set +e
-          cargo test --locked --all-features --workspace --target ${{ matrix.environments.target }}
+          cargo atest --locked --target ${{ matrix.environments.target }}
           exitcode="$?"
           if [[ "${{ matrix.environments.optional }}" == "true" && "$exitcode" != "0" ]] ; then
             # Propagate failure as a warning


### PR DESCRIPTION
Introduce cargo `aliases` so that the same commands can be easily shared between local dev env and CI.
I introduced a `a` prefix (fo `amaru` ?) to distinguish those, feel free to suggest a better alternative :)

Can be used as:

```shell
cargo atest --target wasm32-unknown-unknown
```