### PR TITLE
Track withdrawals in ledger state + important fixes

### DIFF
--- a/crates/amaru/src/bin/amaru/cmd/import.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import.rs
@@ -61,8 +61,14 @@ pub async fn run(args: Args) -> miette::Result<()> {
 
     let epoch = decode_new_epoch_state(&db, &bytes, &point)?;
 
-    db.save(&point, None, Default::default(), Default::default())
-        .into_diagnostic()?;
+    db.save(
+        &point,
+        None,
+        Default::default(),
+        Default::default(),
+        iter::empty(),
+    )
+    .into_diagnostic()?;
 
     db.next_snapshot(epoch, None).into_diagnostic()?;
 
@@ -296,6 +302,7 @@ fn import_utxo(
                 accounts: iter::empty(),
             },
             Default::default(),
+            iter::empty(),
         )
         .into_diagnostic()?;
 
@@ -361,6 +368,7 @@ fn import_stake_pools(
             utxo: iter::empty(),
             accounts: iter::empty(),
         },
+        iter::empty(),
     )
     .into_diagnostic()
 }
@@ -439,6 +447,7 @@ fn import_accounts(
                 accounts: chunk,
             },
             Default::default(),
+            iter::empty(),
         )
         .into_diagnostic()?;
 

--- a/crates/amaru/src/ledger/kernel.rs
+++ b/crates/amaru/src/ledger/kernel.rs
@@ -85,9 +85,6 @@ pub const OPTIMAL_STAKE_POOLS_COUNT: usize = 500;
 // Re-exports & extra aliases
 // ----------------------------------------------------------------------------
 
-// FIXME: Switch to BigInt or BigUInt eventually. Not doing it _now_ because of laziness, not
-// having to deal with serialisation and deserialisation of those right now; and also because so
-// far it isn't causing any problem.
 pub type Lovelace = u64;
 
 pub type Point = pallas_network::miniprotocols::Point;
@@ -249,25 +246,25 @@ pub fn encode_bech32(hrp: &str, payload: &[u8]) -> Result<String, bech32::Encode
 }
 
 /// Calculate the epoch number corresponding to a given slot on the PreProd network.
-// FIXME: Design and implement a proper abstraction for slot arithmetic. See https://github.com/pragma-org/amaru/pull/26/files#r1807394364
+// TODO: Design and implement a proper abstraction for slot arithmetic. See https://github.com/pragma-org/amaru/pull/26/files#r1807394364
 pub fn epoch_from_slot(slot: u64) -> u64 {
     let shelley_slots = slot - BYRON_TOTAL_SLOTS as u64;
     (shelley_slots / SHELLEY_EPOCH_LENGTH as u64) + PREPROD_SHELLEY_TRANSITION_EPOCH as u64
 }
 
 /// Obtain the slot number relative to the epoch.
-// FIXME: Design and implement a proper abstraction for slot arithmetic. See https://github.com/pragma-org/amaru/pull/26/files#r1807394364
+// TODO: Design and implement a proper abstraction for slot arithmetic. See https://github.com/pragma-org/amaru/pull/26/files#r1807394364
 pub fn relative_slot(slot: u64) -> u64 {
     let shelley_previous_slots = (epoch_from_slot(slot) - PREPROD_SHELLEY_TRANSITION_EPOCH as u64)
         * SHELLEY_EPOCH_LENGTH as u64;
     slot - shelley_previous_slots - BYRON_TOTAL_SLOTS as u64
 }
 
-/// FIXME: Ideally, we should either:
+/// TODO: Ideally, we should either:
 ///
 /// - Have pallas_traverse or a similar API works directly from base objects instead of KeepRaw
 ///   objects (i.e. MintedTransactionOutput)
-/// - Ensure that our database iterator yields MintedTransactionOutput and not TransactionOutput, o
+/// - Ensure that our database iterator yields MintedTransactionOutput and not TransactionOutput, so
 ///   we can use pallas_traverse out of the box.
 ///
 /// Doing the latter properly is a lifetime hell I am not willing to explore right now.
@@ -284,7 +281,7 @@ pub fn output_lovelace(output: &TransactionOutput) -> Lovelace {
     }
 }
 
-/// FIXME: See 'output_lovelace', same remark applies.
+/// TODO: See 'output_lovelace', same remark applies.
 pub fn output_stake_credential(output: &TransactionOutput) -> Option<StakeCredential> {
     let address = Address::from_bytes(match output {
         TransactionOutput::Legacy(legacy) => &legacy.address[..],

--- a/crates/amaru/src/ledger/kernel.rs
+++ b/crates/amaru/src/ledger/kernel.rs
@@ -315,3 +315,10 @@ pub fn reward_account_to_stake_credential(account: &RewardAccount) -> Option<Sta
         None
     }
 }
+
+/// An 'unsafe' version of `reward_account_to_stake_credential` that panics when the given
+/// RewardAccount isn't a `StakeCredential`.
+pub fn expect_stake_credential(account: &RewardAccount) -> StakeCredential {
+    reward_account_to_stake_credential(account)
+        .unwrap_or_else(|| panic!("unexpected malformed reward account: {:?}", account))
+}

--- a/crates/amaru/src/ledger/kernel.rs
+++ b/crates/amaru/src/ledger/kernel.rs
@@ -11,7 +11,7 @@ pub use ouroboros::ledger::PoolSigma;
 use pallas_addresses::*;
 pub use pallas_codec::{
     minicbor as cbor,
-    utils::{Nullable, Set},
+    utils::{NonEmptyKeyValuePairs, Nullable, Set},
 };
 pub use pallas_crypto::hash::{Hash, Hasher};
 pub use pallas_primitives::{

--- a/crates/amaru/src/ledger/rewards.rs
+++ b/crates/amaru/src/ledger/rewards.rs
@@ -84,10 +84,10 @@ certain mutations are applied to the system.
 
 use crate::ledger::{
     kernel::{
-        encode_bech32, output_lovelace, output_stake_credential,
-        reward_account_to_stake_credential, Epoch, Hash, Lovelace, PoolId, PoolParams,
-        StakeCredential, ACTIVE_SLOT_COEFF_INVERSE, MAX_LOVELACE_SUPPLY, MONETARY_EXPANSION,
-        OPTIMAL_STAKE_POOLS_COUNT, PLEDGE_INFLUENCE, SHELLEY_EPOCH_LENGTH, TREASURY_TAX,
+        encode_bech32, expect_stake_credential, output_lovelace, output_stake_credential, Epoch,
+        Hash, Lovelace, PoolId, PoolParams, StakeCredential, ACTIVE_SLOT_COEFF_INVERSE,
+        MAX_LOVELACE_SUPPLY, MONETARY_EXPANSION, OPTIMAL_STAKE_POOLS_COUNT, PLEDGE_INFLUENCE,
+        SHELLEY_EPOCH_LENGTH, TREASURY_TAX,
     },
     store::{columns::*, Store},
 };
@@ -765,16 +765,8 @@ impl RewardsSummary {
 
         let rewards_leader = pool.leader_rewards(rewards_pot, owner_stake, total_stake);
 
-        let credential = reward_account_to_stake_credential(&pool.parameters.reward_account)
-            .unwrap_or_else(|| {
-                panic!(
-                    "unexpected malformed reward account: {:?}",
-                    &pool.parameters.reward_account
-                )
-            });
-
         accounts
-            .entry(credential)
+            .entry(expect_stake_credential(&pool.parameters.reward_account))
             .and_modify(|rewards| *rewards += rewards_leader)
             .or_insert(rewards_leader);
 

--- a/crates/amaru/src/ledger/snapshots/amaru__ledger__rewards__tests__rewards_summary_169.snap
+++ b/crates/amaru/src/ledger/snapshots/amaru__ledger__rewards__tests__rewards_summary_169.snap
@@ -11,7 +11,7 @@ expression: rewards_summary
   "available_rewards": 24797475166304,
   "pots": {
     "treasury": 1113836489073602,
-    "reserves": 13861692862209948,
+    "reserves": 13861692862209947,
     "fees": 10184705481
   },
   "pools": {

--- a/crates/amaru/src/ledger/snapshots/amaru__ledger__rewards__tests__rewards_summary_171.snap
+++ b/crates/amaru/src/ledger/snapshots/amaru__ledger__rewards__tests__rewards_summary_171.snap
@@ -10,8 +10,8 @@ expression: rewards_summary
   "treasury_tax": 6132690476765,
   "available_rewards": 24530761907062,
   "pots": {
-    "treasury": null,
-    "reserves": null,
+    "treasury": 1126146801281370,
+    "reserves": 13849012241710049,
     "fees": 10971955509
   },
   "pools": {

--- a/crates/amaru/src/ledger/snapshots/amaru__ledger__rewards__tests__rewards_summary_172.snap
+++ b/crates/amaru/src/ledger/snapshots/amaru__ledger__rewards__tests__rewards_summary_172.snap
@@ -10,8 +10,8 @@ expression: rewards_summary
   "treasury_tax": 6329695725848,
   "available_rewards": 25318782903392,
   "pots": {
-    "treasury": null,
-    "reserves": null,
+    "treasury": 1132279884286415,
+    "reserves": 13842693961409407,
     "fees": 10232541886
   },
   "pools": {

--- a/crates/amaru/src/ledger/state.rs
+++ b/crates/amaru/src/ledger/state.rs
@@ -148,16 +148,23 @@ impl<S: Store<Error = E>, E: std::fmt::Debug> State<S, E> {
                 fees,
                 add,
                 remove,
+                withdrawals,
             } = now_stable.into_store_update();
 
             info_span!(target: STATE_EVENT_TARGET, parent: span, "save").in_scope(|| {
-                db.save(&stable_point, Some(&stable_issuer), add, remove)
-                    .and_then(|()| {
-                        db.with_pots(|mut row| {
-                            row.borrow_mut().fees += fees;
-                        })
+                db.save(
+                    &stable_point,
+                    Some(&stable_issuer),
+                    add,
+                    remove,
+                    withdrawals,
+                )
+                .and_then(|()| {
+                    db.with_pots(|mut row| {
+                        row.borrow_mut().fees += fees;
                     })
-                    .map_err(ForwardErr::StorageErr)
+                })
+                .map_err(ForwardErr::StorageErr)
             })?;
 
             // Once we reach the stability window,

--- a/crates/amaru/src/ledger/state/transaction.rs
+++ b/crates/amaru/src/ledger/state/transaction.rs
@@ -10,7 +10,7 @@ use crate::ledger::kernel::{
 use std::collections::{BTreeMap, BTreeSet};
 use tracing::{debug, info_span, Span};
 
-const TRANSACTION_EVENT_TARGET: &str = "amaru::ledger::state::transaction";
+const EVENT_TARGET: &str = "amaru::ledger::state::transaction";
 
 pub fn apply<T>(
     state: &mut VolatileState<T>,
@@ -21,7 +21,7 @@ pub fn apply<T>(
     resolved_collateral_inputs: Vec<TransactionOutput>,
 ) {
     let span = info_span!(
-        target: TRANSACTION_EVENT_TARGET,
+        target: EVENT_TARGET,
         parent: parent,
         "apply.transaction",
         transaction.id = %transaction_id,
@@ -198,21 +198,21 @@ fn apply_certificates(
     for certificate in certificates {
         match certificate {
                 Certificate::StakeRegistration(credential) | Certificate::Reg(credential, ..) | Certificate::VoteRegDeleg(credential, ..) => {
-                    debug!(name: "certificate.stake.registration", target: TRANSACTION_EVENT_TARGET, parent: parent, credential = ?credential);
+                    debug!(name: "certificate.stake.registration", target: EVENT_TARGET, parent: parent, credential = ?credential);
                         accounts
                         .register(credential, STAKE_CREDENTIAL_DEPOSIT as Lovelace, None);
                 }
                 Certificate::StakeDelegation(credential, pool)
                 // FIXME: register DRep delegation
                 | Certificate::StakeVoteDeleg(credential, pool, ..) => {
-                    debug!(name: "certificate.stake.delegation", target: TRANSACTION_EVENT_TARGET, parent: parent, credential = ?credential, pool = %pool);
+                    debug!(name: "certificate.stake.delegation", target: EVENT_TARGET, parent: parent, credential = ?credential, pool = %pool);
                     accounts.bind(credential, Some(pool));
                 }
                 Certificate::StakeRegDeleg(credential, pool, ..)
                 // FIXME: register DRep delegation
                 | Certificate::StakeVoteRegDeleg(credential, pool, ..) => {
-                    debug!(name: "certificate.stake.registration", target: TRANSACTION_EVENT_TARGET, parent: parent, credential = ?credential);
-                    debug!(name: "certificate.stake.delegation", target: TRANSACTION_EVENT_TARGET, parent: parent, credential = ?credential, pool = %pool);
+                    debug!(name: "certificate.stake.registration", target: EVENT_TARGET, parent: parent, credential = ?credential);
+                    debug!(name: "certificate.stake.delegation", target: EVENT_TARGET, parent: parent, credential = ?credential, pool = %pool);
                     accounts.register(
                         credential,
                         STAKE_CREDENTIAL_DEPOSIT as Lovelace,
@@ -221,11 +221,11 @@ fn apply_certificates(
                 }
                 Certificate::StakeDeregistration(credential)
                 | Certificate::UnReg(credential, ..) => {
-                    debug!(name: "certificate.stake.deregistration", target: TRANSACTION_EVENT_TARGET, parent: parent, credential = ?credential);
+                    debug!(name: "certificate.stake.deregistration", target: EVENT_TARGET, parent: parent, credential = ?credential);
                     accounts.unregister(credential);
                 }
                 Certificate::PoolRetirement(id, epoch) => {
-                    debug!(name: "certificate.pool.retirement", target: TRANSACTION_EVENT_TARGET, parent: parent, pool = %id, epoch = %epoch);
+                    debug!(name: "certificate.pool.retirement", target: EVENT_TARGET, parent: parent, pool = %id, epoch = %epoch);
                     pools.unregister(id, epoch)
                 }
                 Certificate::PoolRegistration {
@@ -252,7 +252,7 @@ fn apply_certificates(
                     };
                     debug!(
                         name: "certificate.pool.registration",
-                        target: TRANSACTION_EVENT_TARGET,
+                        target: EVENT_TARGET,
                         parent: parent,
                         pool = %id,
                         params = ?params,

--- a/crates/amaru/src/ledger/state/volatile_db.rs
+++ b/crates/amaru/src/ledger/state/volatile_db.rs
@@ -6,7 +6,7 @@ use crate::ledger::{
     },
     store::{self, columns::*},
 };
-use std::collections::VecDeque;
+use std::collections::{BTreeSet, VecDeque};
 
 // VolatileDB
 // ----------------------------------------------------------------------------
@@ -117,6 +117,7 @@ pub struct VolatileState<A> {
     pub utxo: DiffSet<TransactionInput, TransactionOutput>,
     pub pools: DiffEpochReg<PoolId, PoolParams>,
     pub accounts: DiffBind<StakeCredential, PoolId, Lovelace>,
+    pub withdrawals: BTreeSet<StakeCredential>,
     pub fees: Lovelace,
 }
 
@@ -127,6 +128,7 @@ impl Default for VolatileState<()> {
             utxo: Default::default(),
             pools: Default::default(),
             accounts: Default::default(),
+            withdrawals: Default::default(),
             fees: 0,
         }
     }
@@ -139,6 +141,7 @@ impl VolatileState<()> {
             utxo: self.utxo,
             pools: self.pools,
             accounts: self.accounts,
+            withdrawals: self.withdrawals,
             fees: self.fees,
         }
     }
@@ -151,18 +154,21 @@ impl VolatileState<()> {
 // StoreUpdate
 // ----------------------------------------------------------------------------
 
-pub struct StoreUpdate<A, R> {
+pub struct StoreUpdate<W, A, R> {
     pub point: Point,
     pub issuer: PoolId,
     pub fees: Lovelace,
+    pub withdrawals: W,
     pub add: A,
     pub remove: R,
 }
 
 impl VolatileState<(Point, PoolId)> {
+    #[allow(clippy::type_complexity)]
     pub fn into_store_update(
         self,
     ) -> StoreUpdate<
+        impl Iterator<Item = accounts::Key>,
         store::Columns<
             impl Iterator<Item = (utxo::Key, utxo::Value)>,
             impl Iterator<Item = pools::Value>,
@@ -179,6 +185,7 @@ impl VolatileState<(Point, PoolId)> {
             point: self.anchor.0,
             issuer: self.anchor.1,
             fees: self.fees,
+            withdrawals: self.withdrawals.into_iter(),
             add: store::Columns {
                 utxo: self.utxo.produced.into_iter(),
                 pools: self

--- a/crates/amaru/src/ledger/state/volatile_db.rs
+++ b/crates/amaru/src/ledger/state/volatile_db.rs
@@ -11,7 +11,7 @@ use std::collections::{BTreeSet, VecDeque};
 // VolatileDB
 // ----------------------------------------------------------------------------
 
-// FIXME: Currently, the cache owns data that are also available in the sequence. We could
+// TODO: Currently, the cache owns data that are also available in the sequence. We could
 // potentially avoid cloning and re-allocation altogether by sharing an allocator and having them
 // both reference from within that allocator (e.g. an arena allocator like bumpalo)
 //

--- a/crates/amaru/src/ledger/store.rs
+++ b/crates/amaru/src/ledger/store.rs
@@ -31,6 +31,7 @@ pub trait Store {
             impl Iterator<Item = (pools::Key, Epoch)>,
             impl Iterator<Item = accounts::Key>,
         >,
+        withdrawals: impl Iterator<Item = accounts::Key>,
     ) -> Result<(), Self::Error>;
 
     /// The most recent snapshot. Note that we never starts from genesis; so there's always a

--- a/crates/amaru/src/ledger/store/rocksdb/mod.rs
+++ b/crates/amaru/src/ledger/store/rocksdb/mod.rs
@@ -163,6 +163,7 @@ impl Store for RocksDB {
             impl Iterator<Item = (pools::Key, Epoch)>,
             impl Iterator<Item = accounts::Key>,
         >,
+        withdrawals: impl Iterator<Item = accounts::Key>,
     ) -> Result<(), Self::Error> {
         let batch = self.db.transaction();
 
@@ -197,6 +198,8 @@ impl Store for RocksDB {
                 utxo::rocksdb::remove(&batch, remove.utxo)?;
                 pools::rocksdb::remove(&batch, remove.pools)?;
                 accounts::rocksdb::remove(&batch, remove.accounts)?;
+
+                accounts::rocksdb::reset(&batch, withdrawals)?;
             }
         }
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -122,6 +122,47 @@ Filters can be provided as a sequence of `,`-separated values. Right-most filter
 | `epoch` | The epoch being snapshot, typically the immediately previous epoch |
 </details>
 
+### target: `amaru::ledger::state::rewards`
+
+#### Spans
+
+ø
+
+#### Traces
+
+| name                          | severity | description                                                              |
+| ---                           | ---      | ---                                                                      |
+| `stake_distribution.snapshot` | `info`   | A new stake distribution snapshot has been computed and is now available |
+| `rewards.summary`             | `info`   | Rewards have been computed and are now available                         |
+
+<details><summary>trace: `stake_distribution.snapshot`</summary>
+
+| field          | description                                                                |
+| ---            | ---                                                                        |
+| `active_stake` | Total stake, in Lovelace, delegated to registered pools                    |
+| `accounts`     | Total number of *active* (i.e. delegated to active pools) staking accounts |
+| `pools`        | Total number of active pools                                               |
+</details>
+
+<details><summary>trace: `rewards.summary`</summary>
+
+| field               | description                                                                                                                         |
+| ---                 | ---                                                                                                                                 |
+| `efficiency`        | The ratio of total blocks produced in the epoch, over the expected number of blocks (determined by protocol parameters).            |
+| `incentives`        | The amount of Ada taken out of the reserves as incentivies at this particular epoch (a.k.a ΔR1).                                    |
+| `treasury_tax`      | Portion of the rewards going to the treasury (irrespective of unallocated pool rewards).                                            |
+| `total_rewards`     | Total amount of rewards available before the treasury tax. In particular, we have: total_rewards = treasury_tax + available_rewards |
+| `available_rewards` | Remaining rewards available to stake pools (and delegators)                                                                         |
+| `effective_rewards` | Effective amount of rewards _actually given out_. The surplus is "sent back" to the reserves.                                       |
+| `pots.reserves`     | Value, in Lovelace, of the reserves after rewards distribution.                                                                     |
+| `pots.treasury`     | Value, in Lovelace, of the treasury after rewards distribution.                                                                     |  |
+| `pots.fees`         | Values, in Lovelace, generated from fees during an epoch.                                                                           |
+</details>
+
+### target: `amaru::ledger::state::transaction`
+
+#### Spans
+
 <details><summary>span: `apply.transaction`</summary>
 
 | field                      | description                                               |
@@ -130,13 +171,8 @@ Filters can be provided as a sequence of `,`-separated values. Right-most filter
 | `transaction.certificates` | The number of certificates within the transaction         |
 | `transaction.inputs`       | The number of (collateral) inputs within the transaction  |
 | `transaction.outputs`      | The number of (collateral) outputs within the transaction |
+| `transaction.withdrawals`  | The number of withdrawals within the transaction          |
 </details>
-
-### target: `amaru::ledger::state::apply::transaction`
-
-#### Spans
-
-ø
 
 #### Traces
 


### PR DESCRIPTION
This PR solves the remaining discrepancy in the rewards calculations before governance ones kicks in. In particular, it now correctly reset rewards account on withdrawals (which are always necessary withdrawing the full amount available on the account). 

Also, it includes a fix where accounts supposed to receive multiple rewards (either because a reward account is being used for multiple pools, or because it used both as a reward account for a pool and delegated to another -- thus receiving member rewards). 

The snapshots are now therefore correct all the way from epoch 163 to epoch 172 💪 ! Starting from epoch 173, things start to diverge again because this is the first epoch where a governance proposal gets refunded; which is quite visible from the diff (we're missing exactly 100k ADA): 

```diff
 "40b3c98d3b5f5a7748829d612e9e1ccd5f429970abc9abfeae867af9": {
-   "lovelace": 101001639743,
+   "lovelace": 1001639743,
    "pool": "pool1rccstu3l9ty3k0a5cd06fl3szsss9r34dcg5j38fqgq9kvng0tg"
},
``` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added support for withdrawal transactions in the ledger state management.
	- Introduced a new function to reset reward counters for multiple accounts.

- **Improvements**
	- Enhanced reward calculation logic to accumulate rewards correctly.
	- Updated database save methods to accommodate withdrawals.

- **Technical Updates**
	- Modified state tracking mechanisms to include withdrawal information.
	- Added new telemetry for monitoring stake distribution and rewards computation.

The release introduces more robust handling of blockchain transactions, particularly focusing on withdrawal processes and reward management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->