### PR TITLE
chore: use stderr to print panic errors

### DIFF
--- a/crates/amaru/src/bin/amaru/panic.rs
+++ b/crates/amaru/src/bin/amaru/panic.rs
@@ -63,7 +63,7 @@ pub fn panic_handler() {
             location = location,
         };
 
-        println!("\n{}", indent(&error_message, 3));
+        eprintln!("\n{}", indent(&error_message, 3));
     }));
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Revised error reporting so that error messages are now directed to the standard error stream, ensuring clearer categorisation of output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->