### PR TITLE
feat: allow to simply build all examples

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -244,13 +244,10 @@ jobs:
       fail-fast: false
       matrix:
         projects:
-          - path: ledger-in-nodejs
-            commands: |
-              rustup target add wasm32-unknown-unknown
-              make
+          - ledger-in-nodejs
     defaults:
       run:
-        working-directory: examples/${{ matrix.projects.path }}
+        working-directory: examples/${{ matrix.projects }}
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
@@ -261,5 +258,5 @@ jobs:
           key: cargo-wasm32-unknown-unknown
           restore-keys: |
             cargo-wasm32-unknown-unknown
-      - name: Run commands
-        run: ${{ matrix.projects.commands }}
+      - name: Run make
+        run: make

--- a/Makefile
+++ b/Makefile
@@ -67,3 +67,14 @@ test-e2e: ## Run snapshot tests, assuming snapshots are available.
 
 demo: ## Synchronize Amaru until a target epoch $DEMO_TARGET_EPOCH
 	./scripts/demo.sh $(AMARU_PEER_ADDRESS) $(DEMO_TARGET_EPOCH) $(NETWORK)
+
+build-examples: ## Build all examples
+	@for dir in $(wildcard examples/*/.); do \
+		if [ -f $$dir/Makefile ]; then \
+			echo "Building $$dir"; \
+			$(MAKE) -C $$dir; \
+			if [ $$? != "0" ]; then \
+				exit $$?; \
+			fi; \
+		fi; \
+	done

--- a/examples/ledger-in-nodejs/Makefile
+++ b/examples/ledger-in-nodejs/Makefile
@@ -1,7 +1,10 @@
-all: build run
+all: setup build run
+
+setup:
+	rustup target add wasm32-unknown-unknown
 
 build:
-	cargo build --release --artifact-dir assets
+	cargo build --artifact-dir assets
 
 run:
 	node index.mjs

--- a/examples/shared/Makefile
+++ b/examples/shared/Makefile
@@ -1,0 +1,4 @@
+all: build
+
+build:
+	cargo build

--- a/examples/shared/src/store.rs
+++ b/examples/shared/src/store.rs
@@ -9,7 +9,7 @@ pub struct MemoryStore {}
 
 impl Snapshot for MemoryStore {
     fn epoch(&self) -> Epoch {
-        0
+        10
     }
 
     fn pool(


### PR DESCRIPTION
Added a make target to build all examples: `make build-examples`.
Helps with ensuring a PR doesn't break them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a bulk build process for example projects, enabling multiple examples to be compiled in one go.
  - Added dedicated build targets to streamline project setup and component compilation.
  - Implemented a new target for setting up Rust environment requirements.

- **Chores**
  - Simplified the continuous integration setup for example projects by consolidating build steps, reducing configuration complexity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->