### PR TITLE
chore: move network definition to kernel module

### DIFF
--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -55,6 +55,7 @@ use std::{array::TryFromSliceError, convert::Infallible, ops::Deref, sync::LazyL
 pub use pallas_traverse::{ComputeHash, OriginalHash};
 
 pub mod macros;
+pub mod network;
 pub mod protocol_parameters;
 
 // Constants

--- a/crates/amaru-kernel/src/network.rs
+++ b/crates/amaru-kernel/src/network.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 PRAGMA
+// Copyright 2025 PRAGMA
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap::Parser;
-
-#[derive(Debug, Clone, Copy, Parser)]
+#[derive(Debug, Clone, Copy)]
 pub enum NetworkName {
     Mainnet,
     Preprod,

--- a/crates/amaru/src/bin/amaru/cmd/daemon.rs
+++ b/crates/amaru/src/bin/amaru/cmd/daemon.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{config::NetworkName, metrics::track_system_metrics};
+use crate::metrics::track_system_metrics;
 use amaru::sync::Config;
+use amaru_kernel::network::NetworkName;
 use clap::{builder::TypedValueParser as _, ArgAction, Parser};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use pallas_network::facades::PeerClient;

--- a/crates/amaru/src/bin/amaru/cmd/import_headers.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_headers.rs
@@ -1,11 +1,10 @@
-use crate::config::NetworkName;
 use amaru::sync;
 use amaru_consensus::{
     consensus::store::{rocksdb::RocksDBStore, ChainStore},
     peer::{Peer, PeerSession},
     IsHeader,
 };
-use amaru_kernel::{from_cbor, Header, Point};
+use amaru_kernel::{from_cbor, network::NetworkName, Header, Point};
 use clap::{builder::TypedValueParser as _, Parser};
 use gasket::framework::*;
 use indicatif::{ProgressBar, ProgressStyle};

--- a/crates/amaru/src/bin/amaru/main.rs
+++ b/crates/amaru/src/bin/amaru/main.rs
@@ -16,7 +16,6 @@ use clap::{Parser, Subcommand};
 use panic::panic_handler;
 
 mod cmd;
-mod config;
 mod metrics;
 mod observability;
 mod panic;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `network` module, enhancing public interfaces.

- **Refactor**
  - Consolidated network references and updated related components for improved consistency.
  - Reorganised import paths and removed redundant configuration elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->