### PR TITLE
chore: fix aarch64-unknown-linux-musl build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,10 +45,13 @@ jobs:
             target: wasm32-unknown-unknown
             packages: -p amaru-ledger
             optional: true
-          # Disabled for now
-          #- runner: ubuntu-latest
-          #  target: aarch64-unknown-linux-musl
-          #  cross-compile: true
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            cross-compile: true
+          - runner: macos-latest
+            target: aarch64-unknown-linux-musl
     timeout-minutes: 30
     runs-on: ${{ matrix.environments.runner }}
     steps:
@@ -62,10 +65,11 @@ jobs:
           set +e
           SCOPE="${{ matrix.environments.packages || '--workspace' }}"
           if [[ "${{ matrix.environments.cross-compile }}" == "true" ]] ; then
-            cargo install cross --git https://github.com/cross-rs/cross
-            # cross doesn't load .cargo/config.toml, see https://github.com/cross-rs/cross/issues/562
-            $HOME/.cargo/bin/cross test --locked --all-features $SCOPE --target ${{ matrix.environments.target }}
+            sudo snap install zig --classic --beta
+            cargo install --locked cargo-zigbuild
+            cargo zigbuild --target ${{ matrix.environments.target }}
           else
+            export CC=aarch64-linux-gnu-gcc 
             cargo test $SCOPE --locked --target ${{ matrix.environments.target }}
           fi
           exitcode="$?"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,6 @@ dependencies = [
  "pallas-traverse",
  "proptest",
  "rand",
- "rocksdb",
  "sys_metrics",
  "tempfile",
  "test-case",
@@ -1924,18 +1923,15 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.16.0+8.10.0"
+version = "0.17.1+9.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+checksum = "2b7869a512ae9982f4d46ba482c2a304f1efd80c6412a3d4bf57bb79a619679f"
 dependencies = [
  "bindgen",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
- "lz4-sys",
- "zstd-sys",
 ]
 
 [[package]]
@@ -1975,16 +1971,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 dependencies = [
  "value-bag",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.11.1+lz4-1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -2873,9 +2859,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+checksum = "26ec73b20525cb235bad420f911473b69f9fe27cc856c5461bccd7e4af037f43"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -4130,14 +4116,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ pallas-primitives = "0.32.0"
 pallas-traverse = "0.32.0"
 rand = "0.8"
 rayon = "1.10"
-rocksdb = "0.22.0"
+rocksdb = { version = "0.23.0", default-features = false, features = ["bindgen-runtime", "snappy"] }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0.128", default-features = false }
 tempfile = "3.15.0"

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -29,7 +29,6 @@ pallas-network.workspace = true
 pallas-primitives.workspace = true
 pallas-traverse.workspace = true
 rand.workspace = true
-rocksdb.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "signal"] }
 tokio-util.workspace = true

--- a/crates/stores/Cargo.toml
+++ b/crates/stores/Cargo.toml
@@ -17,3 +17,6 @@ tracing.workspace = true
 pallas-codec.workspace = true
 thiserror.workspace = true
 hex.workspace = true
+
+#[target.aarch64-unknown-linux-musl.dependencies]
+#rocksdb = { workspace = true, features = ["bindgen-static", "snappy"] }


### PR DESCRIPTION
This PR was an attempt to fix the compilation for `aarch64-linux` (e.g. raspberry) without success so far.

Here is a recap:

# Using cross

Fails without proper error message:

```console
[cross] warning: Found conflicting cross configuration in `/home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.3.1/Cargo.toml`, use `[workspace.metadata.cross]` in the workspace manifest instead.
Currently only using configuration from `/home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/getrandom-0.2.15/Cargo.toml`
info: downloading component 'rust-src'
info: installing component 'rust-src'
[cross] error: Errors encountered before cross compilation, aborting.
```

# Direct cargo cross-compilation

Using the command `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc CC=aarch64-linux-gnu-gcc cargo build --target aarch64-unknown-linux-musl`

## On `macos-latest`

Follow https://github.com/messense/homebrew-macos-cross-toolchains

Fails during compilation while compiling `libz-sys v1.1.21`

```console
aarch64-linux-gnu-gcc: error: unrecognized command-line option '-arch'; did you mean '-march='?
aarch64-linux-gnu-gcc: error: unrecognized command-line option '-mmacosx-version-min=15.2'
```

## On `ubuntu-latest`

Fails during compilation while compiling `libz-sys v1.1.21`

```console
aarch64-linux-gnu-gcc: error: unrecognized command-line option '-m64'
```

## On `ubuntu-24.04-arm`

Fails during compilation while compiling `libz-sys v1.1.21`

```console
aarch64-linux-gnu-gcc: error: unrecognized command-line option '-m64'
```