### PR TITLE
chore: cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ chain.db
 # Insta not-yet reviewed snapshots
 *.snap.new
 
+# Files downloaded for the demo
+snapshots/
+
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "gasket"
-version = "0.9.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37057b6b0b48bb9bdcd4c2bc8ec51090a6cd754744caf28d44b813584473be3a"
+checksum = "75b60154514ed9e060f0b2b78819602fa5d68746d6b618efb2ea2fecc6f89f32"
 dependencies = [
  "async-trait",
  "crossbeam",
@@ -1005,15 +1005,14 @@ dependencies = [
  "signal-hook",
  "thiserror 1.0.69",
  "tokio",
- "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "gasket-derive"
-version = "0.9.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c4883f898206041f02b010ab10400715e89e7845c63410f6bad162a3841174"
+checksum = "d16f3b9da5c685c55178b9749f79bf6a6c62d1bd07656a0c8eeddadb80ef29c8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1.83"
 bech32 = "0.11.0"
 clap = { version = "4.5.35", features = ["derive", "env"] }
 futures-util = "0.3.31"
-gasket = { version = "0.9.0", features = ["derive"] }
+gasket = { version = "0.8.0", features = ["derive"] }
 hex = "0.4.3"
 indicatif = "0.17.9"
 indoc = "2.0"

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -200,11 +200,6 @@ impl<S: Store> State<S> {
             epoch_transition(&mut *db, current_epoch, self.rewards_summary.take())?;
         }
 
-        let anchor_slot = now_stable.anchor.0.slot_or_default();
-        let epoch = self
-            .era_history
-            .slot_to_epoch(From::from(anchor_slot))
-            .map_err(|e| StateError::ErrorComputingEpoch(anchor_slot, e))?;
         let StoreUpdate {
             point: stable_point,
             issuer: stable_issuer,
@@ -213,7 +208,7 @@ impl<S: Store> State<S> {
             remove,
             withdrawals,
             voting_dreps,
-        } = now_stable.into_store_update(epoch);
+        } = now_stable.into_store_update(current_epoch);
 
         db.save(
             &stable_point,


### PR DESCRIPTION
Remove some code redundancy.
Also downgrades `gasket` due to a [println leftover](https://github.com/construkts/gasket-rs/pull/34) that [breaks our tests](https://github.com/pragma-org/amaru/actions/runs/14309916229/job/40103689863#step:13:77) due to a cascade of issues related to [rust handling of `sigpipe`](https://github.com/rust-lang/rust/issues/119980). Fixing this requires some extra dependency to `libc` not worth the hassle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Adjusted repository configurations to streamline file tracking by excluding temporary snapshot data.
  
- **Refactor**
  - Simplified internal logic to enhance maintainability and clarity without affecting user-facing functionality.
  
- **Dependency Updates**
  - Downgraded the version of the `gasket` dependency from `0.9.0` to `0.8.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->