### PR TITLE
feat: format logs as Json by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3781,6 +3781,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3790,12 +3800,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = "2.0.3"
 tokio = { version = "1.40.0", features = ["rt", "rt-multi-thread", "signal"] }
 tokio-util = "0.7.12"
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter", "std"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "std", "json"] }
 rocksdb = "0.22.0"
 indicatif = "0.17.9"
 vec1 = "1.12.1"

--- a/crates/amaru/src/bin/amaru/main.rs
+++ b/crates/amaru/src/bin/amaru/main.rs
@@ -138,6 +138,7 @@ pub fn setup_tracing() -> (TracerProvider, SdkMeterProvider, Counter<u64>) {
             .with(
                 fmt::layer()
                     .event_format(fmt::format().json())
+                    .fmt_fields(tracing_subscriber::fmt::format::JsonFields::new())
                     .with_span_events(fmt::format::FmtSpan::ENTER | fmt::format::FmtSpan::EXIT)
                     .with_filter(filter(AMARU_DEV_LOG)),
             )

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -7,6 +7,10 @@ We provide example configurations using different compositions of tools:
 - [Jaeger + Prometheus](./jaeger) _(simple)_
 - [Grafana + Tempo + Prometheus](./grafana-tempo) _(more advanced)_
 
+## Formatting traces
+
+Events are by default formatted as Json, one line per event. To format events prettily, set environment variable `AMARU_LOG_FORMAT=pretty`.
+
 ## Filtering traces
 
 Any event (trace, span or metric) can be filtered by target and severity using two environment variables:


### PR DESCRIPTION
And allow user to select 'pretty' formatting through environment variables if they so choose.
I could not avoid the duplication although I tried for quite some time factoring types, parameters, bounds and what not to the point the compiler had to dump types to files!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for configurable log formatting.
	- Introduced an environment variable to control log output style.

- **Documentation**
	- Updated monitoring README with instructions for log format customisation.

- **Improvements**
	- Enhanced tracing configuration to support JSON and pretty-print log formats.
	- Enabled dynamic log formatting at runtime based on environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->