### PR TITLE
Another stab at observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,9 +629,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "bzip2-sys"
@@ -716,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -738,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2501,18 +2501,18 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3151,9 +3151,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3496,6 +3496,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3505,12 +3515,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3622,9 +3635,9 @@ dependencies = [
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -34,7 +34,7 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "signal"] }
 tokio-util.workspace = true
 tracing-opentelemetry.workspace = true
-tracing-subscriber = { workspace = true, features = ["env-filter", "std"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "std", "json"] }
 tracing.workspace = true
 
 amaru-consensus = { path = "../consensus" }

--- a/crates/amaru/src/bin/amaru/main.rs
+++ b/crates/amaru/src/bin/amaru/main.rs
@@ -13,37 +13,14 @@
 // limitations under the License.
 
 use clap::{Parser, Subcommand};
-use miette::IntoDiagnostic;
-use opentelemetry_sdk::{metrics::SdkMeterProvider, trace::TracerProvider};
 use panic::panic_handler;
-use std::env;
-use tracing_subscriber::{
-    filter::Filtered,
-    fmt::{
-        format::{FmtSpan, Format, Json, JsonFields},
-        Layer,
-    },
-    layer::{Layered, SubscriberExt},
-    prelude::*,
-    util::SubscriberInitExt,
-    EnvFilter, Registry,
-};
 
 mod cmd;
 mod config;
 mod exit;
 mod metrics;
+mod observability;
 mod panic;
-
-pub const SERVICE_NAME: &str = "amaru";
-
-pub const AMARU_LOG_VAR: &str = "AMARU_LOG";
-
-pub const DEFAULT_AMARU_LOG_FILTER: &str = "amaru=info";
-
-pub const AMARU_TRACE_VAR: &str = "AMARU_TRACE";
-
-pub const DEFAULT_AMARU_TRACE_FILTER: &str = "amaru=debug";
 
 #[derive(Debug, Subcommand)]
 enum Command {
@@ -70,94 +47,22 @@ struct Cli {
     with_json_traces: bool,
 }
 
-#[allow(clippy::large_enum_variant)]
-#[derive(Default)]
-enum TracingSubscriber<S> {
-    #[default]
-    Empty,
-    Registry(Registry),
-    WithOpenTelemetry(OpenTelemetryLayer<S>),
-    WithJson(JsonLayer<S>),
-    WithBoth(JsonLayer<OpenTelemetryLayer<S>>),
-}
-
-type OpenTelemetryLayer<S> = Layered<OpenTelemetryFilter<S>, S>;
-
-type OpenTelemetryFilter<S> = Filtered<
-    tracing_opentelemetry::OpenTelemetryLayer<S, opentelemetry_sdk::trace::Tracer>,
-    EnvFilter,
-    S,
->;
-
-type JsonLayer<S> = Layered<JsonFilter<S>, S>;
-
-type JsonFilter<S> = Filtered<Layer<S, JsonFields, Format<Json>>, EnvFilter, S>;
-
-impl TracingSubscriber<Registry> {
-    fn new() -> Self {
-        Self::Registry(tracing_subscriber::registry())
-    }
-
-    fn with_open_telemetry(&mut self, layer: OpenTelemetryFilter<Registry>) {
-        match std::mem::take(self) {
-            Self::Registry(registry) => {
-                *self = TracingSubscriber::WithOpenTelemetry(registry.with(layer));
-            }
-            _ => panic!("'with_open_telemetry' called after 'with_json'"),
-        }
-    }
-
-    fn with_json<F, G>(&mut self, layer_json: F, layer_both: G)
-    where
-        F: FnOnce() -> JsonFilter<Registry>,
-        G: FnOnce() -> JsonFilter<OpenTelemetryLayer<Registry>>,
-    {
-        match std::mem::take(self) {
-            Self::Registry(registry) => {
-                *self = TracingSubscriber::WithJson(registry.with(layer_json()));
-            }
-            Self::WithOpenTelemetry(layered) => {
-                *self = TracingSubscriber::WithBoth(layered.with(layer_both()));
-            }
-            _ => panic!("'with_open_telemetry' called after 'with_json'"),
-        }
-    }
-
-    fn init(self) {
-        match self {
-            TracingSubscriber::Empty => unreachable!(),
-            TracingSubscriber::Registry(registry) => registry.init(),
-            TracingSubscriber::WithOpenTelemetry(layered) => layered.init(),
-            TracingSubscriber::WithJson(layered) => layered.init(),
-            TracingSubscriber::WithBoth(layered) => layered.init(),
-        }
-    }
-}
-
 #[tokio::main]
 async fn main() -> miette::Result<()> {
     panic_handler();
 
     let args = Cli::parse();
 
-    let mut subscriber = TracingSubscriber::new();
+    let mut subscriber = observability::TracingSubscriber::new();
 
-    let (metrics, teardown) = if args.with_open_telemetry {
-        let (otl, metrics) = setup_open_telemetry(&mut subscriber);
-        (
-            Some(metrics.clone()),
-            Box::new(|| teardown_open_telemetry(otl, metrics))
-                as Box<dyn FnOnce() -> miette::Result<()>>,
-        )
+    let observability::OpenTelemetryHandle { metrics, teardown } = if args.with_open_telemetry {
+        observability::setup_open_telemetry(&mut subscriber)
     } else {
-        (
-            None::<SdkMeterProvider>,
-            Box::new(|| Ok(())) as Box<dyn FnOnce() -> miette::Result<()>>,
-        )
+        observability::OpenTelemetryHandle::default()
     };
 
     if args.with_json_traces {
-        setup_json_traces(&mut subscriber);
+        observability::setup_json_traces(&mut subscriber);
     }
 
     subscriber.init();
@@ -174,112 +79,4 @@ async fn main() -> miette::Result<()> {
     }
 
     result
-}
-
-fn setup_json_traces(subscriber: &mut TracingSubscriber<Registry>) {
-    let format = || tracing_subscriber::fmt::format().json();
-    let events = || FmtSpan::ENTER | FmtSpan::EXIT;
-    let filter = || default_filter(AMARU_TRACE_VAR, DEFAULT_AMARU_TRACE_FILTER);
-
-    subscriber.with_json(
-        || {
-            tracing_subscriber::fmt::layer()
-                .event_format(format())
-                .fmt_fields(JsonFields::new())
-                .with_span_events(events())
-                .with_filter(filter())
-        },
-        || {
-            tracing_subscriber::fmt::layer()
-                .event_format(format())
-                .fmt_fields(JsonFields::new())
-                .with_span_events(events())
-                .with_filter(filter())
-        },
-    )
-}
-
-fn setup_open_telemetry(
-    subscriber: &mut TracingSubscriber<Registry>,
-) -> (TracerProvider, SdkMeterProvider) {
-    use opentelemetry::{trace::TracerProvider as _, KeyValue};
-    use opentelemetry_sdk::{metrics::Temporality, Resource};
-
-    let resource = Resource::new(vec![KeyValue::new("service.name", SERVICE_NAME)]);
-
-    // Traces & span
-    let opentelemetry_provider = opentelemetry_sdk::trace::TracerProvider::builder()
-        .with_resource(resource.clone())
-        .with_batch_exporter(
-            opentelemetry_otlp::SpanExporter::builder()
-                .with_tonic()
-                .build()
-                .unwrap_or_else(|e| panic!("failed to setup opentelemetry span exporter: {e}")),
-            opentelemetry_sdk::runtime::Tokio,
-        )
-        .build();
-
-    // Metrics
-    // NOTE: We use the http exporter here because not every OTLP receivers (in particular Jaeger)
-    // support gRPC for metrics.
-    let metric_exporter = opentelemetry_otlp::MetricExporter::builder()
-        .with_http()
-        .with_temporality(Temporality::default())
-        .build()
-        .unwrap_or_else(|e| panic!("unable to create metric exporter: {e:?}"));
-
-    let metric_reader = opentelemetry_sdk::metrics::PeriodicReader::builder(
-        metric_exporter,
-        opentelemetry_sdk::runtime::Tokio,
-    )
-    .build();
-
-    let metrics_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
-        .with_reader(metric_reader)
-        .with_resource(resource)
-        .build();
-
-    opentelemetry::global::set_meter_provider(metrics_provider.clone());
-
-    // Subscriber
-    let opentelemetry_tracer = opentelemetry_provider.tracer(SERVICE_NAME);
-    let opentelemetry_layer = tracing_opentelemetry::layer()
-        .with_tracer(opentelemetry_tracer)
-        .with_filter(default_filter(AMARU_TRACE_VAR, DEFAULT_AMARU_TRACE_FILTER));
-
-    subscriber.with_open_telemetry(opentelemetry_layer);
-
-    (opentelemetry_provider, metrics_provider)
-}
-
-fn teardown_open_telemetry(
-    tracing: TracerProvider,
-    metrics: SdkMeterProvider,
-) -> miette::Result<()> {
-    // Shut down the providers so that it flushes any remaining spans
-    // TODO: we might also want to wrap this in a timeout, so we don't hold the process open forever?
-    tracing.shutdown().into_diagnostic()?;
-    metrics.shutdown().into_diagnostic()?;
-
-    // This appears to be a deprecated method that will be removed soon
-    // and just *releases* a reference to it, but doesn't actually call shutdown
-    // still, we call it just in case until it gets removed
-    // See:
-    // https://github.com/tokio-rs/tracing-opentelemetry/issues/159
-    // https://github.com/tokio-rs/tracing-opentelemetry/pull/175
-    // https://github.com/open-telemetry/opentelemetry-rust/issues/1961
-    opentelemetry::global::shutdown_tracer_provider();
-
-    Ok(())
-}
-
-fn default_filter(var: &str, default: &str) -> EnvFilter {
-    // NOTE: We filter all logs using 'none' to avoid dependencies polluting our traces & logs,
-    // which is a not so nice side-effects of the tracing library.
-    EnvFilter::builder()
-        .parse(format!(
-            "none,{}",
-            env::var(var).ok().as_deref().unwrap_or(default)
-        ))
-        .unwrap_or_else(|e| panic!("invalid {var} filters: {e}"))
 }

--- a/crates/amaru/src/bin/amaru/metrics.rs
+++ b/crates/amaru/src/bin/amaru/metrics.rs
@@ -48,8 +48,8 @@ pub fn track_system_metrics(metrics: SdkMeterProvider) -> JoinHandle<()> {
 
 #[cfg(windows)]
 pub fn track_system_metrics(_metrics: SdkMeterProvider) -> JoinHandle<()> {
-    use tracing::info;
-    info!("System metrics currently not supported on Windows");
+    use tracing::warn;
+    warn!("System metrics currently not supported on Windows");
     tokio::spawn(async {})
 }
 

--- a/crates/amaru/src/bin/amaru/observability.rs
+++ b/crates/amaru/src/bin/amaru/observability.rs
@@ -1,0 +1,224 @@
+use miette::IntoDiagnostic;
+use opentelemetry_sdk::{metrics::SdkMeterProvider, trace::TracerProvider};
+use std::env;
+use tracing_subscriber::{
+    filter::Filtered,
+    fmt::{
+        format::{FmtSpan, Format, Json, JsonFields},
+        Layer,
+    },
+    layer::{Layered, SubscriberExt},
+    prelude::*,
+    util::SubscriberInitExt,
+    EnvFilter, Registry,
+};
+
+const SERVICE_NAME: &str = "amaru";
+
+const AMARU_LOG_VAR: &str = "AMARU_LOG";
+
+const DEFAULT_AMARU_LOG_FILTER: &str = "amaru=info";
+
+const AMARU_TRACE_VAR: &str = "AMARU_TRACE";
+
+const DEFAULT_AMARU_TRACE_FILTER: &str = "amaru=debug";
+
+type OpenTelemetryLayer<S> = Layered<OpenTelemetryFilter<S>, S>;
+
+type OpenTelemetryFilter<S> = Filtered<
+    tracing_opentelemetry::OpenTelemetryLayer<S, opentelemetry_sdk::trace::Tracer>,
+    EnvFilter,
+    S,
+>;
+
+type JsonLayer<S> = Layered<JsonFilter<S>, S>;
+
+type JsonFilter<S> = Filtered<Layer<S, JsonFields, Format<Json>>, EnvFilter, S>;
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Default)]
+pub enum TracingSubscriber<S> {
+    #[default]
+    Empty,
+    Registry(Registry),
+    WithOpenTelemetry(OpenTelemetryLayer<S>),
+    WithJson(JsonLayer<S>),
+    WithBoth(JsonLayer<OpenTelemetryLayer<S>>),
+}
+
+impl TracingSubscriber<Registry> {
+    pub fn new() -> Self {
+        Self::Registry(tracing_subscriber::registry())
+    }
+
+    pub fn with_open_telemetry(&mut self, layer: OpenTelemetryFilter<Registry>) {
+        match std::mem::take(self) {
+            Self::Registry(registry) => {
+                *self = TracingSubscriber::WithOpenTelemetry(registry.with(layer));
+            }
+            _ => panic!("'with_open_telemetry' called after 'with_json'"),
+        }
+    }
+
+    pub fn with_json<F, G>(&mut self, layer_json: F, layer_both: G)
+    where
+        F: FnOnce() -> JsonFilter<Registry>,
+        G: FnOnce() -> JsonFilter<OpenTelemetryLayer<Registry>>,
+    {
+        match std::mem::take(self) {
+            Self::Registry(registry) => {
+                *self = TracingSubscriber::WithJson(registry.with(layer_json()));
+            }
+            Self::WithOpenTelemetry(layered) => {
+                *self = TracingSubscriber::WithBoth(layered.with(layer_both()));
+            }
+            _ => panic!("'with_open_telemetry' called after 'with_json'"),
+        }
+    }
+
+    pub fn init(self) {
+        match self {
+            TracingSubscriber::Empty => unreachable!(),
+            TracingSubscriber::Registry(registry) => registry.init(),
+            TracingSubscriber::WithOpenTelemetry(layered) => layered.init(),
+            TracingSubscriber::WithJson(layered) => layered.init(),
+            TracingSubscriber::WithBoth(layered) => layered.init(),
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// JSON
+// -----------------------------------------------------------------------------
+
+pub fn setup_json_traces(subscriber: &mut TracingSubscriber<Registry>) {
+    let format = || tracing_subscriber::fmt::format().json();
+    let events = || FmtSpan::ENTER | FmtSpan::EXIT;
+    let filter = || default_filter(AMARU_TRACE_VAR, DEFAULT_AMARU_TRACE_FILTER);
+
+    subscriber.with_json(
+        || {
+            tracing_subscriber::fmt::layer()
+                .event_format(format())
+                .fmt_fields(JsonFields::new())
+                .with_span_events(events())
+                .with_filter(filter())
+        },
+        || {
+            tracing_subscriber::fmt::layer()
+                .event_format(format())
+                .fmt_fields(JsonFields::new())
+                .with_span_events(events())
+                .with_filter(filter())
+        },
+    )
+}
+
+// -----------------------------------------------------------------------------
+// OPEN TELEMETRY
+// -----------------------------------------------------------------------------
+
+pub struct OpenTelemetryHandle {
+    pub metrics: Option<SdkMeterProvider>,
+    pub teardown: Box<dyn FnOnce() -> miette::Result<()>>,
+}
+
+impl Default for OpenTelemetryHandle {
+    fn default() -> Self {
+        OpenTelemetryHandle {
+            metrics: None::<SdkMeterProvider>,
+            teardown: Box::new(|| Ok(())) as Box<dyn FnOnce() -> miette::Result<()>>,
+        }
+    }
+}
+
+pub fn setup_open_telemetry(subscriber: &mut TracingSubscriber<Registry>) -> OpenTelemetryHandle {
+    use opentelemetry::{trace::TracerProvider as _, KeyValue};
+    use opentelemetry_sdk::{metrics::Temporality, Resource};
+
+    let resource = Resource::new(vec![KeyValue::new("service.name", SERVICE_NAME)]);
+
+    // Traces & span
+    let opentelemetry_provider = opentelemetry_sdk::trace::TracerProvider::builder()
+        .with_resource(resource.clone())
+        .with_batch_exporter(
+            opentelemetry_otlp::SpanExporter::builder()
+                .with_tonic()
+                .build()
+                .unwrap_or_else(|e| panic!("failed to setup opentelemetry span exporter: {e}")),
+            opentelemetry_sdk::runtime::Tokio,
+        )
+        .build();
+
+    // Metrics
+    // NOTE: We use the http exporter here because not every OTLP receivers (in particular Jaeger)
+    // support gRPC for metrics.
+    let metric_exporter = opentelemetry_otlp::MetricExporter::builder()
+        .with_http()
+        .with_temporality(Temporality::default())
+        .build()
+        .unwrap_or_else(|e| panic!("unable to create metric exporter: {e:?}"));
+
+    let metric_reader = opentelemetry_sdk::metrics::PeriodicReader::builder(
+        metric_exporter,
+        opentelemetry_sdk::runtime::Tokio,
+    )
+    .build();
+
+    let metrics_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+        .with_reader(metric_reader)
+        .with_resource(resource)
+        .build();
+
+    opentelemetry::global::set_meter_provider(metrics_provider.clone());
+
+    // Subscriber
+    let opentelemetry_tracer = opentelemetry_provider.tracer(SERVICE_NAME);
+    let opentelemetry_layer = tracing_opentelemetry::layer()
+        .with_tracer(opentelemetry_tracer)
+        .with_filter(default_filter(AMARU_TRACE_VAR, DEFAULT_AMARU_TRACE_FILTER));
+
+    subscriber.with_open_telemetry(opentelemetry_layer);
+
+    OpenTelemetryHandle {
+        metrics: Some(metrics_provider.clone()),
+        teardown: Box::new(|| teardown_open_telemetry(opentelemetry_provider, metrics_provider))
+            as Box<dyn FnOnce() -> miette::Result<()>>,
+    }
+}
+
+fn teardown_open_telemetry(
+    tracing: TracerProvider,
+    metrics: SdkMeterProvider,
+) -> miette::Result<()> {
+    // Shut down the providers so that it flushes any remaining spans
+    // TODO: we might also want to wrap this in a timeout, so we don't hold the process open forever?
+    tracing.shutdown().into_diagnostic()?;
+    metrics.shutdown().into_diagnostic()?;
+
+    // This appears to be a deprecated method that will be removed soon
+    // and just *releases* a reference to it, but doesn't actually call shutdown
+    // still, we call it just in case until it gets removed
+    // See:
+    // https://github.com/tokio-rs/tracing-opentelemetry/issues/159
+    // https://github.com/tokio-rs/tracing-opentelemetry/pull/175
+    // https://github.com/open-telemetry/opentelemetry-rust/issues/1961
+    opentelemetry::global::shutdown_tracer_provider();
+
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// ENV FILTER
+// -----------------------------------------------------------------------------
+
+fn default_filter(var: &str, default: &str) -> EnvFilter {
+    // NOTE: We filter all logs using 'none' to avoid dependencies polluting our traces & logs,
+    // which is a not so nice side-effects of the tracing library.
+    EnvFilter::builder()
+        .parse(format!(
+            "none,{}",
+            env::var(var).ok().as_deref().unwrap_or(default)
+        ))
+        .unwrap_or_else(|e| panic!("invalid {var} filters: {e}"))
+}

--- a/crates/amaru/src/sync/mod.rs
+++ b/crates/amaru/src/sync/mod.rs
@@ -24,7 +24,6 @@ use amaru_ouroboros::protocol::peer::{Peer, PeerSession};
 use amaru_ouroboros::protocol::Point;
 use amaru_stores::rocksdb::RocksDB;
 use gasket::runtime::Tether;
-use opentelemetry::metrics::Counter;
 use pallas_crypto::hash::Hash;
 use pallas_network::facades::PeerClient;
 use pallas_primitives::conway::Epoch;
@@ -43,7 +42,6 @@ pub struct Config {
     pub upstream_peer: String,
     pub network_magic: u32,
     pub nonces: HashMap<Epoch, Hash<32>>,
-    pub counter: Counter<u64>,
 }
 
 fn define_gasket_policy() -> gasket::runtime::Policy {
@@ -68,7 +66,7 @@ pub fn bootstrap(config: Config, client: &Arc<Mutex<PeerClient>>) -> miette::Res
     // FIXME: Take from config / command args
     let store = RocksDB::new(&config.ledger_dir)
         .unwrap_or_else(|e| panic!("unable to open ledger store: {e:?}"));
-    let (mut ledger, tip) = amaru_ledger::Stage::new(store, config.counter.clone());
+    let (mut ledger, tip) = amaru_ledger::Stage::new(store);
 
     let peer_session = PeerSession {
         peer: Peer::new(&config.upstream_peer),

--- a/crates/ledger/src/lib.rs
+++ b/crates/ledger/src/lib.rs
@@ -21,7 +21,7 @@ use pallas_codec::minicbor as cbor;
 use std::sync::Arc;
 use store::Store;
 use tokio::sync::Mutex;
-use tracing::{error, info_span, warn};
+use tracing::{debug_span, error, warn};
 
 const EVENT_TARGET: &str = "amaru::ledger";
 
@@ -104,7 +104,7 @@ impl<T: Store> gasket::framework::Worker<Stage<T>> for Worker {
     ) -> Result<(), WorkerError> {
         match unit {
             ValidateHeaderEvent::Validated(point, raw_block) => {
-                let span_forward = info_span!(
+                let span_forward = debug_span!(
                     target: EVENT_TARGET,
                     "forward",
                     header.height = tracing::field::Empty,
@@ -116,7 +116,7 @@ impl<T: Store> gasket::framework::Worker<Stage<T>> for Worker {
                 )
                 .entered();
 
-                let span_parse_block = info_span!(
+                let span_parse_block = debug_span!(
                     target: EVENT_TARGET,
                     parent: &span_forward,
                     "parse_block",
@@ -144,7 +144,7 @@ impl<T: Store> gasket::framework::Worker<Stage<T>> for Worker {
             }
 
             ValidateHeaderEvent::Rollback(point) => {
-                let span_backward = info_span!(
+                let span_backward = debug_span!(
                     target: EVENT_TARGET,
                     "backward",
                     point.slot = point.slot_or_default(),

--- a/crates/ledger/src/lib.rs
+++ b/crates/ledger/src/lib.rs
@@ -17,7 +17,6 @@ use crate::{
     state::BackwardErr,
 };
 use gasket::framework::*;
-use opentelemetry::metrics::Counter;
 use pallas_codec::minicbor as cbor;
 use std::sync::Arc;
 use store::Store;
@@ -51,7 +50,6 @@ where
 {
     pub upstream: UpstreamPort,
     pub state: Arc<Mutex<state::State<T, T::Error>>>,
-    pub counter: Counter<u64>,
 }
 
 impl<T: Store> gasket::framework::Stage for Stage<T> {
@@ -68,7 +66,7 @@ impl<T: Store> gasket::framework::Stage for Stage<T> {
 }
 
 impl<T: Store> Stage<T> {
-    pub fn new(store: T, counter: Counter<u64>) -> (Self, Point) {
+    pub fn new(store: T) -> (Self, Point) {
         let state = state::State::new(Arc::new(std::sync::Mutex::new(store)));
 
         let tip = state.tip().into_owned();
@@ -77,7 +75,6 @@ impl<T: Store> Stage<T> {
             Self {
                 upstream: Default::default(),
                 state: Arc::new(Mutex::new(state)),
-                counter,
             },
             tip,
         )
@@ -135,8 +132,6 @@ impl<T: Store> gasket::framework::Worker<Stage<T>> for Worker {
                 span_forward.record("header.height", block.header.header_body.block_number);
                 span_forward.record("header.slot", block.header.header_body.slot);
                 span_forward.record("header.hash", hex::encode(block_header_hash));
-
-                stage.counter.add(1, &[]);
 
                 let mut state = stage.state.lock().await;
 

--- a/crates/ledger/src/state.rs
+++ b/crates/ledger/src/state.rs
@@ -32,7 +32,7 @@ use std::{
     collections::BTreeSet,
     sync::{Arc, Mutex},
 };
-use tracing::{info, info_span, Span};
+use tracing::{debug, debug_span, info_span, Span};
 
 const STATE_EVENT_TARGET: &str = "amaru::ledger::state";
 
@@ -141,7 +141,7 @@ impl<S: Store<Error = E>, E: std::fmt::Debug> State<S, E> {
                         .map_err(ForwardErr::StorageErr)
                 })?;
 
-                info_span!(target: STATE_EVENT_TARGET, parent: span, "tick.pool").in_scope(
+                debug_span!(target: STATE_EVENT_TARGET, parent: span, "tick.pool").in_scope(
                     || {
                         // Then we, can tick pools to compute their new state at the epoch boundary. Notice
                         // how we tick with the _current epoch_ however, but we take the snapshot before
@@ -165,7 +165,7 @@ impl<S: Store<Error = E>, E: std::fmt::Debug> State<S, E> {
                 withdrawals,
             } = now_stable.into_store_update();
 
-            info_span!(target: STATE_EVENT_TARGET, parent: span, "save").in_scope(|| {
+            debug_span!(target: STATE_EVENT_TARGET, parent: span, "save").in_scope(|| {
                 db.save(
                     &stable_point,
                     Some(&stable_issuer),
@@ -189,7 +189,7 @@ impl<S: Store<Error = E>, E: std::fmt::Debug> State<S, E> {
                 );
             }
         } else {
-            info!(target: STATE_EVENT_TARGET, parent: span, size = self.volatile.len(), "volatile.warming_up",);
+            debug!(target: STATE_EVENT_TARGET, parent: span, size = self.volatile.len(), "volatile.warming_up",);
         }
 
         span.record("tip.epoch", epoch_from_slot(point.slot_or_default()));
@@ -262,7 +262,7 @@ impl<S: Store<Error = E>, E: std::fmt::Debug> State<S, E> {
         let total_count = transaction_bodies.len();
         let failed_count = failed_transactions.inner.len();
 
-        let span_apply_block = info_span!(
+        let span_apply_block = debug_span!(
             target: STATE_EVENT_TARGET,
             parent: parent,
             "block.body.validate",

--- a/crates/ledger/src/state/transaction.rs
+++ b/crates/ledger/src/state/transaction.rs
@@ -22,7 +22,7 @@ use crate::kernel::{
     TransactionInput, TransactionOutput, STAKE_CREDENTIAL_DEPOSIT,
 };
 use std::collections::{BTreeMap, BTreeSet};
-use tracing::{debug, info_span, Span};
+use tracing::{debug, debug_span, Span};
 
 const EVENT_TARGET: &str = "amaru::ledger::state::transaction";
 
@@ -34,7 +34,7 @@ pub fn apply<T>(
     mut transaction_body: MintedTransactionBody<'_>,
     resolved_collateral_inputs: Vec<TransactionOutput>,
 ) {
-    let span = info_span!(
+    let span = debug_span!(
         target: EVENT_TARGET,
         parent: parent,
         "apply.transaction",


### PR DESCRIPTION
Here's my (implemented) proposal regarding how we deal with observability in Amaru -- attempting to please everyone:

- By default, the application prints **logs** on **stderr** in a pretty format. 

- All **traces** and **spans** can be made available on **stdout** by passing `--with-json-traces` as a command-line flag (could be _possibly_ doubled with an environment variable). 

- All **traces**, **spans** and **metrics** can be made available via OTLP by passing `--with-open-telemetry` as a command-line flag (could be _possibly_ doubled with an environment variable).

- I've (attempted to) clarify the frontier between **logs** and **traces** by following a simple rule: any event at the INFO level is considered a **log** whereas any event at the DEBUG level is considered a **trace** (so traces includes logs, I did not bother defining two separate namespaces).

- Both traces and logs can still be filtered using environment variables `AMARU_LOG=...` and `AMARU_TRACES=...` to target specific namespaces or fields (as detailed in the monitoring documentation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an observability module that enables flexible telemetry configuration, including JSON-formatted traces and OpenTelemetry integration.
- **Refactor**
	- Simplified metrics management by removing redundant tracking parameters.
	- Adjusted logging levels from informational to debug for more granular diagnostic output, enhancing logging visibility.

This release enhances the application's diagnostics and trace customisation, offering end-users improved observability and a cleaner monitoring interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->