### PR TITLE
chore: ledger refactoring in preparation for governance work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ target/
 # Default database location for the ledger
 ledger.db
 
+# Default database location for the consensus
+chain.db
+
 # Insta not-yet reviewed snapshots
 *.snap.new
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "bech32 0.11.0",
  "gasket",
  "hex",
+ "miette",
  "num",
  "opentelemetry",
  "pallas-addresses",
@@ -113,6 +114,7 @@ dependencies = [
  "pallas-primitives",
  "proptest",
  "serde",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
 ]
@@ -150,7 +152,6 @@ version = "0.1.0"
 dependencies = [
  "amaru-ledger",
  "hex",
- "miette",
  "pallas-codec",
  "rocksdb",
  "thiserror 2.0.11",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ dependencies = [
  "rocksdb",
  "sys_metrics",
  "tempfile",
+ "test-case",
  "thiserror 2.0.11",
  "tokio",
  "tokio-util",
@@ -3225,6 +3226,39 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "test-case-core",
+]
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ proptest = "1.5.0"
 insta = "1.41.1"
 envpath = "0.0.1-beta.3"
 criterion = "0.5.1"
+test-case = "3.3.1"
 
 # build-dependencies
 built = "0.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ pallas-traverse = "0.32.0"
 rand = "0.8"
 rayon = "1.10"
 rocksdb = "0.22.0"
-serde = "1.0"
+serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0.128", default-features = false }
 tempfile = "3.15.0"
 thiserror = "2.0.3"

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -51,6 +51,7 @@ insta = { workspace = true, features = ["json"] }
 proptest.workspace = true
 rand.workspace = true
 tempfile.workspace = true
+test-case.workspace = true
 
 [build-dependencies]
 built = { workspace = true, features = ["git2"] }

--- a/crates/amaru/src/bin/amaru/cmd/import.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import.rs
@@ -317,20 +317,6 @@ fn import_utxo(
 ) -> miette::Result<()> {
     info!(what = "utxo_entries", size = utxo.len());
 
-    let progress_delete = ProgressBar::no_length().with_style(
-        ProgressStyle::with_template("  Pruning UTxO entries {spinner} {elapsed}").unwrap(),
-    );
-
-    db.with_utxo(|iterator| {
-        for (_, mut handle) in iterator {
-            *handle.borrow_mut() = None;
-            progress_delete.tick();
-        }
-    })
-    .into_diagnostic()?;
-
-    progress_delete.finish_and_clear();
-
     let progress = ProgressBar::new(utxo.len() as u64).with_style(
         ProgressStyle::with_template("  UTxO entries {bar:70} {pos:>7}/{len:7}").unwrap(),
     );

--- a/crates/amaru/tests/rewards.rs
+++ b/crates/amaru/tests/rewards.rs
@@ -19,6 +19,7 @@ use amaru_ledger::{
 use amaru_stores::rocksdb::RocksDB;
 use pallas_primitives::Epoch;
 use std::{path::PathBuf, sync::LazyLock};
+use test_case::test_case;
 
 pub static LEDGER_DB: LazyLock<PathBuf> = LazyLock::new(|| PathBuf::from("../../ledger.db"));
 
@@ -27,6 +28,24 @@ fn open_db(epoch: Epoch) -> RocksDB {
         .unwrap_or_else(|_| panic!("Failed to open ledger snapshot for epoch {}", epoch))
 }
 
+#[test_case(163)]
+#[test_case(164)]
+#[test_case(165)]
+#[test_case(166)]
+#[test_case(167)]
+#[test_case(168)]
+#[test_case(169)]
+#[test_case(170)]
+#[test_case(171)]
+#[test_case(172)]
+#[test_case(173)]
+#[test_case(174)]
+#[test_case(175)]
+#[test_case(176)]
+#[test_case(177)]
+#[test_case(178)]
+#[test_case(179)]
+#[ignore]
 fn compare_preprod_snapshot(epoch: Epoch) {
     let db = open_db(epoch);
 
@@ -35,106 +54,4 @@ fn compare_preprod_snapshot(epoch: Epoch) {
 
     let rewards_summary = RewardsSummary::new(&db.for_epoch(epoch + 2).unwrap(), snapshot).unwrap();
     insta::assert_json_snapshot!(format!("rewards_summary_{}", epoch), rewards_summary);
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_163() {
-    compare_preprod_snapshot(163)
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_164() {
-    compare_preprod_snapshot(164)
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_165() {
-    compare_preprod_snapshot(165)
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_166() {
-    compare_preprod_snapshot(166)
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_167() {
-    compare_preprod_snapshot(167)
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_168() {
-    compare_preprod_snapshot(168)
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_169() {
-    compare_preprod_snapshot(169)
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_170() {
-    compare_preprod_snapshot(170)
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_171() {
-    compare_preprod_snapshot(171)
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_172() {
-    compare_preprod_snapshot(172)
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_173() {
-    compare_preprod_snapshot(173)
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_174() {
-    compare_preprod_snapshot(174)
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_175() {
-    compare_preprod_snapshot(175)
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_176() {
-    compare_preprod_snapshot(176)
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_177() {
-    compare_preprod_snapshot(177)
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_178() {
-    compare_preprod_snapshot(178)
-}
-
-#[test]
-#[ignore]
-fn compare_preprod_snapshot_179() {
-    compare_preprod_snapshot(179)
 }

--- a/crates/consensus/src/chain_forward.rs
+++ b/crates/consensus/src/chain_forward.rs
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::consensus::header::{point_hash, ConwayHeader};
-use crate::consensus::store::ChainStore;
+use crate::consensus::{
+    header::{point_hash, ConwayHeader},
+    store::ChainStore,
+};
 use amaru_ledger::BlockValidationResult;
 use gasket::framework::*;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 pub type UpstreamPort = gasket::messaging::InputPort<BlockValidationResult>;
 
@@ -74,7 +76,7 @@ impl gasket::framework::Worker<ForwardStage> for Worker {
     ) -> Result<(), WorkerError> {
         match unit {
             BlockValidationResult::BlockValidated(point) => {
-                info!(target: EVENT_TARGET, slot = ?point.slot_or_default(), hash = point_hash(point).to_string(), "block_validated");
+                debug!(target: EVENT_TARGET, slot = ?point.slot_or_default(), hash = point_hash(point).to_string(), "block_validated");
                 Ok(())
             }
             BlockValidationResult::BlockForwardStorageFailed(point) => {

--- a/crates/ledger/Cargo.toml
+++ b/crates/ledger/Cargo.toml
@@ -22,9 +22,11 @@ pallas-codec.workspace = true
 pallas-crypto.workspace = true
 pallas-network.workspace = true
 pallas-primitives.workspace = true
-serde = { workspace = true, features = ["derive"] }
+serde.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+miette.workspace = true
+thiserror.workspace = true
 
 amaru-ouroboros = { path = "../ouroboros" }
 

--- a/crates/ledger/src/rewards.rs
+++ b/crates/ledger/src/rewards.rs
@@ -155,10 +155,15 @@ impl StakeDistribution {
         let mut accounts = db
             .iter_accounts()?
             .filter_map(|(credential, account)| {
-                account.delegatee.map(|pool| (credential, AccountState {
-                    pool,
-                    lovelace: account.rewards,
-                }))
+                account.delegatee.map(|pool| {
+                    (
+                        credential,
+                        AccountState {
+                            pool,
+                            lovelace: account.rewards,
+                        },
+                    )
+                })
             })
             .collect::<BTreeMap<StakeCredential, AccountState>>();
 

--- a/crates/ledger/src/rewards.rs
+++ b/crates/ledger/src/rewards.rs
@@ -171,14 +171,13 @@ impl StakeDistribution {
             })
             .collect::<BTreeMap<StakeCredential, AccountState>>();
 
-        let credentials = db.iter_utxos()?.filter_map(|(_, out)| {
-            output_stake_credential(&out).map(|credential| (out, credential))
-        });
-        credentials.for_each(|(output, credential)| {
-            let value = output_lovelace(&output);
-            accounts
-                .entry(credential)
-                .and_modify(|account| account.lovelace += value);
+        db.iter_utxos()?.for_each(|(_, output)| {
+            if let Some(credential) = output_stake_credential(&output) {
+                let value = output_lovelace(&output);
+                accounts
+                    .entry(credential)
+                    .and_modify(|account| account.lovelace += value);
+            }
         });
 
         let mut pools = db

--- a/crates/ledger/src/rewards.rs
+++ b/crates/ledger/src/rewards.rs
@@ -103,7 +103,7 @@ use crate::{
         MAX_LOVELACE_SUPPLY, MONETARY_EXPANSION, OPTIMAL_STAKE_POOLS_COUNT, PLEDGE_INFLUENCE,
         SHELLEY_EPOCH_LENGTH, TREASURY_TAX,
     },
-    store::{columns::*, Store},
+    store::{columns::*, Snapshot, StoreError},
 };
 use num::{
     rational::Ratio,
@@ -151,58 +151,55 @@ impl StakeDistribution {
     /// Clompute a new stake distribution snapshot using data available in the `Store`.
     ///
     /// Invariant: The given store is expected to be a snapshot taken at the end of an epoch.
-    pub fn new<E>(db: &impl Store<Error = E>) -> Result<Self, E> {
-        let mut accounts = BTreeMap::new();
-        db.with_accounts(|rows| {
-            for (credential, row) in rows {
-                if let Some(account) = row.borrow() {
-                    if let Some(pool) = account.delegatee {
-                        accounts.insert(
-                            credential,
-                            AccountState {
-                                pool,
-                                lovelace: account.rewards,
-                            },
-                        );
-                    }
-                }
-            }
-        })?;
-
-        db.with_utxo(|rows| {
-            for (_, row) in rows {
-                if let Some(output) = row.borrow() {
-                    if let Some(credential) = output_stake_credential(output) {
-                        let value = output_lovelace(output);
-                        accounts
-                            .entry(credential)
-                            .and_modify(|account| account.lovelace += value);
-                    }
-                }
-            }
-        })?;
-
-        let mut pools: BTreeMap<PoolId, PoolState> = BTreeMap::new();
-        db.with_pools(|rows| {
-            for (pool, row) in rows {
-                if let Some(row) = row.borrow() {
-                    pools.insert(
+    pub fn new(db: &impl Snapshot) -> Result<Self, StoreError> {
+        // TODO: Avoid creating this intermediate map, and directly create the keys/scripts ones.
+        // Then, when looking for _active accounts_ delegated to pools, we can prune those not
+        // referenced anywhere.
+        let mut accounts = db
+            .iter_accounts()?
+            .filter_map(|(credential, account)| {
+                account.delegatee.map(|pool| (pool, credential, account))
+            })
+            .map(|(pool, credential, account)| {
+                (
+                    credential,
+                    AccountState {
                         pool,
-                        PoolState {
-                            stake: 0,
-                            blocks_count: 0,
-                            // NOTE: pre-compute margin here (1 - m), which gets used for all
-                            // member and leader rewards calculation.
-                            margin: safe_ratio(
-                                row.current_params.margin.numerator,
-                                row.current_params.margin.denominator,
-                            ),
-                            parameters: row.current_params.clone(),
-                        },
-                    );
-                }
-            }
-        })?;
+                        lovelace: account.rewards,
+                    },
+                )
+            })
+            .collect::<BTreeMap<StakeCredential, AccountState>>();
+
+        let credentials = db.iter_utxos()?.filter_map(|(_, out)| {
+            output_stake_credential(&out).map(|credential| (out, credential))
+        });
+        credentials.for_each(|(output, credential)| {
+            let value = output_lovelace(&output);
+            accounts
+                .entry(credential)
+                .and_modify(|account| account.lovelace += value);
+        });
+
+        let mut pools = db
+            .iter_pools()?
+            .map(|(pool, row)| {
+                (
+                    pool,
+                    PoolState {
+                        stake: 0,
+                        blocks_count: 0,
+                        // NOTE: pre-compute margin here (1 - m), which gets used for all
+                        // member and leader rewards calculation.
+                        margin: safe_ratio(
+                            row.current_params.margin.numerator,
+                            row.current_params.margin.denominator,
+                        ),
+                        parameters: row.current_params.clone(),
+                    },
+                )
+            })
+            .collect::<BTreeMap<Hash<28>, PoolState>>();
 
         let mut scripts = BTreeMap::new();
         let mut keys = BTreeMap::new();
@@ -225,15 +222,12 @@ impl StakeDistribution {
             }
         }
 
-        db.with_block_issuers(|rows| {
-            for (_, row) in rows {
-                if let Some(issuer) = row.borrow() {
-                    pools
-                        .entry(issuer.slot_leader)
-                        .and_modify(|pool| pool.blocks_count += 1);
-                }
-            }
-        })?;
+        let block_issuers = db.iter_block_issuers()?;
+        block_issuers.for_each(|(_, issuer)| {
+            pools
+                .entry(issuer.slot_leader)
+                .and_modify(|pool| pool.blocks_count += 1);
+        });
 
         let epoch = db.most_recent_snapshot();
 
@@ -604,8 +598,8 @@ impl serde::Serialize for RewardsSummary {
 }
 
 impl RewardsSummary {
-    pub fn new<E>(db: &impl Store<Error = E>, snapshot: StakeDistribution) -> Result<Self, E> {
-        let pots = db.with_pots(|entry| Pots::from(entry.borrow()))?;
+    pub fn new(db: &impl Snapshot, snapshot: StakeDistribution) -> Result<Self, StoreError> {
+        let pots = db.pots()?;
 
         let (mut blocks_count, mut blocks_per_pool) = RewardsSummary::count_blocks(db)?;
 
@@ -708,21 +702,18 @@ impl RewardsSummary {
     }
 
     /// Count blocks produced by pools, returning the total count and map indexed by poolid.
-    fn count_blocks<E>(db: &impl Store<Error = E>) -> Result<(u64, BTreeMap<PoolId, u64>), E> {
+    fn count_blocks(db: &impl Snapshot) -> Result<(u64, BTreeMap<PoolId, u64>), StoreError> {
         let mut total: u64 = 0;
         let mut per_pool: BTreeMap<Hash<28>, u64> = BTreeMap::new();
 
-        db.with_block_issuers(|rows| {
-            for (_, row) in rows {
-                if let Some(issuer) = row.borrow() {
-                    total += 1;
-                    per_pool
-                        .entry(issuer.slot_leader)
-                        .and_modify(|n| *n += 1)
-                        .or_insert(1);
-                }
-            }
-        })?;
+        let block_issuers = db.iter_block_issuers()?.map(|(_, issuer)| issuer);
+        block_issuers.for_each(|issuer| {
+            total += 1;
+            per_pool
+                .entry(issuer.slot_leader)
+                .and_modify(|n| *n += 1)
+                .or_insert(1);
+        });
 
         Ok((total, per_pool))
     }

--- a/crates/ledger/src/rewards.rs
+++ b/crates/ledger/src/rewards.rs
@@ -152,22 +152,13 @@ impl StakeDistribution {
     ///
     /// Invariant: The given store is expected to be a snapshot taken at the end of an epoch.
     pub fn new(db: &impl Snapshot) -> Result<Self, StoreError> {
-        // TODO: Avoid creating this intermediate map, and directly create the keys/scripts ones.
-        // Then, when looking for _active accounts_ delegated to pools, we can prune those not
-        // referenced anywhere.
         let mut accounts = db
             .iter_accounts()?
             .filter_map(|(credential, account)| {
-                account.delegatee.map(|pool| (pool, credential, account))
-            })
-            .map(|(pool, credential, account)| {
-                (
-                    credential,
-                    AccountState {
-                        pool,
-                        lovelace: account.rewards,
-                    },
-                )
+                account.delegatee.map(|pool| (credential, AccountState {
+                    pool,
+                    lovelace: account.rewards,
+                }))
             })
             .collect::<BTreeMap<StakeCredential, AccountState>>();
 

--- a/crates/ledger/src/state/diff_bind.rs
+++ b/crates/ledger/src/state/diff_bind.rs
@@ -32,7 +32,7 @@ impl<K: Ord, J, V> Default for DiffBind<K, J, V> {
     }
 }
 
-impl<K: Ord + std::fmt::Debug, J: Clone + std::fmt::Debug, V> DiffBind<K, J, V> {
+impl<K: Ord, J: Clone, V> DiffBind<K, J, V> {
     pub fn register(&mut self, k: K, v: V, j: Option<J>) {
         self.unregistered.remove(&k);
         self.registered.insert(k, (j, Some(v)));

--- a/crates/ledger/src/state/transaction.rs
+++ b/crates/ledger/src/state/transaction.rs
@@ -26,8 +26,8 @@ use tracing::{debug, debug_span, Span};
 
 const EVENT_TARGET: &str = "amaru::ledger::state::transaction";
 
-pub fn apply<T>(
-    state: &mut VolatileState<T>,
+pub fn apply(
+    state: &mut VolatileState,
     parent: &Span,
     is_failed: bool,
     transaction_id: Hash<32>,

--- a/crates/ledger/src/state/volatile_db.rs
+++ b/crates/ledger/src/state/volatile_db.rs
@@ -37,7 +37,7 @@ use std::collections::{BTreeSet, VecDeque};
 #[derive(Default)]
 pub struct VolatileDB {
     cache: VolatileCache,
-    sequence: VecDeque<VolatileState<(Point, PoolId)>>,
+    sequence: VecDeque<AnchoredVolatileState>,
 }
 
 impl VolatileDB {
@@ -49,7 +49,7 @@ impl VolatileDB {
         self.sequence.len()
     }
 
-    pub fn view_back(&self) -> Option<&VolatileState<(Point, PoolId)>> {
+    pub fn view_back(&self) -> Option<&AnchoredVolatileState> {
         self.sequence.back()
     }
 
@@ -58,45 +58,52 @@ impl VolatileDB {
     }
 
     pub fn iter_pools(&self) -> impl Iterator<Item = (Epoch, &DiffEpochReg<PoolId, PoolParams>)> {
-        self.sequence
-            .iter()
-            .map(|st| (epoch_from_slot(st.anchor.0.slot_or_default()), &st.pools))
+        self.sequence.iter().map(|st| {
+            (
+                epoch_from_slot(st.anchor.0.slot_or_default()),
+                &st.state.pools,
+            )
+        })
     }
 
-    pub fn pop_front(&mut self) -> Option<VolatileState<(Point, PoolId)>> {
+    pub fn pop_front(&mut self) -> Option<AnchoredVolatileState> {
         self.sequence.pop_front().inspect(|state| {
             // NOTE: It is imperative to remove consumed and produced UTxOs from the cache as we
             // remove them from the sequence to prevent the cache from growing out of proportion.
-            for k in state.utxo.consumed.iter() {
+            for k in state.state.utxo.consumed.iter() {
                 self.cache.utxo.consumed.remove(k);
             }
 
-            for (k, _) in state.utxo.produced.iter() {
+            for (k, _) in state.state.utxo.produced.iter() {
                 self.cache.utxo.produced.remove(k);
             }
         })
     }
 
-    pub fn push_back(&mut self, state: VolatileState<(Point, PoolId)>) {
+    pub fn push_back(&mut self, state: AnchoredVolatileState) {
         // TODO: See NOTE on VolatileDB regarding the .clone()
-        self.cache.merge(state.utxo.clone());
+        self.cache.merge(state.state.utxo.clone());
         self.sequence.push_back(state);
     }
 
-    pub fn rollback_to<E>(&mut self, point: &Point, on_unknown_point: E) -> Result<(), E> {
+    pub fn rollback_to<E>(
+        &mut self,
+        point: &Point,
+        on_unknown_point: impl Fn(&Point) -> E,
+    ) -> Result<(), E> {
         self.cache = VolatileCache::default();
 
         let mut ix = 0;
         for diff in self.sequence.iter() {
             if diff.anchor.0.slot_or_default() <= point.slot_or_default() {
                 // TODO: See NOTE on VolatileDB regarding the .clone()
-                self.cache.merge(diff.utxo.clone());
+                self.cache.merge(diff.state.utxo.clone());
                 ix += 1;
             }
         }
 
         if ix >= self.sequence.len() {
-            Err(on_unknown_point)
+            Err(on_unknown_point(point))
         } else {
             self.sequence.resize_with(ix, || {
                 unreachable!("ix is necessarly strictly smaller than the length")
@@ -126,8 +133,8 @@ impl VolatileCache {
 // VolatileState
 // ----------------------------------------------------------------------------
 
-pub struct VolatileState<A> {
-    pub anchor: A,
+#[derive(Default)]
+pub struct VolatileState {
     pub utxo: DiffSet<TransactionInput, TransactionOutput>,
     pub pools: DiffEpochReg<PoolId, PoolParams>,
     pub accounts: DiffBind<StakeCredential, PoolId, Lovelace>,
@@ -135,28 +142,16 @@ pub struct VolatileState<A> {
     pub fees: Lovelace,
 }
 
-impl Default for VolatileState<()> {
-    fn default() -> Self {
-        Self {
-            anchor: (),
-            utxo: Default::default(),
-            pools: Default::default(),
-            accounts: Default::default(),
-            withdrawals: Default::default(),
-            fees: 0,
-        }
-    }
+pub struct AnchoredVolatileState {
+    pub anchor: (Point, PoolId),
+    pub state: VolatileState,
 }
 
-impl VolatileState<()> {
-    pub fn anchor(self, point: &Point, issuer: PoolId) -> VolatileState<(Point, PoolId)> {
-        VolatileState {
+impl VolatileState {
+    pub fn anchor(self, point: &Point, issuer: PoolId) -> AnchoredVolatileState {
+        AnchoredVolatileState {
             anchor: (point.clone(), issuer),
-            utxo: self.utxo,
-            pools: self.pools,
-            accounts: self.accounts,
-            withdrawals: self.withdrawals,
-            fees: self.fees,
+            state: self,
         }
     }
 
@@ -177,7 +172,7 @@ pub struct StoreUpdate<W, A, R> {
     pub remove: R,
 }
 
-impl VolatileState<(Point, PoolId)> {
+impl AnchoredVolatileState {
     #[allow(clippy::type_complexity)]
     pub fn into_store_update(
         self,
@@ -198,15 +193,12 @@ impl VolatileState<(Point, PoolId)> {
         StoreUpdate {
             point: self.anchor.0,
             issuer: self.anchor.1,
-            fees: self.fees,
-            withdrawals: self.withdrawals.into_iter(),
+            fees: self.state.fees,
+            withdrawals: self.state.withdrawals.into_iter(),
             add: store::Columns {
-                utxo: self.utxo.produced.into_iter(),
-                pools: self
-                    .pools
-                    .registered
-                    .into_iter()
-                    .flat_map(move |(_, registrations)| {
+                utxo: self.state.utxo.produced.into_iter(),
+                pools: self.state.pools.registered.into_iter().flat_map(
+                    move |(_, registrations)| {
                         registrations
                             .into_iter()
                             // NOTE/TODO: Re-registrations (a.k.a pool params updates) are always
@@ -219,17 +211,19 @@ impl VolatileState<(Point, PoolId)> {
                             // don't _have to_.
                             .map(|pool| (pool, epoch + 1))
                             .collect::<Vec<_>>()
-                    }),
+                    },
+                ),
                 accounts: self
+                    .state
                     .accounts
                     .registered
                     .into_iter()
                     .map(|(credential, (pool, deposit))| (credential, (pool, deposit, 0))),
             },
             remove: store::Columns {
-                utxo: self.utxo.consumed.into_iter(),
-                pools: self.pools.unregistered.into_iter(),
-                accounts: self.accounts.unregistered.into_iter(),
+                utxo: self.state.utxo.consumed.into_iter(),
+                pools: self.state.pools.unregistered.into_iter(),
+                accounts: self.state.accounts.unregistered.into_iter(),
             },
         }
     }

--- a/crates/ledger/src/store.rs
+++ b/crates/ledger/src/store.rs
@@ -140,6 +140,9 @@ pub trait Store: Snapshot + Send + Sync {
     /// stored as a bounded FIFO, so it only make sense to use this function at the end of an epoch
     /// (or at the beginning, before any block is applied, depending on your perspective).
     fn with_block_issuers(&self, with: impl FnMut(slots::Iter<'_, '_>)) -> Result<(), StoreError>;
+
+    /// Provide an access to iterate over utxo, similar to 'with_pools'.
+    fn with_utxo(&self, with: impl FnMut(utxo::Iter<'_, '_>)) -> Result<(), StoreError>;
 }
 
 // Columns

--- a/crates/ledger/src/store.rs
+++ b/crates/ledger/src/store.rs
@@ -140,9 +140,6 @@ pub trait Store: Snapshot + Send + Sync {
     /// stored as a bounded FIFO, so it only make sense to use this function at the end of an epoch
     /// (or at the beginning, before any block is applied, depending on your perspective).
     fn with_block_issuers(&self, with: impl FnMut(slots::Iter<'_, '_>)) -> Result<(), StoreError>;
-
-    /// Provide an access to iterate over utxo, similar to 'with_pools'.
-    fn with_utxo(&self, with: impl FnMut(utxo::Iter<'_, '_>)) -> Result<(), StoreError>;
 }
 
 // Columns

--- a/crates/ledger/src/store/columns/slots.rs
+++ b/crates/ledger/src/store/columns/slots.rs
@@ -19,8 +19,12 @@ use crate::{
 };
 use pallas_codec::minicbor::{self as cbor};
 
+pub type Key = Slot;
+
+pub type Value = Row;
+
 /// Iterator used to browse rows from the Pools column. Meant to be referenced using qualified imports.
-pub type Iter<'a, 'b> = iter_borrow::IterBorrow<'a, 'b, Slot, Option<Row>>;
+pub type Iter<'a, 'b> = iter_borrow::IterBorrow<'a, 'b, Key, Option<Value>>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Row {

--- a/crates/stores/Cargo.toml
+++ b/crates/stores/Cargo.toml
@@ -15,6 +15,5 @@ amaru-ledger = { path = "../ledger" }
 rocksdb.workspace = true
 tracing.workspace = true
 pallas-codec.workspace = true
-miette.workspace = true
 thiserror.workspace = true
 hex.workspace = true

--- a/crates/stores/src/rocksdb/columns/accounts.rs
+++ b/crates/stores/src/rocksdb/columns/accounts.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use crate::rocksdb::common::{as_key, as_value, PREFIX_LEN};
-use rocksdb::{self, Transaction};
+use amaru_ledger::store::StoreError;
+use rocksdb::Transaction;
 use tracing::error;
 
 use amaru_ledger::store::columns::accounts::{Key, Row, Value, EVENT_TARGET};
@@ -25,25 +26,31 @@ pub const PREFIX: [u8; PREFIX_LEN] = [0x61, 0x63, 0x63, 0x74];
 pub fn add<DB>(
     db: &Transaction<'_, DB>,
     rows: impl Iterator<Item = (Key, Value)>,
-) -> Result<(), rocksdb::Error> {
+) -> Result<(), StoreError> {
     for (credential, (delegatee, deposit, rewards)) in rows {
         let key = as_key(&PREFIX, &credential);
 
         // In case where a registration already exists, then we must only update the underlying
         // entry, while preserving the reward amount.
-        if let Some(mut row) = db.get(&key)?.map(Row::unsafe_decode) {
+        if let Some(mut row) = db
+            .get(&key)
+            .map_err(|err| StoreError::Internal(err.into()))?
+            .map(Row::unsafe_decode)
+        {
             row.delegatee = delegatee;
             if let Some(deposit) = deposit {
                 row.deposit = deposit;
             }
-            db.put(key, as_value(row))?;
+            db.put(key, as_value(row))
+                .map_err(|err| StoreError::Internal(err.into()))?;
         } else if let Some(deposit) = deposit {
             let row = Row {
                 delegatee,
                 deposit,
                 rewards,
             };
-            db.put(key, as_value(row))?;
+            db.put(key, as_value(row))
+                .map_err(|err| StoreError::Internal(err.into()))?;
         } else {
             error!(
                 target: EVENT_TARGET,
@@ -60,13 +67,18 @@ pub fn add<DB>(
 pub fn reset<DB>(
     db: &Transaction<'_, DB>,
     rows: impl Iterator<Item = Key>,
-) -> Result<(), rocksdb::Error> {
+) -> Result<(), StoreError> {
     for credential in rows {
         let key = as_key(&PREFIX, &credential);
 
-        if let Some(mut row) = db.get(&key)?.map(Row::unsafe_decode) {
+        if let Some(mut row) = db
+            .get(&key)
+            .map_err(|err| StoreError::Internal(err.into()))?
+            .map(Row::unsafe_decode)
+        {
             row.rewards = 0;
-            db.put(key, as_value(row))?;
+            db.put(key, as_value(row))
+                .map_err(|err| StoreError::Internal(err.into()))?;
         } else {
             error!(
                 target: EVENT_TARGET,
@@ -83,9 +95,10 @@ pub fn reset<DB>(
 pub fn remove<DB>(
     db: &Transaction<'_, DB>,
     rows: impl Iterator<Item = Key>,
-) -> Result<(), rocksdb::Error> {
+) -> Result<(), StoreError> {
     for credential in rows {
-        db.delete(as_key(&PREFIX, &credential))?;
+        db.delete(as_key(&PREFIX, &credential))
+            .map_err(|err| StoreError::Internal(err.into()))?;
     }
 
     Ok(())

--- a/crates/stores/src/rocksdb/columns/pools.rs
+++ b/crates/stores/src/rocksdb/columns/pools.rs
@@ -14,8 +14,8 @@
 
 use super::super::common::{as_key, as_value, PREFIX_LEN};
 use crate::rocksdb::scolumns::pools::{Key, Row, Value, EVENT_TARGET};
-use amaru_ledger::kernel::{Epoch, PoolId};
-use rocksdb::{self, OptimisticTransactionDB, ThreadMode, Transaction};
+use amaru_ledger::{kernel::Epoch, store::StoreError};
+use rocksdb::{OptimisticTransactionDB, ThreadMode, Transaction};
 use tracing::error;
 
 /// Name prefixed used for storing Pool entries. UTF-8 encoding for "pool"
@@ -23,15 +23,18 @@ pub const PREFIX: [u8; PREFIX_LEN] = [0x70, 0x6f, 0x6f, 0x6c];
 
 pub fn get<T: ThreadMode>(
     db: &OptimisticTransactionDB<T>,
-    pool: &PoolId,
-) -> Result<Option<Row>, rocksdb::Error> {
-    Ok(db.get(as_key(&PREFIX, pool))?.map(Row::unsafe_decode))
+    pool: &Key,
+) -> Result<Option<Row>, StoreError> {
+    Ok(db
+        .get(as_key(&PREFIX, pool))
+        .map_err(|err| StoreError::Internal(err.into()))?
+        .map(Row::unsafe_decode))
 }
 
 pub fn add<DB>(
     db: &Transaction<'_, DB>,
     rows: impl Iterator<Item = Value>,
-) -> Result<(), rocksdb::Error> {
+) -> Result<(), StoreError> {
     for (params, epoch) in rows {
         let pool = params.id;
 
@@ -45,12 +48,16 @@ pub fn add<DB>(
         //
         // TODO: We might want to define a MERGE OPERATOR to speed this up if
         // necessary.
-        let params = match db.get(as_key(&PREFIX, pool))? {
+        let params = match db
+            .get(as_key(&PREFIX, pool))
+            .map_err(|err| StoreError::Internal(err.into()))?
+        {
             None => as_value(Row::new(params)),
             Some(existing_params) => Row::extend(existing_params, (Some(params), epoch)),
         };
 
-        db.put(as_key(&PREFIX, pool), params)?;
+        db.put(as_key(&PREFIX, pool), params)
+            .map_err(|err| StoreError::Internal(err.into()))?;
     }
 
     Ok(())
@@ -59,19 +66,24 @@ pub fn add<DB>(
 pub fn remove<DB>(
     db: &Transaction<'_, DB>,
     rows: impl Iterator<Item = (Key, Epoch)>,
-) -> Result<(), rocksdb::Error> {
+) -> Result<(), StoreError> {
     for (pool, epoch) in rows {
         // We do not delete pool immediately but rather schedule the
         // removal as an empty parameter update. The 'pool reaping' happens on
         // every epoch boundary.
-        match db.get(as_key(&PREFIX, pool))? {
+        match db
+            .get(as_key(&PREFIX, pool))
+            .map_err(|err| StoreError::Internal(err.into()))?
+        {
             None => {
                 error!(target: EVENT_TARGET, ?pool, "remove.unknown")
             }
-            Some(existing_params) => db.put(
-                as_key(&PREFIX, pool),
-                Row::extend(existing_params, (None, epoch)),
-            )?,
+            Some(existing_params) => db
+                .put(
+                    as_key(&PREFIX, pool),
+                    Row::extend(existing_params, (None, epoch)),
+                )
+                .map_err(|err| StoreError::Internal(err.into()))?,
         };
     }
 

--- a/crates/stores/src/rocksdb/columns/pots.rs
+++ b/crates/stores/src/rocksdb/columns/pots.rs
@@ -14,17 +14,21 @@
 
 use super::super::common::{as_value, PREFIX_LEN};
 use crate::rocksdb::scolumns::pots::Row;
-use rocksdb::{self, Transaction};
+use amaru_ledger::store::StoreError;
+use rocksdb::Transaction;
 
 /// Name prefixed used for storing protocol pots. UTF-8 encoding for "pots"
 pub const PREFIX: [u8; PREFIX_LEN] = [0x70, 0x6f, 0x74, 0x73];
 
-pub fn get<DB>(db: &Transaction<'_, DB>) -> Result<Row, rocksdb::Error> {
-    Ok(Row::unsafe_decode(db.get(PREFIX)?.unwrap_or_else(|| {
-        panic!("no protocol pots (treasury, reserves, fees, ...) found")
-    })))
+pub fn get<DB>(db: &Transaction<'_, DB>) -> Result<Row, StoreError> {
+    Ok(Row::unsafe_decode(
+        db.get(PREFIX)
+            .map_err(|err| StoreError::Internal(err.into()))?
+            .unwrap_or_else(|| panic!("no protocol pots (treasury, reserves, fees, ...) found")),
+    ))
 }
 
-pub fn put<DB>(db: &Transaction<'_, DB>, row: Row) -> Result<(), rocksdb::Error> {
+pub fn put<DB>(db: &Transaction<'_, DB>, row: Row) -> Result<(), StoreError> {
     db.put(PREFIX, as_value(row))
+        .map_err(|err| StoreError::Internal(err.into()))
 }

--- a/crates/stores/src/rocksdb/columns/slots.rs
+++ b/crates/stores/src/rocksdb/columns/slots.rs
@@ -13,20 +13,24 @@
 // limitations under the License.
 
 use super::super::common::{as_key, as_value, PREFIX_LEN};
-use crate::rocksdb::scolumns::slots::Row;
-use amaru_ledger::kernel::Slot;
-use rocksdb::{self, OptimisticTransactionDB, ThreadMode, Transaction};
+use crate::rocksdb::scolumns::slots::{Key, Value};
+use amaru_ledger::store::StoreError;
+use rocksdb::{OptimisticTransactionDB, ThreadMode, Transaction};
 
 /// Name prefixed used for storing Pool entries. UTF-8 encoding for "slot"
 pub const PREFIX: [u8; PREFIX_LEN] = [0x73, 0x6c, 0x6f, 0x74];
 
 pub fn get<T: ThreadMode>(
     db: &OptimisticTransactionDB<T>,
-    slot: &Slot,
-) -> Result<Option<Row>, rocksdb::Error> {
-    Ok(db.get(as_key(&PREFIX, slot))?.map(Row::unsafe_decode))
+    key: &Key,
+) -> Result<Option<Value>, StoreError> {
+    Ok(db
+        .get(as_key(&PREFIX, key))
+        .map_err(|err| StoreError::Internal(err.into()))?
+        .map(Value::unsafe_decode))
 }
 
-pub fn put<DB>(db: &Transaction<'_, DB>, slot: &Slot, row: Row) -> Result<(), rocksdb::Error> {
-    db.put(as_key(&PREFIX, slot), as_value(row))
+pub fn put<DB>(db: &Transaction<'_, DB>, key: &Key, value: Value) -> Result<(), StoreError> {
+    db.put(as_key(&PREFIX, key), as_value(value))
+        .map_err(|err| StoreError::Internal(err.into()))
 }

--- a/crates/stores/src/rocksdb/mod.rs
+++ b/crates/stores/src/rocksdb/mod.rs
@@ -434,6 +434,10 @@ impl Store for RocksDB {
         }
     }
 
+    fn with_utxo(&self, with: impl FnMut(scolumns::utxo::Iter<'_, '_>)) -> Result<(), StoreError> {
+        with_prefix_iterator(self.db.transaction(), utxo::PREFIX, with)
+    }
+
     fn with_pools(
         &self,
         with: impl FnMut(scolumns::pools::Iter<'_, '_>),

--- a/crates/stores/src/rocksdb/mod.rs
+++ b/crates/stores/src/rocksdb/mod.rs
@@ -434,10 +434,6 @@ impl Store for RocksDB {
         }
     }
 
-    fn with_utxo(&self, with: impl FnMut(scolumns::utxo::Iter<'_, '_>)) -> Result<(), StoreError> {
-        with_prefix_iterator(self.db.transaction(), utxo::PREFIX, with)
-    }
-
     fn with_pools(
         &self,
         with: impl FnMut(scolumns::pools::Iter<'_, '_>),


### PR DESCRIPTION
Refactoring of the current `state` handling to prepare for `governance` support inclusion.

The general direction of this refactoring is to:

* decouple `store` usage from reward calculation so that they become stateless
* introduce a higher-level data structure that smoothen integration between stable and volatile storage
* introduce a basic abstract `Error` struct; no more crate specific errors (e.g. `rocksdb`)

Some extra specifics:

* remove non-storage related functions from `Store` trait
* introduce `AnchoredVolatileState` to clearly separate anchored from non-anchored `VolatileState`

Replaces https://github.com/pragma-org/amaru/pull/76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - Internal improvements have streamlined state management and error handling, resulting in greater system robustness and clearer error messages.
  
- **Chores**
  - Dependency and build configuration updates have been implemented to enhance overall maintenance and ensure smoother operations.
  
- **Bug Fixes**
  - Enhanced error reporting now provides more detailed feedback during failure events, aiding in quicker diagnosis and resolution.

These updates contribute to a more stable and reliable experience for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->