### PR TITLE
fix: use different caching strategy for Rust dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,12 @@ env:
   CARGO_PROFILE_TEST_DEBUG: 0
   CARGO_PROFILE_RELEASE_LTO: true
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
+  RUST_CACHE_PATH: |
+    ~/.cargo/bin/
+    ~/.cargo/registry/index/
+    ~/.cargo/registry/cache/
+    ~/.cargo/git/db/
+    target/
 
 jobs:
   sanity:
@@ -23,9 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/cache/restore@v4
         with:
-          prefix-key: ${{ runner.os }}
+          path: ${{ env.RUST_CACHE_PATH }}
+          key: cargo-x86_64-unknown-linux-gnu
+          restore-keys: |
+            cargo-x86_64-unknown-linux-gnu
       - name: Check format
         run: cargo fmt-amaru
       - name: Run clippy
@@ -66,9 +75,22 @@ jobs:
     runs-on: ${{ matrix.environments.runner }}
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
+      # Cache dependencies when pushing (i.e. merging into allowed branch).
+      - uses: actions/cache@v4
+        if: ${{ github.event.push }}
         with:
-          prefix-key: ${{ runner.os }}-${{ matrix.environments.target }}
+          path: ${{ env.RUST_CACHE_PATH }}
+          key: cargo-${{ matrix.environments.target }}
+          restore-keys: |
+            cargo-${{ matrix.environments.target }}
+      # Only restore cache for other types of events (e.g. Pull requests).
+      - uses: actions/cache/restore@v4
+        if: ${{ !github.event.push }}
+        with:
+          path: ${{ env.RUST_CACHE_PATH }}
+          key: cargo-${{ matrix.environments.target }}
+          restore-keys: |
+            cargo-${{ matrix.environments.target }}
       - name: Run tests
         run: |
           set +e
@@ -145,7 +167,12 @@ jobs:
               --socket-path /ipc/node.socket \
               --topology /config/topology.json
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.RUST_CACHE_PATH }}
+          key: cargo-x86_64-unknown-linux-gnu
+          restore-keys: |
+            cargo-x86_64-unknown-linux-gnu
 
       - name: Build Amaru
         run: |
@@ -229,8 +256,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/cache/restore@v4
         with:
-          prefix-key: ${{ matrix.projects.path }}
+          path: ${{ env.RUST_CACHE_PATH }}
+          key: cargo-wasm32-unknown-unknown
+          restore-keys: |
+            cargo-wasm32-unknown-unknown
       - name: Run commands
         run: ${{ matrix.projects.commands }}


### PR DESCRIPTION
> [!NOTE]
>
> Work-in-progress, I've only replaced one occurrence so far just to try things out.

This comes to address few issues we've been having with caches.
  Namely:

  - The cache size is limited to 10GB, and with all the targets we have, a single round of caching ~2.25GB per build. Github clears old cache based on when they were last created (not used). So we often end up purging caches that are still useful (e.g. `main`'s caches, or the cardano-node preprod data).

  - Because GitHub doesn't allow cache to be re-used across PRs, the previous point means that an active PR may rapidly make all other PRs slower, since after 4 changes causing 4 different caches overwrite, the base cache for all other PRs is likely lost. So every PR competes against one another constantly.

  - The Swatinem/RustCache action is reportedly slow and has bizarre cache invalidation strategies, often yielding to not re-using available caches. It probably tries to do many smart things behind the scene, but likely being _too smart_ for our own sake.

  In this new approach, we only replace the cache when pushing onto `main`. PRs will only re-use the cache `main`, and rebuild from there. This implies that for heavy PRs doing many changes and causing heavy rebuilds, it's going to get slightly annoying. Although, this can also be seen as a feature:

  - it forces small PRs;
  - it forces to split large depenedencies changes into separate PRs so they get merged faster;
  - it forces PRs to remain up-to-date by rebasing onto `main` often (and especially after a large deps change causing cache invalidations).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved the continuous integration process with an enhanced caching strategy. A new environment variable `RUST_CACHE_PATH` has been introduced to optimise build caching, leading to more efficient and reliable CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->