### PR TITLE
chore: CI speedups

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,4 +3,4 @@
 [alias]
 fmt-amaru = "fmt --all -- --check"
 clippy-amaru = "clippy --workspace --all-targets --all-features -- -D warnings"
-test-amaru = "test --workspace --all-targets --all-features "
+test-amaru = "test --workspace --all-features "

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,4 +3,4 @@
 [alias]
 fmt-amaru = "fmt --all -- --check"
 clippy-amaru = "clippy --workspace --all-targets --all-features -- -D warnings"
-test-amaru = "test --workspace --all-features "
+test-amaru = "test --workspace --all-features"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,8 +17,21 @@ env:
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
 
 jobs:
+  sanity:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: ${{ runner.os }}
+      - name: Check format
+        run: cargo fmt-amaru
+      - name: Run clippy
+        run: cargo clippy-amaru
   build:
     name: Build on ${{ matrix.environments.runner }} with target ${{ matrix.environments.target }}
+    needs: sanity
     strategy:
       fail-fast: false
       matrix:
@@ -43,10 +56,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: ${{ runner.os }}-${{ matrix.environments.target }}
-      - name: Check format
-        run: cargo fmt-amaru
-      - name: Run clippy
-        run: cargo clippy-amaru
       - run: rustup target add ${{ matrix.environments.target }}
       - name: Run tests
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,16 +38,12 @@ jobs:
         environments:
           - runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - runner: ubuntu-latest
-            target: wasm32-unknown-unknown
-            optional: true
           - runner: macos-latest
             target: aarch64-apple-darwin
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
           - runner: ubuntu-latest
             target: aarch64-unknown-linux-musl
-            optional: true
             cross-compile: true
     timeout-minutes: 30
     runs-on: ${{ matrix.environments.runner }}
@@ -67,6 +63,30 @@ jobs:
           else
             cargo test-amaru --locked --target ${{ matrix.environments.target }}
           fi
+        shell: bash
+  build-crates:
+    name: Build crates on ${{ matrix.environments.runner }} with target ${{ matrix.environments.target }}
+    needs: sanity
+    strategy:
+      fail-fast: false
+      matrix:
+        environments:
+          - runner: ubuntu-latest
+            target: wasm32-unknown-unknown
+            package: amaru-ledger
+            optional: true
+    timeout-minutes: 30
+    runs-on: ${{ matrix.environments.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: ${{ runner.os }}-${{ matrix.environments.target }}
+      - run: rustup target add ${{ matrix.environments.target }}
+      - name: Run tests
+        run: |
+          set +e
+          cargo test --locked --all-features -p ${{ matrix.environments.package }} --target ${{ matrix.environments.target }}
           exitcode="$?"
           if [[ "${{ matrix.environments.optional }}" == "true" && "$exitcode" != "0" ]] ; then
             # Propagate failure as a warning


### PR DESCRIPTION
Some CI improvements:

* only run `target` specifics per target (i.e. run `fmt` only once)
* lib only target (e.g. `wasm`) do not run on final `amaru` CLI