### PR TITLE
Debug as trace and env for flags

### DIFF
--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 
 [dependencies]
 async-trait.workspace = true
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive", "env"] }
 gasket = { workspace = true, features = ["derive"] }
 hex.workspace = true
 indicatif.workspace = true

--- a/crates/amaru/src/bin/amaru/cmd/daemon.rs
+++ b/crates/amaru/src/bin/amaru/cmd/daemon.rs
@@ -22,7 +22,7 @@ use pallas_network::facades::PeerClient;
 use std::{path::PathBuf, sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error};
+use tracing::{error, trace};
 
 #[derive(Debug, Parser)]
 pub struct Args {
@@ -90,13 +90,13 @@ pub async fn run_pipeline(pipeline: gasket::daemon::Daemon, exit: CancellationTo
                 }
             }
             _ = exit.cancelled() => {
-                debug!("exit requested");
+                trace!("exit requested");
                 break;
             }
         }
     }
 
-    debug!("shutting down pipeline");
+    trace!("shutting down pipeline");
 
     pipeline.teardown();
 }

--- a/crates/amaru/src/bin/amaru/exit.rs
+++ b/crates/amaru/src/bin/amaru/exit.rs
@@ -14,9 +14,9 @@
 
 use tokio_util::sync::CancellationToken;
 #[cfg(windows)]
-use tracing::debug;
+use tracing::trace;
 #[cfg(unix)]
-use tracing::{debug, warn};
+use tracing::{trace, warn};
 
 #[inline]
 #[cfg(unix)]
@@ -46,7 +46,7 @@ pub fn hook_exit_token() -> CancellationToken {
     let cancel2 = cancel.clone();
     tokio::spawn(async move {
         wait_for_exit_signal().await;
-        debug!("notifying exit");
+        trace!("notifying exit");
         cancel2.cancel();
     });
 

--- a/crates/amaru/src/bin/amaru/main.rs
+++ b/crates/amaru/src/bin/amaru/main.rs
@@ -41,9 +41,9 @@ enum Command {
 struct Cli {
     #[command(subcommand)]
     command: Command,
-    #[clap(long, action)]
+    #[clap(long, action, env("AMARU_WITH_OPEN_TELEMETRY"))]
     with_open_telemetry: bool,
-    #[clap(long, action)]
+    #[clap(long, action, env("AMARU_WITH_JSON_TRACES"))]
     with_json_traces: bool,
 }
 

--- a/crates/amaru/src/bin/amaru/observability.rs
+++ b/crates/amaru/src/bin/amaru/observability.rs
@@ -84,7 +84,7 @@ impl TracingSubscriber<Registry> {
     }
 
     pub fn init(self) {
-        let log_format = || tracing_subscriber::fmt::format().with_ansi(true).pretty();
+        let log_format = || tracing_subscriber::fmt::format().with_ansi(true).compact();
         let log_writer = || io::stderr as fn() -> io::Stderr;
         let log_events = || FmtSpan::ENTER;
         let log_filter = || default_filter(AMARU_LOG_VAR, DEFAULT_AMARU_LOG_FILTER);

--- a/crates/amaru/src/bin/amaru/observability.rs
+++ b/crates/amaru/src/bin/amaru/observability.rs
@@ -20,11 +20,11 @@ const SERVICE_NAME: &str = "amaru";
 
 const AMARU_LOG_VAR: &str = "AMARU_LOG";
 
-const DEFAULT_AMARU_LOG_FILTER: &str = "amaru=info";
+const DEFAULT_AMARU_LOG_FILTER: &str = "amaru=debug";
 
 const AMARU_TRACE_VAR: &str = "AMARU_TRACE";
 
-const DEFAULT_AMARU_TRACE_FILTER: &str = "amaru=debug";
+const DEFAULT_AMARU_TRACE_FILTER: &str = "amaru=trace";
 
 // -----------------------------------------------------------------------------
 // TracingSubscriber

--- a/crates/amaru/src/sync/pull.rs
+++ b/crates/amaru/src/sync/pull.rs
@@ -66,7 +66,14 @@ impl Stage {
         self.chain_tip.set(tip.0.slot_or_default() as i64);
     }
 
-    #[instrument(level = Level::DEBUG, skip(self), fields(peer = ?self.peer_session.peer.name, intersection = self.intersection.last().unwrap().slot_or_default()))]
+    #[instrument(
+        level = Level::TRACE,
+        skip(self),
+        fields(
+            peer = self.peer_session.peer.name,
+            intersection.slot = self.intersection.last().unwrap().slot_or_default(),
+        ),
+    )]
     pub async fn find_intersection(&self) -> Result<(), WorkerError> {
         let mut peer_client = self.peer_session.peer_client.lock().await;
         let client = (*peer_client).chainsync();

--- a/crates/consensus/src/chain_forward.rs
+++ b/crates/consensus/src/chain_forward.rs
@@ -20,7 +20,7 @@ use amaru_ledger::BlockValidationResult;
 use gasket::framework::*;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, trace, warn};
 
 pub type UpstreamPort = gasket::messaging::InputPort<BlockValidationResult>;
 
@@ -76,19 +76,19 @@ impl gasket::framework::Worker<ForwardStage> for Worker {
     ) -> Result<(), WorkerError> {
         match unit {
             BlockValidationResult::BlockValidated(point) => {
-                debug!(target: EVENT_TARGET, slot = ?point.slot_or_default(), hash = point_hash(point).to_string(), "block_validated");
+                trace!(target: EVENT_TARGET, slot = point.slot_or_default(), hash = %point_hash(point), "block_validated");
                 Ok(())
             }
             BlockValidationResult::BlockForwardStorageFailed(point) => {
-                error!(target: EVENT_TARGET, slot = ?point.slot_or_default(), hash = point_hash(point).to_string(), "storage_failed");
+                error!(target: EVENT_TARGET, slot = point.slot_or_default(), hash = %point_hash(point), "storage_failed");
                 Err(WorkerError::Panic)
             }
             BlockValidationResult::InvalidRollbackPoint(point) => {
-                warn!(target: EVENT_TARGET, slot = ?point.slot_or_default(), hash = point_hash(point).to_string(), "invalid_rollback_point");
+                warn!(target: EVENT_TARGET, slot = point.slot_or_default(), hash = %point_hash(point), "invalid_rollback_point");
                 Ok(())
             }
             BlockValidationResult::RolledBackTo(point) => {
-                info!(target: EVENT_TARGET, slot = ?point.slot_or_default(), hash = point_hash(point).to_string(),  "rolled_back_to");
+                info!(target: EVENT_TARGET, slot = point.slot_or_default(), hash = %point_hash(point),  "rolled_back_to");
                 Ok(())
             }
         }

--- a/crates/consensus/src/consensus/chain_selection.rs
+++ b/crates/consensus/src/consensus/chain_selection.rs
@@ -166,7 +166,14 @@ where
     ///
     /// The function returns the result of the chain selection process, which might lead
     /// to a new tip, a switch to a fork, no change, or some change in status for the peer.
-    #[instrument(level = Level::DEBUG, skip(self, header), fields(header.slot = header.slot(), header.hash = header.hash().to_string()))]
+    #[instrument(
+        level = Level::TRACE,
+        skip(self, header),
+        fields(
+            header.slot = header.slot(),
+            header.hash = %header.hash(),
+        ),
+    )]
     pub fn roll_forward(&mut self, peer: &Peer, header: H) -> ChainSelection<H> {
         let fragment = self.peers_chains.get_mut(peer).unwrap();
 
@@ -209,7 +216,7 @@ where
     /// If the chain of the peer is still the longest, the function will return a
     /// `RollbackTo` result, otherwise it will return a `NewTip` result with the new
     /// tip of the chain.
-    #[instrument(level = Level::DEBUG, skip(self), fields(peer = peer.name, %point))]
+    #[instrument(level = Level::TRACE, skip(self), fields(peer = peer.name, point.hash = %point))]
     pub fn rollback(&mut self, peer: &Peer, point: Hash<32>) -> ChainSelection<H> {
         self.rollback_fragment(peer, point);
 
@@ -234,7 +241,7 @@ where
         result
     }
 
-    #[instrument(level = Level::DEBUG, skip(self))]
+    #[instrument(level = Level::TRACE, skip(self))]
     fn find_best_chain(&self) -> Option<(Peer, H)> {
         let mut best: Option<(Peer, H)> = None;
         for (peer, fragment) in self.peers_chains.iter() {
@@ -246,7 +253,7 @@ where
         best
     }
 
-    #[instrument(level = Level::DEBUG, skip(self), fields(peer = peer.name, %point))]
+    #[instrument(level = Level::TRACE, skip(self), fields(peer = peer.name, point.hash = %point))]
     fn rollback_fragment(&mut self, peer: &Peer, point: Hash<32>) {
         let fragment = self.peers_chains.get_mut(peer).unwrap();
         let rollback_point = fragment.position_of(point).map_or(0, |p| p + 1);

--- a/crates/consensus/src/consensus/header_validation.rs
+++ b/crates/consensus/src/consensus/header_validation.rs
@@ -23,7 +23,7 @@ use tracing::{instrument, warn, Level};
 
 use super::header::{ConwayHeader, Header};
 
-#[instrument(level = Level::DEBUG, skip_all)]
+#[instrument(level = Level::TRACE, skip_all)]
 pub fn assert_header<'a>(
     header: &ConwayHeader,
     cbor: &'a [u8],

--- a/crates/consensus/src/consensus/store/rocksdb.rs
+++ b/crates/consensus/src/consensus/store/rocksdb.rs
@@ -33,7 +33,7 @@ impl<H: Header> ChainStore<H> for RocksDBStore {
             .and_then(|bytes| H::from_cbor(bytes?.as_ref()))
     }
 
-    #[instrument(level = Level::DEBUG, skip(self, header, hash), fields(hash = hash.to_string()))]
+    #[instrument(level = Level::TRACE, skip_all, fields(%hash))]
     fn store_header(&mut self, hash: &Hash<32>, header: &H) -> Result<(), super::StoreError> {
         self.db
             .put(hash, header.to_cbor())

--- a/crates/ledger/src/lib.rs
+++ b/crates/ledger/src/lib.rs
@@ -19,7 +19,7 @@ use state::BackwardError;
 use std::sync::Arc;
 use store::Store;
 use tokio::sync::Mutex;
-use tracing::{debug_span, instrument, warn, Level};
+use tracing::{instrument, trace_span, warn, Level};
 
 const EVENT_TARGET: &str = "amaru::ledger";
 
@@ -95,7 +95,7 @@ impl<S: Store> Stage<S> {
         raw_block: RawBlock,
     ) -> BlockValidationResult {
         // TODO: use instrument macro
-        let span_forward = debug_span!(
+        let span_forward = trace_span!(
             target: EVENT_TARGET,
             "forward",
             header.height = tracing::field::Empty,
@@ -125,7 +125,7 @@ impl<S: Store> Stage<S> {
     }
 
     pub async fn rollback_to(&mut self, point: Point) -> BlockValidationResult {
-        let span_backward = debug_span!(
+        let span_backward = trace_span!(
             target: EVENT_TARGET,
             "backward",
             point.slot = point.slot_or_default(),
@@ -187,7 +187,7 @@ impl<S: Store> gasket::framework::Worker<Stage<S>> for Worker {
     }
 }
 
-#[instrument(level = Level::DEBUG, skip(bytes), fields(block.size = bytes.len()))]
+#[instrument(level = Level::TRACE, skip(bytes), fields(block.size = bytes.len()))]
 fn parse_block(bytes: &[u8]) -> (Hash<32>, MintedBlock<'_>) {
     let (_, block): (u16, MintedBlock<'_>) = cbor::decode(bytes)
         .unwrap_or_else(|_| panic!("failed to decode Conway block: {:?}", hex::encode(bytes)));

--- a/crates/ledger/src/state/transaction.rs
+++ b/crates/ledger/src/state/transaction.rs
@@ -22,7 +22,7 @@ use crate::kernel::{
     TransactionInput, TransactionOutput, STAKE_CREDENTIAL_DEPOSIT,
 };
 use std::collections::{BTreeMap, BTreeSet};
-use tracing::{debug, debug_span, Span};
+use tracing::{trace, trace_span, Span};
 
 const EVENT_TARGET: &str = "amaru::ledger::state::transaction";
 
@@ -34,7 +34,7 @@ pub fn apply(
     mut transaction_body: MintedTransactionBody<'_>,
     resolved_collateral_inputs: Vec<TransactionOutput>,
 ) {
-    let span = debug_span!(
+    let span = trace_span!(
         target: EVENT_TARGET,
         parent: parent,
         "apply.transaction",
@@ -212,21 +212,20 @@ fn apply_certificates(
     for certificate in certificates {
         match certificate {
                 Certificate::StakeRegistration(credential) | Certificate::Reg(credential, ..) | Certificate::VoteRegDeleg(credential, ..) => {
-                    debug!(name: "certificate.stake.registration", target: EVENT_TARGET, parent: parent, credential = ?credential);
-                        accounts
-                        .register(credential, STAKE_CREDENTIAL_DEPOSIT as Lovelace, None);
+                    trace!(name: "certificate.stake.registration", target: EVENT_TARGET, parent: parent, credential = ?credential);
+                    accounts.register(credential, STAKE_CREDENTIAL_DEPOSIT as Lovelace, None);
                 }
                 Certificate::StakeDelegation(credential, pool)
                 // FIXME: register DRep delegation
                 | Certificate::StakeVoteDeleg(credential, pool, ..) => {
-                    debug!(name: "certificate.stake.delegation", target: EVENT_TARGET, parent: parent, credential = ?credential, pool = %pool);
+                    trace!(name: "certificate.stake.delegation", target: EVENT_TARGET, parent: parent, credential = ?credential, pool = %pool);
                     accounts.bind(credential, Some(pool));
                 }
                 Certificate::StakeRegDeleg(credential, pool, ..)
                 // FIXME: register DRep delegation
                 | Certificate::StakeVoteRegDeleg(credential, pool, ..) => {
-                    debug!(name: "certificate.stake.registration", target: EVENT_TARGET, parent: parent, credential = ?credential);
-                    debug!(name: "certificate.stake.delegation", target: EVENT_TARGET, parent: parent, credential = ?credential, pool = %pool);
+                    trace!(name: "certificate.stake.registration", target: EVENT_TARGET, parent: parent, credential = ?credential);
+                    trace!(name: "certificate.stake.delegation", target: EVENT_TARGET, parent: parent, credential = ?credential, pool = %pool);
                     accounts.register(
                         credential,
                         STAKE_CREDENTIAL_DEPOSIT as Lovelace,
@@ -235,11 +234,11 @@ fn apply_certificates(
                 }
                 Certificate::StakeDeregistration(credential)
                 | Certificate::UnReg(credential, ..) => {
-                    debug!(name: "certificate.stake.deregistration", target: EVENT_TARGET, parent: parent, credential = ?credential);
+                    trace!(name: "certificate.stake.deregistration", target: EVENT_TARGET, parent: parent, credential = ?credential);
                     accounts.unregister(credential);
                 }
                 Certificate::PoolRetirement(id, epoch) => {
-                    debug!(name: "certificate.pool.retirement", target: EVENT_TARGET, parent: parent, pool = %id, epoch = %epoch);
+                    trace!(name: "certificate.pool.retirement", target: EVENT_TARGET, parent: parent, pool = %id, epoch = %epoch);
                     pools.unregister(id, epoch)
                 }
                 Certificate::PoolRegistration {
@@ -264,7 +263,7 @@ fn apply_certificates(
                         relays,
                         metadata,
                     };
-                    debug!(
+                    trace!(
                         name: "certificate.pool.registration",
                         target: EVENT_TARGET,
                         parent: parent,

--- a/crates/ledger/src/store/columns/pools.rs
+++ b/crates/ledger/src/store/columns/pools.rs
@@ -17,7 +17,7 @@ use crate::{
     kernel::{Epoch, PoolId, PoolParams},
 };
 use pallas_codec::minicbor::{self as cbor};
-use tracing::debug;
+use tracing::trace;
 
 pub const EVENT_TARGET: &str = "amaru::ledger::store::pools";
 
@@ -76,7 +76,7 @@ impl Row {
             // which is taken care of in the fold above (returning 'None').
             if let Some(epoch) = retirement {
                 if epoch <= current_epoch {
-                    debug!(
+                    trace!(
                         target: EVENT_TARGET,
                         pool = %pool
                             .as_ref()
@@ -123,7 +123,7 @@ impl Row {
                 .unwrap_or_else(|| unreachable!("pre-condition: needs_update"));
 
             if let Some(new_params) = update {
-                debug!(
+                trace!(
                     target: EVENT_TARGET,
                     pool = %pool.current_params.id,
                     ?new_params,

--- a/engineering-decision-records/007-observability.md
+++ b/engineering-decision-records/007-observability.md
@@ -37,8 +37,8 @@ We would like the codebase to organize the metrics it tracks in a simple, consis
   - We will make judicious use of [Spans](https://opentelemetry.io/docs/concepts/observability-primer/#spans) to expose the structured nature of the workload the Amaru node performs.
 
 - We define the frontier between logs and traces by following a simple rule:
-  - Any event at the INFO level is considered a log
-  - Any event at the DEBUG level is considered a trace
+  - Any event at the DEBUG level or above is considered a log
+  - Any event at the TRACE level is considered a trace
 
 ### Metrics
 


### PR DESCRIPTION
- :round_pushpin: **chore: lower trace severities down to ... trace**
    Turns out we actually have a Trace severity level available in the
  tracing library, so we need not to "abuse" the Debug severity for it.
  Overall, it clarifies even better the boundary between logs and
  traces.

- :round_pushpin: **chore: switch log format to from 'pretty' to 'compact'**
    Note: they are still quite pretty.

- :round_pushpin: **feat: allow driving log/trace behaviour via environment variables too.**
    This increases the flexibility of the observability interface since
  one can now pre-configure its environment using the desired behaviour
  and omit using the CLI flags. So for example, one can define a `.envrc` using:

  ```
  export AMARU_LOG=off
  export AMARU_WITH_JSON_TRACES=true
  ```

  To automatically get structured JSON logs on stdout, and nothing on stderr.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- New Features  
  • Environment variable support has been added for telemetry and JSON trace options, allowing for easier configuration via the command line.

- Bug Fixes  
  • Enhanced logging granularity across various components, improving the detail of logged information for better debugging.

- Chores  
  • Logging has been refined throughout the application, with trace-level detail and a more compact output to enhance debugging and monitoring.

- Documentation  
  • The observability guidelines have been updated to clearly distinguish between logs and traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->