### PR TITLE
chore: make Epoch a type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,6 @@ dependencies = [
  "pallas-codec",
  "pallas-crypto",
  "pallas-network",
- "pallas-primitives",
  "pallas-traverse",
  "proptest",
  "rand 0.9.1",
@@ -2181,17 +2180,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2669,7 +2657,6 @@ dependencies = [
  "hex",
  "minicbor",
  "proptest",
- "proptest-derive",
  "serde",
  "thiserror 2.0.12",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,7 @@ name = "amaru-ouroboros-traits"
 version = "0.1.0"
 dependencies = [
  "amaru-kernel",
+ "slot-arithmetic",
 ]
 
 [[package]]
@@ -2180,6 +2181,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,6 +2669,7 @@ dependencies = [
  "hex",
  "minicbor",
  "proptest",
+ "proptest-derive",
  "serde",
  "thiserror 2.0.12",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "rand 0.9.1",
  "serde",
  "serde_json",
+ "slot-arithmetic",
  "tempfile",
  "test-case",
  "tokio",

--- a/crates/amaru-consensus/Cargo.toml
+++ b/crates/amaru-consensus/Cargo.toml
@@ -36,3 +36,4 @@ rand.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 tracing-subscriber.workspace = true
+slot-arithmetic = { workspace = true, features = ["test-utils"] }

--- a/crates/amaru-consensus/src/consensus/store.rs
+++ b/crates/amaru-consensus/src/consensus/store.rs
@@ -159,6 +159,7 @@ mod test {
     use amaru_kernel::{from_cbor, hash, network::NetworkName, to_cbor, Header};
     use amaru_ouroboros_traits::{IsHeader, Praos};
     use proptest::{prelude::*, prop_compose, proptest};
+    use slot_arithmetic::Epoch;
     use std::{collections::BTreeMap, sync::LazyLock};
 
     // Epoch 164's last header
@@ -167,7 +168,7 @@ mod test {
     // Epoch 165's before-last header
     include_header!(PREPROD_HEADER_70070331, 70070331);
     static PREPROD_NONCES_70070331: LazyLock<Nonces> = LazyLock::new(|| Nonces {
-        epoch: 165,
+        epoch: Epoch::from(165),
         active: hash!("a7c4477e9fcfd519bf7dcba0d4ffe35a399125534bc8c60fa89ff6b50a060a7a"),
         candidate: hash!("74fe03b10c4f52dd41105a16b5f6a11015ec890a001a5253db78a779fe43f6b6",),
         evolving: hash!("9b945f3c45b140f796f0d2ec81c48b50730044bf75eb7208c85f6195f68e9b8c"),
@@ -177,7 +178,7 @@ mod test {
     // Epoch 165's last header
     include_header!(PREPROD_HEADER_70070379, 70070379);
     static PREPROD_NONCES_70070379: LazyLock<Nonces> = LazyLock::new(|| Nonces {
-        epoch: 165,
+        epoch: Epoch::from(165),
         active: hash!("a7c4477e9fcfd519bf7dcba0d4ffe35a399125534bc8c60fa89ff6b50a060a7a"),
         candidate: hash!("74fe03b10c4f52dd41105a16b5f6a11015ec890a001a5253db78a779fe43f6b6"),
         evolving: hash!("24bb737ee28652cd99ca41f1f7be568353b4103d769c6e1ddb531fc874dd6718"),
@@ -187,7 +188,7 @@ mod test {
     // Epoch 166's first header
     include_header!(PREPROD_HEADER_70070426, 70070426);
     static PREPROD_NONCES_70070426: LazyLock<Nonces> = LazyLock::new(|| Nonces {
-        epoch: 166,
+        epoch: Epoch::from(166),
         active: hash!("b2853ec951e7ed91b674a47c8276189f414e22b19d61d9da0ac7490801e4bf0d"),
         candidate: hash!("fd6b302f9e0f02cdc784b3d6ca4652788a6e2c5b27f5771509846ee2beb7508c",),
         evolving: hash!("fd6b302f9e0f02cdc784b3d6ca4652788a6e2c5b27f5771509846ee2beb7508c"),
@@ -197,7 +198,7 @@ mod test {
     // Epoch 166's second header
     include_header!(PREPROD_HEADER_70070464, 70070464);
     static PREPROD_NONCES_70070464: LazyLock<Nonces> = LazyLock::new(|| Nonces {
-        epoch: 166,
+        epoch: Epoch::from(166),
         active: hash!("b2853ec951e7ed91b674a47c8276189f414e22b19d61d9da0ac7490801e4bf0d"),
         candidate: hash!("18eec9f448f64ebe173563b5bca7d9f788f0db83653a49c449285f4770e9adb1"),
         evolving: hash!("18eec9f448f64ebe173563b5bca7d9f788f0db83653a49c449285f4770e9adb1"),
@@ -308,7 +309,7 @@ mod test {
             evolving in any::<[u8; 32]>(),
             candidate in any::<[u8; 32]>(),
             tail in any::<[u8; 32]>(),
-            epoch in any::<u64>(),
+            epoch in any::<Epoch>(),
         ) -> Nonces {
             Nonces {
                 active: Nonce::from(active),

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -59,8 +59,8 @@ pub use pallas_primitives::{
     babbage::{Header, MintedHeader},
     conway::{
         AddrKeyhash, Anchor, AuxiliaryData, Block, BootstrapWitness, Certificate, Coin,
-        Constitution, CostModel, CostModels, DRep, DRepVotingThresholds, Epoch, ExUnitPrices,
-        ExUnits, GovAction, GovActionId as ProposalId, HeaderBody, KeepRaw, MintedBlock,
+        Constitution, CostModel, CostModels, DRep, DRepVotingThresholds, ExUnitPrices, ExUnits,
+        GovAction, GovActionId as ProposalId, HeaderBody, KeepRaw, MintedBlock,
         MintedTransactionBody, MintedTransactionOutput, MintedTx, MintedWitnessSet, Multiasset,
         NonEmptySet, NonZeroInt, PoolMetadata, PoolVotingThresholds, PostAlonzoTransactionOutput,
         ProposalProcedure as Proposal, ProtocolParamUpdate, ProtocolVersion, PseudoScript,
@@ -102,8 +102,8 @@ pub enum Point {
 impl Point {
     pub fn slot_or_default(&self) -> Slot {
         match self {
-            Point::Origin => From::from(0),
-            Point::Specific(slot, _) => From::from(*slot),
+            Point::Origin => Slot::from(0),
+            Point::Specific(slot, _) => Slot::from(*slot),
         }
     }
 }
@@ -1004,8 +1004,8 @@ mod test {
         };
 
         (
-            new_pointer((From::from(left.0), left.1, left.2)),
-            new_pointer((From::from(right.0), right.1, right.2)),
+            new_pointer((Slot::from(left.0), left.1, left.2)),
+            new_pointer((Slot::from(right.0), right.1, right.2)),
         )
     }
 

--- a/crates/amaru-kernel/src/network.rs
+++ b/crates/amaru-kernel/src/network.rs
@@ -15,6 +15,7 @@
 use std::{fs::File, io::BufReader, path::Path, sync::LazyLock};
 
 pub use slot_arithmetic::{Bound, EraHistory, EraParams, Summary};
+use slot_arithmetic::{Epoch, Slot};
 
 /// Era history for Preprod retrieved with:
 ///
@@ -30,13 +31,13 @@ static PREPROD_ERA_HISTORY: LazyLock<EraHistory> = LazyLock::new(|| {
         Summary {
             start: Bound {
                 time_ms: 0,
-                slot: From::from(0),
-                epoch: 0,
+                slot: Slot::from(0),
+                epoch: Epoch::from(0),
             },
             end: Bound {
                 time_ms: 1728000000,
-                slot: From::from(86400),
-                epoch: 4,
+                slot: Slot::from(86400),
+                epoch: Epoch::from(4),
             },
             params: EraParams {
                 epoch_size_slots: 21600,
@@ -46,13 +47,13 @@ static PREPROD_ERA_HISTORY: LazyLock<EraHistory> = LazyLock::new(|| {
         Summary {
             start: Bound {
                 time_ms: 1728000000,
-                slot: From::from(86400),
-                epoch: 4,
+                slot: Slot::from(86400),
+                epoch: Epoch::from(4),
             },
             end: Bound {
                 time_ms: 2160000000,
-                slot: From::from(518400),
-                epoch: 5,
+                slot: Slot::from(518400),
+                epoch: Epoch::from(5),
             },
             params: EraParams {
                 epoch_size_slots: 432000,
@@ -62,13 +63,13 @@ static PREPROD_ERA_HISTORY: LazyLock<EraHistory> = LazyLock::new(|| {
         Summary {
             start: Bound {
                 time_ms: 2160000000,
-                slot: From::from(518400),
-                epoch: 5,
+                slot: Slot::from(518400),
+                epoch: Epoch::from(5),
             },
             end: Bound {
                 time_ms: 2592000000,
-                slot: From::from(950400),
-                epoch: 6,
+                slot: Slot::from(950400),
+                epoch: Epoch::from(6),
             },
 
             params: EraParams {
@@ -79,13 +80,13 @@ static PREPROD_ERA_HISTORY: LazyLock<EraHistory> = LazyLock::new(|| {
         Summary {
             start: Bound {
                 time_ms: 2592000000,
-                slot: From::from(950400),
-                epoch: 6,
+                slot: Slot::from(950400),
+                epoch: Epoch::from(6),
             },
             end: Bound {
                 time_ms: 3024000000,
-                slot: From::from(1382400),
-                epoch: 7,
+                slot: Slot::from(1382400),
+                epoch: Epoch::from(7),
             },
 
             params: EraParams {
@@ -96,13 +97,13 @@ static PREPROD_ERA_HISTORY: LazyLock<EraHistory> = LazyLock::new(|| {
         Summary {
             start: Bound {
                 time_ms: 3024000000,
-                slot: From::from(1382400),
-                epoch: 7,
+                slot: Slot::from(1382400),
+                epoch: Epoch::from(7),
             },
             end: Bound {
                 time_ms: 5184000000,
-                slot: From::from(3542400),
-                epoch: 12,
+                slot: Slot::from(3542400),
+                epoch: Epoch::from(12),
             },
 
             params: EraParams {
@@ -113,13 +114,13 @@ static PREPROD_ERA_HISTORY: LazyLock<EraHistory> = LazyLock::new(|| {
         Summary {
             start: Bound {
                 time_ms: 5184000000,
-                slot: From::from(3542400),
-                epoch: 12,
+                slot: Slot::from(3542400),
+                epoch: Epoch::from(12),
             },
             end: Bound {
                 time_ms: 70416000000,
-                slot: From::from(68774400),
-                epoch: 163,
+                slot: Slot::from(68774400),
+                epoch: Epoch::from(163),
             },
 
             params: EraParams {
@@ -130,13 +131,13 @@ static PREPROD_ERA_HISTORY: LazyLock<EraHistory> = LazyLock::new(|| {
         Summary {
             start: Bound {
                 time_ms: 70416000000,
-                slot: From::from(68774400),
-                epoch: 163,
+                slot: Slot::from(68774400),
+                epoch: Epoch::from(163),
             },
             end: Bound {
                 time_ms: 89424000000,
-                slot: From::from(87782400),
-                epoch: 207,
+                slot: Slot::from(87782400),
+                epoch: Epoch::from(207),
             },
 
             params: EraParams {
@@ -159,13 +160,13 @@ static TESTNET_ERA_HISTORY: LazyLock<EraHistory> = LazyLock::new(|| {
     let default_testnet_eras: [Summary; 1] = [Summary {
         start: Bound {
             time_ms: 0,
-            slot: From::from(0),
-            epoch: 0,
+            slot: Slot::from(0),
+            epoch: Epoch::from(0),
         },
         end: Bound {
             time_ms: 432000000000,
-            slot: From::from(432000000),
-            epoch: 1000,
+            slot: Slot::from(432000000),
+            epoch: Epoch::from(1000),
         },
 
         params: EraParams {
@@ -287,6 +288,7 @@ mod tests {
         NetworkName::{self, *},
     };
     use proptest::{prelude::*, prop_oneof, proptest};
+    use slot_arithmetic::{Epoch, Slot};
     use std::{env, fs::File, io::Write, path::Path, str::FromStr};
 
     fn any_network() -> impl Strategy<Value = NetworkName> {
@@ -312,22 +314,34 @@ mod tests {
     #[test]
     fn can_compute_slot_to_epoch_for_preprod() {
         let era_history = &*PREPROD_ERA_HISTORY;
-        assert_eq!(4, era_history.slot_to_epoch(From::from(86400)).unwrap());
-        assert_eq!(11, era_history.slot_to_epoch(From::from(3542399)).unwrap());
-        assert_eq!(12, era_history.slot_to_epoch(From::from(3542400)).unwrap());
+        assert_eq!(
+            Epoch::from(4),
+            era_history.slot_to_epoch(Slot::from(86400)).unwrap()
+        );
+        assert_eq!(
+            Epoch::from(11),
+            era_history.slot_to_epoch(Slot::from(3542399)).unwrap()
+        );
+        assert_eq!(
+            Epoch::from(12),
+            era_history.slot_to_epoch(Slot::from(3542400)).unwrap()
+        );
     }
 
     #[test]
     fn can_compute_next_epoch_first_slot_for_preprod() {
         let era_history = &*PREPROD_ERA_HISTORY;
-        assert_eq!(era_history.next_epoch_first_slot(3), Ok(From::from(86400)));
         assert_eq!(
-            era_history.next_epoch_first_slot(114),
-            Ok(From::from(48038400))
+            era_history.next_epoch_first_slot(Epoch::from(3)),
+            Ok(Slot::from(86400))
         );
         assert_eq!(
-            era_history.next_epoch_first_slot(150),
-            Ok(From::from(63590400))
+            era_history.next_epoch_first_slot(Epoch::from(114)),
+            Ok(Slot::from(48038400))
+        );
+        assert_eq!(
+            era_history.next_epoch_first_slot(Epoch::from(150)),
+            Ok(Slot::from(63590400))
         );
     }
 

--- a/crates/amaru-ledger/Cargo.toml
+++ b/crates/amaru-ledger/Cargo.toml
@@ -25,10 +25,14 @@ amaru-kernel.workspace = true
 amaru-ouroboros-traits.workspace = true
 slot-arithmetic.workspace = true
 tracing-json.workspace = true
+proptest = { workspace = true, optional = true }
 
 [dev-dependencies]
-proptest = { workspace = true, features = ["std"] }
+proptest.workspace = true
 test-case.workspace = true
+
+[features]
+test-utils = ["proptest"]
 
 [target.'cfg(not(std))'.dependencies]
 num = { workspace = true, default-features = false, features = [

--- a/crates/amaru-ledger/src/context.rs
+++ b/crates/amaru-ledger/src/context.rs
@@ -17,9 +17,10 @@ mod default;
 
 use crate::state::diff_bind;
 use amaru_kernel::{
-    Anchor, CertificatePointer, DRep, Epoch, Hash, Lovelace, PoolId, PoolParams, Proposal,
-    ProposalId, ProposalPointer, StakeCredential, TransactionInput, TransactionOutput,
+    Anchor, CertificatePointer, DRep, Hash, Lovelace, PoolId, PoolParams, Proposal, ProposalId,
+    ProposalPointer, StakeCredential, TransactionInput, TransactionOutput,
 };
+use slot_arithmetic::Epoch;
 use std::{collections::BTreeSet, fmt, marker::PhantomData};
 
 pub use default::*;

--- a/crates/amaru-ledger/src/context/assert.rs
+++ b/crates/amaru-ledger/src/context/assert.rs
@@ -20,10 +20,11 @@ use crate::context::{
 };
 use amaru_kernel::{
     serde_utils, stake_credential_hash, stake_credential_type, Anchor, CertificatePointer, DRep,
-    Epoch, Lovelace, PoolId, PoolParams, Proposal, ProposalId, ProposalPointer, StakeCredential,
+    Lovelace, PoolId, PoolParams, Proposal, ProposalId, ProposalPointer, StakeCredential,
     TransactionInput, TransactionOutput,
 };
 use core::mem;
+use slot_arithmetic::Epoch;
 use std::collections::{BTreeMap, BTreeSet};
 use tracing::{instrument, Level};
 

--- a/crates/amaru-ledger/src/context/default/validation.rs
+++ b/crates/amaru-ledger/src/context/default/validation.rs
@@ -21,10 +21,11 @@ use crate::{
     state::volatile_db::VolatileState,
 };
 use amaru_kernel::{
-    Anchor, CertificatePointer, DRep, Epoch, Hash, Lovelace, PoolId, PoolParams, Proposal,
-    ProposalId, ProposalPointer, StakeCredential, TransactionInput, TransactionOutput,
+    Anchor, CertificatePointer, DRep, Hash, Lovelace, PoolId, PoolParams, Proposal, ProposalId,
+    ProposalPointer, StakeCredential, TransactionInput, TransactionOutput,
 };
 use core::mem;
+use slot_arithmetic::Epoch;
 use std::collections::{BTreeMap, BTreeSet};
 use tracing::trace;
 

--- a/crates/amaru-ledger/src/rules/block.rs
+++ b/crates/amaru-ledger/src/rules/block.rs
@@ -25,6 +25,7 @@ use amaru_kernel::{
     protocol_parameters::ProtocolParameters, AuxiliaryData, ExUnits, HasExUnits, Hash, MintedBlock,
     OriginalHash, StakeCredential, TransactionPointer,
 };
+use slot_arithmetic::Slot;
 use std::{
     ops::{ControlFlow, Deref, FromResidual, Try},
     process::{ExitCode, Termination},
@@ -168,7 +169,7 @@ pub fn execute<C: ValidationContext<FinalState = S>, S: From<C>>(
             });
 
         let pointer = TransactionPointer {
-            slot: From::from(block.header.header_body.slot),
+            slot: Slot::from(block.header.header_body.slot),
             transaction_index: i as usize, // From u32
         };
 

--- a/crates/amaru-ledger/src/rules/transaction/certificates.rs
+++ b/crates/amaru-ledger/src/rules/transaction/certificates.rs
@@ -20,6 +20,7 @@ use amaru_kernel::{
     protocol_parameters::ProtocolParameters, Certificate, CertificatePointer, DRep, NonEmptySet,
     PoolId, PoolParams, StakeCredential, TransactionPointer,
 };
+use slot_arithmetic::Epoch;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -113,7 +114,7 @@ where
 
         Certificate::PoolRetirement(id, epoch) => {
             context.require_witness(StakeCredential::AddrKeyhash(id));
-            PoolsSlice::retire(context, id, epoch);
+            PoolsSlice::retire(context, id, Epoch::from(epoch));
             Ok(())
         }
 

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -183,7 +183,6 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             .map_err(|e| StateError::ErrorComputingEpoch(slot, e))
     }
 
-    #[allow(clippy::unwrap_used)]
     pub fn protocol_parameters(&self) -> &ProtocolParameters {
         &self.protocol_parameters
     }

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -451,7 +451,7 @@ pub fn recover_stake_distribution(
 // Epoch Transitions
 // ----------------------------------------------------------------------------
 
-#[instrument(level = Level::INFO, skip_all, fields(from = ?next_epoch - 1, into = ?next_epoch))]
+#[instrument(level = Level::INFO, skip_all, fields(from = %next_epoch - 1, into = %next_epoch))]
 fn epoch_transition(
     db: &mut impl Store,
     next_epoch: Epoch,

--- a/crates/amaru-ledger/src/state/diff_epoch_reg.rs
+++ b/crates/amaru-ledger/src/state/diff_epoch_reg.rs
@@ -161,7 +161,7 @@ mod tests {
     use proptest::prelude::*;
     use std::collections::{btree_map, BTreeMap};
 
-    pub static MAX_EPOCH: u64 = 4;
+    pub const MAX_EPOCH: u64 = 4;
 
     prop_compose! {
         fn any_diff()(
@@ -240,7 +240,7 @@ mod tests {
 
     fn any_message_sequence() -> impl Strategy<Value = Vec<(Epoch, Vec<Message<char, u8>>)>> {
         let any_block = || prop::collection::vec(any_message(MAX_EPOCH), 0..5);
-        prop::collection::vec(0u64..MAX_EPOCH, 1..30).prop_flat_map(move |epochs| {
+        prop::collection::vec(0..MAX_EPOCH, 1..30).prop_flat_map(move |epochs| {
             let mut epochs: Vec<Epoch> = epochs.into_iter().map(Epoch::from).collect();
             epochs.sort();
             prop::collection::vec(any_block(), epochs.len()).prop_map(move |msgs| {

--- a/crates/amaru-ledger/src/state/diff_epoch_reg.rs
+++ b/crates/amaru-ledger/src/state/diff_epoch_reg.rs
@@ -228,7 +228,7 @@ mod tests {
             v in
                 any::<u8>(),
             epoch in
-                prop_oneof![Just(None), (0..max_epoch).prop_map(|e| Some(e))]
+                prop_oneof![Just(None), (0..max_epoch).prop_map(Some)]
         ) -> Message<char, u8> {
             match epoch {
                 None => Message::Register(k, v),

--- a/crates/amaru-ledger/src/state/diff_epoch_reg.rs
+++ b/crates/amaru-ledger/src/state/diff_epoch_reg.rs
@@ -274,8 +274,8 @@ mod tests {
         fn prop_messages_are_in_ascending_epoch(msgs in any_message_sequence()) {
             msgs.into_iter().fold(0, |current_epoch, (epoch, _)| {
                 assert!(epoch <= *MAX_EPOCH);
-                assert!(epoch >= current_epoch);
-                epoch
+                assert!(epoch >= current_epoch.into());
+                epoch.into()
             });
         }
     }

--- a/crates/amaru-ledger/src/state/volatile_db.rs
+++ b/crates/amaru-ledger/src/state/volatile_db.rs
@@ -20,9 +20,10 @@ use super::{
 use crate::store::{self, columns::*};
 use amaru_kernel::{
     protocol_parameters::ProtocolParameters, Anchor, CertificatePointer, ComparableProposalId,
-    DRep, Epoch, Lovelace, Point, PoolId, PoolParams, Proposal, ProposalId, ProposalPointer,
+    DRep, Lovelace, Point, PoolId, PoolParams, Proposal, ProposalId, ProposalPointer,
     StakeCredential, TransactionInput, TransactionOutput,
 };
+use slot_arithmetic::Epoch;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use tracing::error;
 
@@ -200,7 +201,7 @@ impl AnchoredVolatileState {
             impl Iterator<Item = proposals::Key>,
         >,
     > {
-        let gov_action_lifetime: Epoch = protocol_parameters.gov_action_lifetime as Epoch;
+        let gov_action_lifetime = protocol_parameters.gov_action_lifetime as u64;
 
         StoreUpdate {
             point: self.anchor.0,

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -22,7 +22,6 @@ use amaru_kernel::{
     cbor as minicbor,
     protocol_parameters::ProtocolParameters,
     CertificatePointer,
-    Epoch,
     Lovelace,
     Point,
     PoolId,
@@ -31,6 +30,7 @@ use amaru_kernel::{
     TransactionOutput,
 };
 use columns::*;
+use slot_arithmetic::Epoch;
 use std::{borrow::BorrowMut, collections::BTreeSet, io, iter};
 use thiserror::Error;
 

--- a/crates/amaru-ledger/src/store/columns/dreps.rs
+++ b/crates/amaru-ledger/src/store/columns/dreps.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use crate::state::diff_bind::Resettable;
-use amaru_kernel::{cbor, Anchor, CertificatePointer, Epoch, Lovelace, StakeCredential};
+use amaru_kernel::{cbor, Anchor, CertificatePointer, Lovelace, StakeCredential};
 use iter_borrow::IterBorrow;
+use slot_arithmetic::Epoch;
 
 pub const EVENT_TARGET: &str = "amaru::ledger::store::dreps";
 
@@ -92,10 +93,10 @@ impl<'a, C> cbor::decode::Decode<'a, C> for Row {
 pub(crate) mod tests {
     use super::Row;
     use amaru_kernel::{
-        prop_cbor_roundtrip, Anchor, CertificatePointer, Epoch, Hash, Lovelace, Slot,
-        TransactionPointer,
+        prop_cbor_roundtrip, Anchor, CertificatePointer, Hash, Lovelace, Slot, TransactionPointer,
     };
     use proptest::{option, prelude::*, string};
+    use slot_arithmetic::Epoch;
 
     prop_cbor_roundtrip!(Row, any_row());
 

--- a/crates/amaru-ledger/src/store/columns/pools.rs
+++ b/crates/amaru-ledger/src/store/columns/pools.rs
@@ -284,7 +284,7 @@ pub(crate) mod tests {
             .prop_flat_map(|epochs| {
                 epochs
                     .into_iter()
-                    .map(any_future_params)
+                    .map(|u: u64| any_future_params(Epoch::from(u)))
                     .collect::<Vec<_>>()
             })
             .prop_flat_map(|future_params| {

--- a/crates/amaru-ledger/src/store/columns/proposals.rs
+++ b/crates/amaru-ledger/src/store/columns/proposals.rs
@@ -378,8 +378,8 @@ pub(crate) mod tests {
         prop_compose! {
             fn any_committee_registration()(
                 credential in any_stake_credential(),
-                epoch in any::<Epoch>(),
-            ) -> (StakeCredential, Epoch) {
+                epoch in any::<u64>(),
+            ) -> (StakeCredential, u64) {
                 (credential, epoch)
             }
         }

--- a/crates/amaru-ledger/src/store/columns/proposals.rs
+++ b/crates/amaru-ledger/src/store/columns/proposals.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{cbor, Epoch, Proposal, ProposalId, ProposalPointer};
+use amaru_kernel::{cbor, Proposal, ProposalId, ProposalPointer};
 use iter_borrow::IterBorrow;
+use slot_arithmetic::Epoch;
 
 pub const EVENT_TARGET: &str = "amaru::ledger::store::proposals";
 

--- a/crates/amaru-ledger/src/store/columns/proposals.rs
+++ b/crates/amaru-ledger/src/store/columns/proposals.rs
@@ -225,7 +225,7 @@ pub(crate) mod tests {
             max_block_header_size in option::of(any::<u64>()),
             key_deposit in option::of(any::<Lovelace>()),
             pool_deposit in option::of(any::<Lovelace>()),
-            maximum_epoch in option::of(any::<Epoch>()),
+            maximum_epoch in option::of(any::<u64>()),
             desired_number_of_stake_pools in option::of(any::<u64>()),
             pool_pledge_influence in option::of(any_unit_interval()),
             expansion_rate in option::of(any_unit_interval()),
@@ -242,11 +242,11 @@ pub(crate) mod tests {
             pool_voting_thresholds in option::of(any_pool_voting_thresholds()),
             drep_voting_thresholds in option::of(any_drep_voting_thresholds()),
             min_committee_size in option::of(any::<u64>()),
-            committee_term_limit in option::of(any::<Epoch>()),
-            governance_action_validity_period in option::of(any::<Epoch>()),
+            committee_term_limit in option::of(any::<u64>()),
+            governance_action_validity_period in option::of(any::<u64>()),
             governance_action_deposit in option::of(any::<Lovelace>()),
             drep_deposit in option::of(any::<Lovelace>()),
-            drep_inactivity_period in option::of(any::<Epoch>()),
+            drep_inactivity_period in option::of(any::<u64>()),
             minfee_refscript_cost_per_byte in option::of(any_unit_interval()),
         ) -> ProtocolParamUpdate {
             ProtocolParamUpdate {

--- a/crates/amaru-ledger/src/summary/governance.rs
+++ b/crates/amaru-ledger/src/summary/governance.rs
@@ -405,9 +405,9 @@ mod tests {
         let v10 = test_with(PROTOCOL_VERSION_10);
 
         if v9 == v10 {
-            Consistent(v10)
+            Consistent(v10.into())
         } else {
-            Inconsistent { v9, v10 }
+            Inconsistent { v9: v9.into(), v10: v10.into() }
         }
     }
 

--- a/crates/amaru-ledger/src/summary/governance.rs
+++ b/crates/amaru-ledger/src/summary/governance.rs
@@ -407,7 +407,10 @@ mod tests {
         if v9 == v10 {
             Consistent(v10.into())
         } else {
-            Inconsistent { v9: v9.into(), v10: v10.into() }
+            Inconsistent {
+                v9: v9.into(),
+                v10: v10.into(),
+            }
         }
     }
 

--- a/crates/amaru-ledger/src/summary/governance.rs
+++ b/crates/amaru-ledger/src/summary/governance.rs
@@ -17,10 +17,10 @@ mod backward_compatibility;
 use crate::store::{columns::dreps, Snapshot, StoreError};
 use amaru_kernel::{
     expect_stake_credential, network::EraHistory, protocol_parameters::ProtocolParameters, Anchor,
-    CertificatePointer, DRep, Epoch, EpochInterval, Lovelace, ProtocolVersion, Slot,
-    StakeCredential, TransactionPointer,
+    CertificatePointer, DRep, EpochInterval, Lovelace, ProtocolVersion, Slot, StakeCredential,
+    TransactionPointer,
 };
-use slot_arithmetic::TimeHorizonError;
+use slot_arithmetic::{Epoch, TimeHorizonError};
 use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Debug)]
@@ -94,7 +94,7 @@ impl GovernanceSummary {
         let mandate = drep_mandate_calculator(
             protocol_version,
             protocol_parameters.gov_action_lifetime,
-            protocol_parameters.drep_expiry,
+            protocol_parameters.drep_expiry as u64,
             era_history,
             current_epoch,
             proposals,
@@ -240,7 +240,7 @@ impl GovernanceSummary {
 fn drep_mandate_calculator(
     protocol_version: ProtocolVersion,
     governance_action_lifetime: EpochInterval,
-    drep_expiry: Epoch,
+    drep_expiry: u64,
     era_history: &EraHistory,
     current_epoch: Epoch,
     proposals: BTreeSet<(TransactionPointer, Epoch)>,
@@ -268,7 +268,7 @@ fn drep_mandate_calculator(
             // epoch with no proposal but on the last slot is arguably dormant. But as a
             // consequence, we may also label as dormant epochs with proposals submitted on the
             // very first slot too.
-            (*start + 1..=*start + governance_action_lifetime as Epoch).collect::<BTreeSet<_>>()
+            (*start + 1..=*start + governance_action_lifetime as u64).collect::<BTreeSet<_>>()
         })
         .collect::<BTreeSet<Epoch>>();
 
@@ -355,7 +355,7 @@ fn drep_mandate_calculator(
                     }
                 };
 
-                bonus_bug_dormant + v10_onwards(registered_at, last_interaction)
+                v10_onwards(registered_at, last_interaction) + bonus_bug_dormant
             },
         );
     }
@@ -373,8 +373,8 @@ mod tests {
 
     #[derive(Debug, PartialEq)]
     enum EpochResult {
-        Consistent(Epoch),
-        Inconsistent { v9: Epoch, v10: Epoch },
+        Consistent(u64),
+        Inconsistent { v9: u64, v10: u64 },
     }
 
     fn test_drep_mandate(
@@ -431,16 +431,16 @@ mod tests {
     #[test_case(135,    None, 13 => Inconsistent { v9: 25, v10: 23 })]
     fn test_drep_mandate_no_dormant_period(
         registered_at: u64,
-        last_interaction: Option<Epoch>,
-        current_epoch: Epoch,
+        last_interaction: Option<u64>,
+        current_epoch: u64,
     ) -> EpochResult {
         test_drep_mandate(
             3,                // governance_action_lifetime
             10,               // drep_expiry
             vec![ptr(85, 0)], // proposals
             registered_at,
-            last_interaction,
-            current_epoch,
+            last_interaction.map(Epoch::from),
+            Epoch::from(current_epoch),
         )
     }
 
@@ -468,16 +468,16 @@ mod tests {
     #[test_case(136,     None, 13 => Consistent(23))]
     fn test_drep_mandate_single_dormant_period(
         registered_at: u64,
-        last_interaction: Option<Epoch>,
-        current_epoch: Epoch,
+        last_interaction: Option<u64>,
+        current_epoch: u64,
     ) -> EpochResult {
         test_drep_mandate(
             3,                             // governance_action_lifetime
             10,                            // drep_expiry
             vec![ptr(85, 0), ptr(135, 0)], // proposals
             registered_at,
-            last_interaction,
-            current_epoch,
+            last_interaction.map(Epoch::from),
+            Epoch::from(current_epoch),
         )
     }
 
@@ -507,16 +507,16 @@ mod tests {
     #[test_case(150,    None, 15 => Inconsistent{ v9: 26, v10: 25 })]
     fn test_drep_mandate_multiple_dormant_periods(
         registered_at: u64,
-        last_interaction: Option<Epoch>,
-        current_epoch: Epoch,
+        last_interaction: Option<u64>,
+        current_epoch: u64,
     ) -> EpochResult {
         test_drep_mandate(
             3,                                        // governance_action_lifetime
             10,                                       // drep_expiry
             vec![ptr(5, 0), ptr(65, 0), ptr(115, 0)], // proposals
             registered_at,
-            last_interaction,
-            current_epoch,
+            last_interaction.map(Epoch::from),
+            Epoch::from(current_epoch),
         )
     }
 }

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -120,7 +120,7 @@ use crate::{
 use amaru_kernel::{
     expect_stake_credential,
     protocol_parameters::{GlobalParameters, ProtocolParameters},
-    Epoch, Hash, Lovelace, PoolId, StakeCredential,
+    Hash, Lovelace, PoolId, StakeCredential,
 };
 use iter_borrow::borrowable_proxy::BorrowableProxy;
 use num::{
@@ -128,6 +128,7 @@ use num::{
     BigUint,
 };
 use serde::ser::SerializeStruct;
+use slot_arithmetic::Epoch;
 use std::collections::BTreeMap;
 use tracing::info;
 

--- a/crates/amaru-ledger/src/summary/stake_distribution.rs
+++ b/crates/amaru-ledger/src/summary/stake_distribution.rs
@@ -23,11 +23,12 @@ use crate::{
 };
 use amaru_kernel::{
     expect_stake_credential, output_stake_credential, protocol_parameters::ProtocolParameters,
-    DRep, Epoch, HasLovelace, Lovelace, Network, PoolId, ProtocolVersion, StakeCredential,
+    DRep, HasLovelace, Lovelace, Network, PoolId, ProtocolVersion, StakeCredential,
     PROTOCOL_VERSION_10,
 };
 use iter_borrow::borrowable_proxy::BorrowableProxy;
 use serde::ser::SerializeStruct;
+use slot_arithmetic::Epoch;
 use std::collections::{BTreeMap, BTreeSet};
 use tracing::info;
 

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/dreps.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/dreps.rs
@@ -13,12 +13,13 @@
 // limitations under the License.
 
 use crate::rocksdb::common::{as_key, as_value, PREFIX_LEN};
-use amaru_kernel::{CertificatePointer, Epoch, StakeCredential};
+use amaru_kernel::{CertificatePointer, StakeCredential};
 use amaru_ledger::store::{
     columns::dreps::{Key, Row, Value, EVENT_TARGET},
     StoreError,
 };
 use rocksdb::Transaction;
+use slot_arithmetic::Epoch;
 use std::collections::BTreeSet;
 use tracing::error;
 

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/pools.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/pools.rs
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 use crate::rocksdb::common::{as_key, as_value, PREFIX_LEN};
-use amaru_kernel::Epoch;
 use amaru_ledger::store::{
     columns::pools::{Key, Row, Value, EVENT_TARGET},
     StoreError,
 };
 use rocksdb::{OptimisticTransactionDB, ThreadMode, Transaction};
+use slot_arithmetic::Epoch;
 use tracing::error;
 
 /// Name prefixed used for storing Pool entries. UTF-8 encoding for "pool"

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -579,7 +579,7 @@ impl RocksDBHistoricalStores {
             epoch,
             db: OptimisticTransactionDB::open(
                 &opts,
-                base_dir.join(PathBuf::from(format!("{epoch:?}"))),
+                base_dir.join(PathBuf::from(format!("{epoch}"))),
             )
             .map_err(|err| StoreError::Internal(err.into()))?,
         })

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -14,8 +14,8 @@
 
 use ::rocksdb::{self, checkpoint, OptimisticTransactionDB, Options, SliceTransform};
 use amaru_kernel::{
-    protocol_parameters::ProtocolParameters, CertificatePointer, Epoch, EraHistory, Lovelace,
-    Point, PoolId, StakeCredential, TransactionInput, TransactionOutput,
+    protocol_parameters::ProtocolParameters, CertificatePointer, EraHistory, Lovelace, Point,
+    PoolId, StakeCredential, TransactionInput, TransactionOutput,
 };
 use amaru_ledger::{
     store::{
@@ -27,6 +27,7 @@ use amaru_ledger::{
 use iter_borrow::{self, borrowable_proxy::BorrowableProxy, IterBorrow};
 use pallas_codec::minicbor::{self as cbor};
 use rocksdb::{Direction, IteratorMode, ReadOptions, Transaction};
+use slot_arithmetic::Epoch;
 use std::{
     collections::BTreeSet,
     fmt, fs,

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -28,7 +28,6 @@ opentelemetry_sdk.workspace = true
 pallas-codec.workspace = true
 pallas-crypto.workspace = true
 pallas-network.workspace = true
-pallas-primitives.workspace = true
 pallas-traverse.workspace = true
 serde_json.workspace = true
 slot-arithmetic.workspace = true

--- a/crates/amaru/src/bin/amaru/cmd/import_ledger_state.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_ledger_state.rs
@@ -14,9 +14,8 @@
 
 use amaru_kernel::{
     network::NetworkName, protocol_parameters::ProtocolParameters, Anchor, CertificatePointer,
-    DRep, Epoch, EraHistory, Lovelace, Point, PoolId, PoolParams, Proposal, ProposalId,
-    ProposalPointer, Set, Slot, StakeCredential, TransactionInput, TransactionOutput,
-    TransactionPointer,
+    DRep, EraHistory, Lovelace, Point, PoolId, PoolParams, Proposal, ProposalId, ProposalPointer,
+    Set, Slot, StakeCredential, TransactionInput, TransactionOutput, TransactionPointer,
 };
 use amaru_ledger::{
     self,
@@ -29,6 +28,7 @@ use amaru_stores::rocksdb::RocksDB;
 use clap::Parser;
 use indicatif::{ProgressBar, ProgressStyle};
 use pallas_codec::minicbor as cbor;
+use slot_arithmetic::Epoch;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fs, iter,
@@ -142,7 +142,7 @@ async fn import_one(
     let db = RocksDB::empty(ledger_dir, era_history)?;
     let bytes = fs::read(snapshot)?;
 
-    let epoch = decode_new_epoch_state(&db, &bytes, &point, era_history)?;
+    let epoch = Epoch::from(decode_new_epoch_state(&db, &bytes, &point, era_history)?);
     let transaction = db.create_transaction();
     transaction.save(
         &point,
@@ -154,7 +154,7 @@ async fn import_one(
     )?;
     transaction.commit()?;
 
-    let snapshot = db.snapshots()?.last().map(|s| s + 1).unwrap_or(epoch);
+    let snapshot = db.snapshots()?.last().map(|s| *s + 1).unwrap_or(epoch);
     db.next_snapshot(snapshot)?;
 
     let transaction = db.create_transaction();
@@ -176,13 +176,13 @@ fn decode_new_epoch_state(
     bytes: &[u8],
     point: &Point,
     era_history: &EraHistory,
-) -> Result<u64, Box<dyn std::error::Error>> {
+) -> Result<Epoch, Box<dyn std::error::Error>> {
     let mut d = cbor::Decoder::new(bytes);
 
     d.array()?;
 
     // EpochNo
-    let epoch = d.u64()?;
+    let epoch = Epoch::from(d.u64()?);
     assert_eq!(epoch, era_history.slot_to_epoch(point.slot_or_default())?);
 
     // Previous blocks made
@@ -512,13 +512,13 @@ fn import_dreps(
                 let (registration_slot, last_interaction) = if epoch == era_first_epoch {
                     let last_interaction = era_first_epoch;
                     let epoch_bound = era_history.epoch_bounds(last_interaction).unwrap();
-                    if state.expiry > epoch + protocol_parameters.drep_expiry {
+                    if state.expiry > epoch + protocol_parameters.drep_expiry as u64 {
                         (epoch_bound.start, last_interaction)
                     } else {
                         (epoch_bound.end, last_interaction)
                     }
                 } else {
-                    let last_interaction = state.expiry - protocol_parameters.drep_expiry;
+                    let last_interaction = state.expiry - protocol_parameters.drep_expiry as u64;
                     let epoch_bound = era_history.epoch_bounds(last_interaction).unwrap();
                     // start or end doesn't matter here.
                     (epoch_bound.start, last_interaction)
@@ -594,7 +594,7 @@ fn import_proposals(
                                 proposal_index,
                             },
                             valid_until: proposal.proposed_in
-                                + protocol_parameters.gov_action_lifetime as Epoch,
+                                + protocol_parameters.gov_action_lifetime as u64,
                             proposal: proposal.procedure,
                         },
                     ))

--- a/crates/amaru/src/bin/amaru/cmd/import_ledger_state.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_ledger_state.rs
@@ -142,7 +142,7 @@ async fn import_one(
     let db = RocksDB::empty(ledger_dir, era_history)?;
     let bytes = fs::read(snapshot)?;
 
-    let epoch = Epoch::from(decode_new_epoch_state(&db, &bytes, &point, era_history)?);
+    let epoch = decode_new_epoch_state(&db, &bytes, &point, era_history)?;
     let transaction = db.create_transaction();
     transaction.save(
         &point,

--- a/crates/amaru/tests/summary.rs
+++ b/crates/amaru/tests/summary.rs
@@ -25,7 +25,7 @@ use amaru_ledger::{
     },
 };
 use amaru_stores::rocksdb::{RocksDBHistoricalStores, RocksDBSnapshot};
-use pallas_primitives::Epoch;
+use slot_arithmetic::Epoch;
 use std::{
     collections::BTreeMap,
     path::PathBuf,
@@ -84,7 +84,8 @@ fn db(epoch: Epoch) -> Arc<impl Snapshot + Send + Sync> {
 #[test_case(179)]
 #[ignore]
 #[allow(clippy::unwrap_used)]
-fn compare_preprod_snapshot(epoch: Epoch) {
+fn compare_preprod_snapshot(epoch: u64) {
+    let epoch = Epoch::from(epoch);
     let snapshot = db(epoch);
     let global_parameters = GlobalParameters::default();
     let protocol_parameters = ProtocolParameters::default();
@@ -125,7 +126,7 @@ fn compare_preprod_snapshot(epoch: Epoch) {
 }
 
 fn preprod_protocol_version(epoch: Epoch) -> ProtocolVersion {
-    if epoch <= 180 {
+    if epoch <= Epoch::from(180) {
         return PROTOCOL_VERSION_9;
     }
 

--- a/crates/ouroboros-traits/Cargo.toml
+++ b/crates/ouroboros-traits/Cargo.toml
@@ -14,3 +14,4 @@ rust-version.workspace = true
 
 [dependencies]
 amaru-kernel.workspace = true
+slot-arithmetic.workspace = true

--- a/crates/ouroboros-traits/src/has_stake_distribution/mock.rs
+++ b/crates/ouroboros-traits/src/has_stake_distribution/mock.rs
@@ -50,8 +50,8 @@ impl HasStakeDistribution for MockLedgerState {
         })
     }
 
-    fn slot_to_kes_period(&self, slot: u64) -> u64 {
-        slot / self.slots_per_kes_period
+    fn slot_to_kes_period(&self, slot: Slot) -> u64 {
+        u64::from(slot) / self.slots_per_kes_period
     }
 
     fn max_kes_evolutions(&self) -> u64 {

--- a/crates/ouroboros-traits/src/has_stake_distribution/mod.rs
+++ b/crates/ouroboros-traits/src/has_stake_distribution/mod.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{Lovelace, PoolId, Slot, VrfKeyhash};
+use amaru_kernel::{Lovelace, PoolId, VrfKeyhash};
+use slot_arithmetic::Slot;
 
 pub mod mock;
 
@@ -33,7 +34,7 @@ pub trait HasStakeDistribution: Send + Sync {
     fn get_pool(&self, slot: Slot, pool: &PoolId) -> Option<PoolSummary>;
 
     /// Calculate the KES period given an absolute slot and some shelley-genesis values
-    fn slot_to_kes_period(&self, slot: u64) -> u64;
+    fn slot_to_kes_period(&self, slot: Slot) -> u64;
 
     /// Get the maximum number of KES evolutions from the ledger state
     fn max_kes_evolutions(&self) -> u64;

--- a/crates/ouroboros-traits/src/praos/mod.rs
+++ b/crates/ouroboros-traits/src/praos/mod.rs
@@ -45,7 +45,8 @@ Summarizing:
 */
 
 use crate::is_header::IsHeader;
-use amaru_kernel::{cbor, protocol_parameters::GlobalParameters, Epoch, Hash, Nonce};
+use amaru_kernel::{cbor, protocol_parameters::GlobalParameters, Hash, Nonce};
+use slot_arithmetic::Epoch;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Nonces {

--- a/crates/ouroboros/src/praos/header.rs
+++ b/crates/ouroboros/src/praos/header.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 use amaru_kernel::{Header, Nonce};
 use amaru_ouroboros_traits::HasStakeDistribution;
+use slot_arithmetic::Slot;
 use std::{array::TryFromSliceError, ops::Deref, sync::LazyLock};
 use thiserror::Error;
 
@@ -66,7 +67,7 @@ pub fn assert_all<'a>(
     active_slot_coeff: &'a FixedDecimal,
 ) -> Result<Vec<Assertion<'a>>, AssertHeaderError> {
     // Grab all the values we need to validate the block
-    let absolute_slot = header.header_body.slot;
+    let absolute_slot = Slot::from(header.header_body.slot);
     let issuer = ed25519::PublicKey::from(<[u8; ed25519::PublicKey::SIZE]>::try_from(
         &header.header_body.issuer_vkey[..],
     )?);
@@ -80,7 +81,7 @@ pub fn assert_all<'a>(
         Hash<{ vrf::PublicKey::HASH_SIZE }>,
         FixedDecimal,
     ) = ledger_state
-        .get_pool(From::from(absolute_slot), &pool)
+        .get_pool(absolute_slot, &pool)
         .map(|pool| {
             (
                 pool.vrf,

--- a/crates/ouroboros/src/praos/nonce.rs
+++ b/crates/ouroboros/src/praos/nonce.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{protocol_parameters::GlobalParameters, Epoch, EraHistory, Hasher, Nonce};
+use amaru_kernel::{protocol_parameters::GlobalParameters, EraHistory, Hasher, Nonce};
 use amaru_ouroboros_traits::IsHeader;
-use slot_arithmetic::TimeHorizonError;
+use slot_arithmetic::{Epoch, Slot, TimeHorizonError};
 
 /// Obtain the final nonce at an epoch boundary for the epoch from the stable candidate and the
 /// last block (header) of the previous epoch.
@@ -53,11 +53,11 @@ pub fn randomness_stability_window<H: IsHeader>(
     global_parameters: &GlobalParameters,
 ) -> Result<(Epoch, bool), TimeHorizonError> {
     let slot = header.slot();
-    let epoch = era_history.slot_to_epoch(From::from(slot))?;
+    let epoch = era_history.slot_to_epoch(Slot::from(slot))?;
     let next_epoch_first_slot = era_history.next_epoch_first_slot(epoch)?;
 
-    let is_within_stability_window = slot + global_parameters.randomness_stabilization_window
-        < From::from(next_epoch_first_slot);
+    let is_within_stability_window =
+        slot + global_parameters.randomness_stabilization_window < u64::from(next_epoch_first_slot);
 
     Ok((epoch, is_within_stability_window))
 }

--- a/crates/ouroboros/src/vrf/mod.rs
+++ b/crates/ouroboros/src/vrf/mod.rs
@@ -17,6 +17,7 @@
 //! <https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-vrf-03>
 
 pub use pallas_primitives::babbage::{derive_tagged_vrf_output, VrfDerivation as Derivation};
+use slot_arithmetic::Slot;
 use std::{array::TryFromSliceError, ops::Deref};
 
 use crate::{Hash, Hasher};
@@ -117,9 +118,9 @@ impl Input {
     pub const SIZE: usize = 32;
 
     /// Create a new input challenge from an absolute slot number and an epoch entropy (a.k.a η0)
-    pub fn new(absolute_slot: u64, epoch_nonce: &Hash<32>) -> Self {
+    pub fn new(absolute_slot: Slot, epoch_nonce: &Hash<32>) -> Self {
         let mut hasher = Hasher::<{ 8 * Self::SIZE }>::new();
-        hasher.input(&absolute_slot.to_be_bytes());
+        hasher.input(&u64::from(absolute_slot).to_be_bytes());
         hasher.input(epoch_nonce.as_ref());
         Input(hasher.finalize())
     }

--- a/crates/slot-arithmetic/Cargo.toml
+++ b/crates/slot-arithmetic/Cargo.toml
@@ -21,4 +21,3 @@ thiserror.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
-proptest-derive.workspace = true

--- a/crates/slot-arithmetic/Cargo.toml
+++ b/crates/slot-arithmetic/Cargo.toml
@@ -17,7 +17,10 @@ hex.workspace = true
 minicbor.workspace = true
 serde.workspace = true
 thiserror.workspace = true
-
+proptest = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest.workspace = true
+
+[features]
+test-utils = ["proptest"]

--- a/crates/slot-arithmetic/Cargo.toml
+++ b/crates/slot-arithmetic/Cargo.toml
@@ -18,5 +18,7 @@ minicbor.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 
+
 [dev-dependencies]
 proptest.workspace = true
+proptest-derive.workspace = true

--- a/crates/slot-arithmetic/src/lib.rs
+++ b/crates/slot-arithmetic/src/lib.rs
@@ -25,7 +25,7 @@ use minicbor::{Decode, Decoder, Encode};
 
 use serde::{Deserialize, Serialize};
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-utils"))]
 use proptest::prelude::{Arbitrary, BoxedStrategy, Strategy};
 
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd, Ord, Eq, Serialize, Deserialize, Default)]
@@ -89,7 +89,7 @@ impl<'b, C> Decode<'b, C> for Slot {
 #[repr(transparent)]
 pub struct Epoch(u64);
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-utils"))]
 impl Arbitrary for Epoch {
     type Parameters = ();
     type Strategy = BoxedStrategy<Self>;

--- a/crates/slot-arithmetic/src/lib.rs
+++ b/crates/slot-arithmetic/src/lib.rs
@@ -17,7 +17,7 @@
 use std::{
     fmt::Display,
     iter::Step,
-    ops::{Add, Mul, Sub},
+    ops::{Add, Sub},
     str::FromStr,
 };
 
@@ -162,14 +162,6 @@ impl Sub<Epoch> for Epoch {
 
     fn sub(self, rhs: Epoch) -> Self::Output {
         self.0 - rhs.0
-    }
-}
-
-impl Mul<u64> for Epoch {
-    type Output = Self;
-
-    fn mul(self, rhs: u64) -> Self::Output {
-        Epoch(self.0 * rhs)
     }
 }
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -25,6 +25,7 @@ dependencies = [
  "amaru-kernel",
  "amaru-ledger",
  "hex",
+ "slot-arithmetic",
 ]
 
 [[package]]
@@ -67,6 +68,7 @@ name = "amaru-ouroboros-traits"
 version = "0.1.0"
 dependencies = [
  "amaru-kernel",
+ "slot-arithmetic",
 ]
 
 [[package]]

--- a/examples/shared/Cargo.toml
+++ b/examples/shared/Cargo.toml
@@ -14,5 +14,6 @@ publish = false
 [dependencies]
 amaru-kernel = { path = "../../crates/amaru-kernel" }
 amaru-ledger = { path = "../../crates/amaru-ledger" }
+slot-arithmetic = { path = "../../crates/slot-arithmetic" }
 
 hex.workspace = true

--- a/examples/shared/src/store.rs
+++ b/examples/shared/src/store.rs
@@ -1,4 +1,4 @@
-use amaru_kernel::{protocol_parameters::ProtocolParameters, Epoch, Lovelace, Point, StakeCredential};
+use amaru_kernel::{protocol_parameters::ProtocolParameters, Lovelace, Point, StakeCredential};
 use amaru_ledger::{
     store::{
         EpochTransitionProgress, HistoricalStores, ReadOnlyStore, Snapshot, Store, StoreError,
@@ -6,13 +6,14 @@ use amaru_ledger::{
     },
     summary::Pots,
 };
+use slot_arithmetic::Epoch;
 use std::collections::BTreeSet;
 
 pub struct MemoryStore {}
 
 impl Snapshot for MemoryStore {
     fn epoch(&self) -> Epoch {
-        10
+        Epoch::from(10)
     }
 }
 
@@ -277,7 +278,7 @@ impl<'a> TransactionalContext<'a> for MemoryTransactionalContext {
 
 impl Store for MemoryStore {
     fn snapshots(&self) -> Result<Vec<Epoch>, StoreError> {
-        Ok(vec![3])
+        Ok(vec![Epoch::from(3)])
     }
     fn next_snapshot(&self, _epoch: Epoch) -> Result<(), amaru_ledger::store::StoreError> {
         Ok(())

--- a/simulation/amaru-sim/Cargo.toml
+++ b/simulation/amaru-sim/Cargo.toml
@@ -37,6 +37,7 @@ amaru-consensus = { path = "../../crates/amaru-consensus" }
 amaru-ledger = { path = "../../crates/amaru-ledger" }
 amaru-ouroboros = { path = "../../crates/ouroboros" }
 amaru-stores = { path = "../../crates/amaru-stores" }
+slot-arithmetic = { path = "../../crates/slot-arithmetic" }
 anyhow.workspace = true
 
 [dev-dependencies]

--- a/simulation/amaru-sim/src/simulator/ledger.rs
+++ b/simulation/amaru-sim/src/simulator/ledger.rs
@@ -18,6 +18,7 @@ use amaru_ouroboros::{HasStakeDistribution, Nonces, PoolSummary};
 use pallas_crypto::hash::Hash;
 use serde::{Deserialize, Serialize};
 use serde_json::Error;
+use slot_arithmetic::{Epoch, Slot};
 use std::{fs::File, io::BufReader, path::Path};
 
 /// Stake data for a single pool.
@@ -100,8 +101,8 @@ impl HasStakeDistribution for FakeStakeDistribution {
             })
     }
 
-    fn slot_to_kes_period(&self, slot: u64) -> u64 {
-        slot / self.slots_per_kes_period
+    fn slot_to_kes_period(&self, slot: Slot) -> u64 {
+        u64::from(slot) / self.slots_per_kes_period
     }
 
     fn max_kes_evolutions(&self) -> u64 {
@@ -141,7 +142,7 @@ pub(crate) fn populate_chain_store(
         evolving: store.nonce,
         candidate: store.nonce,
         tail: *header,
-        epoch: 0,
+        epoch: Epoch::from(0),
     };
 
     chain_store.put_nonces(header, &nonces).map_err(IoError)?;

--- a/simulation/amaru-sim/src/simulator/mod.rs
+++ b/simulation/amaru-sim/src/simulator/mod.rs
@@ -290,7 +290,7 @@ fn load_tip_from_store<'a>(
 ) -> &'a mut ChainSelectorBuilder<Header> {
     match tip {
         Origin => builder,
-        Specific(..) => match chain_store.load_header(&Slot::from(&tip)) {
+        Specific(..) => match chain_store.load_header(&From::from(&tip)) {
             None => panic!("Tip {:?} not found in chain store", tip),
             Some(header) => builder.set_tip(&header),
         },

--- a/simulation/amaru-sim/src/simulator/mod.rs
+++ b/simulation/amaru-sim/src/simulator/mod.rs
@@ -290,7 +290,7 @@ fn load_tip_from_store<'a>(
 ) -> &'a mut ChainSelectorBuilder<Header> {
     match tip {
         Origin => builder,
-        Specific(..) => match chain_store.load_header(&From::from(&tip)) {
+        Specific(..) => match chain_store.load_header(&Slot::from(&tip)) {
             None => panic!("Tip {:?} not found in chain store", tip),
             Some(header) => builder.set_tip(&header),
         },

--- a/simulation/amaru-sim/src/simulator/sync.rs
+++ b/simulation/amaru-sim/src/simulator/sync.rs
@@ -252,7 +252,7 @@ mod test {
         let header_hash = Hasher::<256>::hash(header.raw_cbor());
         Fwd {
             msg_id: 1,
-            slot: From::from(1234),
+            slot: Slot::from(1234),
             hash: header_hash.to_vec().into(),
             header: header_bytes.into(),
         }
@@ -280,7 +280,7 @@ mod test {
                 ..
             } => {
                 assert_eq!(peer.name, "peer1");
-                assert_eq!(point.slot_or_default(), From::from(1234));
+                assert_eq!(point.slot_or_default(), Slot::from(1234));
                 assert_eq!(Hash::from(&point), expected_hash);
                 assert_eq!(raw_header, hex::decode(TEST_HEADER).unwrap());
             }
@@ -334,14 +334,14 @@ mod test {
             (any::<u64>(), any::<u64>(), any::<[u8; 32]>()).prop_map(|(msg_id, slot, hash)| {
                 ChainSyncMessage::Fwd {
                     msg_id,
-                    slot: From::from(slot),
+                    slot: Slot::from(slot),
                     hash: hash.to_vec().into(),
                     header: Bytes { bytes: vec![] },
                 }
             }),
             (any::<u64>(), any::<u64>(), any::<[u8; 32]>()).prop_map(|(msg_id, slot, hash)| Bck {
                 msg_id,
-                slot: From::from(slot),
+                slot: Slot::from(slot),
                 hash: hash.to_vec().into()
             })
         ]

--- a/simulation/amaru-sim/src/simulator/sync.rs
+++ b/simulation/amaru-sim/src/simulator/sync.rs
@@ -18,10 +18,11 @@ use amaru_consensus::{
     consensus::{ChainSyncEvent, ValidateHeaderEvent},
     peer::Peer,
 };
-use amaru_kernel::{self, Point, Slot};
+use amaru_kernel::{self, Point};
 use futures_util::sink::SinkExt;
 use gasket::framework::*;
 use serde::{Deserialize, Serialize};
+use slot_arithmetic::Slot;
 use tokio::io::{stdin, stdout, AsyncBufReadExt, BufReader, Lines, Stdin, Stdout};
 use tokio_util::codec::{FramedWrite, LinesCodec};
 use tracing::{error, Span};
@@ -231,6 +232,7 @@ mod test {
         prelude::{BoxedStrategy, *},
         proptest,
     };
+    use slot_arithmetic::Slot;
     use tracing::trace_span;
 
     use super::{


### PR DESCRIPTION
Make sure `Epoch` is now a type as detailed in this [EDR](https://github.com/pragma-org/amaru/blob/main/engineering-decision-records/009-avoid-primitive-obsession.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated `Epoch` type for improved type safety, replacing raw `u64` values for epochs throughout the application.

- **Refactor**
  - Updated method and function signatures, struct fields, and test code to use the new `Epoch` and `Slot` types consistently.
  - Standardized conversions and arithmetic involving epochs and slots for greater clarity and consistency.
  - Replaced implicit conversions with explicit `Epoch::from` and `Slot::from` calls across the codebase.

- **Bug Fixes**
  - Improved type consistency in epoch and slot calculations to reduce potential errors.
  - Corrected epoch-related arithmetic and logging for clearer diagnostics.

- **Chores**
  - Added the new `slot-arithmetic` crate as a dependency and updated workspace configurations.
  - Removed unused dependencies and modularized testing utilities with feature flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->