### PR TITLE
chore: make sure draft PR also run snapshot tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -150,7 +150,6 @@ jobs:
   snapshots:
     name: Snapshots
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
     env:
       AMARU_PEER_ADDRESS: 127.0.0.1:3001
     strategy:


### PR DESCRIPTION
`Draft` PR are useful to inform others it's not ready to be reviewed. Still one might want to have full snapshot tests run on them.