### PR TITLE
chore: move ledger state management logic out of the store

### DIFF
--- a/crates/amaru-ledger/src/store/columns/pots.rs
+++ b/crates/amaru-ledger/src/store/columns/pots.rs
@@ -15,7 +15,7 @@
 /// This modules captures protocol-wide value pots such as treasury and reserves accounts.
 use amaru_kernel::{cbor, Lovelace};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Row {
     pub treasury: Lovelace,
     pub reserves: Lovelace,

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/pots.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/pots.rs
@@ -21,11 +21,11 @@ pub const PREFIX: [u8; PREFIX_LEN] = [0x70, 0x6f, 0x74, 0x73];
 
 #[allow(clippy::panic)]
 pub fn get<DB>(db: &Transaction<'_, DB>) -> Result<Row, StoreError> {
-    Ok(Row::unsafe_decode(
-        db.get(PREFIX)
-            .map_err(|err| StoreError::Internal(err.into()))?
-            .unwrap_or_else(|| panic!("no protocol pots (treasury, reserves, fees, ...) found")),
-    ))
+    Ok(db
+        .get(PREFIX)
+        .map_err(|err| StoreError::Internal(err.into()))?
+        .map(Row::unsafe_decode)
+        .unwrap_or_default())
 }
 
 pub fn put<DB>(db: &Transaction<'_, DB>, row: Row) -> Result<(), StoreError> {

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/pots.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/pots.rs
@@ -19,7 +19,6 @@ use rocksdb::Transaction;
 /// Name prefixed used for storing protocol pots. UTF-8 encoding for "pots"
 pub const PREFIX: [u8; PREFIX_LEN] = [0x70, 0x6f, 0x74, 0x73];
 
-#[allow(clippy::panic)]
 pub fn get<DB>(db: &Transaction<'_, DB>) -> Result<Row, StoreError> {
     Ok(db
         .get(PREFIX)

--- a/examples/shared/src/store.rs
+++ b/examples/shared/src/store.rs
@@ -4,7 +4,7 @@ use amaru_ledger::{
         EpochTransitionProgress, HistoricalStores, ReadOnlyStore, Snapshot, Store, StoreError,
         TransactionalContext,
     },
-    summary::{rewards::RewardsSummary, Pots},
+    summary::Pots,
 };
 use std::collections::BTreeSet;
 
@@ -138,14 +138,6 @@ impl<'a> TransactionalContext<'a> for MemoryTransactionalContext {
         Ok(())
     }
 
-    fn reset_fees(&self) -> Result<(), StoreError> {
-        Ok(())
-    }
-
-    fn reset_blocks_count(&self) -> Result<(), StoreError> {
-        Ok(())
-    }
-
     fn try_epoch_transition(
         &self,
         _from: Option<EpochTransitionProgress>,
@@ -154,24 +146,12 @@ impl<'a> TransactionalContext<'a> for MemoryTransactionalContext {
         Ok(true)
     }
 
-    fn apply_rewards(&self, _rewards_summary: &mut RewardsSummary) -> Result<(), StoreError> {
-        Ok(())
-    }
-
-    fn adjust_pots(
-        &self,
-        _delta_treasury: u64,
-        _delta_reserves: u64,
-        _unclaimed_rewards: u64,
-    ) -> Result<(), StoreError> {
-        Ok(())
-    }
-
     fn refund(
         &self,
-        _refunds: impl Iterator<Item = (StakeCredential, Lovelace)>,
-    ) -> Result<(), amaru_ledger::store::StoreError> {
-        Ok(())
+        _credential: &amaru_ledger::store::columns::accounts::Key,
+        _deposit: Lovelace,
+    ) -> Result<Lovelace, StoreError> {
+        Ok(0)
     }
 
     fn save(
@@ -226,15 +206,6 @@ impl<'a> TransactionalContext<'a> for MemoryTransactionalContext {
         >,
         _withdrawals: impl Iterator<Item = amaru_ledger::store::columns::accounts::Key>,
         _voting_dreps: BTreeSet<StakeCredential>,
-    ) -> Result<(), amaru_ledger::store::StoreError> {
-        Ok(())
-    }
-
-    fn set_pots(
-        &self,
-        _treasury: amaru_kernel::Lovelace,
-        _reserves: amaru_kernel::Lovelace,
-        _fees: amaru_kernel::Lovelace,
     ) -> Result<(), amaru_ledger::store::StoreError> {
         Ok(())
     }


### PR DESCRIPTION
This happened mostly out of convenience but was plain wrong in terms of dispatching responsibilities. We shall strive to keep the store as dumb as possible and have higher-level functions combining the stores primitives in the ledger.

This is now much cleaner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined and modularized epoch transition operations, improving clarity and maintainability of state updates at epoch boundaries.
  - Updated refund logic to process refunds individually instead of in batches.
  - Enhanced handling of missing data in the ledger, defaulting to safe values instead of errors.
  - Adjusted internal state reset and update mechanisms for improved reliability.
- **Bug Fixes**
  - Improved error handling to prevent panics when ledger data is missing.
- **Chores**
  - Simplified and cleaned up internal interfaces and removed unused methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->