### PR TITLE
chore: define a default run

### DIFF
--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -12,6 +12,7 @@ homepage.workspace = true
 documentation.workspace = true
 rust-version.workspace = true
 build = "build.rs"
+default-run = "amaru"
 
 [dependencies]
 async-trait.workspace = true


### PR DESCRIPTION
Make sure `cargo run` works and picks up the right binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The package now automatically selects a designated executable when run, streamlining the start-up process for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->