### PR TITLE
chore: use regular riscv target

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,15 +48,14 @@ jobs:
             command: build
             setup: rustup target add wasm32-unknown-unknown
           - runner: ubuntu-latest
-            target: riscv32im-risc0-zkvm-elf
+            target: riscv32im-unknown-none-elf
             packages: -p amaru-ledger
             extra-args: +nightly -Zbuild-std=std,panic_abort
             command: build
             setup: |
-              curl -L https://risczero.com/install | bash
-              /home/runner/.risc0/bin/rzup install
               rustup toolchain add nightly-x86_64-unknown-linux-gnu
               rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+              rustup target add riscv32im-unknown-none-elf
           # Disabled for now
           #- runner: ubuntu-latest
           #  target: aarch64-unknown-linux-musl


### PR DESCRIPTION
Use regular `riscv` target, not `risc0` specific.