### PR TITLE
chore: move consensus store implementation to crate stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,6 @@ dependencies = [
  "proptest",
  "rand",
  "rayon",
- "rocksdb",
  "slot-arithmetic",
  "tempfile",
  "thiserror 2.0.12",
@@ -180,6 +179,7 @@ dependencies = [
  "amaru-kernel",
  "amaru-ledger",
  "amaru-ouroboros",
+ "amaru-stores",
  "async-trait",
  "built",
  "clap",
@@ -208,13 +208,18 @@ dependencies = [
 name = "amaru-stores"
 version = "0.1.0"
 dependencies = [
+ "amaru-consensus",
  "amaru-kernel",
  "amaru-ledger",
+ "amaru-ouroboros-traits",
  "hex",
  "iter-borrow",
  "pallas-codec",
  "proptest",
+ "rand",
  "rocksdb",
+ "slot-arithmetic",
+ "tempfile",
  "tracing",
 ]
 

--- a/crates/amaru-consensus/Cargo.toml
+++ b/crates/amaru-consensus/Cargo.toml
@@ -20,7 +20,6 @@ pallas-crypto.workspace = true
 pallas-math.workspace = true
 pallas-network.workspace = true
 rayon.workspace = true
-rocksdb.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/amaru-consensus/src/consensus/store.rs
+++ b/crates/amaru-consensus/src/consensus/store.rs
@@ -21,8 +21,6 @@ use slot_arithmetic::TimeHorizonError;
 use std::fmt::Display;
 use thiserror::Error;
 
-pub mod rocksdb;
-
 #[derive(Error, Debug)]
 pub enum StoreError {
     WriteError { error: String },

--- a/crates/amaru-stores/Cargo.toml
+++ b/crates/amaru-stores/Cargo.toml
@@ -17,10 +17,15 @@ hex.workspace = true
 pallas-codec.workspace = true
 rocksdb.workspace = true
 tracing.workspace = true
+rand.workspace = true
 
-iter-borrow.workspace = true
 amaru-kernel.workspace = true
 amaru-ledger.workspace = true
+amaru-consensus.workspace = true
+amaru-ouroboros-traits.workspace = true
+iter-borrow.workspace = true
+slot-arithmetic.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
+tempfile.workspace = true

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -36,6 +36,7 @@ use tracing::{info, instrument, trace, warn, Level};
 
 pub mod columns;
 pub mod common;
+pub mod consensus;
 
 const EVENT_TARGET: &str = "amaru::ledger::store";
 

--- a/crates/amaru/src/bin/amaru/cmd/import_headers.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_headers.rs
@@ -1,10 +1,11 @@
 use amaru::sync;
 use amaru_consensus::{
-    consensus::store::{rocksdb::RocksDBStore, ChainStore},
+    consensus::store::ChainStore,
     peer::{Peer, PeerSession},
     IsHeader,
 };
 use amaru_kernel::{from_cbor, network::NetworkName, Header, Point};
+use amaru_stores::rocksdb::consensus::RocksDBStore;
 use clap::Parser;
 use gasket::framework::*;
 use indicatif::{ProgressBar, ProgressStyle};

--- a/crates/amaru/src/bin/amaru/cmd/import_nonces.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_nonces.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_consensus::consensus::store::{rocksdb::RocksDBStore, ChainStore, Nonces};
+use amaru_consensus::consensus::store::{ChainStore, Nonces};
 use amaru_kernel::{network::NetworkName, Hash, Header, Nonce, Point};
+use amaru_stores::rocksdb::consensus::RocksDBStore;
 use clap::Parser;
 use std::path::PathBuf;
 use tracing::info;

--- a/crates/amaru/src/sync.rs
+++ b/crates/amaru/src/sync.rs
@@ -18,7 +18,7 @@ use amaru_consensus::{
         chain_selection::{ChainSelector, ChainSelectorBuilder},
         fetch::BlockFetchStage,
         header_validation::Consensus,
-        store::{rocksdb::RocksDBStore, ChainStore},
+        store::ChainStore,
         wiring::{HeaderStage, PullEvent},
     },
     peer::{Peer, PeerSession},
@@ -28,7 +28,7 @@ use amaru_kernel::{
     network::{EraHistory, NetworkName},
     Hash, Header, Point,
 };
-use amaru_stores::rocksdb::RocksDB;
+use amaru_stores::rocksdb::{consensus::RocksDBStore, RocksDB};
 use gasket::{
     messaging::{tokio::funnel_ports, OutputPort},
     runtime::Tether,

--- a/simulation/amaru-sim/Cargo.toml
+++ b/simulation/amaru-sim/Cargo.toml
@@ -35,6 +35,7 @@ amaru-kernel = { path = "../../crates/amaru-kernel" }
 amaru-consensus = { path = "../../crates/amaru-consensus" }
 amaru-ledger = { path = "../../crates/amaru-ledger" }
 amaru-ouroboros = { path = "../../crates/ouroboros" }
+amaru-stores = { path = "../../crates/amaru-stores" }
 
 [dev-dependencies]
 envpath = { workspace = true, features = ["rand"] }

--- a/simulation/amaru-sim/src/simulator/mod.rs
+++ b/simulation/amaru-sim/src/simulator/mod.rs
@@ -20,7 +20,7 @@ use amaru_consensus::consensus::wiring::PullEvent;
 use amaru_consensus::consensus::{
     chain_selection::{ChainSelector, ChainSelectorBuilder},
     header_validation::Consensus,
-    store::{rocksdb::RocksDBStore, ChainStore},
+    store::ChainStore,
 };
 use amaru_consensus::peer::Peer;
 use amaru_kernel::network::NetworkName;
@@ -29,6 +29,7 @@ use amaru_kernel::{
     Header,
     Point::{self, *},
 };
+use amaru_stores::rocksdb::consensus::RocksDBStore;
 use bytes::Bytes;
 use clap::Parser;
 use ledger::{populate_chain_store, FakeStakeDistribution};


### PR DESCRIPTION
Move consensus `rocksdb` store into the `stores` crate. Part of being able to compile `amaru-consensus` in wasm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated module namespace to enhance the integration of core components.
  - Incorporated updated dependency configurations to support improved simulation processes.

- **Refactor**
  - Reorganised module import paths and public interfaces to streamline component interactions and promote consistency.

- **Chores**
  - Revised dependency declarations by removing obsolete entries and reordering items for enhanced maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->