### PR TITLE
chore: add raspberry PI support for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,10 @@ jobs:
             target: aarch64-apple-darwin
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
+          - runner: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            optional: true
+            cross-compile: true
     timeout-minutes: 30
     runs-on: ${{ matrix.environments.runner }}
     steps:
@@ -40,7 +44,12 @@ jobs:
       - name: Run tests
         run: |
           set +e
-          cargo test-amaru --locked --target ${{ matrix.environments.target }}
+          if [[ "${{ matrix.environments.cross-compile }}" == "true" ]] ; then
+            cargo install cross --git https://github.com/cross-rs/cross
+            $HOME/.cargo/bin/cross test-amaru --locked --all-features --workspace --target ${{ matrix.environments.target }}
+          else
+            cargo test-amaru --locked --target ${{ matrix.environments.target }}
+          fi
           exitcode="$?"
           if [[ "${{ matrix.environments.optional }}" == "true" && "$exitcode" != "0" ]] ; then
             # Propagate failure as a warning

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
           - runner: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
             optional: true
             cross-compile: true
     timeout-minutes: 30

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: ${{ runner.os }}-${{ matrix.environments.target }}
       - name: Check format
         run: cargo fmt-amaru
       - name: Run clippy

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,8 @@ jobs:
           set +e
           if [[ "${{ matrix.environments.cross-compile }}" == "true" ]] ; then
             cargo install cross --git https://github.com/cross-rs/cross
-            $HOME/.cargo/bin/cross test-amaru --locked --all-features --workspace --target ${{ matrix.environments.target }}
+            # cross doesn't load .cargo/config.toml, see https://github.com/cross-rs/cross/issues/562
+            $HOME/.cargo/bin/cross test --locked --all-features --workspace --target ${{ matrix.environments.target }}
           else
             cargo test-amaru --locked --target ${{ matrix.environments.target }}
           fi


### PR DESCRIPTION
Add CI support for  `aarch64` on linux. This allows to ensure that `amaru` can build for recent raspberry (including `zero`).

Running on a rapsberry 5:
![demo](https://github.com/user-attachments/assets/b6f2d386-20ed-473f-8170-68bb10c1de7f)
