### PR TITLE
chore: restore fast windows build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,6 +42,7 @@ jobs:
             target: aarch64-apple-darwin
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
+            command: test --profile dev-debug
           - runner: ubuntu-latest
             target: wasm32-unknown-unknown
             packages: -p amaru-ledger -p amaru-ouroboros -p slot-arithmetic

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,9 @@ opt-level = 2
 debug = false
 
 [profile.dev-debug]
+# Restore default 'dev' profile (see https://doc.rust-lang.org/cargo/reference/profiles.html#dev)
 inherits = "dev"
+opt-level = 0
 debug = true
 
 [profile.release]


### PR DESCRIPTION
Restore default `dev` profile for windows to make sure CI runs fast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the testing process on Windows, ensuring tests now execute with a dedicated debug profile.
	- Adjusted the development debug build settings to explicitly control performance optimisation, leading to more consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->