### PR TITLE
chore: use fancy miette reporting

### DIFF
--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -17,7 +17,7 @@ async-trait = "0.1.83"
 clap = { version = "4.5.20", features = ["derive"] }
 gasket = { version = "0.8.0", features = ["derive"] }
 hex = "0.4.3"
-miette = "7.2.0"
+miette = { version = "7.2.0", features = ["fancy"] }
 indoc = "2.0"
 ouroboros = { git = "https://github.com/pragma-org/ouroboros", rev = "ca1d447a6c106e421e6c2b1c7d9d59abf5ca9589" }
 ouroboros-praos = { git = "https://github.com/pragma-org/ouroboros", rev = "ca1d447a6c106e421e6c2b1c7d9d59abf5ca9589" }


### PR DESCRIPTION
Use miette [fancy reporting](https://docs.rs/miette/latest/miette/#installing). This helps improve the error displayed in the console and remove this note: 
`NOTE: If you're looking for the fancy error reports, install miette with the `fancy` feature, or write your own and hook it up with miette::set_hook().`

An alternative is to not use `fancy` reporting, but find a way to disable this `NOTE`.

**BEFORE**

```shell
Error: Diagnostic { message: "No such file or directory (os error 2)" }
````

**AFTER**

```shell
Error: 
  × No such file or directory (os error 2)
````