### PR TITLE
feat: introduce new stage for block validation

### DIFF
--- a/crates/consensus/src/chain_forward.rs
+++ b/crates/consensus/src/chain_forward.rs
@@ -22,6 +22,8 @@ use tracing::{error, info, warn};
 
 pub type UpstreamPort = gasket::messaging::InputPort<BlockValidationResult>;
 
+pub const EVENT_TARGET: &str = "amaru::consensus::chain_forward";
+
 /// Forwarding stage of the consensus where blocks are stored and made
 /// available to downstream peers.
 ///
@@ -72,19 +74,19 @@ impl gasket::framework::Worker<ForwardStage> for Worker {
     ) -> Result<(), WorkerError> {
         match unit {
             BlockValidationResult::BlockValidated(point) => {
-                info!(name: "block_validated", target: "amaru::consensus::chain_forward", slot = ?point.slot_or_default(), hash = ?point_hash(point).to_string());
+                info!(target: EVENT_TARGET, slot = ?point.slot_or_default(), hash = point_hash(point).to_string(), "block_validated");
                 Ok(())
             }
             BlockValidationResult::BlockForwardStorageFailed(point) => {
-                error!(name: "storage_failed", target: "amaru::consensus::chain_forward", slot = ?point.slot_or_default(), hash = ?point_hash(point).to_string());
+                error!(target: EVENT_TARGET, slot = ?point.slot_or_default(), hash = point_hash(point).to_string(), "storage_failed");
                 Err(WorkerError::Panic)
             }
             BlockValidationResult::InvalidRollbackPoint(point) => {
-                warn!(name: "invalid_rollback_point", target: "amaru::consensus::chain_forward", slot = ?point.slot_or_default(), hash = ?point_hash(point).to_string());
+                warn!(target: EVENT_TARGET, slot = ?point.slot_or_default(), hash = point_hash(point).to_string(), "invalid_rollback_point");
                 Ok(())
             }
             BlockValidationResult::RolledBackTo(point) => {
-                info!(name:  "rolled_back_to", target: "amaru::consensus::chain_forward", slot = ?point.slot_or_default(), hash = ?point_hash(point).to_string());
+                info!(target: EVENT_TARGET, slot = ?point.slot_or_default(), hash = point_hash(point).to_string(),  "rolled_back_to");
                 Ok(())
             }
         }

--- a/crates/consensus/src/chain_forward.rs
+++ b/crates/consensus/src/chain_forward.rs
@@ -1,0 +1,92 @@
+// Copyright 2024 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::consensus::header::{point_hash, ConwayHeader};
+use crate::consensus::store::ChainStore;
+use amaru_ledger::BlockValidationResult;
+use gasket::framework::*;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tracing::{error, info, warn};
+
+pub type UpstreamPort = gasket::messaging::InputPort<BlockValidationResult>;
+
+/// Forwarding stage of the consensus where blocks are stored and made
+/// available to downstream peers.
+///
+/// TODO: currently does nothing, should store block, update chain state, and
+/// forward new chain downstream
+
+#[derive(Stage)]
+#[stage(
+    name = "consensus.forward",
+    unit = "BlockValidationResult",
+    worker = "Worker"
+)]
+pub struct ForwardStage {
+    pub store: Arc<Mutex<dyn ChainStore<ConwayHeader>>>,
+    pub upstream: UpstreamPort,
+}
+
+impl ForwardStage {
+    pub fn new(store: Arc<Mutex<dyn ChainStore<ConwayHeader>>>) -> Self {
+        Self {
+            store,
+            upstream: Default::default(),
+        }
+    }
+}
+
+pub struct Worker {}
+
+#[async_trait::async_trait(?Send)]
+impl gasket::framework::Worker<ForwardStage> for Worker {
+    async fn bootstrap(_stage: &ForwardStage) -> Result<Self, WorkerError> {
+        Ok(Self {})
+    }
+
+    async fn schedule(
+        &mut self,
+        stage: &mut ForwardStage,
+    ) -> Result<WorkSchedule<BlockValidationResult>, WorkerError> {
+        let unit = stage.upstream.recv().await.or_panic()?;
+
+        Ok(WorkSchedule::Unit(unit.payload))
+    }
+
+    async fn execute(
+        &mut self,
+        unit: &BlockValidationResult,
+        _stage: &mut ForwardStage,
+    ) -> Result<(), WorkerError> {
+        match unit {
+            BlockValidationResult::BlockValidated(point) => {
+                info!(name: "block_validated", target: "amaru::consensus::chain_forward", slot = ?point.slot_or_default(), hash = ?point_hash(point).to_string());
+                Ok(())
+            }
+            BlockValidationResult::BlockForwardStorageFailed(point) => {
+                error!(name: "storage_failed", target: "amaru::consensus::chain_forward", slot = ?point.slot_or_default(), hash = ?point_hash(point).to_string());
+                Err(WorkerError::Panic)
+            }
+            BlockValidationResult::InvalidRollbackPoint(point) => {
+                warn!(name: "invalid_rollback_point", target: "amaru::consensus::chain_forward", slot = ?point.slot_or_default(), hash = ?point_hash(point).to_string());
+                Ok(())
+            }
+            BlockValidationResult::RolledBackTo(point) => {
+                info!(name:  "rolled_back_to", target: "amaru::consensus::chain_forward", slot = ?point.slot_or_default(), hash = ?point_hash(point).to_string());
+                Ok(())
+            }
+        }
+    }
+}

--- a/crates/consensus/src/consensus/mod.rs
+++ b/crates/consensus/src/consensus/mod.rs
@@ -130,7 +130,10 @@ impl HeaderStage {
         Ok(())
     }
 
-    #[instrument(level = Level::DEBUG, skip(self, raw_header))]
+    #[instrument(level = Level::DEBUG, skip_all,
+                 fields(peer = peer.name,
+                        slot = &point.slot_or_default(),
+                        hash = point_hash(point).to_string()))]
     async fn handle_roll_forward(
         &mut self,
         peer: &Peer,

--- a/crates/consensus/src/consensus/mod.rs
+++ b/crates/consensus/src/consensus/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::consensus::header_validation::assert_header;
-use amaru_ledger::{RawBlock, ValidateHeaderEvent};
+use amaru_ledger::{RawBlock, ValidateBlockEvent};
 use amaru_ouroboros::{
     ledger::LedgerState,
     protocol::{peer, peer::*, Point, PullEvent},
@@ -32,7 +32,7 @@ use tokio::sync::Mutex;
 use tracing::{instrument, Level};
 
 pub type UpstreamPort = gasket::messaging::InputPort<PullEvent>;
-pub type DownstreamPort = gasket::messaging::OutputPort<ValidateHeaderEvent>;
+pub type DownstreamPort = gasket::messaging::OutputPort<ValidateBlockEvent>;
 
 pub mod chain_selection;
 pub mod header;
@@ -41,8 +41,8 @@ pub mod nonce;
 pub mod store;
 
 #[derive(Stage)]
-#[stage(name = "consensus", unit = "PullEvent", worker = "Worker")]
-pub struct Stage {
+#[stage(name = "consensus.header", unit = "PullEvent", worker = "Worker")]
+pub struct HeaderStage {
     peer_sessions: HashMap<Peer, PeerSession>,
     chain_selector: Arc<Mutex<ChainSelector<ConwayHeader>>>,
     ledger: Arc<Mutex<dyn LedgerState>>,
@@ -62,7 +62,7 @@ pub struct Stage {
     validation_tip: gasket::metrics::Gauge,
 }
 
-impl Stage {
+impl HeaderStage {
     pub fn new(
         peer_sessions: Vec<PeerSession>,
         ledger: Arc<Mutex<dyn LedgerState>>,
@@ -106,7 +106,7 @@ impl Stage {
         };
 
         self.downstream
-            .send(ValidateHeaderEvent::Validated(point, block).into())
+            .send(ValidateBlockEvent::Validated(point, block).into())
             .await
             .or_panic()
     }
@@ -119,7 +119,7 @@ impl Stage {
         fork: Vec<ConwayHeader>,
     ) -> Result<(), WorkerError> {
         self.downstream
-            .send(ValidateHeaderEvent::Rollback(rollback_point.clone()).into())
+            .send(ValidateBlockEvent::Rollback(rollback_point.clone()).into())
             .await
             .or_panic()?;
 
@@ -195,7 +195,7 @@ impl Stage {
             }
             chain_selection::ChainSelection::RollbackTo(_) => {
                 self.downstream
-                    .send(ValidateHeaderEvent::Rollback(rollback.clone()).into())
+                    .send(ValidateBlockEvent::Rollback(rollback.clone()).into())
                     .await
                     .or_panic()?;
                 self.rollback_count.inc(1);
@@ -214,21 +214,25 @@ impl Stage {
 pub struct Worker {}
 
 #[async_trait::async_trait(?Send)]
-impl gasket::framework::Worker<Stage> for Worker {
-    async fn bootstrap(_stage: &Stage) -> Result<Self, WorkerError> {
+impl gasket::framework::Worker<HeaderStage> for Worker {
+    async fn bootstrap(_stage: &HeaderStage) -> Result<Self, WorkerError> {
         Ok(Self {})
     }
 
     async fn schedule(
         &mut self,
-        stage: &mut Stage,
+        stage: &mut HeaderStage,
     ) -> Result<WorkSchedule<PullEvent>, WorkerError> {
         let unit = stage.upstream.recv().await.or_panic()?;
 
         Ok(WorkSchedule::Unit(unit.payload))
     }
 
-    async fn execute(&mut self, unit: &PullEvent, stage: &mut Stage) -> Result<(), WorkerError> {
+    async fn execute(
+        &mut self,
+        unit: &PullEvent,
+        stage: &mut HeaderStage,
+    ) -> Result<(), WorkerError> {
         match unit {
             PullEvent::RollForward(peer, point, raw_header) => {
                 stage.handle_roll_forward(peer, point, raw_header).await

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -16,3 +16,6 @@
 ///
 /// The consensus interface is responsible for validating block headers.
 pub mod consensus;
+
+/// Chain forward stage
+pub mod chain_forward;

--- a/crates/ledger/src/lib.rs
+++ b/crates/ledger/src/lib.rs
@@ -189,7 +189,7 @@ impl<T: Store> gasket::framework::Worker<Stage<T>> for Worker {
     }
 }
 
-#[instrument(skip(bytes), fields(block.size = bytes.len()))]
+#[instrument(level = Level::DEBUG, skip(bytes), fields(block.size = bytes.len()))]
 fn parse_block(bytes: &[u8]) -> (Hash<32>, MintedBlock<'_>) {
     let (_, block): (u16, MintedBlock<'_>) = cbor::decode(bytes)
         .unwrap_or_else(|_| panic!("failed to decode Conway block: {:?}", hex::encode(bytes)));

--- a/crates/ledger/src/lib.rs
+++ b/crates/ledger/src/lib.rs
@@ -21,7 +21,7 @@ use pallas_codec::minicbor as cbor;
 use std::sync::Arc;
 use store::Store;
 use tokio::sync::Mutex;
-use tracing::{debug_span, instrument, warn};
+use tracing::{debug_span, instrument, warn, Level};
 
 const EVENT_TARGET: &str = "amaru::ledger";
 


### PR DESCRIPTION
This commit breaks down the consensus monolithic pipeline in 2 stages, with ledger block validation in between. While the last stage currently does nothing beyond logging the result of the ledger validation, it is intended it will be responsible for:

1. storing the blocks on disk
2. updating the node's chain candidate depending on ledger validation result
3. forward new selected chain to downstream peers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated stage to streamline block processing, improving data flow and validation.
  - Added new event types and validation results to enhance block validation processes.

- **Refactor**
  - Updated the consensus process to focus on complete block validation rather than header-only checks.
  - Enhanced the ledger’s validation and rollback handling for clearer error reporting and improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->