### PR TITLE
chore: make GlobalParameters derived from Network

### DIFF
--- a/crates/amaru-consensus/src/consensus/store.rs
+++ b/crates/amaru-consensus/src/consensus/store.rs
@@ -268,7 +268,7 @@ mod test {
                 &PREPROD_HEADER_69638382,
                 (&PREPROD_HEADER_70070331, &PREPROD_NONCES_70070331),
                 &PREPROD_HEADER_70070379,
-                &GlobalParameters::default()
+                NetworkName::Preprod.into()
             )
             .as_ref(),
             Some(&*PREPROD_NONCES_70070379)
@@ -282,7 +282,7 @@ mod test {
                 &PREPROD_HEADER_69638382,
                 (&PREPROD_HEADER_70070379, &PREPROD_NONCES_70070379),
                 &PREPROD_HEADER_70070426,
-                &GlobalParameters::default()
+                NetworkName::Preprod.into()
             )
             .as_ref(),
             Some(&*PREPROD_NONCES_70070426)
@@ -296,7 +296,7 @@ mod test {
                 &PREPROD_HEADER_70070379,
                 (&PREPROD_HEADER_70070426, &PREPROD_NONCES_70070426),
                 &PREPROD_HEADER_70070464,
-                &GlobalParameters::default()
+                NetworkName::Preprod.into()
             )
             .as_ref(),
             Some(&*PREPROD_NONCES_70070464)

--- a/crates/amaru-kernel/src/network.rs
+++ b/crates/amaru-kernel/src/network.rs
@@ -215,14 +215,54 @@ static PREPROD_GLOBAL_PARAMETERS: LazyLock<GlobalParameters> = LazyLock::new(|| 
     }
 });
 
+static PREVIEW_GLOBAL_PARAMETERS: LazyLock<GlobalParameters> = LazyLock::new(|| {
+    let consensus_security_param = 432;
+    let active_slot_coeff_inverse = 20;
+    let epoch_length_scale_factor = 10;
+    let epoch_length =
+        active_slot_coeff_inverse * epoch_length_scale_factor * consensus_security_param;
+    GlobalParameters {
+        consensus_security_param,
+        epoch_length_scale_factor,
+        active_slot_coeff_inverse,
+        max_lovelace_supply: 45_000_000_000_000_000,
+        slots_per_kes_period: 129_600,
+        max_kes_evolution: 62,
+        epoch_length,
+        stability_window: active_slot_coeff_inverse * consensus_security_param * 2,
+        randomness_stabilization_window: (4 * consensus_security_param * active_slot_coeff_inverse)
+            as u64,
+    }
+});
+
+static TESTNET_GLOBAL_PARAMETERS: LazyLock<GlobalParameters> = LazyLock::new(|| {
+    let consensus_security_param = 432;
+    let active_slot_coeff_inverse = 20;
+    let epoch_length_scale_factor = 10;
+    let epoch_length =
+        active_slot_coeff_inverse * epoch_length_scale_factor * consensus_security_param;
+    GlobalParameters {
+        consensus_security_param,
+        epoch_length_scale_factor,
+        active_slot_coeff_inverse,
+        max_lovelace_supply: 45_000_000_000_000_000,
+        slots_per_kes_period: 129_600,
+        max_kes_evolution: 62,
+        epoch_length,
+        stability_window: active_slot_coeff_inverse * consensus_security_param * 2,
+        randomness_stabilization_window: (4 * consensus_security_param * active_slot_coeff_inverse)
+            as u64,
+    }
+});
+
 #[allow(clippy::todo)]
 impl From<NetworkName> for &GlobalParameters {
     fn from(value: NetworkName) -> Self {
         match value {
             NetworkName::Mainnet => todo!(),
             NetworkName::Preprod => &PREPROD_GLOBAL_PARAMETERS,
-            NetworkName::Preview => todo!(),
-            NetworkName::Testnet(_) => todo!(),
+            NetworkName::Preview => &PREVIEW_GLOBAL_PARAMETERS,
+            NetworkName::Testnet(_) => &TESTNET_GLOBAL_PARAMETERS,
         }
     }
 }

--- a/crates/amaru-kernel/src/network.rs
+++ b/crates/amaru-kernel/src/network.rs
@@ -198,25 +198,18 @@ static PREPROD_GLOBAL_PARAMETERS: LazyLock<GlobalParameters> = LazyLock::new(|| 
     // https://cips.cardano.org/cip/CIP-9
     let consensus_security_param = 2160;
     let active_slot_coeff_inverse = 20;
-    let shelley_epoch_length_scale_factor = 10;
-    let shelley_epoch_length =
-        active_slot_coeff_inverse * shelley_epoch_length_scale_factor * consensus_security_param;
-    let byron_epoch_length_scale_factor = 10;
-    let byron_epoch_length = byron_epoch_length_scale_factor * consensus_security_param;
-    let shelley_transition_epoch = 4;
+    let epoch_length_scale_factor = 10;
+    let epoch_length =
+        active_slot_coeff_inverse * epoch_length_scale_factor * consensus_security_param;
     GlobalParameters {
         consensus_security_param,
-        shelley_epoch_length_scale_factor,
+        epoch_length_scale_factor,
         active_slot_coeff_inverse,
-        byron_epoch_length_scale_factor,
-        shelley_transition_epoch,
         max_lovelace_supply: 45_000_000_000_000_000,
         slots_per_kes_period: 129_600,
         max_kes_evolution: 62,
-        shelley_epoch_length,
+        epoch_length,
         stability_window: active_slot_coeff_inverse * consensus_security_param * 2,
-        byron_epoch_length,
-        byron_total_slots: byron_epoch_length * shelley_transition_epoch,
         randomness_stabilization_window: (4 * consensus_security_param * active_slot_coeff_inverse)
             as u64,
     }

--- a/crates/amaru-kernel/src/network.rs
+++ b/crates/amaru-kernel/src/network.rs
@@ -17,6 +17,8 @@ use std::{fs::File, io::BufReader, path::Path, sync::LazyLock};
 pub use slot_arithmetic::{Bound, EraHistory, EraParams, Summary};
 use slot_arithmetic::{Epoch, Slot};
 
+use crate::protocol_parameters::GlobalParameters;
+
 /// Era history for Preprod retrieved with:
 ///
 /// ```bash
@@ -188,6 +190,46 @@ impl From<NetworkName> for &EraHistory {
             NetworkName::Preprod => &PREPROD_ERA_HISTORY,
             NetworkName::Preview => todo!(),
             NetworkName::Testnet(_) => &TESTNET_ERA_HISTORY,
+        }
+    }
+}
+
+static PREPROD_GLOBAL_PARAMETERS: LazyLock<GlobalParameters> = LazyLock::new(|| {
+    // https://cips.cardano.org/cip/CIP-9
+    let consensus_security_param = 2160;
+    let active_slot_coeff_inverse = 20;
+    let shelley_epoch_length_scale_factor = 10;
+    let shelley_epoch_length =
+        active_slot_coeff_inverse * shelley_epoch_length_scale_factor * consensus_security_param;
+    let byron_epoch_length_scale_factor = 10;
+    let byron_epoch_length = byron_epoch_length_scale_factor * consensus_security_param;
+    let shelley_transition_epoch = 4;
+    GlobalParameters {
+        consensus_security_param,
+        shelley_epoch_length_scale_factor,
+        active_slot_coeff_inverse,
+        byron_epoch_length_scale_factor,
+        shelley_transition_epoch,
+        max_lovelace_supply: 45_000_000_000_000_000,
+        slots_per_kes_period: 129_600,
+        max_kes_evolution: 62,
+        shelley_epoch_length,
+        stability_window: active_slot_coeff_inverse * consensus_security_param * 2,
+        byron_epoch_length,
+        byron_total_slots: byron_epoch_length * shelley_transition_epoch,
+        randomness_stabilization_window: (4 * consensus_security_param * active_slot_coeff_inverse)
+            as u64,
+    }
+});
+
+#[allow(clippy::todo)]
+impl From<NetworkName> for &GlobalParameters {
+    fn from(value: NetworkName) -> Self {
+        match value {
+            NetworkName::Mainnet => todo!(),
+            NetworkName::Preprod => &PREPROD_GLOBAL_PARAMETERS,
+            NetworkName::Preview => todo!(),
+            NetworkName::Testnet(_) => todo!(),
         }
     }
 }

--- a/crates/amaru-kernel/src/protocol_parameters.rs
+++ b/crates/amaru-kernel/src/protocol_parameters.rs
@@ -316,17 +316,11 @@ pub struct GlobalParameters {
     /// which aren't yet considered final.
     pub consensus_security_param: usize,
 
-    /// Multiplier applied to the CONSENSUS_SECURITY_PARAM to determine Shelley's epoch length.
-    pub shelley_epoch_length_scale_factor: usize,
+    /// Multiplier applied to the CONSENSUS_SECURITY_PARAM to determine the epoch length.
+    pub epoch_length_scale_factor: usize,
 
     /// Inverse of the active slot coefficient (i.e. 1/f);
     pub active_slot_coeff_inverse: usize,
-
-    /// Multiplier applied to the CONSENSUS_SECURITY_PARAM to determine Byron's epoch length.
-    pub byron_epoch_length_scale_factor: usize,
-
-    /// Epoch number in which the network transitioned to Shelley.
-    pub shelley_transition_epoch: usize,
 
     /// Maximum supply of Ada, in lovelace (1 Ada = 1,000,000 Lovelace)
     pub max_lovelace_supply: Lovelace,
@@ -338,17 +332,11 @@ pub struct GlobalParameters {
     /// indicates the validity period of a KES key before a new one is required.
     pub max_kes_evolution: u8,
 
-    /// Number of slots in a Shelley epoch
-    pub shelley_epoch_length: usize,
+    /// Number of slots in an epoch
+    pub epoch_length: usize,
 
     /// Relative slot from which data of the previous epoch can be considered stable.
     pub stability_window: usize,
-
-    /// Number of blocks in a Byron epoch
-    pub byron_epoch_length: usize,
-
-    /// Number of slots in the Byron era
-    pub byron_total_slots: usize,
 
     /// Number of slots at the end of each epoch which do NOT contribute randomness to the candidate
     /// nonce of the following epoch.

--- a/crates/amaru-kernel/src/protocol_parameters.rs
+++ b/crates/amaru-kernel/src/protocol_parameters.rs
@@ -355,38 +355,6 @@ pub struct GlobalParameters {
     pub randomness_stabilization_window: u64,
 }
 
-impl Default for GlobalParameters {
-    fn default() -> Self {
-        // https://cips.cardano.org/cip/CIP-9
-        let consensus_security_param = 2160;
-        let active_slot_coeff_inverse = 20;
-        let shelley_epoch_length_scale_factor = 10;
-        let shelley_epoch_length = active_slot_coeff_inverse
-            * shelley_epoch_length_scale_factor
-            * consensus_security_param;
-        let byron_epoch_length_scale_factor = 10;
-        let byron_epoch_length = byron_epoch_length_scale_factor * consensus_security_param;
-        let shelley_transition_epoch = 4;
-        Self {
-            consensus_security_param,
-            shelley_epoch_length_scale_factor,
-            active_slot_coeff_inverse,
-            byron_epoch_length_scale_factor,
-            shelley_transition_epoch,
-            max_lovelace_supply: 45_000_000_000_000_000,
-            slots_per_kes_period: 129_600,
-            max_kes_evolution: 62,
-            shelley_epoch_length,
-            stability_window: active_slot_coeff_inverse * consensus_security_param * 2,
-            byron_epoch_length,
-            byron_total_slots: byron_epoch_length * shelley_transition_epoch,
-            randomness_stabilization_window: (4
-                * consensus_security_param
-                * active_slot_coeff_inverse) as u64,
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Prices {
     pub mem: RationalNumber,

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -402,7 +402,7 @@ impl RewardsSummary {
 
         let efficiency = safe_ratio(
             blocks_count * global_parameters.active_slot_coeff_inverse as u64,
-            global_parameters.shelley_epoch_length as u64,
+            global_parameters.epoch_length as u64,
         );
 
         blocks_count = blocks_count.max(1);

--- a/crates/amaru/src/stages/mod.rs
+++ b/crates/amaru/src/stages/mod.rs
@@ -81,7 +81,7 @@ pub fn bootstrap(
     let era_history: &EraHistory = config.network.into();
     let store = RocksDB::new(&config.ledger_dir, era_history)?;
     let snapshots = RocksDBHistoricalStores::new(&config.ledger_dir);
-    let global_parameters = GlobalParameters::default();
+    let global_parameters: &GlobalParameters = config.network.into();
     let (mut ledger, tip) = ledger::ValidateBlockStage::new(
         store,
         snapshots,
@@ -124,7 +124,7 @@ pub fn bootstrap(
 
     let mut receive_header_stage = ReceiveHeaderStage::default();
 
-    let mut validate_header_stage = ValidateHeaderStage::new(consensus, &global_parameters);
+    let mut validate_header_stage = ValidateHeaderStage::new(consensus, global_parameters);
 
     let mut store_header_stage = StoreHeaderStage::new(StoreHeader::new(chain_ref.clone()));
 

--- a/crates/amaru/tests/summary.rs
+++ b/crates/amaru/tests/summary.rs
@@ -86,14 +86,15 @@ fn db(epoch: Epoch) -> Arc<impl Snapshot + Send + Sync> {
 #[allow(clippy::unwrap_used)]
 fn compare_preprod_snapshot(epoch: u64) {
     let epoch = Epoch::from(epoch);
+    let network = NetworkName::Preprod;
     let snapshot = db(epoch);
-    let global_parameters = GlobalParameters::default();
+    let global_parameters: &GlobalParameters = network.into();
     let protocol_parameters = ProtocolParameters::default();
 
     let dreps = GovernanceSummary::new(
         snapshot.as_ref(),
         preprod_protocol_version(epoch),
-        NetworkName::Preprod.into(),
+        network.into(),
         &protocol_parameters,
     )
     .unwrap();
@@ -115,7 +116,7 @@ fn compare_preprod_snapshot(epoch: u64) {
     let rewards_summary = RewardsSummary::new(
         snapshot_from_the_future.as_ref(),
         stake_distr,
-        &global_parameters,
+        global_parameters,
         &protocol_parameters,
     )
     .unwrap()

--- a/examples/shared/src/lib.rs
+++ b/examples/shared/src/lib.rs
@@ -22,9 +22,10 @@ pub fn forward_ledger(raw_block: &str) {
     let bytes = hex::decode(raw_block).unwrap();
 
     let (_hash, block): BlockWrapper = cbor::decode(&bytes).unwrap();
-    let era_history: &EraHistory = NetworkName::Preprod.into();
+    let network = NetworkName::Preprod;
+    let era_history: &EraHistory = network.into();
 
-    let global_parameters = GlobalParameters::default();
+    let global_parameters: &GlobalParameters = network.into();
     let store = MemoryStore {};
     let mut state = State::new(
         store,

--- a/simulation/amaru-sim/src/simulator/ledger.rs
+++ b/simulation/amaru-sim/src/simulator/ledger.rs
@@ -171,7 +171,7 @@ pub struct ConsensusContext {
 #[cfg(test)]
 mod test {
     use amaru_consensus::consensus::store::{ChainStore, StoreError};
-    use amaru_kernel::{network::NetworkName, protocol_parameters::GlobalParameters, Header};
+    use amaru_kernel::{network::NetworkName, Header};
 
     use super::populate_chain_store;
 
@@ -194,7 +194,7 @@ mod test {
         let stake_distribution_file = "tests/data/stake-distribution.json";
         let stake_distribution = FakeStakeDistribution::from_file(
             &PathBuf::from(stake_distribution_file),
-            &GlobalParameters::default(),
+            NetworkName::Preprod.into(),
         )
         .unwrap();
         let pool_id: Hash<28> = amaru_kernel::Hash::from(
@@ -213,7 +213,7 @@ mod test {
         let stake_distribution_file = "tests/data/stake-distribution.json";
         let stake_distribution = FakeStakeDistribution::from_file(
             &PathBuf::from(stake_distribution_file),
-            &GlobalParameters::default(),
+            NetworkName::Preprod.into(),
         )
         .unwrap();
         let pool_id: Hash<28> = amaru_kernel::Hash::from(


### PR DESCRIPTION
`GlobalParameters` are stil hardcoded but derived from `NetworkName`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for network-specific protocol parameters for Preprod, Preview, and Testnet Cardano networks, ensuring more accurate configuration across environments.

- **Refactor**
  - Updated how global protocol parameters are initialized and accessed throughout the application and tests, removing reliance on default values and ensuring explicit network context is used.
  - Simplified and generalized the structure of protocol parameters by removing legacy fields and focusing on current epoch-wide parameters.
  - Modified simulation and bootstrap processes to consistently use network-based global parameters, enhancing configuration coherence.

- **Bug Fixes**
  - Improved calculation of reward efficiency by using the correct epoch length parameter, leading to more accurate metrics in rewards summaries.

- **Tests**
  - Updated test cases to use network-specific protocol parameters for greater consistency and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->