### PR TITLE
chore: leaner final binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,8 @@ insta.opt-level = 3
 
 [profile.test.package]
 proptest.opt-level = 3
+
+[profile.release]
+# See https://doc.rust-lang.org/cargo/reference/profiles.html
+lto = true
+codegen-units = 1


### PR DESCRIPTION
Reduce the final binary size from 21MB to 16MB on my machine (so close to 25%).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the release build configuration to enhance optimisations, leading to improved performance in production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->