### PR TITLE
Rolling stake distributions

### DIFF
--- a/crates/amaru/tests/rewards.rs
+++ b/crates/amaru/tests/rewards.rs
@@ -14,14 +14,14 @@
 
 use std::path::PathBuf;
 
-use amaru_ledger::{rewards::StakeDistributionSnapshot, store::RewardsSummary};
+use amaru_ledger::{rewards::StakeDistribution, store::RewardsSummary};
 use amaru_stores::rocksdb::RocksDB;
 use pallas_primitives::Epoch;
 
 const LEDGER_DB: &str = "../../ledger.db";
 
 fn compare_preprod_snapshot(epoch: Epoch) {
-    let snapshot = StakeDistributionSnapshot::new(
+    let snapshot = StakeDistribution::new(
         &RocksDB::from_snapshot(&PathBuf::from(LEDGER_DB), epoch)
             .unwrap_or_else(|_| panic!("Failed to open ledger snapshot for epoch {}", epoch)),
     )

--- a/crates/consensus/src/consensus/mod.rs
+++ b/crates/consensus/src/consensus/mod.rs
@@ -111,6 +111,7 @@ impl Stage {
             .or_panic()
     }
 
+    #[instrument(level = Level::INFO, skip(self))]
     async fn switch_to_fork(
         &mut self,
         peer: &Peer,

--- a/crates/ledger/src/rewards.rs
+++ b/crates/ledger/src/rewards.rs
@@ -126,7 +126,7 @@ const EVENT_TARGET: &str = "amaru::ledger::state::rewards";
 #[derive(Debug)]
 pub struct StakeDistribution {
     /// Epoch number for this snapshot (taken at the end of the epoch)
-    epoch: Epoch,
+    pub epoch: Epoch,
 
     /// Total stake, in Lovelace, delegated to registered pools
     active_stake: Lovelace,

--- a/crates/ledger/src/rewards.rs
+++ b/crates/ledger/src/rewards.rs
@@ -61,20 +61,20 @@ each epoch (related to different snapshots) since it is a continuous cycle.
 
 
                                                             Computing rewards[^1] using:
-                                                            │ - snapshot(e + 1) for
+                                                            │ - snapshot(e + 2) for
                                                             │     - pool performances
                                                             │     - treasury & reserves
-                    Stake is delegated                      │ - snapshot(e) for:
-                    │                                       │     - stake distribution
-                    │                                       │     - pool parameters
-                    │                Using snapshot(e - 1)  │
-                    │                for leader schedule    │                 Distributing rewards
-                    │                │                      │                 earned from (e)
-                    │                │                      │                 │
-snapshot(e - 1)     │  snapshot(e)   │    snapshot(e + 1)   │                 │snapshot(e + 2)
-              ╽     ╽            ╽   ╽                  ╽   ╽                 ╽╽
+                   Stake is delegated                       │ - snapshot(e) for:
+                   │                                        │     - stake distribution
+                   │                                        │     - pool parameters
+                   │                 Using snapshot(e)      │
+                   │                 for leader schedule    │                 Distributing rewards
+                   │                 │                      │                 earned from (e)
+                   │                 │                      │                 │
+    snapshot(e)    │ snapshot(e+1)   │    snapshot(e + 2)   │                 │snapshot(e + 3)
+              ╽    ╽             ╽   ╽                  ╽   ╽                 ╽╽
 ━━━━━━━━━━━━╸╸╸╋━━━━━━━━━━━━━━━━╸╸╸╋╸╸╸━━━━━━━━━━━━━━━━╸╸╸╋╸╸╸━━━━━━━━━━━━━━━╸╸╸╋╸╸╸━━━━━━━━>
-   e - 1               e                    e + 1                 e + 2              e + 3
+     e                e + 1                 e + 2                 e + 3              e + 4
 
 [^1]: Technically, we need to wait a few slots for the snapshot (e + 1) to stabilise; otherwise
 we risk doing an expensive computation which may be rolled back. In practice, the calculation
@@ -238,12 +238,12 @@ impl StakeDistribution {
         let epoch = db.most_recent_snapshot();
 
         info!(
-            name: "stake_distribution.snapshot",
             target: EVENT_TARGET,
             epoch = ?epoch,
             active_stake = ?active_stake,
             accounts = ?(keys.len() + scripts.len()),
             pools = ?pools.len(),
+            "stake_distribution.snapshot",
         );
 
         Ok(StakeDistribution {
@@ -679,7 +679,6 @@ impl RewardsSummary {
         });
 
         info!(
-            name: "rewards.summary",
             target: EVENT_TARGET,
             epoch = ?snapshot.epoch,
             ?efficiency,
@@ -691,6 +690,7 @@ impl RewardsSummary {
             pots.reserves = ?pots.reserves,
             pots.treasury = ?pots.treasury,
             pots.fees = ?pots.fees,
+            "rewards.summary",
         );
 
         Ok(RewardsSummary {

--- a/crates/ledger/src/state.rs
+++ b/crates/ledger/src/state.rs
@@ -240,6 +240,12 @@ impl<S: Store<Error = E>, E: std::fmt::Debug> State<S, E> {
     }
 
     pub fn backward<'b>(&mut self, to: &'b Point) -> Result<(), BackwardErr<'b>> {
+        // NOTE: This happens typically on start-up; The consensus layer will typically ask us to
+        // rollback to the last known point, which ought to be the tip of the database.
+        if self.volatile.is_empty() && self.tip().as_ref() == to {
+            return Ok(());
+        }
+
         self.volatile
             .rollback_to(to, BackwardErr::UnknownRollbackPoint(to))
     }

--- a/crates/ledger/src/state.rs
+++ b/crates/ledger/src/state.rs
@@ -23,7 +23,7 @@ use crate::{
         self, epoch_from_slot, Hash, Hasher, MintedBlock, Point, PoolId, PoolParams, PoolSigma,
         TransactionInput, TransactionOutput, CONSENSUS_SECURITY_PARAM, STABILITY_WINDOW,
     },
-    rewards::RewardsSummary,
+    rewards::{RewardsSummary, StakeDistribution},
     state::volatile_db::{StoreUpdate, VolatileDB, VolatileState},
     store::{columns::*, Store},
 };

--- a/crates/ledger/src/store.rs
+++ b/crates/ledger/src/store.rs
@@ -15,7 +15,7 @@
 pub mod columns;
 
 use super::kernel::{Epoch, Point, PoolId, TransactionInput, TransactionOutput};
-pub use crate::rewards::RewardsSummary;
+pub use crate::rewards::{RewardsSummary, StakeDistribution};
 use columns::*;
 use std::{borrow::BorrowMut, iter};
 
@@ -75,8 +75,14 @@ pub trait Store: Send + Sync {
         input: &TransactionInput,
     ) -> Result<Option<TransactionOutput>, Self::Error>;
 
-    /// Compute rewards using database snapshots.
-    fn rewards_summary(&self, epoch: Epoch) -> Result<RewardsSummary, Self::Error>;
+    /// Compute stake distribution using database snapshots.
+    fn stake_distribution(&self, epoch: Epoch) -> Result<StakeDistribution, Self::Error>;
+
+    /// Compute rewards using database snapshots and a previously computed stake distribution.
+    fn rewards_summary(
+        &self,
+        stake_distribution: StakeDistribution,
+    ) -> Result<RewardsSummary, Self::Error>;
 
     /// Get current values of the treasury and reserves accounts.
     fn with_pots<A>(

--- a/crates/stores/src/rocksdb/mod.rs
+++ b/crates/stores/src/rocksdb/mod.rs
@@ -210,11 +210,11 @@ impl Store for RocksDB {
                 pools::add(&batch, add.pools)?;
                 accounts::add(&batch, add.accounts)?;
 
+                accounts::reset(&batch, withdrawals)?;
+
                 utxo::remove(&batch, remove.utxo)?;
                 pools::remove(&batch, remove.pools)?;
                 accounts::remove(&batch, remove.accounts)?;
-
-                accounts::reset(&batch, withdrawals)?;
             }
         }
 

--- a/crates/stores/src/rocksdb/mod.rs
+++ b/crates/stores/src/rocksdb/mod.rs
@@ -19,7 +19,7 @@ use amaru_ledger::{
         borrow::{borrowable_proxy::BorrowableProxy, IterBorrow},
     },
     kernel::{Epoch, Point, PoolId, TransactionInput, TransactionOutput},
-    rewards::StakeDistributionSnapshot,
+    rewards::StakeDistribution,
     store::{columns as scolumns, Columns, RewardsSummary, Store},
 };
 use columns::*;

--- a/crates/stores/src/rocksdb/mod.rs
+++ b/crates/stores/src/rocksdb/mod.rs
@@ -30,7 +30,7 @@ use std::{
     fmt, fs, io,
     path::{Path, PathBuf},
 };
-use tracing::{debug, debug_span, info, warn};
+use tracing::{debug, debug_span, info, info_span, warn};
 
 pub mod columns;
 pub mod common;
@@ -236,7 +236,7 @@ impl Store for RocksDB {
         let snapshot = self.snapshots.last().map(|s| s + 1).unwrap_or(epoch);
         if snapshot == epoch {
             if let Some(mut rewards_summary) = rewards_summary {
-                debug_span!(target: EVENT_TARGET, "snapshot.applying_rewards").in_scope(|| {
+                info_span!(target: EVENT_TARGET, "snapshot.applying_rewards").in_scope(|| {
                     self.with_accounts(|iterator| {
                         for (account, mut row) in iterator {
                             if let Some(rewards) = rewards_summary.extract_rewards(&account) {

--- a/crates/stores/src/rocksdb/mod.rs
+++ b/crates/stores/src/rocksdb/mod.rs
@@ -296,21 +296,25 @@ impl Store for RocksDB {
         Ok(())
     }
 
-    fn rewards_summary(&self, epoch: Epoch) -> Result<RewardsSummary, Self::Error> {
-        let stake_distr = StakeDistributionSnapshot::new(
-            &Self::from_snapshot(&self.dir, epoch - 2).unwrap_or_else(|e| {
-                panic!(
-                    "unable to open database snapshot for epoch {:?}: {:?}",
-                    epoch - 2,
-                    e
-                )
-            }),
-        )?;
+    fn stake_distribution(&self, epoch: Epoch) -> Result<StakeDistribution, Self::Error> {
+        StakeDistribution::new(&Self::from_snapshot(&self.dir, epoch).unwrap_or_else(|e| {
+            panic!(
+                "unable to open database snapshot for epoch {:?}: {:?}",
+                epoch, e
+            )
+        }))
+    }
+
+    fn rewards_summary(
+        &self,
+        stake_distr: StakeDistribution,
+    ) -> Result<RewardsSummary, Self::Error> {
         RewardsSummary::new(
-            &Self::from_snapshot(&self.dir, epoch).unwrap_or_else(|e| {
+            &Self::from_snapshot(&self.dir, stake_distr.epoch + 2).unwrap_or_else(|e| {
                 panic!(
                     "unable to open database snapshot for epoch {:?}: {:?}",
-                    epoch, e
+                    stake_distr.epoch + 2,
+                    e
                 )
             }),
             stake_distr,

--- a/crates/stores/src/rocksdb/mod.rs
+++ b/crates/stores/src/rocksdb/mod.rs
@@ -91,7 +91,6 @@ impl RocksDB {
                 .unwrap_or_default()
                 .parse::<Epoch>()
             {
-                info!(target: EVENT_TARGET, epoch, "new.found_snapshot");
                 snapshots.push(epoch);
             } else if entry.file_name() != DIR_LIVE_DB {
                 warn!(
@@ -103,6 +102,8 @@ impl RocksDB {
         }
 
         snapshots.sort();
+
+        info!(target: EVENT_TARGET, snapshots = ?snapshots, "new.known_snapshots");
 
         let mut opts = Options::default();
         opts.create_if_missing(true);


### PR DESCRIPTION
This PR ensures that we now keep the last 2 stake distributions readily available in plain memory. The most recent one is meant to be used by the consensus to validate the leader schedule, whereas the oldest one intervenes in the rewards calculation mid-epoch. 

The rewards calculation consumes the stake distribution, and pushes a new one from the previous epoch. 

It also fixes a couple of small things I noticed along the way regarding withdrawals, traces or diagrams 😬 ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded rewards processing now utilises updated distribution data for more accurate and consistent summaries.
  
- **Refactor**
	- Reorganised rewards and state management across core systems for improved clarity and reliability.
	- These updates streamline backend operations, ensuring a smoother and more dependable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->