### PR TITLE
feat: allow testnets with magic in network names

### DIFF
--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -21,6 +21,7 @@ It's also the right place to put rather general functions or types that ought to
 While elements are being contributed upstream, they might transiently live in this module.
 */
 
+use network::PREPROD_SHELLEY_TRANSITION_EPOCH;
 use num::{rational::Ratio, BigUint};
 pub use pallas_addresses::{byron::AddrType, Address, StakeAddress, StakePayload};
 use pallas_addresses::{Error, *};
@@ -92,9 +93,6 @@ pub const BYRON_EPOCH_LENGTH: usize = BYRON_EPOCH_LENGTH_SCALE_FACTOR * CONSENSU
 
 /// Number of slots in the Byron era, for PreProd
 pub const BYRON_TOTAL_SLOTS: usize = BYRON_EPOCH_LENGTH * PREPROD_SHELLEY_TRANSITION_EPOCH;
-
-/// Epoch number in which the PreProd network transitioned to Shelley.
-pub const PREPROD_SHELLEY_TRANSITION_EPOCH: usize = 4;
 
 /// Value, in Lovelace, that one must deposit when registering a new stake pool
 pub const STAKE_POOL_DEPOSIT: usize = 500000000;

--- a/crates/amaru-kernel/src/network.rs
+++ b/crates/amaru-kernel/src/network.rs
@@ -12,21 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[derive(Debug, Clone, Copy)]
+/// Epoch number in which the PreProd network transitioned to Shelley.
+pub const PREPROD_SHELLEY_TRANSITION_EPOCH: usize = 4;
+
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum NetworkName {
     Mainnet,
     Preprod,
     Preview,
+    Testnet(u32),
 }
 
 impl std::fmt::Display for NetworkName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Mainnet => "mainnet",
-            Self::Preprod => "preprod",
-            Self::Preview => "preview",
+            Self::Mainnet => write!(f, "mainnet"),
+            Self::Preprod => write!(f, "preprod"),
+            Self::Preview => write!(f, "preview"),
+            Self::Testnet(magic) => write!(f, "testnet<{}>", magic),
         }
-        .fmt(f)
     }
 }
 
@@ -38,7 +42,13 @@ impl std::str::FromStr for NetworkName {
             "mainnet" => Ok(Self::Mainnet),
             "preprod" => Ok(Self::Preprod),
             "preview" => Ok(Self::Preview),
-            _ => Err(format!("unknown network name: {s}")),
+            _ => {
+                let magic = s
+                    .strip_prefix("testnet<")
+                    .and_then(|s| s.strip_suffix(">"))
+                    .ok_or(format!("Invalid network name {}", s))?;
+                magic.parse::<u32>().map(NetworkName::Testnet).map_err(|e| e.to_string())
+            }
         }
     }
 }
@@ -53,6 +63,35 @@ impl NetworkName {
             Self::Mainnet => 764824073,
             Self::Preprod => 1,
             Self::Preview => 2,
+            Self::Testnet(magic) => magic,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NetworkName::{self, *};
+    use proptest::prelude::*;
+    use proptest::{prop_oneof, proptest};
+    use std::str::FromStr;
+
+    fn any_network() -> impl Strategy<Value = NetworkName> {
+        prop_oneof![
+            Just(Mainnet),
+            Just(Preprod),
+            Just(Preview),
+            (3..u32::MAX).prop_map(Testnet)
+        ]
+    }
+
+    proptest! {
+        #[test]
+        fn prop_can_parse_pretty_print_network_name(network in any_network()) {
+            let name = format!("{}", network);
+            assert_eq!(
+                FromStr::from_str(&name),
+                Ok(network),
+            )
         }
     }
 }

--- a/crates/amaru-kernel/src/network.rs
+++ b/crates/amaru-kernel/src/network.rs
@@ -29,7 +29,7 @@ impl std::fmt::Display for NetworkName {
             Self::Mainnet => write!(f, "mainnet"),
             Self::Preprod => write!(f, "preprod"),
             Self::Preview => write!(f, "preview"),
-            Self::Testnet(magic) => write!(f, "testnet<{}>", magic),
+            Self::Testnet(magic) => write!(f, "testnet:{}", magic),
         }
     }
 }
@@ -44,9 +44,9 @@ impl std::str::FromStr for NetworkName {
             "preview" => Ok(Self::Preview),
             _ => {
                 let magic = s
-                    .strip_prefix("testnet<")
-                    .and_then(|s| s.strip_suffix(">"))
+                    .strip_prefix("testnet:")
                     .ok_or(format!("Invalid network name {}", s))?;
+
                 magic
                     .parse::<u32>()
                     .map(NetworkName::Testnet)

--- a/crates/amaru-kernel/src/network.rs
+++ b/crates/amaru-kernel/src/network.rs
@@ -47,17 +47,16 @@ impl std::str::FromStr for NetworkName {
                     .strip_prefix("testnet<")
                     .and_then(|s| s.strip_suffix(">"))
                     .ok_or(format!("Invalid network name {}", s))?;
-                magic.parse::<u32>().map(NetworkName::Testnet).map_err(|e| e.to_string())
+                magic
+                    .parse::<u32>()
+                    .map(NetworkName::Testnet)
+                    .map_err(|e| e.to_string())
             }
         }
     }
 }
 
 impl NetworkName {
-    pub fn possible_values<'a>() -> &'a [&'a str; 3] {
-        &["mainnet", "preprod", "preview"]
-    }
-
     pub fn to_network_magic(self) -> u32 {
         match self {
             Self::Mainnet => 764824073,

--- a/crates/amaru/src/bin/amaru/cmd/daemon.rs
+++ b/crates/amaru/src/bin/amaru/cmd/daemon.rs
@@ -33,6 +33,9 @@ pub struct Args {
     peer_address: Vec<String>,
 
     /// The target network to choose from.
+    ///
+    /// Should be one of 'mainnet', 'preprod', 'preview' or 'testnet:<magic>' where
+    /// `magic` is a 32-bits unsigned value denoting a particular testnet.
     #[arg(
         long,
         value_name = "NETWORK",

--- a/crates/amaru/src/bin/amaru/cmd/daemon.rs
+++ b/crates/amaru/src/bin/amaru/cmd/daemon.rs
@@ -15,7 +15,7 @@
 use crate::metrics::track_system_metrics;
 use amaru::sync::Config;
 use amaru_kernel::network::NetworkName;
-use clap::{builder::TypedValueParser as _, ArgAction, Parser};
+use clap::{ArgAction, Parser};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use pallas_network::facades::PeerClient;
 use std::{path::PathBuf, sync::Arc, time::Duration};
@@ -37,8 +37,6 @@ pub struct Args {
         long,
         value_name = "NETWORK",
         default_value_t = NetworkName::Preprod,
-        value_parser = clap::builder::PossibleValuesParser::new(NetworkName::possible_values())
-            .map(|s| s.parse::<NetworkName>().unwrap()),
     )]
     network: NetworkName,
 

--- a/crates/amaru/src/bin/amaru/cmd/import_headers.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_headers.rs
@@ -28,6 +28,9 @@ pub struct Args {
     peer_address: String,
 
     /// Network to use for the connection.
+    ///
+    /// Should be one of 'mainnet', 'preprod', 'preview' or 'testnet:<magic>' where
+    /// `magic` is a 32-bits unsigned value denoting a particular testnet.
     #[arg(
         long,
         value_name = "NETWORK",

--- a/crates/amaru/src/bin/amaru/cmd/import_headers.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_headers.rs
@@ -5,7 +5,7 @@ use amaru_consensus::{
     IsHeader,
 };
 use amaru_kernel::{from_cbor, network::NetworkName, Header, Point};
-use clap::{builder::TypedValueParser as _, Parser};
+use clap::Parser;
 use gasket::framework::*;
 use indicatif::{ProgressBar, ProgressStyle};
 use pallas_network::{
@@ -32,8 +32,6 @@ pub struct Args {
         long,
         value_name = "NETWORK",
         default_value_t = NetworkName::Preprod,
-        value_parser = clap::builder::PossibleValuesParser::new(NetworkName::possible_values())
-            .map(|s| s.parse::<NetworkName>().unwrap()),
     )]
     network: NetworkName,
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for test networks with a dedicated variant, allowing users to specify a network via an associated numeric identifier. Enhanced parsing and display of network names ensure a smoother user experience when dealing with test configurations.

- **Refactor**
	- Updated network configuration by sourcing a key network transition value from an external definition rather than a fixed internal value, streamlining the network parameter management process.
	- Simplified argument parsing for the network field, removing custom validation logic for input values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->