### PR TITLE
chore: remove unnecessary once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,6 @@ dependencies = [
  "insta",
  "miette 7.4.0",
  "num",
- "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -48,7 +48,6 @@ opentelemetry-otlp = { version = "0.27.0", features = [
     "reqwest-client",
 ] }
 tracing-opentelemetry = { version = "0.28.0" }
-once_cell = "1.20.2"
 serde_json = { version = "1.0.135", features = ["raw_value"] }
 
 [target.'cfg(not(windows))'.dependencies]

--- a/crates/amaru/src/ledger/kernel.rs
+++ b/crates/amaru/src/ledger/kernel.rs
@@ -5,8 +5,9 @@
 // It's also the right place to put rather general functions or types that ought to be in pallas.
 // While elements are being contributed upstream, they might transiently live in this module.
 
+use std::sync::LazyLock;
+
 use num::{rational::Ratio, BigUint};
-use once_cell::sync::Lazy;
 pub use ouroboros::ledger::PoolSigma;
 use pallas_addresses::*;
 pub use pallas_codec::{
@@ -68,16 +69,16 @@ pub const STAKE_POOL_DEPOSIT: usize = 500000000;
 pub const STAKE_CREDENTIAL_DEPOSIT: usize = 2000000;
 
 // The monetary expansion value, a.k.a ρ
-pub static MONETARY_EXPANSION: Lazy<Ratio<BigUint>> =
-    Lazy::new(|| Ratio::new_raw(BigUint::from(3_u64), BigUint::from(1000_u64)));
+pub static MONETARY_EXPANSION: LazyLock<Ratio<BigUint>> =
+    LazyLock::new(|| Ratio::new_raw(BigUint::from(3_u64), BigUint::from(1000_u64)));
 
 /// Treasury tax, a.k.a τ
-pub static TREASURY_TAX: Lazy<Ratio<BigUint>> =
-    Lazy::new(|| Ratio::new_raw(BigUint::from(20_u64), BigUint::from(100_u64)));
+pub static TREASURY_TAX: LazyLock<Ratio<BigUint>> =
+    LazyLock::new(|| Ratio::new_raw(BigUint::from(20_u64), BigUint::from(100_u64)));
 
 /// Pledge influence parameter, a.k.a a0
-pub static PLEDGE_INFLUENCE: Lazy<Ratio<BigUint>> =
-    Lazy::new(|| Ratio::new_raw(BigUint::from(3_u64), BigUint::from(10_u64)));
+pub static PLEDGE_INFLUENCE: LazyLock<Ratio<BigUint>> =
+    LazyLock::new(|| Ratio::new_raw(BigUint::from(3_u64), BigUint::from(10_u64)));
 
 /// The optimal number of stake pools target for the incentives, a.k.a k
 pub const OPTIMAL_STAKE_POOLS_COUNT: usize = 500;


### PR DESCRIPTION
Starting [Rust 1.80](https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html#lazycell-and-lazylock) [LazyLock](https://doc.rust-lang.org/beta/std/sync/struct.LazyLock.html) can replace `once_cell::Lazy` usages involving static values. This allows to get rid of `once_cell` dependency altogether.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Refactor**
	- Replaced `once_cell` library dependency with standard library's `LazyLock` for static variable initialisation
	- Updated static variable type declarations from `Lazy` to `LazyLock` for `MONETARY_EXPANSION`, `TREASURY_TAX`, and `PLEDGE_INFLUENCE`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->