### PR TITLE
chore: simplify readme

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Build Amaru
         run: |
-          cargo test --no-run -p amaru
+          cargo test --release --no-run -p amaru
 
       - name: Cache Amaru's ledger.db
         id: cache-ledger-db

--- a/Makefile
+++ b/Makefile
@@ -43,26 +43,26 @@ download-haskell-config: ## Download Cardano Haskell configuration for $NETWORK
 	curl -O --output-dir $(HASKELL_NODE_CONFIG_DIR) $(HASKELL_NODE_CONFIG_SOURCE)/$(NETWORK)/conway-genesis.json
 
 import-snapshots: snapshots ## Import PreProd snapshots for demo
-	cargo run -- import-ledger-state \
+	cargo run --release -- import-ledger-state \
 	--ledger-dir $(LEDGER_DIR) \
 	--snapshot $^/69206375.6f99b5f3deaeae8dc43fce3db2f3cd36ad8ed174ca3400b5b1bed76fdf248912.cbor \
 	--snapshot $^/69638382.5da6ba37a4a07df015c4ea92c880e3600d7f098b97e73816f8df04bbb5fad3b7.cbor \
 	--snapshot $^/70070379.d6fe6439aed8bddc10eec22c1575bf0648e4a76125387d9e985e9a3f8342870d.cbor
 
 import-headers: ## Import headers from $AMARU_PEER_ADDRESS for demo
-	cargo run -- import-headers \
+	cargo run --release -- import-headers \
 	--chain-dir $(CHAIN_DIR) \
 	--peer-address ${AMARU_PEER_ADDRESS} \
 	--starting-point 69638365.4ec0f5a78431fdcc594eab7db91aff7dfd91c13cc93e9fbfe70cd15a86fadfb2 \
 	--count 2
-	cargo run -- import-headers \
+	cargo run --release -- import-headers \
 	--chain-dir $(CHAIN_DIR) \
 	--peer-address ${AMARU_PEER_ADDRESS} \
 	--starting-point 70070331.076218aa483344e34620d3277542ecc9e7b382ae2407a60e177bc3700548364c \
 	--count 2
 
 import-nonces: ## Import PreProd nonces for demo
-	cargo run -- import-nonces \
+	cargo run --release -- import-nonces \
 	--chain-dir $(CHAIN_DIR) \
 	--at 70070379.d6fe6439aed8bddc10eec22c1575bf0648e4a76125387d9e985e9a3f8342870d \
 	--active a7c4477e9fcfd519bf7dcba0d4ffe35a399125534bc8c60fa89ff6b50a060a7a \
@@ -84,7 +84,7 @@ dev: ## Compile and run for development with default options
 	--listen-address $(LISTEN_ADDRESS)
 
 test-e2e: ## Run snapshot tests, assuming snapshots are available.
-	cargo test -p amaru -- --ignored
+	cargo test --release -p amaru -- --ignored
 
 test-e2-from-scratch: clean-dbs bootstrap demo test-e2e ## Run end-to-end tests from scratch
 

--- a/README.md
+++ b/README.md
@@ -22,69 +22,19 @@ cargo build --release
 > These instructions assume one starts from scratch, and has access to a running [cardano-node](https://github.com/IntersectMBO/cardano-node/)
 on the [preprod](https://book.world.dev.cardano.org/env-preprod.html) network (see bottom of page for more info).
 
-1. Download at least three [ledger snapshots](./data/README.md#cardano-ledger-snapshots):
+1. Bootstrap the node:
 
 ```bash
-mkdir -p snapshots;
-curl -s -o - "https://raw.githubusercontent.com/pragma-org/amaru/refs/heads/main/data/snapshots.json" \
-  | jq -r '.[] | "\(.point)  \(.url)"' \
-  | while read p u ; do  \
-      echo "Fetching $p.cbor"; \
-      curl --progress-bar -o - $u \
-        | gunzip > snapshots/$p.cbor ; \
-    done
+make bootstrap
 ```
 
-2. Import the snapshots just downloaded:
-
-```console
-cargo run --release -- import-ledger-state \
-  --snapshot snapshots/69206375.6f99b5f3deaeae8dc43fce3db2f3cd36ad8ed174ca3400b5b1bed76fdf248912.cbor \
-  --snapshot snapshots/69638382.5da6ba37a4a07df015c4ea92c880e3600d7f098b97e73816f8df04bbb5fad3b7.cbor \
-  --snapshot snapshots/70070379.d6fe6439aed8bddc10eec22c1575bf0648e4a76125387d9e985e9a3f8342870d.cbor
-```
-
-3. Import chain data from remote peer:
-
-> [!TIP]
->
-> You only need two headers to bootstrap Amaru:
->
-> - The last header of your imported snapshots
-> - The last header of the epoch before your last imported epoch
->
-> Although, importing _more_ headers won't hurt. So you can do a single
-> synchronization of an entire epoch (~21600 blocks on good days, likely less
-> on PreProd and Preview networks).
-
-```console
-cargo run --release -- import-headers \
-  --peer-address 127.0.0.1:3000 \
-  --starting-point 69638365.4ec0f5a78431fdcc594eab7db91aff7dfd91c13cc93e9fbfe70cd15a86fadfb2 \
-  --count 21600
-```
-
-4. Import VRF nonces information
-
-You need nonces states corresponding to the last header from the snapshots
-(i.e. the last block of PreProd's epoch 165 → `70070379.d6fe6439aed8bddc10eec22c1575bf0648e4a76125387d9e985e9a3f8342870d`):
-
-```console
-cargo run --release -- import-nonces \
-  --at 70070379.d6fe6439aed8bddc10eec22c1575bf0648e4a76125387d9e985e9a3f8342870d \
-  --active a7c4477e9fcfd519bf7dcba0d4ffe35a399125534bc8c60fa89ff6b50a060a7a \
-  --candidate 74fe03b10c4f52dd41105a16b5f6a11015ec890a001a5253db78a779fe43f6b6 \
-  --evolving 24bb737ee28652cd99ca41f1f7be568353b4103d769c6e1ddb531fc874dd6718 \
-  --tail 5da6ba37a4a07df015c4ea92c880e3600d7f098b97e73816f8df04bbb5fad3b7
-```
-
-5. _(Optional)_ Setup observability backends:
+2. _(Optional)_ Setup observability backends:
 
 ```console
 docker-compose -f monitoring/jaeger/docker-compose.yml up
 ```
 
-6. Run the node:
+3. Run the node:
 
 ```console
 cargo run --release -- daemon \

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -30,7 +30,7 @@ CHAIN_DIR=${CHAIN_DIR:-./chain.db}
 
 echo -e "      \033[1;32mTarget\033[00m epoch $TARGET_EPOCH"
 set -eo pipefail
-AMARU_TRACE="amaru=info" cargo run -- --with-json-traces daemon \
+AMARU_TRACE="amaru=info" cargo run --release -- --with-json-traces daemon \
            --peer-address="${PEER_ADDRESS}" \
            --listen-address="${LISTEN_ADDRESS}" \
            --network="${NETWORK}" \


### PR DESCRIPTION
Simplify `README` instructions to bootstrap an`amaru` node.
Also move CI `demo` to `release` mode to improve stability and reduce processing time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated all relevant build and test commands to use release mode for improved performance.
  - Simplified node bootstrapping in the documentation, replacing multiple manual steps with a single command.
  - Streamlined demo script to run in release mode for optimized execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->