### PR TITLE
chore: rework and align ledger.db arg passing across commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,12 @@ cargo build --release
 
 ```console
 cargo run --release -- import \
-    --out ledger.db \
-    --snapshot 69206375.6f99b5f3deaeae8dc43fce3db2f3cd36ad8ed174ca3400b5b1bed76fdf248912.cbor
+  --snapshot 69206375.6f99b5f3deaeae8dc43fce3db2f3cd36ad8ed174ca3400b5b1bed76fdf248912.cbor
 
 cargo run --release -- import \
-  --out ledger.db \
   --snapshot 69638382.5da6ba37a4a07df015c4ea92c880e3600d7f098b97e73816f8df04bbb5fad3b7.cbor
 
 cargo run --release -- import \
-  --out ledger.db \
   --snapshot 70070379.d6fe6439aed8bddc10eec22c1575bf0648e4a76125387d9e985e9a3f8342870d.cbor
 ```
 

--- a/crates/amaru/src/bin/amaru/cmd/import.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import.rs
@@ -33,9 +33,9 @@ pub struct Args {
     #[arg(long, verbatim_doc_comment)]
     snapshot: PathBuf,
 
-    /// Path to the ledger database folder.
-    #[arg(long)]
-    out: PathBuf,
+    /// Path of the ledger on-disk storage.
+    #[arg(long, default_value = super::DEFAULT_LEDGER_DB_DIR)]
+    ledger_dir: PathBuf,
 }
 
 #[derive(Debug, thiserror::Error, Diagnostic)]
@@ -55,8 +55,8 @@ pub async fn run(args: Args) -> miette::Result<()> {
     )
     .into_diagnostic()?;
 
-    fs::create_dir_all(&args.out).into_diagnostic()?;
-    let mut db = ledger::store::rocksdb::RocksDB::empty(&args.out).into_diagnostic()?;
+    fs::create_dir_all(&args.ledger_dir).into_diagnostic()?;
+    let mut db = ledger::store::rocksdb::RocksDB::empty(&args.ledger_dir).into_diagnostic()?;
     let bytes = fs::read(&args.snapshot).into_diagnostic()?;
 
     let epoch = decode_new_epoch_state(&db, &bytes, &point)?;

--- a/crates/amaru/src/bin/amaru/cmd/mod.rs
+++ b/crates/amaru/src/bin/amaru/cmd/mod.rs
@@ -3,6 +3,12 @@ use amaru::sync::Point;
 pub(crate) mod daemon;
 pub(crate) mod import;
 
+/// Default path to the on-disk ledger storage.
+pub(crate) const DEFAULT_LEDGER_DB_DIR: &str = "./ledger.db";
+
+/// Default path to pre-computed on-chain data needed for block header validation.
+pub(crate) const DEFAULT_DATA_DIR: &str = "./data";
+
 pub(crate) fn parse_point<'a, F, E>(raw_str: &str, bail: F) -> Result<Point, E>
 where
     F: Fn(&'a str) -> E + 'a,

--- a/crates/amaru/src/sync/mod.rs
+++ b/crates/amaru/src/sync/mod.rs
@@ -22,6 +22,7 @@ pub enum PullEvent {
 }
 
 pub struct Config {
+    pub ledger_dir: PathBuf,
     pub upstream_peer: String,
     pub network_magic: u32,
     pub nonces: HashMap<Epoch, Hash<32>>,
@@ -48,8 +49,7 @@ fn define_gasket_policy() -> gasket::runtime::Policy {
 
 pub fn bootstrap(config: Config, client: &Arc<Mutex<PeerClient>>) -> miette::Result<Vec<Tether>> {
     // FIXME: Take from config / command args
-    let ledger_store = PathBuf::from("./ledger.db");
-    let (mut ledger, tip) = ledger::Stage::new(&ledger_store, config.counter.clone());
+    let (mut ledger, tip) = ledger::Stage::new(&config.ledger_dir, config.counter.clone());
 
     let mut pull = pull::Stage::new(client.clone(), vec![tip]);
     let mut header_validation =


### PR DESCRIPTION
  - Use module constants to avoid repetitions;
  - Align option names across commands when they refer to the same thing;
  - Promote hard-coded filepath to command arguments on the 'daemon' command