### PR TITLE
chore: make windows CI not optional

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,6 @@ jobs:
             target: aarch64-apple-darwin
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
-            optional: true
     timeout-minutes: 30
     runs-on: ${{ matrix.environments.runner }}
     steps:


### PR DESCRIPTION
Now that the windows env on `CI` builds fine, make sure it is not optional so that future breakage do not get ignored.