### PR TITLE
feat: connect span across stages

### DIFF
--- a/crates/amaru/src/sync/pull.rs
+++ b/crates/amaru/src/sync/pull.rs
@@ -22,7 +22,7 @@ use pallas_network::miniprotocols::{
 use pallas_traverse::MultiEraHeader;
 use std::time::Duration;
 use tokio::time::timeout;
-use tracing::{instrument, Level};
+use tracing::{debug_span, instrument, Level};
 
 pub fn to_traverse(header: &HeaderContent) -> Result<MultiEraHeader<'_>, WorkerError> {
     let out = match header.byron_prefix {
@@ -34,6 +34,8 @@ pub fn to_traverse(header: &HeaderContent) -> Result<MultiEraHeader<'_>, WorkerE
 }
 
 pub type DownstreamPort = gasket::messaging::OutputPort<PullEvent>;
+
+const EVENT_TARGET: &str = "amaru::sync";
 
 pub enum WorkUnit {
     Pull,
@@ -86,6 +88,45 @@ impl Stage {
         let _intersection = point.ok_or(miette!("couldn't find intersect")).or_panic()?;
         Ok(())
     }
+
+    pub async fn roll_forward(&mut self, header: &HeaderContent) -> Result<(), WorkerError> {
+        let span_forward = debug_span!(
+            target: EVENT_TARGET,
+            "pull.roll_forward",
+            header.slot = tracing::field::Empty,
+            header.hash = tracing::field::Empty,
+            peer = self.peer_session.peer.name
+        );
+
+        let peer = &self.peer_session.peer;
+        let header = to_traverse(header).or_panic()?;
+        let point = Point::Specific(header.slot(), header.hash().to_vec());
+
+        let raw_header: RawHeader = header.cbor().to_vec();
+
+        self.downstream
+            .send(PullEvent::RollForward(peer.clone(), point, raw_header, span_forward).into())
+            .await
+            .or_panic()
+    }
+
+    pub async fn roll_back(&mut self, point: Point, tip: Tip) -> Result<(), WorkerError> {
+        let span_backward = debug_span!(
+            target: EVENT_TARGET,
+            "pull.roll_back",
+            point = tracing::field::Empty,
+            tip = tracing::field::Empty,
+            peer = self.peer_session.peer.name
+        );
+
+        self.track_tip(&tip);
+
+        let peer = &self.peer_session.peer;
+        self.downstream
+            .send(PullEvent::Rollback(peer.clone(), point, span_backward).into())
+            .await
+            .or_panic()
+    }
 }
 
 pub struct Worker {}
@@ -132,31 +173,12 @@ impl gasket::framework::Worker<Stage> for Worker {
             }
         };
 
-        let peer = &stage.peer_session.peer;
-
         match next {
-            NextResponse::RollForward(header, tip) => {
-                let header = to_traverse(&header).or_panic()?;
-                let point = Point::Specific(header.slot(), header.hash().to_vec());
-
-                let raw_header: RawHeader = header.cbor().to_vec();
-
-                stage
-                    .downstream
-                    .send(PullEvent::RollForward(peer.clone(), point, raw_header).into())
-                    .await
-                    .or_panic()?;
-
-                stage.track_tip(&tip);
+            NextResponse::RollForward(header, _tip) => {
+                stage.roll_forward(&header).await?;
             }
             NextResponse::RollBackward(point, tip) => {
-                stage
-                    .downstream
-                    .send(PullEvent::Rollback(peer.clone(), point).into())
-                    .await
-                    .or_panic()?;
-
-                stage.track_tip(&tip);
+                stage.roll_back(point, tip).await?;
             }
             NextResponse::Await => {}
         };

--- a/crates/amaru/src/sync/pull.rs
+++ b/crates/amaru/src/sync/pull.rs
@@ -22,7 +22,7 @@ use pallas_network::miniprotocols::{
 use pallas_traverse::MultiEraHeader;
 use std::time::Duration;
 use tokio::time::timeout;
-use tracing::{debug_span, instrument, Level};
+use tracing::{instrument, trace_span, Level};
 
 pub fn to_traverse(header: &HeaderContent) -> Result<MultiEraHeader<'_>, WorkerError> {
     let out = match header.byron_prefix {
@@ -90,7 +90,7 @@ impl Stage {
     }
 
     pub async fn roll_forward(&mut self, header: &HeaderContent) -> Result<(), WorkerError> {
-        let span_forward = debug_span!(
+        let span_forward = trace_span!(
             target: EVENT_TARGET,
             "pull.roll_forward",
             header.slot = tracing::field::Empty,
@@ -111,7 +111,7 @@ impl Stage {
     }
 
     pub async fn roll_back(&mut self, point: Point, tip: Tip) -> Result<(), WorkerError> {
-        let span_backward = debug_span!(
+        let span_backward = trace_span!(
             target: EVENT_TARGET,
             "pull.roll_back",
             point = tracing::field::Empty,

--- a/crates/consensus/src/chain_forward.rs
+++ b/crates/consensus/src/chain_forward.rs
@@ -95,7 +95,7 @@ impl gasket::framework::Worker<ForwardStage> for Worker {
                     parent: span,
                     "forward.storage_failed",
                     slot = ?point.slot_or_default(),
-                    hash = point_hash(point).to_string()
+                    hash = %point_hash(point)
                 );
 
                 Err(WorkerError::Panic)

--- a/crates/consensus/src/chain_forward.rs
+++ b/crates/consensus/src/chain_forward.rs
@@ -20,7 +20,7 @@ use amaru_ledger::BlockValidationResult;
 use gasket::framework::*;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::{error, info, trace, warn};
+use tracing::{error_span, info, trace_span, warn};
 
 pub type UpstreamPort = gasket::messaging::InputPort<BlockValidationResult>;
 
@@ -75,12 +75,29 @@ impl gasket::framework::Worker<ForwardStage> for Worker {
         _stage: &mut ForwardStage,
     ) -> Result<(), WorkerError> {
         match unit {
-            BlockValidationResult::BlockValidated(point) => {
-                trace!(target: EVENT_TARGET, slot = point.slot_or_default(), hash = %point_hash(point), "block_validated");
+            BlockValidationResult::BlockValidated(point, span) => {
+                // FIXME: this span is just a placeholder to hold a link to t
+                // the parent, it will be filled once we had the storage and
+                // forwarding logic.
+                let _span = trace_span!(
+                    target: EVENT_TARGET,
+                    parent: span,
+                    "forward.block_validated",
+                    slot = ?point.slot_or_default(),
+                    hash = point_hash(point).to_string()
+                );
+
                 Ok(())
             }
-            BlockValidationResult::BlockForwardStorageFailed(point) => {
-                error!(target: EVENT_TARGET, slot = point.slot_or_default(), hash = %point_hash(point), "storage_failed");
+            BlockValidationResult::BlockForwardStorageFailed(point, span) => {
+                let _span = error_span!(
+                    target: EVENT_TARGET,
+                    parent: span,
+                    "forward.storage_failed",
+                    slot = ?point.slot_or_default(),
+                    hash = point_hash(point).to_string()
+                );
+
                 Err(WorkerError::Panic)
             }
             BlockValidationResult::InvalidRollbackPoint(point) => {

--- a/crates/consensus/src/consensus/mod.rs
+++ b/crates/consensus/src/consensus/mod.rs
@@ -29,7 +29,7 @@ use pallas_traverse::ComputeHash;
 use std::{collections::HashMap, sync::Arc};
 use store::ChainStore;
 use tokio::sync::Mutex;
-use tracing::{instrument, trace, Level};
+use tracing::{instrument, trace, Level, Span};
 
 pub type UpstreamPort = gasket::messaging::InputPort<PullEvent>;
 pub type DownstreamPort = gasket::messaging::OutputPort<ValidateBlockEvent>;
@@ -94,7 +94,12 @@ impl HeaderStage {
         self.validation_tip.set(tip.slot_or_default() as i64);
     }
 
-    async fn forward_block(&mut self, peer: &Peer, header: &dyn Header) -> Result<(), WorkerError> {
+    async fn forward_block(
+        &mut self,
+        peer: &Peer,
+        header: &dyn Header,
+        parent_span: &Span,
+    ) -> Result<(), WorkerError> {
         let point = header.point();
         let block = {
             // FIXME: should not crash if the peer is not found
@@ -108,7 +113,7 @@ impl HeaderStage {
         };
 
         self.downstream
-            .send(ValidateBlockEvent::Validated(point, block).into())
+            .send(ValidateBlockEvent::Validated(point, block, parent_span.clone()).into())
             .await
             .or_panic()
     }
@@ -127,6 +132,7 @@ impl HeaderStage {
         peer: &Peer,
         rollback_point: &Point,
         fork: Vec<ConwayHeader>,
+        parent_span: &Span,
     ) -> Result<(), WorkerError> {
         self.downstream
             .send(ValidateBlockEvent::Rollback(rollback_point.clone()).into())
@@ -134,7 +140,7 @@ impl HeaderStage {
             .or_panic()?;
 
         for header in fork {
-            self.forward_block(peer, &header).await?;
+            self.forward_block(peer, &header, parent_span).await?;
         }
 
         Ok(())
@@ -154,6 +160,7 @@ impl HeaderStage {
         peer: &Peer,
         point: &Point,
         raw_header: &[u8],
+        parent_span: &Span,
     ) -> Result<(), WorkerError> {
         let header: babbage::MintedHeader<'_> = minicbor::decode(raw_header)
             .map_err(|e| miette!(e))
@@ -181,7 +188,7 @@ impl HeaderStage {
         match result {
             chain_selection::ChainSelection::NewTip(hdr) => {
                 trace!(target: EVENT_TARGET, hash = %hdr.hash(), "new_tip");
-                self.forward_block(peer, &hdr).await?;
+                self.forward_block(peer, &hdr, parent_span).await?;
 
                 self.block_count.inc(1);
                 self.track_validation_tip(point);
@@ -195,17 +202,24 @@ impl HeaderStage {
                 tip: _,
                 fork,
             } => {
-                self.switch_to_fork(&peer, &rollback_point, fork).await?;
+                self.switch_to_fork(&peer, &rollback_point, fork, parent_span)
+                    .await?;
             }
             chain_selection::ChainSelection::NoChange => {
                 trace!(target: EVENT_TARGET, hash = %header.hash(), "no_change");
             }
         }
+
         Ok(())
     }
 
-    #[instrument(level = Level::TRACE, skip(self))]
-    async fn handle_roll_back(&mut self, peer: &Peer, rollback: &Point) -> Result<(), WorkerError> {
+    #[instrument(level = Level::TRACE, skip(self, parent_span))]
+    async fn handle_roll_back(
+        &mut self,
+        peer: &Peer,
+        rollback: &Point,
+        parent_span: &Span,
+    ) -> Result<(), WorkerError> {
         let result = self
             .chain_selector
             .lock()
@@ -233,7 +247,10 @@ impl HeaderStage {
                 rollback_point,
                 fork,
                 tip: _,
-            } => self.switch_to_fork(&peer, &rollback_point, fork).await?,
+            } => {
+                self.switch_to_fork(&peer, &rollback_point, fork, parent_span)
+                    .await?
+            }
         }
 
         Ok(())
@@ -263,10 +280,14 @@ impl gasket::framework::Worker<HeaderStage> for Worker {
         stage: &mut HeaderStage,
     ) -> Result<(), WorkerError> {
         match unit {
-            PullEvent::RollForward(peer, point, raw_header) => {
-                stage.handle_roll_forward(peer, point, raw_header).await
+            PullEvent::RollForward(peer, point, raw_header, span) => {
+                stage
+                    .handle_roll_forward(peer, point, raw_header, span)
+                    .await
             }
-            PullEvent::Rollback(peer, rollback) => stage.handle_roll_back(peer, rollback).await,
+            PullEvent::Rollback(peer, rollback, span) => {
+                stage.handle_roll_back(peer, rollback, span).await
+            }
         }
     }
 }

--- a/crates/ouroboros/src/protocol/mod.rs
+++ b/crates/ouroboros/src/protocol/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use peer::Peer;
+use tracing::span::Span;
 
 pub mod peer;
 
@@ -21,6 +22,6 @@ pub type Point = pallas_network::miniprotocols::Point;
 
 #[derive(Clone)]
 pub enum PullEvent {
-    RollForward(Peer, Point, RawHeader),
-    Rollback(Peer, Point),
+    RollForward(Peer, Point, RawHeader, Span),
+    Rollback(Peer, Point, Span),
 }


### PR DESCRIPTION
As the name implies, this PR connects tracing across all the stages we currently have through a _parent span_ that's threaded through the messages sent between layers.

![Screenshot 2025-02-07 at 15 21 02](https://github.com/user-attachments/assets/ea6b2fb2-919b-43bd-9b6c-723842b96d99)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced tracing across event processing, improving diagnostics, monitoring, and overall transparency for chain events.
	- Introduced asynchronous handling for advancing and reverting chain events, ensuring smoother operation.

- **Refactor**
	- Organised event workflows by restructuring and renaming key methods, which improves clarity and control flow without altering external behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->