### PR TITLE
chore: better dev build options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,16 @@ panic = "warn"
 todo = "warn"
 unwrap_used = "warn"
 
-[profile.release]
 # See https://doc.rust-lang.org/cargo/reference/profiles.html
+
+[profile.dev]
+opt-level = 2
+debug = false
+
+[profile.dev-debug]
+inherits = "dev"
+debug = true
+
+[profile.release]
 lto = true
 codegen-units = 1


### PR DESCRIPTION
The default 'dev' profile is a bit too slow, and it makes synchronizing annoyingly slow. That's why we would typically run commands with ; but we recently tweaked those options to set  and  which now make compilation and pre-linking phases significantly slower (okay for a production build, not so much for a dev build).

So, these new options for the 'dev' profile should strike a correct balance between runtime and builtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced build profiles that offer an optimised setup for development and a dedicated debug configuration, improving the overall build process for development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->