### PR TITLE
feat: add backtrace to panic_handler

### DIFF
--- a/crates/amaru/src/bin/amaru/panic.rs
+++ b/crates/amaru/src/bin/amaru/panic.rs
@@ -17,7 +17,6 @@
 pub fn panic_handler() {
     let prev = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
-
         // We present the user with a helpful and welcoming error message;
         // Block producing nodes should be considered mission critical software, and so
         // They should endeavor *never* to crash, and should always handle and recover from errors.

--- a/crates/amaru/src/bin/amaru/panic.rs
+++ b/crates/amaru/src/bin/amaru/panic.rs
@@ -15,29 +15,8 @@
 /// Installs a panic handler that prints some useful diagnostics and
 /// asks the user to report the issue.
 pub fn panic_handler() {
+    let prev = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
-        let message = info
-            .payload()
-            .downcast_ref::<&str>()
-            .map(|s| (*s).to_string())
-            .or_else(|| {
-                info.payload()
-                    .downcast_ref::<String>()
-                    .map(|s| s.to_string())
-            })
-            .unwrap_or_else(|| "unknown error".to_string());
-
-        let location = info.location().map_or_else(
-            || "".into(),
-            |location| {
-                format!(
-                    "{}:{}:{}\n\n    ",
-                    location.file(),
-                    location.line(),
-                    location.column(),
-                )
-            },
-        );
 
         // We present the user with a helpful and welcoming error message;
         // Block producing nodes should be considered mission critical software, and so
@@ -56,14 +35,13 @@ pub fn panic_handler() {
                         In your bug report please provide the information below and if possible the code
                         that produced it.
                         {info}
-
-                        {location}{message}"#,
+                        
+                        "#,
             info = node_info(),
             fatal = "amaru::fatal::error",
-            location = location,
         };
-
         eprintln!("\n{}", indent(&error_message, 3));
+        prev(info);
     }));
 }
 


### PR DESCRIPTION
Modify the `panic_handler` so that it piggybacks on the default one to print the backtrace (depends on `RUST_BACKTRACE` usage). Somehow I couldn't add a meaningful backtrace directly ([Backtrace#force_capture](https://doc.rust-lang.org/std/backtrace/struct.Backtrace.html#method.force_capture) captures the panic trace) 

**before**

```rust
   amaru::fatal::error
   Whoops! The Amaru process panicked, rather than handling the error it encountered gracefully.
   
   This is almost certainly a bug, and we'd appreciate a report so we can improve Amaru.
   
   Please report this error at https://github.com/pragma-org/amaru/issues/new.
   
   In your bug report please provide the information below and if possible the code
   that produced it.
   
   Operating System: macos
   Architecture:     aarch64
   Version:          v0.1.0+c3b288f
   
   /Users/julien/.cargo/registry/src/index.crates.io-6f17d22bba15001f/gasket-0.8.0/src/daemon.rs:64:36
   
       stage stops: TetherDropped
```

**after**

```rust
   amaru::fatal::error
   Whoops! The Amaru process panicked, rather than handling the error it encountered gracefully.
   
   This is almost certainly a bug, and we'd appreciate a report so we can improve Amaru.
   
   Please report this error at https://github.com/pragma-org/amaru/issues/new.
   
   In your bug report please provide the information below and if possible the code
   that produced it.
   
   Operating System: macos
   Architecture:     aarch64
   Version:          v0.1.0+c3b288f
   
thread 'main' panicked at /Users/julien/.cargo/registry/src/index.crates.io-6f17d22bba15001f/gasket-0.8.0/src/daemon.rs:64:36:
stage stops: TetherDropped
stack backtrace:
   0:        0x10351abd4 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h39ba3129e355bb22
   1:        0x103538d4c - core::fmt::write::h8b50d3a0f616451a
   2:        0x1035174ac - std::io::Write::write_fmt::h4b3bbae7048e35f8
   3:        0x10351aa88 - std::sys::backtrace::BacktraceLock::print::h7934b1e389160086
   4:        0x10351bc48 - std::panicking::default_hook::{{closure}}::hbcd636b20f603d1e
   5:        0x10351ba7c - std::panicking::default_hook::ha9081970ba26bc6c
   6:        0x102b03150 - amaru::panic::panic_handler::{{closure}}::h8ccf7dfbd50d5b71
   7:        0x10351c478 - std::panicking::rust_panic_with_hook::h9a5dc30b684e2ff4
   8:        0x10351c0b0 - std::panicking::begin_panic_handler::{{closure}}::hbcb5de8b840ae91c
   9:        0x10351b098 - std::sys::backtrace::__rust_end_short_backtrace::ha657d4b4d65dc993
  10:        0x10351bd68 - _rust_begin_unwind
  11:        0x10356bbb8 - core::panicking::panic_fmt::hda207213c7ca0065
  12:        0x10356bfa8 - core::result::unwrap_failed::h8075069206468d45
  13:        0x1033d3d38 - gasket::daemon::Daemon::teardown::haae4969ec97d0391
  14:        0x102af4b18 - amaru::main::{{closure}}::hf26c351b4689ac2e
  15:        0x102b0a494 - tokio::runtime::park::CachedParkThread::block_on::h2e987dbf673a6bdf
  16:        0x102ac7284 - tokio::runtime::context::runtime::enter_runtime::hfacb8b64e63aa183
  17:        0x102a94774 - tokio::runtime::runtime::Runtime::block_on::h7a6fb3b55a88ccfe
  18:        0x102adfdcc - amaru::main::h26ce2b42efbeb077
  19:        0x102a99ec0 - std::sys::backtrace::__rust_begin_short_backtrace::h86f6649d0cb1b13b
  20:        0x102a9bbd8 - std::rt::lang_start::{{closure}}::hb552009e5363bb16
  21:        0x103511b40 - std::rt::lang_start_internal::hf1bc3d9041088441
  22:        0x102adfedc - _main
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified error reporting by removing overly detailed technical diagnostics during unexpected failures, resulting in cleaner and more user-friendly error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->