### PR TITLE
chore: move to rust 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "A Cardano blockchain node implementation"
 license = "Apache-2.0"
 authors = ["Amaru Maintainers <amaru@pragma.builders>"]
 repository = "https://github.com/pragma-org/amaru"
 homepage = "https://github.com/pragma-org/amaru"
 documentation = "https://docs.rs/amaru"
-rust-version = "1.81.0"
+rust-version = "1.85.0"
 
 [workspace]
 members = ["crates/*", "simulation/*"]

--- a/crates/amaru-consensus/src/chain_forward.rs
+++ b/crates/amaru-consensus/src/chain_forward.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::consensus::{
-    header::{point_hash, ConwayHeader},
+    header::{ConwayHeader, point_hash},
     store::ChainStore,
 };
 use amaru_ledger::BlockValidationResult;

--- a/crates/amaru-consensus/src/consensus/chain_selection.rs
+++ b/crates/amaru-consensus/src/consensus/chain_selection.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 use super::header::Header;
-use crate::{peer::Peer, ConsensusError};
+use crate::{ConsensusError, peer::Peer};
 use amaru_kernel::Point;
 use pallas_crypto::hash::Hash;
 use std::{collections::HashMap, fmt::Debug};
-use tracing::{instrument, Level};
+use tracing::{Level, instrument};
 
 /// A fragment of the chain, represented by a list of headers
 /// and an anchor.
@@ -278,7 +278,7 @@ where
 mod tests {
 
     use super::*;
-    use crate::consensus::header::test::{generate_headers_anchored_at, random_bytes, TestHeader};
+    use crate::consensus::header::test::{TestHeader, generate_headers_anchored_at, random_bytes};
 
     #[test]
     fn extends_the_chain_with_single_header_from_peer() {

--- a/crates/amaru-consensus/src/consensus/header.rs
+++ b/crates/amaru-consensus/src/consensus/header.rs
@@ -110,7 +110,7 @@ pub mod test {
     use pallas_codec::minicbor as cbor;
     use pallas_crypto::hash::Hasher;
     use proptest::prelude::*;
-    use rand::{rngs::StdRng, RngCore, SeedableRng};
+    use rand::{RngCore, SeedableRng, rngs::StdRng};
     use std::fmt::{self, Display, Formatter};
 
     /// Basic `Header` implementation for testing purposes.
@@ -185,10 +185,14 @@ pub mod test {
                     body_hash,
                 } => {
                     write!(
-                f,
-                "TestHeader {{ hash: {}, block_number: {}, slot: {}, parent: {}, body_hash: {} }}",
-                self.hash(), block_number, slot, parent, body_hash
-            )
+                        f,
+                        "TestHeader {{ hash: {}, block_number: {}, slot: {}, parent: {}, body_hash: {} }}",
+                        self.hash(),
+                        block_number,
+                        slot,
+                        parent,
+                        body_hash
+                    )
                 }
                 TestHeader::Genesis => write!(f, "Genesis"),
             }

--- a/crates/amaru-consensus/src/consensus/header_validation.rs
+++ b/crates/amaru-consensus/src/consensus/header_validation.rs
@@ -13,15 +13,15 @@
 // limitations under the License.
 
 use crate::{
+    ConsensusError,
     consensus::{
         chain_selection::{self, ChainSelector, Fork},
-        header::{point_hash, ConwayHeader, Header},
+        header::{ConwayHeader, Header, point_hash},
         store::ChainStore,
     },
     peer::{Peer, PeerSession},
-    ConsensusError,
 };
-use amaru_kernel::{epoch_from_slot, Point, ACTIVE_SLOT_COEFF_INVERSE};
+use amaru_kernel::{ACTIVE_SLOT_COEFF_INVERSE, Point, epoch_from_slot};
 use amaru_ledger::ValidateBlockEvent;
 use amaru_ouroboros::praos;
 use amaru_ouroboros_traits::HasStakeDistribution;
@@ -32,7 +32,7 @@ use pallas_primitives::{babbage, conway::Epoch};
 use pallas_traverse::ComputeHash;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
-use tracing::{instrument, trace, trace_span, Level, Span};
+use tracing::{Level, Span, instrument, trace, trace_span};
 
 const EVENT_TARGET: &str = "amaru::consensus";
 

--- a/crates/amaru-consensus/src/consensus/store/rocksdb.rs
+++ b/crates/amaru-consensus/src/consensus/store/rocksdb.rs
@@ -3,7 +3,7 @@ use crate::consensus::header::Header;
 use pallas_crypto::hash::Hash;
 use rocksdb::{OptimisticTransactionDB, Options};
 use std::path::PathBuf;
-use tracing::{instrument, Level};
+use tracing::{Level, instrument};
 
 pub struct RocksDBStore {
     pub basedir: PathBuf,
@@ -46,7 +46,7 @@ impl<H: Header> ChainStore<H> for RocksDBStore {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::consensus::header::test::{random_bytes, TestHeader};
+    use crate::consensus::header::test::{TestHeader, random_bytes};
     use std::fs::create_dir;
 
     #[test]

--- a/crates/amaru-consensus/src/consensus/wiring.rs
+++ b/crates/amaru-consensus/src/consensus/wiring.rs
@@ -1,4 +1,4 @@
-use crate::{peer::Peer, Point};
+use crate::{Point, peer::Peer};
 use amaru_ledger::ValidateBlockEvent;
 use gasket::framework::*;
 use tracing::Span;

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -23,10 +23,10 @@ While elements are being contributed upstream, they might transiently live in th
 
 use std::sync::LazyLock;
 
-use num::{rational::Ratio, BigUint};
+use num::{BigUint, rational::Ratio};
 use pallas_addresses::Error;
 use pallas_addresses::*;
-use pallas_codec::minicbor::{decode, encode, Decode, Decoder, Encode, Encoder};
+use pallas_codec::minicbor::{Decode, Decoder, Encode, Encoder, decode, encode};
 pub use pallas_codec::{
     minicbor as cbor,
     utils::{NonEmptyKeyValuePairs, Nullable, Set},

--- a/crates/amaru-ledger/src/rewards.rs
+++ b/crates/amaru-ledger/src/rewards.rs
@@ -96,17 +96,17 @@ the system at a certain point in time. We always take snapshots _at the end of e
 certain mutations are applied to the system.
 */
 
-use crate::store::{columns::*, Snapshot, StoreError};
+use crate::store::{Snapshot, StoreError, columns::*};
 use amaru_kernel::{
-    encode_bech32, expect_stake_credential, output_lovelace, output_stake_credential, Epoch, Hash,
-    Lovelace, PoolId, PoolParams, StakeCredential, ACTIVE_SLOT_COEFF_INVERSE, MAX_LOVELACE_SUPPLY,
-    MONETARY_EXPANSION, OPTIMAL_STAKE_POOLS_COUNT, PLEDGE_INFLUENCE, SHELLEY_EPOCH_LENGTH,
-    TREASURY_TAX,
+    ACTIVE_SLOT_COEFF_INVERSE, Epoch, Hash, Lovelace, MAX_LOVELACE_SUPPLY, MONETARY_EXPANSION,
+    OPTIMAL_STAKE_POOLS_COUNT, PLEDGE_INFLUENCE, PoolId, PoolParams, SHELLEY_EPOCH_LENGTH,
+    StakeCredential, TREASURY_TAX, encode_bech32, expect_stake_credential, output_lovelace,
+    output_stake_credential,
 };
 use num::{
+    BigUint,
     rational::Ratio,
     traits::{One, Zero},
-    BigUint,
 };
 use serde::ser::SerializeStruct;
 use std::{collections::BTreeMap, iter};

--- a/crates/amaru-ledger/src/rules.rs
+++ b/crates/amaru-ledger/src/rules.rs
@@ -1,16 +1,16 @@
 mod block;
 
 use amaru_kernel::{
-    alonzo::MaybeIndefArray, cbor, protocol_parameters::ProtocolParameters, Block, Hash, Hasher,
-    MintedBlock, Redeemers,
+    Block, Hash, Hasher, MintedBlock, Redeemers, alonzo::MaybeIndefArray, cbor,
+    protocol_parameters::ProtocolParameters,
 };
 
 use block::{
-    body_size::{block_body_size_valid, BlockBodySizeTooBig},
+    body_size::{BlockBodySizeTooBig, block_body_size_valid},
     ex_units::*,
-    header_size::{block_header_size_valid, BlockHeaderSizeTooBig},
+    header_size::{BlockHeaderSizeTooBig, block_header_size_valid},
 };
-use tracing::{instrument, Level};
+use tracing::{Level, instrument};
 
 pub enum RuleViolation {
     BlockBodySizeTooBig(BlockBodySizeTooBig),
@@ -93,8 +93,10 @@ mod tests {
 
         let pp = ProtocolParameters::default();
 
-        assert!(validate_block(bytes.as_slice(), pp)
-            .is_err_and(|e| matches!(e, BlockValidationError::SerializationError)))
+        assert!(
+            validate_block(bytes.as_slice(), pp)
+                .is_err_and(|e| matches!(e, BlockValidationError::SerializationError))
+        )
     }
 
     #[test]

--- a/crates/amaru-ledger/src/rules/block/body_size.rs
+++ b/crates/amaru-ledger/src/rules/block/body_size.rs
@@ -1,5 +1,5 @@
 use crate::rules::RuleViolation;
-use amaru_kernel::{protocol_parameters::ProtocolParameters, HeaderBody};
+use amaru_kernel::{HeaderBody, protocol_parameters::ProtocolParameters};
 pub struct BlockBodySizeTooBig {
     pub supplied: usize,
     pub max: usize,
@@ -41,7 +41,7 @@ pub fn block_body_size_valid(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use amaru_kernel::{cbor, Block, MintedBlock};
+    use amaru_kernel::{Block, MintedBlock, cbor};
     #[test]
     fn test_block_body_size_valid() {
         // These bytes are Conway3.block from Pallas https://github.com/txpipe/pallas/blob/main/test_data/conway3.block

--- a/crates/amaru-ledger/src/rules/block/ex_units.rs
+++ b/crates/amaru-ledger/src/rules/block/ex_units.rs
@@ -1,4 +1,4 @@
-use amaru_kernel::{protocol_parameters::ProtocolParameters, sum_ex_units, ExUnits};
+use amaru_kernel::{ExUnits, protocol_parameters::ProtocolParameters, sum_ex_units};
 
 use crate::rules::RuleViolation;
 

--- a/crates/amaru-ledger/src/rules/block/header_size.rs
+++ b/crates/amaru-ledger/src/rules/block/header_size.rs
@@ -34,7 +34,7 @@ pub fn block_header_size_valid(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use amaru_kernel::{cbor, MintedBlock};
+    use amaru_kernel::{MintedBlock, cbor};
 
     #[test]
     fn test_block_header_size_valid() {

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -21,12 +21,12 @@ pub mod volatile_db;
 use crate::{
     rewards::{RewardsSummary, StakeDistribution},
     state::volatile_db::{StoreUpdate, VolatileDB, VolatileState},
-    store::{columns::*, Store, StoreError},
+    store::{Store, StoreError, columns::*},
 };
 use amaru_kernel::{
-    self, epoch_from_slot, Epoch, Hash, Hasher, MintedBlock, Point, PoolId, Slot, TransactionInput,
-    TransactionOutput, CONSENSUS_SECURITY_PARAM, MAX_KES_EVOLUTION, SLOTS_PER_KES_PERIOD,
-    STABILITY_WINDOW,
+    self, CONSENSUS_SECURITY_PARAM, Epoch, Hash, Hasher, MAX_KES_EVOLUTION, MintedBlock, Point,
+    PoolId, SLOTS_PER_KES_PERIOD, STABILITY_WINDOW, Slot, TransactionInput, TransactionOutput,
+    epoch_from_slot,
 };
 use amaru_ouroboros_traits::{HasStakeDistribution, PoolSummary};
 use std::{
@@ -35,7 +35,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 use thiserror::Error;
-use tracing::{info_span, trace, trace_span, Span};
+use tracing::{Span, info_span, trace, trace_span};
 
 const EVENT_TARGET: &str = "amaru::ledger::state";
 

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -141,7 +141,7 @@ impl<S: Store> State<S> {
 
     /// Obtain a view of the stake distribution, to allow decoupling the ledger from other
     /// components that require access to it.
-    pub fn view_stake_distribution(&self) -> impl HasStakeDistribution {
+    pub fn view_stake_distribution(&self) -> impl HasStakeDistribution + use<S> {
         StakeDistributionView {
             view: self.stake_distributions.clone(),
         }

--- a/crates/amaru-ledger/src/state/diff_bind.rs
+++ b/crates/amaru-ledger/src/state/diff_bind.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, btree_map::Entry};
 
 /// A compact data-structure tracking changes in a DAG which supports optional linking of values with
 /// another data-structure. Items can only be linked if they have been registered first. Yet, they

--- a/crates/amaru-ledger/src/state/diff_epoch_reg.rs
+++ b/crates/amaru-ledger/src/state/diff_epoch_reg.rs
@@ -158,7 +158,7 @@ impl<'a, V> Fold<'a, V> {
 mod tests {
     use super::*;
     use proptest::prelude::*;
-    use std::collections::{btree_map, BTreeMap};
+    use std::collections::{BTreeMap, btree_map};
 
     pub const MAX_EPOCH: Epoch = 4;
 

--- a/crates/amaru-ledger/src/state/transaction.rs
+++ b/crates/amaru-ledger/src/state/transaction.rs
@@ -17,12 +17,12 @@ use super::{
     volatile_db::VolatileState,
 };
 use amaru_kernel::{
-    output_lovelace, reward_account_to_stake_credential, Certificate, Hash, Lovelace,
-    MintedTransactionBody, NonEmptyKeyValuePairs, PoolId, PoolParams, Set, StakeCredential,
-    TransactionInput, TransactionOutput, STAKE_CREDENTIAL_DEPOSIT,
+    Certificate, Hash, Lovelace, MintedTransactionBody, NonEmptyKeyValuePairs, PoolId, PoolParams,
+    STAKE_CREDENTIAL_DEPOSIT, Set, StakeCredential, TransactionInput, TransactionOutput,
+    output_lovelace, reward_account_to_stake_credential,
 };
 use std::collections::{BTreeMap, BTreeSet};
-use tracing::{trace, trace_span, Span};
+use tracing::{Span, trace, trace_span};
 
 const EVENT_TARGET: &str = "amaru::ledger::state::transaction";
 

--- a/crates/amaru-ledger/src/state/volatile_db.rs
+++ b/crates/amaru-ledger/src/state/volatile_db.rs
@@ -15,8 +15,8 @@
 use super::{diff_bind::DiffBind, diff_epoch_reg::DiffEpochReg, diff_set::DiffSet};
 use crate::store::{self, columns::*};
 use amaru_kernel::{
-    epoch_from_slot, Epoch, Lovelace, Point, PoolId, PoolParams, StakeCredential, TransactionInput,
-    TransactionOutput,
+    Epoch, Lovelace, Point, PoolId, PoolParams, StakeCredential, TransactionInput,
+    TransactionOutput, epoch_from_slot,
 };
 use std::collections::{BTreeSet, VecDeque};
 

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -16,7 +16,7 @@ pub mod columns;
 
 use crate::rewards::Pots;
 pub use crate::rewards::{RewardsSummary, StakeDistribution};
-use amaru_kernel::{cbor, Epoch, Point, PoolId, TransactionInput, TransactionOutput};
+use amaru_kernel::{Epoch, Point, PoolId, TransactionInput, TransactionOutput, cbor};
 use columns::*;
 use std::{borrow::BorrowMut, io, iter};
 use thiserror::Error;

--- a/crates/amaru-ledger/src/store/columns/accounts.rs
+++ b/crates/amaru-ledger/src/store/columns/accounts.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{cbor, Lovelace, PoolId, StakeCredential};
+use amaru_kernel::{Lovelace, PoolId, StakeCredential, cbor};
 use iter_borrow::IterBorrow;
 
 pub const EVENT_TARGET: &str = "amaru::ledger::store::accounts";

--- a/crates/amaru-ledger/src/store/columns/pools.rs
+++ b/crates/amaru-ledger/src/store/columns/pools.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{cbor, Epoch, PoolId, PoolParams};
+use amaru_kernel::{Epoch, PoolId, PoolParams, cbor};
 use iter_borrow::IterBorrow;
 use tracing::trace;
 

--- a/crates/amaru-ledger/src/store/columns/pots.rs
+++ b/crates/amaru-ledger/src/store/columns/pots.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /// This modules captures protocol-wide value pots such as treasury and reserves accounts.
-use amaru_kernel::{cbor, Lovelace};
+use amaru_kernel::{Lovelace, cbor};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Row {

--- a/crates/amaru-stores/src/rocksdb/columns/accounts.rs
+++ b/crates/amaru-stores/src/rocksdb/columns/accounts.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::rocksdb::common::{as_key, as_value, PREFIX_LEN};
+use crate::rocksdb::common::{PREFIX_LEN, as_key, as_value};
 use amaru_ledger::store::StoreError;
 use rocksdb::Transaction;
 use tracing::error;
 
-use amaru_ledger::store::columns::accounts::{Key, Row, Value, EVENT_TARGET};
+use amaru_ledger::store::columns::accounts::{EVENT_TARGET, Key, Row, Value};
 
 /// Name prefixed used for storing Account entries. UTF-8 encoding for "acct"
 pub const PREFIX: [u8; PREFIX_LEN] = [0x61, 0x63, 0x63, 0x74];

--- a/crates/amaru-stores/src/rocksdb/columns/pools.rs
+++ b/crates/amaru-stores/src/rocksdb/columns/pools.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::super::common::{as_key, as_value, PREFIX_LEN};
-use crate::rocksdb::scolumns::pools::{Key, Row, Value, EVENT_TARGET};
+use super::super::common::{PREFIX_LEN, as_key, as_value};
+use crate::rocksdb::scolumns::pools::{EVENT_TARGET, Key, Row, Value};
 use amaru_kernel::Epoch;
 use amaru_ledger::store::StoreError;
 use rocksdb::{OptimisticTransactionDB, ThreadMode, Transaction};

--- a/crates/amaru-stores/src/rocksdb/columns/pots.rs
+++ b/crates/amaru-stores/src/rocksdb/columns/pots.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::super::common::{as_value, PREFIX_LEN};
+use super::super::common::{PREFIX_LEN, as_value};
 use crate::rocksdb::scolumns::pots::Row;
 use amaru_ledger::store::StoreError;
 use rocksdb::Transaction;

--- a/crates/amaru-stores/src/rocksdb/columns/slots.rs
+++ b/crates/amaru-stores/src/rocksdb/columns/slots.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::super::common::{as_key, as_value, PREFIX_LEN};
+use super::super::common::{PREFIX_LEN, as_key, as_value};
 use crate::rocksdb::scolumns::slots::{Key, Value};
 use amaru_ledger::store::StoreError;
 use rocksdb::{OptimisticTransactionDB, ThreadMode, Transaction};

--- a/crates/amaru-stores/src/rocksdb/columns/utxo.rs
+++ b/crates/amaru-stores/src/rocksdb/columns/utxo.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::super::common::{as_key, as_value, PREFIX_LEN};
+use super::super::common::{PREFIX_LEN, as_key, as_value};
 use crate::rocksdb::scolumns::utxo::{Key, Value};
 use amaru_ledger::store::StoreError;
 use pallas_codec::minicbor::{self as cbor};

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ::rocksdb::{self, checkpoint, OptimisticTransactionDB, Options, SliceTransform};
+use ::rocksdb::{self, OptimisticTransactionDB, Options, SliceTransform, checkpoint};
 use amaru_kernel::{Epoch, Point, PoolId, TransactionInput, TransactionOutput};
 use amaru_ledger::{
     rewards::Pots,
     store::{
-        columns as scolumns, Columns, OpenErrorKind, RewardsSummary, Snapshot, Store, StoreError,
-        TipErrorKind,
+        Columns, OpenErrorKind, RewardsSummary, Snapshot, Store, StoreError, TipErrorKind,
+        columns as scolumns,
     },
 };
 use columns::*;
-use common::{as_value, PREFIX_LEN};
-use iter_borrow::{self, borrowable_proxy::BorrowableProxy, IterBorrow};
+use common::{PREFIX_LEN, as_value};
+use iter_borrow::{self, IterBorrow, borrowable_proxy::BorrowableProxy};
 use pallas_codec::minicbor::{self as cbor};
 use std::{
     fmt, fs,

--- a/crates/amaru/src/bin/amaru/cmd/daemon.rs
+++ b/crates/amaru/src/bin/amaru/cmd/daemon.rs
@@ -15,7 +15,7 @@
 use crate::{config::NetworkName, metrics::track_system_metrics};
 use amaru::sync::Config;
 use amaru_consensus::consensus::nonce;
-use clap::{builder::TypedValueParser as _, ArgAction, Parser};
+use clap::{ArgAction, Parser, builder::TypedValueParser as _};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use pallas_network::facades::PeerClient;
 use std::{path::PathBuf, sync::Arc, time::Duration};

--- a/crates/amaru/src/bin/amaru/cmd/import.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import.rs
@@ -366,7 +366,7 @@ fn import_stake_pools(
     pools: HashMap<PoolId, PoolParams>,
     updates: HashMap<PoolId, PoolParams>,
     retirements: HashMap<PoolId, Epoch>,
-) -> Result<(), impl std::error::Error> {
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut state = amaru_ledger::state::diff_epoch_reg::DiffEpochReg::default();
     for (pool, params) in pools.into_iter() {
         state.register(pool, params);
@@ -414,7 +414,7 @@ fn import_stake_pools(
             accounts: iter::empty(),
         },
         iter::empty(),
-    )
+    ).map_err(Into::into)
 }
 
 fn import_pots(

--- a/crates/amaru/src/bin/amaru/cmd/import.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use amaru_kernel::{
-    epoch_from_slot, DRep, Epoch, Lovelace, Point, PoolId, PoolParams, Set, StakeCredential,
-    TransactionInput, TransactionOutput, STAKE_CREDENTIAL_DEPOSIT,
+    DRep, Epoch, Lovelace, Point, PoolId, PoolParams, STAKE_CREDENTIAL_DEPOSIT, Set,
+    StakeCredential, TransactionInput, TransactionOutput, epoch_from_slot,
 };
 use amaru_ledger::{
     self,
@@ -22,7 +22,7 @@ use amaru_ledger::{
         Store, {self},
     },
 };
-use amaru_stores::rocksdb::{columns::*, RocksDB};
+use amaru_stores::rocksdb::{RocksDB, columns::*};
 use clap::Parser;
 use indicatif::{ProgressBar, ProgressStyle};
 use pallas_codec::minicbor as cbor;
@@ -61,7 +61,9 @@ pub struct Args {
 enum Error<'a> {
     #[error("malformed date: {}", .0)]
     MalformedDate(&'a str),
-    #[error("You must provide either a single .cbor snapshot file (--snapshot) or a directory containing multiple .cbor snapshots (--snapshot-dir)")]
+    #[error(
+        "You must provide either a single .cbor snapshot file (--snapshot) or a directory containing multiple .cbor snapshots (--snapshot-dir)"
+    )]
     IncorrectUsage,
 }
 
@@ -414,7 +416,8 @@ fn import_stake_pools(
             accounts: iter::empty(),
         },
         iter::empty(),
-    ).map_err(Into::into)
+    )
+    .map_err(Into::into)
 }
 
 fn import_pots(

--- a/crates/amaru/src/bin/amaru/cmd/import_chain_db.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_chain_db.rs
@@ -3,11 +3,11 @@ use amaru::sync;
 use amaru_consensus::{
     consensus::{
         header::{ConwayHeader, Header},
-        store::{rocksdb::RocksDBStore, ChainStore},
+        store::{ChainStore, rocksdb::RocksDBStore},
     },
     peer::{Peer, PeerSession},
 };
-use clap::{builder::TypedValueParser as _, Parser};
+use clap::{Parser, builder::TypedValueParser as _};
 use gasket::framework::*;
 use indicatif::{ProgressBar, ProgressStyle};
 use pallas_network::{

--- a/crates/amaru/src/bin/amaru/metrics.rs
+++ b/crates/amaru/src/bin/amaru/metrics.rs
@@ -40,8 +40,8 @@ pub fn track_system_metrics(metrics: SdkMeterProvider) -> JoinHandle<()> {
 
 mod internals {
     use opentelemetry::{
-        metrics::{Gauge, MeterProvider},
         KeyValue,
+        metrics::{Gauge, MeterProvider},
     };
     use opentelemetry_sdk::metrics::SdkMeterProvider;
     use sysinfo::System;

--- a/crates/amaru/src/bin/amaru/observability.rs
+++ b/crates/amaru/src/bin/amaru/observability.rs
@@ -4,15 +4,15 @@ use std::{
     io::{self},
 };
 use tracing_subscriber::{
+    EnvFilter, Registry,
     filter::Filtered,
     fmt::{
-        format::{FmtSpan, Format, Json, JsonFields},
         Layer,
+        format::{FmtSpan, Format, Json, JsonFields},
     },
     layer::{Layered, SubscriberExt},
     prelude::*,
     util::SubscriberInitExt,
-    EnvFilter, Registry,
 };
 
 const SERVICE_NAME: &str = "amaru";
@@ -180,8 +180,8 @@ impl Default for OpenTelemetryHandle {
 
 #[allow(clippy::panic)]
 pub fn setup_open_telemetry(subscriber: &mut TracingSubscriber<Registry>) -> OpenTelemetryHandle {
-    use opentelemetry::{trace::TracerProvider as _, KeyValue};
-    use opentelemetry_sdk::{metrics::Temporality, Resource};
+    use opentelemetry::{KeyValue, trace::TracerProvider as _};
+    use opentelemetry_sdk::{Resource, metrics::Temporality};
 
     let resource = Resource::new(vec![KeyValue::new("service.name", SERVICE_NAME)]);
 

--- a/crates/amaru/src/pipeline.rs
+++ b/crates/amaru/src/pipeline.rs
@@ -1,14 +1,13 @@
 use std::sync::Arc;
 
-use amaru_kernel::{protocol_parameters::ProtocolParameters, Point};
+use amaru_kernel::{Point, protocol_parameters::ProtocolParameters};
 use gasket::framework::{AsWorkError, WorkSchedule, WorkerError};
-use tracing::{trace_span, Span};
+use tracing::{Span, trace_span};
 
 use amaru_ledger::{
-    rules,
+    BlockValidationResult, RawBlock, ValidateBlockEvent, rules,
     state::{self, BackwardError},
     store::Store,
-    BlockValidationResult, RawBlock, ValidateBlockEvent,
 };
 
 pub type UpstreamPort = gasket::messaging::InputPort<ValidateBlockEvent>;

--- a/crates/amaru/src/sync/mod.rs
+++ b/crates/amaru/src/sync/mod.rs
@@ -13,21 +13,20 @@
 // limitations under the License.
 
 use amaru_consensus::{
-    chain_forward,
+    ConsensusError, chain_forward,
     consensus::{
         chain_selection::{ChainSelector, ChainSelectorBuilder},
-        header::{point_hash, ConwayHeader},
+        header::{ConwayHeader, point_hash},
         header_validation::Consensus,
-        store::{rocksdb::RocksDBStore, ChainStore},
+        store::{ChainStore, rocksdb::RocksDBStore},
         wiring::{HeaderStage, PullEvent},
     },
     peer::{Peer, PeerSession},
-    ConsensusError,
 };
 use amaru_kernel::Point;
 use amaru_stores::rocksdb::RocksDB;
 use gasket::{
-    messaging::{tokio::funnel_ports, OutputPort},
+    messaging::{OutputPort, tokio::funnel_ports},
     runtime::Tether,
 };
 use pallas_crypto::hash::Hash;

--- a/crates/amaru/src/sync/pull.rs
+++ b/crates/amaru/src/sync/pull.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::point::{from_network_point, to_network_point};
-use amaru_consensus::{consensus::wiring::PullEvent, peer::PeerSession, RawHeader};
+use amaru_consensus::{RawHeader, consensus::wiring::PullEvent, peer::PeerSession};
 use amaru_kernel::Point;
 use anyhow::anyhow;
 use gasket::framework::*;
@@ -21,7 +21,7 @@ use pallas_network::miniprotocols::chainsync::{HeaderContent, NextResponse, Tip}
 use pallas_traverse::MultiEraHeader;
 use std::time::Duration;
 use tokio::time::timeout;
-use tracing::{instrument, trace_span, Level};
+use tracing::{Level, instrument, trace_span};
 
 pub fn to_traverse(header: &HeaderContent) -> Result<MultiEraHeader<'_>, WorkerError> {
     let out = match header.byron_prefix {

--- a/crates/iter-borrow/src/lib.rs
+++ b/crates/iter-borrow/src/lib.rs
@@ -59,11 +59,11 @@ impl<const PREFIX: usize, K: Clone, V: Clone> KeyValueIterator<'_, PREFIX, K, V>
 }
 
 impl<
-        'a,
-        const PREFIX: usize,
-        K: Clone + for<'d> cbor::Decode<'d, ()>,
-        V: Clone + for<'d> cbor::Decode<'d, ()>,
-    > KeyValueIterator<'a, PREFIX, K, V>
+    'a,
+    const PREFIX: usize,
+    K: Clone + for<'d> cbor::Decode<'d, ()>,
+    V: Clone + for<'d> cbor::Decode<'d, ()>,
+> KeyValueIterator<'a, PREFIX, K, V>
 where
     Self: 'a,
 {
@@ -73,11 +73,11 @@ where
 }
 
 impl<
-        'a,
-        const PREFIX: usize,
-        K: Clone + for<'d> cbor::Decode<'d, ()>,
-        V: Clone + for<'d> cbor::Decode<'d, ()>,
-    > Iterator for KeyValueIterator<'a, PREFIX, K, V>
+    'a,
+    const PREFIX: usize,
+    K: Clone + for<'d> cbor::Decode<'d, ()>,
+    V: Clone + for<'d> cbor::Decode<'d, ()>,
+> Iterator for KeyValueIterator<'a, PREFIX, K, V>
 where
     Self: 'a,
 {

--- a/crates/ouroboros/src/praos/header.rs
+++ b/crates/ouroboros/src/praos/header.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use crate::{
-    ed25519, issuer_to_pool_id, kes,
+    BlockHeader, Hash, Hasher, OperationalCert, PoolId, VrfCert, ed25519, issuer_to_pool_id, kes,
     math::{ExpOrdering, FixedDecimal, FixedPrecision},
-    vrf, BlockHeader, Hash, Hasher, OperationalCert, PoolId, VrfCert,
+    vrf,
 };
 use amaru_ouroboros_traits::HasStakeDistribution;
 use std::{array::TryFromSliceError, ops::Deref, sync::LazyLock};
@@ -279,7 +279,9 @@ impl AssertLeaderStakeError {
 
 #[derive(Error, Debug, PartialEq)]
 pub enum AssertKesSignatureError {
-    #[error("Operational Certificate KES period ({opcert_kes_period}) is greater than the block slot KES period ({slot_kes_period}).")]
+    #[error(
+        "Operational Certificate KES period ({opcert_kes_period}) is greater than the block slot KES period ({slot_kes_period})."
+    )]
     OpCertKesPeriodTooLarge {
         opcert_kes_period: u64,
         slot_kes_period: u64,
@@ -342,7 +344,7 @@ pub enum AssertOperationalCertificateError {
     #[error(
         "Operational certificate sequence number ({}) is too far ahead of the latest known sequence number ({}).",
         declared_sequence_number,
-        latest_sequence_number,
+        latest_sequence_number
     )]
     SequenceNumberTooFarAhead {
         declared_sequence_number: u64,
@@ -352,7 +354,7 @@ pub enum AssertOperationalCertificateError {
     #[error(
         "Operational certificate sequence number ({}) is less than the latest known sequence number ({}).",
         declared_sequence_number,
-        latest_sequence_number,
+        latest_sequence_number
     )]
     SequenceNumberTooSmall {
         declared_sequence_number: u64,

--- a/crates/ouroboros/src/vrf/mod.rs
+++ b/crates/ouroboros/src/vrf/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! <https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vrf-03>
 
-pub use pallas_primitives::babbage::{derive_tagged_vrf_output, VrfDerivation as Derivation};
+pub use pallas_primitives::babbage::{VrfDerivation as Derivation, derive_tagged_vrf_output};
 use std::{array::TryFromSliceError, ops::Deref};
 
 use crate::{Hash, Hasher};
@@ -127,7 +127,7 @@ impl Input {
     #[cfg(test)]
     /// Generate an arbitrary input challenge filled with random bytes.
     pub fn arbitrary() -> Self {
-        use rand::{thread_rng, Rng};
+        use rand::{Rng, thread_rng};
         let mut challenge = [0u8; Self::SIZE];
         thread_rng().fill(&mut challenge);
         Input(challenge.into())
@@ -244,7 +244,7 @@ mod tests {
     struct WrappedSecretKey(SecretKey);
     impl std::fmt::Debug for WrappedSecretKey {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-            write!(f, "{}", hex::encode(self.0 .0.to_bytes()))
+            write!(f, "{}", hex::encode(self.0.0.to_bytes()))
         }
     }
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "bonsai-sdk"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e274325e6251c944fad96881a9744d82d6cee67244e284f62ebd1d4ede287bd"
+checksum = "758a880c4d654ade8df6e786b663b542a9e31b351591c79a433830217d45f10a"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -1133,7 +1133,6 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 name = "iter-borrow"
 version = "0.1.0"
 dependencies = [
- "hex",
  "minicbor",
 ]
 
@@ -1830,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc047ec0ec944104bf94cf55efa3a697aca63cff506cc949ec8d345c48ef0706"
+checksum = "8b077091fadca2535fcb9a433e71f08a40e3c29d6a1f89c1ef0de6645e82540b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1845,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2336678ab6701f737522f153050c8c688860a2db29ef8fea7a42ae0a1de614d6"
+checksum = "c68b9039b5cafa149085d978a51673d0bd00908a27ce679bbc9c6ac182546025"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1864,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc983c81ee51af9bde296eb1b4dff73501fb436c3401d30d5548e00b2c0a354"
+checksum = "e0f7ed89847d21a35b0e7747bd218cd99a0ef2d91828d25861290e71a200e436"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1880,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d68e1a5344eb83553a6a465fcec5ceb4ab751e7b3b96c46a6c03b697f70856"
+checksum = "4b3aee966e28907d5153385a3875fd8a452e7bbac627624380a154caa42005e4"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1895,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca07c57b1b0eff21288a7b193a06b2b5943b3eceda6dafa0c087cbe0fcfcfa6"
+checksum = "7c1167a6a0c817d2a2643c3171359e95c299b0692eada35a1a349917b432d042"
 dependencies = [
  "anyhow",
  "metal",
@@ -1911,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3ba5078ac767bb5cf35505e6d4da24eff76807fa73bb6ffb88e794654dd4dc"
+checksum = "d56db5c9390a9e51c150d406b780110acad7f0d97886406a89dcfdab1f832ad8"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1921,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2df58accff2fde7e8bad9d144ae91cdfb5d0101addd3365f013fe3e33dccd8"
+checksum = "f0c5595a48efc6e94d303a0d4a87aedec1a0162fa696e2e1b944aba997c8f808"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1942,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e429d1cdb86a702eba04a02b3929bdd62a9a1859ec23b281ba2a8d0c6f418f"
+checksum = "ca0b6424c1a31f0fd8f82b8c4e4b71a37033f4acac6aedee83131c5be674d1c7"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1966,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ecc97ec255ad47e1de41b9691a8d92fa48efb779b611d28c3a1c4b7c79abd0"
+checksum = "d041321ecfe340e112dcbbf1d45fe2f4655e6c53851ede39e2b38c173eac41e3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2000,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3707a298cacf4d665258b9e976d422401dcfe833f50794fa1e7c20d15ab45e7f"
+checksum = "6b81a773bbaae6f499c0c82a4d29a5aa205b542c47cb062b738085603e51e682"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "A set of amaru examples"
 license = "Apache-2.0"
 authors = ["Amaru Maintainers <amaru@pragma.builders>"]

--- a/examples/ledger-in-nodejs/src/lib.rs
+++ b/examples/ledger-in-nodejs/src/lib.rs
@@ -1,6 +1,6 @@
 use amaru_examples_shared::{forward_ledger, RAW_BLOCK_CONWAY_1};
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn ledger() {
     forward_ledger(RAW_BLOCK_CONWAY_1);

--- a/examples/proof-of-ledger/Cargo.toml
+++ b/examples/proof-of-ledger/Cargo.toml
@@ -13,6 +13,6 @@ publish = false
 
 [dependencies]
 methods = { path = "methods" }
-risc0-zkvm = { version = "1.2.3" }
+risc0-zkvm = { version = "1.2.4" }
 amaru-examples-shared = { path = "../shared" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/proof-of-ledger/methods/Cargo.toml
+++ b/examples/proof-of-ledger/methods/Cargo.toml
@@ -11,7 +11,7 @@ documentation.workspace = true
 publish = false
 
 [build-dependencies]
-risc0-build = { version = "1.2.3" }
+risc0-build = { version = "1.2.4" }
 
 [package.metadata.risc0]
 methods = ["guest"]

--- a/examples/proof-of-ledger/methods/guest/Cargo.toml
+++ b/examples/proof-of-ledger/methods/guest/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "1.2.3", default-features = false, features = ['std'] }
+risc0-zkvm = { version = "1.2.4", default-features = false, features = ['std'] }
 amaru-examples-shared = { path = "../../../shared" }

--- a/examples/proof-of-ledger/rust-toolchain.toml
+++ b/examples/proof-of-ledger/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "1.83.0"
-components = ["rustfmt", "rust-src"]
-profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.85"
+profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.85"
 profile = "default"
+components = ["rustfmt", "rust-src"]


### PR DESCRIPTION
Make sure `amaru` compiles with latest rust edition.
Also fixes `rust-toolchain`, enforcing reproducibility (see some [rationale](https://swatinem.de/blog/rust-toolchain/)).

`rust-version` is kept so that `amaru` crates consumers get the right constraints. It must be kept in sync with `rust-toolchain`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the project’s configuration to Rust edition 2024 with the compiler updated to version 1.85.0 for enhanced reliability.
	- Standardised error handling for improved consistency and robustness.
	- Introduced streamlined toolchain settings to ensure alignment with the latest Rust ecosystem advancements.
	- Updated dependency versions for improved performance and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->