### PR TITLE
decision: store logbook in wiki

### DIFF
--- a/engineering-decision-records/008-logbook.md
+++ b/engineering-decision-records/008-logbook.md
@@ -6,6 +6,7 @@ status: accepted
 # Logbooks
 
 ## Context
+
 We introduce the notion of a "Logbook" to complement the [Engineering Decision Records](./001-record-engineering-decisions.md) process by capturing developer musings, notes, tips, and informal documentation throughout the development process.
 
 ## Motivation
@@ -16,8 +17,8 @@ Finally, we want to avoid overly onerous process obsession, so use of the logboo
 
 ## Decision
 
-- We will create a "Logbook" directory intended to capture these kinds of informal notes.
-- It will have a `log.md` file with a series of entries headings with the date in descending order.
+- We activate Amaru [Wiki](https://github.com/pragma-org/amaru/wiki/) to capture these kinds of informal notes.
+- It will have a [`log.md`](https://github.com/pragma-org/amaru/wiki/log) featuring a series of entries headings with the date in descending order.
 - Any developer is encouraged to add an entry to the team logbook tracking their progress, thoughts, experiments, successes, failures, etc.
 - Meetings among the core maintainers should also result in an entry added to the logbook if anything of substance is discussed.
 - Additionally, the logbook can become an unofficial interconnected knowledge base; If you'd like to save some useful command, benchmarking result, musings on some experimental approach, etc. you may create a dedicated markdown file for it in the logbook directory.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new log entry detailing ongoing work on block validation within the consensus to ledger pipeline, emphasising the need for a transactional approach and the challenges faced with current implementation.
  - Introduced the concept of a "Logbook" to capture informal documentation, with a focus on developer notes and meeting summaries, now linked to the Amaru Wiki.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->