### PR TITLE
feat: use era history to compute slot/epoch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
  "proptest",
  "serde",
  "sha3",
+ "slot-arithmetic",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "rand",
  "rayon",
  "rocksdb",
+ "slot-arithmetic",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
@@ -124,6 +125,7 @@ dependencies = [
  "num",
  "proptest",
  "serde",
+ "slot-arithmetic",
  "thiserror 2.0.12",
  "tracing",
 ]
@@ -156,6 +158,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "slot-arithmetic",
  "thiserror 2.0.12",
  "tracing-subscriber",
  "vrf_dalek",
@@ -2920,6 +2923,7 @@ dependencies = [
  "minicbor",
  "proptest",
  "serde",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "slot-arithmetic",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "pallas-traverse",
  "proptest",
  "serde",
+ "serde_json",
  "sha3",
  "slot-arithmetic",
 ]
@@ -2917,6 +2918,7 @@ dependencies = [
  "hex",
  "minicbor",
  "proptest",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ amaru-ouroboros = { path = "crates/ouroboros" }
 amaru-ouroboros-traits = { path = "crates/ouroboros-traits" }
 amaru-stores = { path = "crates/amaru-stores" }
 iter-borrow = { path = "crates/iter-borrow" }
+slot-arithmetic = { path = "crates/slot-arithmetic" }
 
 # The vrf crate has not been fully tested in production environments and still has several upstream issues that are open PRs but not merged yet.
 vrf_dalek = { git = "https://github.com/txpipe/vrf", rev = "044b45a1a919ba9d9c2471fc5c4d441f13086676" }

--- a/crates/amaru-consensus/Cargo.toml
+++ b/crates/amaru-consensus/Cargo.toml
@@ -30,6 +30,7 @@ amaru-kernel.workspace = true
 amaru-ledger.workspace = true
 amaru-ouroboros.workspace = true
 amaru-ouroboros-traits.workspace = true
+slot-arithmetic.workspace = true
 
 [dev-dependencies]
 envpath.workspace = true

--- a/crates/amaru-kernel/Cargo.toml
+++ b/crates/amaru-kernel/Cargo.toml
@@ -24,5 +24,7 @@ pallas-primitives.workspace = true
 pallas-traverse.workspace = true
 serde.workspace = true
 
+slot-arithmetic.workspace = true
+
 [dev-dependencies]
 proptest = { workspace = true, default-features = true }

--- a/crates/amaru-kernel/Cargo.toml
+++ b/crates/amaru-kernel/Cargo.toml
@@ -23,6 +23,7 @@ pallas-crypto.workspace = true
 pallas-primitives.workspace = true
 pallas-traverse.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 
 slot-arithmetic.workspace = true
 

--- a/crates/amaru-kernel/Cargo.toml
+++ b/crates/amaru-kernel/Cargo.toml
@@ -24,6 +24,7 @@ pallas-primitives.workspace = true
 pallas-traverse.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+thiserror.workspace = true
 
 slot-arithmetic.workspace = true
 

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -495,24 +495,6 @@ pub fn relative_slot(slot: u64) -> u64 {
     slot - shelley_previous_slots - BYRON_TOTAL_SLOTS as u64
 }
 
-/// Get the first slot of the next epoch (i.e. the slot coming straight after the last slot of the
-/// epoch).
-///
-/// ```
-/// use amaru_kernel::next_epoch_first_slot;
-/// assert_eq!(next_epoch_first_slot(3), 86400);
-/// assert!(next_epoch_first_slot(114) <= 48038412);
-/// assert!(next_epoch_first_slot(114) > 48038393);
-/// assert!(next_epoch_first_slot(150) <= 63590410);
-/// assert!(next_epoch_first_slot(150) > 63590393);
-/// ```
-// TODO: Design and implement a proper abstraction for slot arithmetic. See https://github.com/pragma-org/amaru/pull/26/files#r1807394364
-pub fn next_epoch_first_slot(current_epoch: u64) -> u64 {
-    (BYRON_TOTAL_SLOTS as u64)
-        + (SHELLEY_EPOCH_LENGTH as u64)
-            * (1 + current_epoch - PREPROD_SHELLEY_TRANSITION_EPOCH as u64)
-}
-
 /// TODO: Ideally, we should either:
 ///
 /// - Have pallas_traverse or a similar API works directly from base objects instead of KeepRaw

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -484,15 +484,6 @@ pub fn encode_bech32(hrp: &str, payload: &[u8]) -> Result<String, Box<dyn std::e
     Ok(bech32::encode::<bech32::Bech32>(hrp, payload)?)
 }
 
-/// Calculate the epoch number corresponding to a given slot on the PreProd network.
-// TODO: Design and implement a proper abstraction for slot arithmetic. See https://github.com/pragma-org/amaru/pull/26/files#r1807394364
-#[allow(clippy::unwrap_used)]
-pub fn epoch_from_slot(slot: u64) -> u64 {
-    // FIXME: currently hardwired to preprod network
-    let era_history: &EraHistory = NetworkName::Preprod.into();
-    era_history.slot_to_epoch(slot).unwrap()
-}
-
 /// Obtain the slot number relative to the epoch.
 // TODO: Design and implement a proper abstraction for slot arithmetic. See https://github.com/pragma-org/amaru/pull/26/files#r1807394364
 #[allow(clippy::unwrap_used)]

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -21,7 +21,7 @@ It's also the right place to put rather general functions or types that ought to
 While elements are being contributed upstream, they might transiently live in this module.
 */
 
-use network::PREPROD_SHELLEY_TRANSITION_EPOCH;
+use network::{preprod_era_history, PREPROD_SHELLEY_TRANSITION_EPOCH};
 use num::{rational::Ratio, BigUint};
 pub use pallas_addresses::{byron::AddrType, Address, StakeAddress, StakePayload};
 use pallas_addresses::{Error, *};
@@ -485,9 +485,10 @@ pub fn encode_bech32(hrp: &str, payload: &[u8]) -> Result<String, Box<dyn std::e
 
 /// Calculate the epoch number corresponding to a given slot on the PreProd network.
 // TODO: Design and implement a proper abstraction for slot arithmetic. See https://github.com/pragma-org/amaru/pull/26/files#r1807394364
+#[allow(clippy::unwrap_used)]
 pub fn epoch_from_slot(slot: u64) -> u64 {
-    let shelley_slots = slot - BYRON_TOTAL_SLOTS as u64;
-    (shelley_slots / SHELLEY_EPOCH_LENGTH as u64) + PREPROD_SHELLEY_TRANSITION_EPOCH as u64
+    // FIXME: currently hardwired to preprod network
+    preprod_era_history().slot_to_epoch(slot).unwrap()
 }
 
 /// Obtain the slot number relative to the epoch.

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -21,7 +21,7 @@ It's also the right place to put rather general functions or types that ought to
 While elements are being contributed upstream, they might transiently live in this module.
 */
 
-use network::{preprod_era_history, PREPROD_SHELLEY_TRANSITION_EPOCH};
+use network::{NetworkName, PREPROD_SHELLEY_TRANSITION_EPOCH};
 use num::{rational::Ratio, BigUint};
 pub use pallas_addresses::{byron::AddrType, Address, StakeAddress, StakePayload};
 use pallas_addresses::{Error, *};
@@ -51,6 +51,7 @@ pub use pallas_primitives::{
 };
 pub use sha3;
 use sha3::{Digest as _, Sha3_256};
+use slot_arithmetic::EraHistory;
 use std::{array::TryFromSliceError, convert::Infallible, ops::Deref, sync::LazyLock};
 
 pub use pallas_traverse::{ComputeHash, OriginalHash};
@@ -488,14 +489,16 @@ pub fn encode_bech32(hrp: &str, payload: &[u8]) -> Result<String, Box<dyn std::e
 #[allow(clippy::unwrap_used)]
 pub fn epoch_from_slot(slot: u64) -> u64 {
     // FIXME: currently hardwired to preprod network
-    preprod_era_history().slot_to_epoch(slot).unwrap()
+    let era_history: &EraHistory = NetworkName::Preprod.into();
+    era_history.slot_to_epoch(slot).unwrap()
 }
 
 /// Obtain the slot number relative to the epoch.
 // TODO: Design and implement a proper abstraction for slot arithmetic. See https://github.com/pragma-org/amaru/pull/26/files#r1807394364
 #[allow(clippy::unwrap_used)]
 pub fn relative_slot(slot: u64) -> u64 {
-    let shelley_previous_slots = (preprod_era_history().slot_to_epoch(slot).unwrap()
+    let era_history: &EraHistory = NetworkName::Preprod.into();
+    let shelley_previous_slots = (era_history.slot_to_epoch(slot).unwrap()
         - PREPROD_SHELLEY_TRANSITION_EPOCH as u64)
         * SHELLEY_EPOCH_LENGTH as u64;
     slot - shelley_previous_slots - BYRON_TOTAL_SLOTS as u64

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -21,7 +21,7 @@ It's also the right place to put rather general functions or types that ought to
 While elements are being contributed upstream, they might transiently live in this module.
 */
 
-use network::{NetworkName, PREPROD_SHELLEY_TRANSITION_EPOCH};
+use network::PREPROD_SHELLEY_TRANSITION_EPOCH;
 use num::{rational::Ratio, BigUint};
 pub use pallas_addresses::{byron::AddrType, Address, StakeAddress, StakePayload};
 use pallas_addresses::{Error, *};
@@ -51,7 +51,6 @@ pub use pallas_primitives::{
 };
 pub use sha3;
 use sha3::{Digest as _, Sha3_256};
-use slot_arithmetic::EraHistory;
 use std::{array::TryFromSliceError, convert::Infallible, ops::Deref, sync::LazyLock};
 
 pub use pallas_traverse::{ComputeHash, OriginalHash};
@@ -482,17 +481,6 @@ where
 pub fn encode_bech32(hrp: &str, payload: &[u8]) -> Result<String, Box<dyn std::error::Error>> {
     let hrp = bech32::Hrp::parse(hrp)?;
     Ok(bech32::encode::<bech32::Bech32>(hrp, payload)?)
-}
-
-/// Obtain the slot number relative to the epoch.
-// TODO: Design and implement a proper abstraction for slot arithmetic. See https://github.com/pragma-org/amaru/pull/26/files#r1807394364
-#[allow(clippy::unwrap_used)]
-pub fn relative_slot(slot: u64) -> u64 {
-    let era_history: &EraHistory = NetworkName::Preprod.into();
-    let shelley_previous_slots = (era_history.slot_to_epoch(slot).unwrap()
-        - PREPROD_SHELLEY_TRANSITION_EPOCH as u64)
-        * SHELLEY_EPOCH_LENGTH as u64;
-    slot - shelley_previous_slots - BYRON_TOTAL_SLOTS as u64
 }
 
 /// TODO: Ideally, we should either:

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -493,8 +493,10 @@ pub fn epoch_from_slot(slot: u64) -> u64 {
 
 /// Obtain the slot number relative to the epoch.
 // TODO: Design and implement a proper abstraction for slot arithmetic. See https://github.com/pragma-org/amaru/pull/26/files#r1807394364
+#[allow(clippy::unwrap_used)]
 pub fn relative_slot(slot: u64) -> u64 {
-    let shelley_previous_slots = (epoch_from_slot(slot) - PREPROD_SHELLEY_TRANSITION_EPOCH as u64)
+    let shelley_previous_slots = (preprod_era_history().slot_to_epoch(slot).unwrap()
+        - PREPROD_SHELLEY_TRANSITION_EPOCH as u64)
         * SHELLEY_EPOCH_LENGTH as u64;
     slot - shelley_previous_slots - BYRON_TOTAL_SLOTS as u64
 }

--- a/crates/amaru-kernel/src/network.rs
+++ b/crates/amaru-kernel/src/network.rs
@@ -323,6 +323,14 @@ mod tests {
     }
 
     #[test]
+    fn can_compute_next_epoch_first_slot_for_preprod() {
+        let era_history = &*PREPROD_ERA_HISTORY;
+        assert_eq!(era_history.next_epoch_first_slot(3), Ok(86400));
+        assert_eq!(era_history.next_epoch_first_slot(114), Ok(48038400));
+        assert_eq!(era_history.next_epoch_first_slot(150), Ok(63590400));
+    }
+
+    #[test]
     fn test_era_history_json_serialization() {
         let original_era_history = &*PREPROD_ERA_HISTORY;
 

--- a/crates/amaru-ledger/Cargo.toml
+++ b/crates/amaru-ledger/Cargo.toml
@@ -22,6 +22,7 @@ thiserror.workspace = true
 iter-borrow.workspace = true
 amaru-kernel.workspace = true
 amaru-ouroboros-traits.workspace = true
+slot-arithmetic.workspace = true
 
 [dev-dependencies]
 proptest = { workspace = true, features = ["std"] }

--- a/crates/amaru/src/bin/amaru/cmd/daemon.rs
+++ b/crates/amaru/src/bin/amaru/cmd/daemon.rs
@@ -62,7 +62,8 @@ pub async fn run(
 
     let mut clients: Vec<(String, Arc<Mutex<PeerClient>>)> = vec![];
     for peer in &config.upstream_peers {
-        let client = PeerClient::connect(peer.clone(), config.network_magic as u64).await?;
+        let client =
+            PeerClient::connect(peer.clone(), config.network.to_network_magic() as u64).await?;
         clients.push((peer.clone(), Arc::new(Mutex::new(client))));
     }
 
@@ -104,6 +105,6 @@ fn parse_args(args: Args) -> Result<Config, Box<dyn std::error::Error>> {
         ledger_dir: args.ledger_dir,
         chain_dir: args.chain_dir,
         upstream_peers: args.peer_address,
-        network_magic: args.network.to_network_magic(),
+        network: args.network,
     })
 }

--- a/crates/amaru/src/bin/amaru/cmd/import_headers.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_headers.rs
@@ -67,7 +67,8 @@ enum What {
 use What::*;
 
 pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
-    let mut db = RocksDBStore::new(args.chain_dir)?;
+    let era_history = args.network.into();
+    let mut db = RocksDBStore::new(args.chain_dir, era_history)?;
 
     let peer_client = Arc::new(Mutex::new(
         PeerClient::connect(

--- a/crates/amaru/src/pipeline.rs
+++ b/crates/amaru/src/pipeline.rs
@@ -1,4 +1,4 @@
-use amaru_kernel::{protocol_parameters::ProtocolParameters, Hasher, Point};
+use amaru_kernel::{network::EraHistory, protocol_parameters::ProtocolParameters, Hasher, Point};
 use amaru_ledger::{
     context,
     rules::{self, parse_block},
@@ -37,8 +37,8 @@ impl<S: Store + Send> gasket::framework::Stage for Stage<S> {
 }
 
 impl<S: Store + Send> Stage<S> {
-    pub fn new(store: S) -> (Self, Point) {
-        let state = state::State::new(Arc::new(std::sync::Mutex::new(store)));
+    pub fn new(store: S, era_history: &EraHistory) -> (Self, Point) {
+        let state = state::State::new(Arc::new(std::sync::Mutex::new(store)), era_history);
 
         let tip = state.tip().into_owned();
 

--- a/crates/ouroboros/Cargo.toml
+++ b/crates/ouroboros/Cargo.toml
@@ -24,6 +24,7 @@ vrf_dalek.workspace = true
 
 amaru-kernel.workspace = true
 amaru-ouroboros-traits.workspace = true
+slot-arithmetic.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true

--- a/crates/ouroboros/src/praos/nonce.rs
+++ b/crates/ouroboros/src/praos/nonce.rs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{
-    network::EraHistory, next_epoch_first_slot, Epoch, Hasher, Nonce,
-    RANDOMNESS_STABILIZATION_WINDOW,
-};
+use amaru_kernel::{network::EraHistory, Epoch, Hasher, Nonce, RANDOMNESS_STABILIZATION_WINDOW};
 use amaru_ouroboros_traits::IsHeader;
 use slot_arithmetic::TimeHorizonError;
 
@@ -54,7 +51,7 @@ pub fn randomness_stability_window<H: IsHeader>(
 ) -> Result<(Epoch, bool), TimeHorizonError> {
     let epoch = era_history.slot_to_epoch(header.slot())?;
 
-    let is_within_stability_window =
-        header.slot() + RANDOMNESS_STABILIZATION_WINDOW >= next_epoch_first_slot(epoch);
-    Ok((epoch, !is_within_stability_window))
+    let is_within_stability_window = header.slot() + RANDOMNESS_STABILIZATION_WINDOW
+        < era_history.next_epoch_first_slot(epoch)?;
+    Ok((epoch, is_within_stability_window))
 }

--- a/crates/ouroboros/src/praos/nonce.rs
+++ b/crates/ouroboros/src/praos/nonce.rs
@@ -43,15 +43,19 @@ pub fn evolve<H: IsHeader>(header: &H, current: &Nonce) -> Nonce {
     )
 }
 
-/// Check whether a header is within the stability of the current epoch, and return its epoch for
-/// convenience.
+/// Determines if a header is within the randomness stability window of its epoch.
+///
+/// Returns the header's epoch and a boolean indicating whether the header is within
+/// the stability window (i.e., far enough from the epoch boundary).
 pub fn randomness_stability_window<H: IsHeader>(
     header: &H,
     era_history: &EraHistory,
 ) -> Result<(Epoch, bool), TimeHorizonError> {
-    let epoch = era_history.slot_to_epoch(header.slot())?;
+    let slot = header.slot();
+    let epoch = era_history.slot_to_epoch(slot)?;
+    let next_epoch_first_slot = era_history.next_epoch_first_slot(epoch)?;
 
-    let is_within_stability_window = header.slot() + RANDOMNESS_STABILIZATION_WINDOW
-        < era_history.next_epoch_first_slot(epoch)?;
+    let is_within_stability_window = slot + RANDOMNESS_STABILIZATION_WINDOW < next_epoch_first_slot;
+
     Ok((epoch, is_within_stability_window))
 }

--- a/crates/slot-arithmetic/Cargo.toml
+++ b/crates/slot-arithmetic/Cargo.toml
@@ -15,6 +15,7 @@ rust-version.workspace = true
 [dependencies]
 hex.workspace = true
 minicbor = { workspace = true, features = ["std", "half", "derive"] }
+serde.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/slot-arithmetic/Cargo.toml
+++ b/crates/slot-arithmetic/Cargo.toml
@@ -16,6 +16,7 @@ rust-version.workspace = true
 hex.workspace = true
 minicbor = { workspace = true, features = ["std", "half", "derive"] }
 serde.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/slot-arithmetic/src/lib.rs
+++ b/crates/slot-arithmetic/src/lib.rs
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 use minicbor::{Decode, Decoder, Encode};
+use serde::{Deserialize, Serialize};
 
 type Slot = u64;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Bound {
     pub time_ms: u64, // Milliseconds
     pub slot: Slot,
@@ -64,7 +65,7 @@ impl<'b, C> Decode<'b, C> for Bound {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EraParams {
     pub epoch_size_slots: u64,
     pub slot_length: u64, // Milliseconds
@@ -114,7 +115,7 @@ impl<'b, C> Decode<'b, C> for EraParams {
 
 // The start is inclusive and the end is exclusive. In a valid EraHistory, the
 // end of each era will equal the start of the next one.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Summary {
     pub start: Bound,
     pub end: Bound,
@@ -148,7 +149,7 @@ impl<'b, C> Decode<'b, C> for Summary {
 }
 
 // A complete history of eras that have taken place.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EraHistory {
     pub eras: Vec<Summary>,
 }

--- a/crates/slot-arithmetic/src/lib.rs
+++ b/crates/slot-arithmetic/src/lib.rs
@@ -66,8 +66,8 @@ impl<'b, C> Decode<'b, C> for Bound {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EraParams {
-    epoch_size_slots: u64,
-    slot_length: u64, // Milliseconds
+    pub epoch_size_slots: u64,
+    pub slot_length: u64, // Milliseconds
 }
 
 impl EraParams {

--- a/crates/slot-arithmetic/src/lib.rs
+++ b/crates/slot-arithmetic/src/lib.rs
@@ -180,9 +180,11 @@ impl<'b, C> Decode<'b, C> for EraHistory {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum TimeHorizonError {
+    #[error("slot past time horizon")]
     PastTimeHorizon,
+    #[error("invalid era history")]
     InvalidEraHistory,
 }
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -31,7 +31,10 @@ dependencies = [
  "pallas-primitives",
  "pallas-traverse",
  "serde",
+ "serde_json",
  "sha3",
+ "slot-arithmetic",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -44,6 +47,7 @@ dependencies = [
  "iter-borrow",
  "num",
  "serde",
+ "slot-arithmetic",
  "thiserror 2.0.11",
  "tracing",
 ]
@@ -496,6 +500,16 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest",
  "keccak",
+]
+
+[[package]]
+name = "slot-arithmetic"
+version = "0.1.0"
+dependencies = [
+ "hex",
+ "minicbor",
+ "serde",
+ "thiserror 2.0.11",
 ]
 
 [[package]]

--- a/examples/shared/src/lib.rs
+++ b/examples/shared/src/lib.rs
@@ -1,6 +1,7 @@
 use amaru_kernel::{
     cbor, protocol_parameters::ProtocolParameters, Bytes, Hash, Hasher, MintedBlock, Point,
     PostAlonzoTransactionOutput, TransactionInput, TransactionOutput, Value,
+    network:: {EraHistory, NetworkName}
 };
 use amaru_ledger::{
     context,
@@ -24,8 +25,9 @@ pub fn forward_ledger(raw_block: &str) {
     let bytes = hex::decode(raw_block).unwrap();
 
     let (_hash, block): BlockWrapper = cbor::decode(&bytes).unwrap();
+    let era_history : &EraHistory = NetworkName::Preprod.into();
 
-    let mut state = State::new(Arc::new(Mutex::new(MemoryStore {})));
+    let mut state = State::new(Arc::new(Mutex::new(MemoryStore {})), era_history);
 
     let point = Point::Specific(
         block.header.header_body.slot,

--- a/simulation/amaru-sim/README.md
+++ b/simulation/amaru-sim/README.md
@@ -16,43 +16,6 @@ To run such tests, one needs to:
 
 ### Compile simulator
 
-> [!IMPORTANT]
->
-> As of 2025-03-24, amaru only supports `preprod` network configuration which means that all epoch/slots conversions are hardwired for this network.
-> In order to be able to run a "test" network, one needs to change those functions manually. This is obviously a temporary kludge
->
-> The following patch can be applied to the repository as a workaround:
->
-> ```diff
-> diff --git a/crates/amaru-kernel/src/lib.rs b/crates/amaru-kernel/src/lib.rs
-> index 29f0e6b..fe240c1 100644
-> --- a/crates/amaru-kernel/src/lib.rs
-> +++ b/crates/amaru-kernel/src/lib.rs
-> @@ -486,9 +486,8 @@ pub fn encode_bech32(hrp: &str, payload: &[u8]) -> Result<String, Box<dyn std::e
->
->  /// Calculate the epoch number corresponding to a given slot on the PreProd network.
->  // TODO: Design and implement a proper abstraction for slot arithmetic. See https://github.com/pragma-org/amaru/pull/26/files#r1807394364
-> -pub fn epoch_from_slot(slot: u64) -> u64 {
-> -    let shelley_slots = slot - BYRON_TOTAL_SLOTS as u64;
-> -    (shelley_slots / SHELLEY_EPOCH_LENGTH as u64) + PREPROD_SHELLEY_TRANSITION_EPOCH as u64
-> +pub fn epoch_from_slot(_slot: u64) -> u64 {
-> +    0
->  }
->
->  /// Obtain the slot number relative to the epoch.
-> @@ -511,10 +510,8 @@ pub fn relative_slot(slot: u64) -> u64 {
->  /// assert!(next_epoch_first_slot(150) > 63590393);
->  /// ```
->  // TODO: Design and implement a proper abstraction for slot arithmetic. See https://github.com/pragma-org/amaru/pull/26/files#r1807394364
-> -pub fn next_epoch_first_slot(current_epoch: u64) -> u64 {
-> -    (BYRON_TOTAL_SLOTS as u64)
-> -        + (SHELLEY_EPOCH_LENGTH as u64)
-> -            * (1 + current_epoch - PREPROD_SHELLEY_TRANSITION_EPOCH as u64)
-> +pub fn next_epoch_first_slot(_current_epoch: u64) -> u64 {
-> +    100000
->  }
-> ```
-
 Build the simulator in debug mode (from toplevel Amaru workspace):
 
 ```

--- a/simulation/amaru-sim/src/simulator/ledger.rs
+++ b/simulation/amaru-sim/src/simulator/ledger.rs
@@ -164,6 +164,7 @@ pub struct ConsensusContext {
 #[cfg(test)]
 mod test {
     use amaru_consensus::consensus::store::{ChainStore, Nonces, StoreError};
+    use amaru_kernel::network::NetworkName;
     use amaru_kernel::Header;
 
     use super::populate_chain_store;
@@ -243,6 +244,10 @@ mod test {
         fn put_nonces(&mut self, header: &Hash<32>, nonces: Nonces) -> Result<(), StoreError> {
             self.nonces.insert(*header, nonces);
             Ok(())
+        }
+
+        fn era_history(&self) -> &amaru_kernel::network::EraHistory {
+            NetworkName::Testnet(42).into()
         }
     }
 

--- a/simulation/amaru-sim/src/simulator/mod.rs
+++ b/simulation/amaru-sim/src/simulator/mod.rs
@@ -23,6 +23,7 @@ use amaru_consensus::consensus::{
     store::{rocksdb::RocksDBStore, ChainStore},
 };
 use amaru_consensus::peer::Peer;
+use amaru_kernel::network::NetworkName;
 use amaru_kernel::to_cbor;
 use amaru_kernel::{
     Header,
@@ -84,14 +85,16 @@ pub async fn bootstrap<T: MessageReader>(args: Args, mut input_reader: T) {
 
     let stake_distribution: FakeStakeDistribution =
         FakeStakeDistribution::from_file(&args.stake_distribution_file).unwrap();
+    let era_history = NetworkName::Testnet(42).into();
 
-    let mut chain_store = RocksDBStore::new(args.chain_dir.clone()).unwrap_or_else(|e| {
-        panic!(
-            "unable to open chain store at {}: {:?}",
-            args.chain_dir.display(),
-            e
-        )
-    });
+    let mut chain_store =
+        RocksDBStore::new(args.chain_dir.clone(), era_history).unwrap_or_else(|e| {
+            panic!(
+                "unable to open chain store at {}: {:?}",
+                args.chain_dir.display(),
+                e
+            )
+        });
 
     populate_chain_store(
         &mut chain_store,


### PR DESCRIPTION
This PR introduces the use of `EraHistory` from `slot-arithmetic` crate into Amaru to provide epoch and slot computations. So far, those computations were hardcoded but in order to be able to test Amaru we need to be able to configure the system with different testing environments. This is a first step in that direction to validate the approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced network time conversion with a refined method for calculating epochs using detailed era history.
	- Expanded project capabilities through the integration of new workspace dependencies, including `serde`, `thiserror`, and `slot-arithmetic`.
	- New methods and fields added to various structs to incorporate era history into state management and database operations.
	- Introduced functionality for era history retrieval in test modules.
- **Bug Fixes**
	- Improved error handling for era history file operations.
- **Tests**
	- Introduced new validations to ensure accurate slot-to-epoch conversions for the PreProd network.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->