### PR TITLE
feat: add stage to store block bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "slot-arithmetic",
  "test-case",
  "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/amaru-consensus/Cargo.toml
+++ b/crates/amaru-consensus/Cargo.toml
@@ -34,5 +34,6 @@ proptest.workspace = true
 rand.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
+tokio = { workspace = true, features = ["rt", "macros"] }
 tracing-subscriber.workspace = true
 slot-arithmetic = { workspace = true, features = ["test-utils"] }

--- a/crates/amaru-consensus/README.md
+++ b/crates/amaru-consensus/README.md
@@ -40,6 +40,6 @@ Stages:
 * [store header](src/consensus/store_header.rs): store valid (and invalid?) headers indexed by hash
 * [select chain](src/consensus/select_chain.rs): proceed to chain (candidate) selection, possibly changing the current best chain,
 * [fetch block](../amaru/src/stages/consensus/fetch_block.rs): fetch block body corresponding to the new header, if any.
-* [validate block](../amaru/src/stages/ledger.rs): validate the fetched block against its parent ledger state
-* store block: store valid (and invalid) block bodies, indexed by header hash. _Not implemented yet_
+* [store block](src/consensus/store_block.rs): store valid (and invalid) block bodies, indexed by header hash. The blocks are stored _before_ validation in order to support [_pipelining_](https://iohk.io/en/blog/posts/2022/02/01/introducing-pipelining-cardanos-consensus-layer-scaling-solution/)
+* [validate block](../amaru/src/stages/ledger.rs): validate the block body against its parent ledger state
 * [forward chain](../amaru/src/stages/consensus/forward_chain/): forward newly selected chain to downstream peers (chain followers)

--- a/crates/amaru-consensus/src/consensus/mod.rs
+++ b/crates/amaru-consensus/src/consensus/mod.rs
@@ -21,6 +21,7 @@ pub mod chain_selection;
 pub mod receive_header;
 pub mod select_chain;
 pub mod store;
+pub mod store_block;
 pub mod store_header;
 pub mod validate_header;
 

--- a/crates/amaru-consensus/src/consensus/store.rs
+++ b/crates/amaru-consensus/src/consensus/store.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{protocol_parameters::GlobalParameters, EraHistory, Nonce, Point};
+use amaru_kernel::{protocol_parameters::GlobalParameters, EraHistory, Nonce, Point, RawBlock};
 use amaru_ouroboros::{praos::nonce, Nonces};
 use amaru_ouroboros_traits::{IsHeader, Praos};
 use pallas_crypto::hash::Hash;
@@ -43,6 +43,9 @@ where
     fn load_header(&self, hash: &Hash<32>) -> Option<H>;
     fn store_header(&mut self, hash: &Hash<32>, header: &H) -> Result<(), StoreError>;
 
+    fn load_block(&self, hash: &Hash<32>) -> Option<RawBlock>;
+    fn store_block(&mut self, hash: &Hash<32>, block: &RawBlock) -> Result<(), StoreError>;
+
     fn get_nonces(&self, header: &Hash<32>) -> Option<Nonces>;
     fn put_nonces(&mut self, header: &Hash<32>, nonces: &Nonces) -> Result<(), StoreError>;
 
@@ -68,6 +71,14 @@ impl<H: IsHeader> ChainStore<H> for Box<dyn ChainStore<H>> {
 
     fn era_history(&self) -> &EraHistory {
         self.as_ref().era_history()
+    }
+
+    fn load_block(&self, hash: &Hash<32>) -> Option<RawBlock> {
+        self.as_ref().load_block(hash)
+    }
+
+    fn store_block(&mut self, hash: &Hash<32>, block: &RawBlock) -> Result<(), StoreError> {
+        self.as_mut().store_block(hash, block)
     }
 }
 
@@ -254,6 +265,14 @@ mod test {
 
         fn era_history(&self) -> &EraHistory {
             NetworkName::Preprod.into()
+        }
+
+        fn load_block(&self, _hash: &Hash<32>) -> Option<RawBlock> {
+            unimplemented!()
+        }
+
+        fn store_block(&mut self, _hash: &Hash<32>, _block: &RawBlock) -> Result<(), StoreError> {
+            unimplemented!()
         }
     }
 

--- a/crates/amaru-consensus/src/consensus/store_block.rs
+++ b/crates/amaru-consensus/src/consensus/store_block.rs
@@ -89,7 +89,7 @@ mod tests {
             unimplemented!()
         }
 
-        fn load_block(&self, _hash: &Hash<32>) -> Option<RawBlock> {
+        fn load_block(&self, _hash: &Hash<32>) -> Result<RawBlock, StoreError> {
             unimplemented!()
         }
 

--- a/crates/amaru-consensus/src/consensus/store_block.rs
+++ b/crates/amaru-consensus/src/consensus/store_block.rs
@@ -1,0 +1,172 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{consensus::store::ChainStore, ConsensusError};
+use amaru_kernel::{block::ValidateBlockEvent, Header, Point, RawBlock};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+pub struct StoreBlock {
+    store: Arc<Mutex<dyn ChainStore<Header>>>,
+}
+
+impl StoreBlock {
+    pub fn new(chain_store: Arc<Mutex<dyn ChainStore<Header>>>) -> Self {
+        StoreBlock { store: chain_store }
+    }
+
+    pub async fn store(&self, point: &Point, block: &RawBlock) -> Result<(), ConsensusError> {
+        self.store
+            .lock()
+            .await
+            .store_block(&point.into(), block)
+            .map_err(|e| ConsensusError::StoreBlockFailed(point.clone(), e))
+    }
+
+    pub async fn handle_event(
+        &self,
+        event: ValidateBlockEvent,
+    ) -> Result<ValidateBlockEvent, ConsensusError> {
+        match event {
+            ValidateBlockEvent::Validated {
+                ref point,
+                ref block,
+                ..
+            } => {
+                self.store(point, block).await?;
+                Ok(event)
+            }
+            ValidateBlockEvent::Rollback { .. } => Ok(event),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::consensus::store::StoreError;
+
+    use super::*;
+    use amaru_kernel::{Hash, Point, RawBlock};
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+    use tracing::Span;
+
+    // Mock implementation of ChainStore for testing
+    struct MockChainStore {
+        stored_blocks: std::collections::HashMap<Hash<32>, RawBlock>,
+    }
+
+    impl MockChainStore {
+        fn new() -> Self {
+            Self {
+                stored_blocks: std::collections::HashMap::new(),
+            }
+        }
+    }
+
+    impl ChainStore<Header> for MockChainStore {
+        fn store_block(&mut self, point: &Hash<32>, block: &RawBlock) -> Result<(), StoreError> {
+            self.stored_blocks.insert(*point, block.clone());
+            Ok(())
+        }
+
+        fn load_header(&self, _hash: &Hash<32>) -> Option<Header> {
+            unimplemented!()
+        }
+
+        fn store_header(&mut self, _hash: &Hash<32>, _header: &Header) -> Result<(), StoreError> {
+            unimplemented!()
+        }
+
+        fn load_block(&self, _hash: &Hash<32>) -> Option<RawBlock> {
+            unimplemented!()
+        }
+
+        fn get_nonces(&self, _header: &Hash<32>) -> Option<amaru_ouroboros::Nonces> {
+            unimplemented!()
+        }
+
+        fn put_nonces(
+            &mut self,
+            _header: &Hash<32>,
+            _nonces: &amaru_ouroboros::Nonces,
+        ) -> Result<(), StoreError> {
+            unimplemented!()
+        }
+
+        fn era_history(&self) -> &amaru_kernel::EraHistory {
+            unimplemented!()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_event_block_validated() {
+        // Setup
+        let mock_store = Arc::new(Mutex::new(MockChainStore::new()));
+        let store_block = StoreBlock::new(mock_store.clone());
+
+        // Create test data
+        let point = Point::Specific(123, Hash::from([1; 32]).to_vec());
+        let block = vec![0, 1, 2, 3];
+        let span = Span::current();
+
+        // Create a BlockValidated event
+        let event = ValidateBlockEvent::Validated {
+            point: point.clone(),
+            block: block.clone(),
+            span,
+        };
+
+        // Call handle_event
+        let result = store_block.handle_event(event).await;
+
+        // Since the implementation is unimplemented!(), this will panic
+        // Once implemented, we would expect:
+        assert!(result.is_ok());
+    }
+
+    #[allow(clippy::wildcard_enum_match_arm)]
+    #[tokio::test]
+    async fn test_handle_event_rolled_back_to() {
+        // Setup
+        let mock_store = Arc::new(Mutex::new(MockChainStore::new()));
+        let store_block = StoreBlock::new(mock_store.clone());
+
+        // Create test data
+        let rollback_point = Point::Specific(100, Hash::from([2; 32]).to_vec());
+        let span = Span::current();
+
+        // Create a RolledBackTo event
+        let event = ValidateBlockEvent::Rollback {
+            rollback_point: rollback_point.clone(),
+            span,
+        };
+
+        // Call handle_event
+        let result = store_block.handle_event(event).await;
+
+        // Verify the result
+        assert!(result.is_ok());
+        let result_event = result.unwrap();
+        match result_event {
+            ValidateBlockEvent::Rollback {
+                rollback_point: result_point,
+                span: _,
+            } => {
+                assert_eq!(result_point, rollback_point);
+            }
+            _ => panic!("Expected RolledBackTo event"),
+        }
+    }
+}

--- a/crates/amaru-consensus/src/consensus/store_header.rs
+++ b/crates/amaru-consensus/src/consensus/store_header.rs
@@ -54,12 +54,3 @@ impl StoreHeader {
         }
     }
 }
-
-pub async fn store_header(
-    store: Arc<Mutex<dyn ChainStore<Header>>>,
-    point: &Point,
-    header: &Header,
-) -> Result<(), ConsensusError> {
-    let store_header = StoreHeader { store };
-    store_header.store(point, header).await
-}

--- a/crates/amaru-consensus/src/lib.rs
+++ b/crates/amaru-consensus/src/lib.rs
@@ -37,6 +37,8 @@ pub enum ConsensusError {
     InvalidHeader(Point, AssertHeaderError),
     #[error("Failed to store header at {0:?}: {1}")]
     StoreHeaderFailed(Point, consensus::store::StoreError),
+    #[error("Failed to store block body at {0:?}: {1}")]
+    StoreBlockFailed(Point, consensus::store::StoreError),
     #[error("Failed to decode header at {0:?}")]
     CannotDecodeHeader(Point),
     #[error("Unknown peer {0:?}, bailing out")]

--- a/crates/amaru-kernel/Cargo.toml
+++ b/crates/amaru-kernel/Cargo.toml
@@ -24,6 +24,7 @@ pallas-traverse.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 slot-arithmetic.workspace = true
 

--- a/crates/amaru-kernel/src/block.rs
+++ b/crates/amaru-kernel/src/block.rs
@@ -12,10 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod fetch_block;
-pub mod forward_chain;
-pub mod receive_header;
-pub mod select_chain;
-pub mod store_block;
-pub mod store_header;
-pub mod validate_header;
+use crate::{Point, RawBlock};
+use tracing::Span;
+
+#[derive(Debug, Clone)]
+pub enum ValidateBlockEvent {
+    Validated {
+        point: Point,
+        block: RawBlock,
+        span: Span,
+    },
+    Rollback {
+        rollback_point: Point,
+        span: Span,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum BlockValidationResult {
+    BlockValidated {
+        point: Point,
+        block: RawBlock,
+        span: Span,
+    },
+    BlockValidationFailed {
+        point: Point,
+        span: Span,
+    },
+    RolledBackTo {
+        rollback_point: Point,
+        span: Span,
+    },
+}

--- a/crates/amaru-kernel/src/block.rs
+++ b/crates/amaru-kernel/src/block.rs
@@ -15,7 +15,7 @@
 use crate::{Point, RawBlock};
 use tracing::Span;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum ValidateBlockEvent {
     Validated {
         point: Point,

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -74,6 +74,7 @@ pub use serde_json as json;
 pub use sha3;
 pub use slot_arithmetic::{Bound, EraHistory, EraParams, Slot, Summary};
 
+pub mod block;
 pub mod macros;
 pub mod network;
 pub mod protocol_parameters;
@@ -162,6 +163,9 @@ impl<'b> Decode<'b, ()> for Point {
         }
     }
 }
+
+/// Convenient type alias to any kind of block
+pub type RawBlock = Vec<u8>;
 
 pub type TransactionId = Hash<32>;
 

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -167,6 +167,8 @@ impl<'b> Decode<'b, ()> for Point {
 /// Convenient type alias to any kind of block
 pub type RawBlock = Vec<u8>;
 
+pub const EMPTY_BLOCK: Vec<u8> = vec![];
+
 pub type TransactionId = Hash<32>;
 
 pub type PoolId = Hash<28>;

--- a/crates/amaru-ledger/src/lib.rs
+++ b/crates/amaru-ledger/src/lib.rs
@@ -14,31 +14,6 @@
 
 #![feature(try_trait_v2)]
 
-use amaru_kernel::Point;
-use tracing::Span;
-
-pub type RawBlock = Vec<u8>;
-
-#[derive(Debug, Clone)]
-pub enum ValidateBlockEvent {
-    Validated {
-        point: Point,
-        block: RawBlock,
-        span: Span,
-    },
-    Rollback {
-        rollback_point: Point,
-        span: Span,
-    },
-}
-
-#[derive(Debug, Clone)]
-pub enum BlockValidationResult {
-    BlockValidated { point: Point, span: Span },
-    BlockValidationFailed { point: Point, span: Span },
-    RolledBackTo { rollback_point: Point, span: Span },
-}
-
 pub mod context;
 pub mod rules;
 pub mod state;

--- a/crates/amaru-stores/src/rocksdb/consensus.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus.rs
@@ -16,7 +16,7 @@ use amaru_consensus::{
     consensus::store::{ChainStore, StoreError},
     Nonces,
 };
-use amaru_kernel::{cbor, from_cbor, network::NetworkName, to_cbor, Hash};
+use amaru_kernel::{cbor, from_cbor, network::NetworkName, to_cbor, Hash, RawBlock};
 use amaru_ouroboros_traits::is_header::IsHeader;
 use rocksdb::{OptimisticTransactionDB, Options};
 use slot_arithmetic::EraHistory;
@@ -46,6 +46,8 @@ impl RocksDBStore {
 }
 
 const NONCES_PREFIX: [u8; 5] = [0x6e, 0x6f, 0x6e, 0x63, 0x65];
+
+const BLOCK_PREFIX: [u8; 5] = [0x62, 0x6c, 0x6f, 0x63, 0x6b];
 
 impl<H: IsHeader + for<'d> cbor::Decode<'d, ()>> ChainStore<H> for RocksDBStore {
     fn load_header(&self, hash: &Hash<32>) -> Option<H> {
@@ -83,6 +85,24 @@ impl<H: IsHeader + for<'d> cbor::Decode<'d, ()>> ChainStore<H> for RocksDBStore 
 
     fn era_history(&self) -> &EraHistory {
         &self.era_history
+    }
+
+    fn load_block(&self, hash: &Hash<32>) -> Option<RawBlock> {
+        self.db
+            .get_pinned([&BLOCK_PREFIX[..], &hash[..]].concat())
+            .map_err(|e| println!("{:?}", e))
+            .ok()
+            .flatten()
+            .as_deref()
+            .map(|bytes| bytes.into())
+    }
+
+    fn store_block(&mut self, hash: &Hash<32>, block: &RawBlock) -> Result<(), StoreError> {
+        self.db
+            .put([&BLOCK_PREFIX[..], &hash[..]].concat(), block)
+            .map_err(|e| StoreError::WriteError {
+                error: e.to_string(),
+            })
     }
 }
 
@@ -125,6 +145,14 @@ impl<H: IsHeader> ChainStore<H> for InMemConsensusStore {
     fn era_history(&self) -> &amaru_kernel::EraHistory {
         NetworkName::Testnet(42).into()
     }
+
+    fn load_block(&self, _hash: &Hash<32>) -> Option<RawBlock> {
+        unimplemented!()
+    }
+
+    fn store_block(&mut self, _hash: &Hash<32>, _block: &RawBlock) -> Result<(), StoreError> {
+        unimplemented!()
+    }
 }
 
 #[cfg(test)]
@@ -144,7 +172,7 @@ mod test {
     }
 
     #[test]
-    fn rocksdb_chain_store_can_get_what_it_puts() {
+    fn rocksdb_chain_store_can_get_header_it_puts() {
         let tempdir = tempfile::tempdir().unwrap();
         let basedir = tempdir.path().join("rocksdb_chain_store");
         let era_history: &EraHistory = NetworkName::Testnet(42).into();
@@ -163,5 +191,24 @@ mod test {
         store.store_header(&header.hash(), &header).unwrap();
         let header2 = store.load_header(&header.hash()).unwrap();
         assert_eq!(header, header2);
+    }
+
+    #[test]
+    fn rocksdb_chain_store_can_get_block_it_puts() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let basedir = tempdir.path().join("rocksdb_chain_store");
+        let era_history: &EraHistory = NetworkName::Testnet(42).into();
+
+        create_dir(&basedir).unwrap();
+        println!("db created at {:?}", basedir);
+        let mut store =
+            RocksDBStore::new(&basedir, era_history).expect("fail to initialise RocksDB");
+
+        let hash: Hash<32> = random_bytes(32).as_slice().into();
+        let block = vec![1; 64];
+
+        <RocksDBStore as ChainStore<FakeHeader>>::store_block(&mut store, &hash, &block).unwrap();
+        let block2 = <RocksDBStore as ChainStore<FakeHeader>>::load_block(&store, &hash).unwrap();
+        assert_eq!(block, block2);
     }
 }

--- a/crates/amaru/src/stages/consensus/fetch_block.rs
+++ b/crates/amaru/src/stages/consensus/fetch_block.rs
@@ -15,8 +15,7 @@
 use std::collections::HashMap;
 
 use amaru_consensus::{consensus::ValidateHeaderEvent, peer::Peer, ConsensusError};
-use amaru_kernel::Point;
-use amaru_ledger::ValidateBlockEvent;
+use amaru_kernel::{block::ValidateBlockEvent, Point};
 use gasket::framework::*;
 use tracing::{instrument, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;

--- a/crates/amaru/src/stages/consensus/forward_chain.rs
+++ b/crates/amaru/src/stages/consensus/forward_chain.rs
@@ -15,8 +15,7 @@
 use crate::stages::PallasPoint;
 use acto::{AcTokio, ActoCell, ActoMsgSuper, ActoRef, ActoRuntime};
 use amaru_consensus::{consensus::store::ChainStore, IsHeader};
-use amaru_kernel::{Hash, Header};
-use amaru_ledger::BlockValidationResult;
+use amaru_kernel::{block::BlockValidationResult, Hash, Header};
 use client_protocol::{client_protocols, ClientProtocolMsg};
 use gasket::framework::*;
 use pallas_network::{
@@ -251,7 +250,7 @@ impl gasket::framework::Worker<ForwardChainStage> for Worker {
         stage: &mut ForwardChainStage,
     ) -> Result<(), WorkerError> {
         match unit {
-            Unit::Block(BlockValidationResult::BlockValidated { point, span }) => {
+            Unit::Block(BlockValidationResult::BlockValidated { point, span, .. }) => {
                 // FIXME: this span is just a placeholder to hold a link to t
                 // the parent, it will be filled once we had the storage and
                 // forwarding logic.

--- a/crates/amaru/src/stages/consensus/forward_chain/test_infra.rs
+++ b/crates/amaru/src/stages/consensus/forward_chain/test_infra.rs
@@ -7,7 +7,7 @@ use amaru_consensus::{
     consensus::store::{ChainStore, StoreError},
     IsHeader, Nonces,
 };
-use amaru_kernel::{block::BlockValidationResult, from_cbor, Hash, Header};
+use amaru_kernel::{block::BlockValidationResult, from_cbor, Hash, Header, RawBlock, EMPTY_BLOCK};
 use gasket::{
     messaging::tokio::ChannelRecvAdapter,
     runtime::{spawn_stage, Tether},
@@ -93,7 +93,7 @@ impl ChainStore<Header> for TestStore {
         unimplemented!()
     }
 
-    fn load_block(&self, _hash: &Hash<32>) -> Option<amaru_kernel::RawBlock> {
+    fn load_block(&self, _hash: &Hash<32>) -> Result<RawBlock, StoreError> {
         unimplemented!()
     }
 
@@ -219,7 +219,7 @@ impl Setup {
             BlockValidationResult::BlockValidated {
                 point: point.clone(),
                 span,
-                block: vec![], // FIXME
+                block: EMPTY_BLOCK,
             }
             .into(),
         );

--- a/crates/amaru/src/stages/consensus/forward_chain/test_infra.rs
+++ b/crates/amaru/src/stages/consensus/forward_chain/test_infra.rs
@@ -7,8 +7,7 @@ use amaru_consensus::{
     consensus::store::{ChainStore, StoreError},
     IsHeader, Nonces,
 };
-use amaru_kernel::{from_cbor, Hash, Header};
-use amaru_ledger::BlockValidationResult;
+use amaru_kernel::{block::BlockValidationResult, from_cbor, Hash, Header};
 use gasket::{
     messaging::tokio::ChannelRecvAdapter,
     runtime::{spawn_stage, Tether},
@@ -91,6 +90,18 @@ impl ChainStore<Header> for TestStore {
     }
 
     fn era_history(&self) -> &slot_arithmetic::EraHistory {
+        unimplemented!()
+    }
+
+    fn load_block(&self, _hash: &Hash<32>) -> Option<amaru_kernel::RawBlock> {
+        unimplemented!()
+    }
+
+    fn store_block(
+        &mut self,
+        _hash: &Hash<32>,
+        _block: &amaru_kernel::RawBlock,
+    ) -> Result<(), StoreError> {
         unimplemented!()
     }
 }
@@ -208,6 +219,7 @@ impl Setup {
             BlockValidationResult::BlockValidated {
                 point: point.clone(),
                 span,
+                block: vec![], // FIXME
             }
             .into(),
         );

--- a/crates/amaru/src/stages/consensus/store_block.rs
+++ b/crates/amaru/src/stages/consensus/store_block.rs
@@ -41,7 +41,7 @@ impl StoreBlockStage {
     }
 
     async fn handle_event(&mut self, event: ValidateBlockEvent) -> Result<(), WorkerError> {
-        let event = self.store_block.handle_event(event).await.map_err(|e| {
+        let event = self.store_block.handle_event(&event).await.map_err(|e| {
             tracing::error!(?e, "Failed to handle store block event");
             WorkerError::Recv
         })?;

--- a/crates/amaru/src/stages/consensus/store_block.rs
+++ b/crates/amaru/src/stages/consensus/store_block.rs
@@ -1,0 +1,80 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use amaru_consensus::consensus::store_block::StoreBlock;
+use amaru_kernel::block::ValidateBlockEvent;
+use gasket::framework::*;
+
+pub type UpstreamPort = gasket::messaging::InputPort<ValidateBlockEvent>;
+pub type DownstreamPort = gasket::messaging::OutputPort<ValidateBlockEvent>;
+
+#[derive(Stage)]
+#[stage(
+    name = "consensus.store_block",
+    unit = "ValidateBlockEvent",
+    worker = "Worker"
+)]
+pub struct StoreBlockStage {
+    pub store_block: StoreBlock,
+    pub upstream: UpstreamPort,
+    pub downstream: DownstreamPort,
+}
+
+impl StoreBlockStage {
+    pub fn new(store_block: StoreBlock) -> Self {
+        Self {
+            store_block,
+            upstream: Default::default(),
+            downstream: Default::default(),
+        }
+    }
+
+    async fn handle_event(&mut self, event: ValidateBlockEvent) -> Result<(), WorkerError> {
+        let event = self
+            .store_block
+            .handle_event(event)
+            .await
+            .map_err(|_| WorkerError::Recv)?;
+
+        self.downstream.send(event.into()).await.or_panic()?;
+
+        Ok(())
+    }
+}
+
+pub struct Worker {}
+
+#[async_trait::async_trait(?Send)]
+impl gasket::framework::Worker<StoreBlockStage> for Worker {
+    async fn bootstrap(_stage: &StoreBlockStage) -> Result<Self, WorkerError> {
+        Ok(Self {})
+    }
+
+    async fn schedule(
+        &mut self,
+        stage: &mut StoreBlockStage,
+    ) -> Result<WorkSchedule<ValidateBlockEvent>, WorkerError> {
+        let unit = stage.upstream.recv().await.or_panic()?;
+
+        Ok(WorkSchedule::Unit(unit.payload))
+    }
+
+    async fn execute(
+        &mut self,
+        unit: &ValidateBlockEvent,
+        stage: &mut StoreBlockStage,
+    ) -> Result<(), WorkerError> {
+        stage.handle_event(unit.clone()).await
+    }
+}

--- a/crates/amaru/src/stages/consensus/store_block.rs
+++ b/crates/amaru/src/stages/consensus/store_block.rs
@@ -41,11 +41,10 @@ impl StoreBlockStage {
     }
 
     async fn handle_event(&mut self, event: ValidateBlockEvent) -> Result<(), WorkerError> {
-        let event = self
-            .store_block
-            .handle_event(event)
-            .await
-            .map_err(|_| WorkerError::Recv)?;
+        let event = self.store_block.handle_event(event).await.map_err(|e| {
+            tracing::error!(?e, "Failed to handle store block event");
+            WorkerError::Recv
+        })?;
 
         self.downstream.send(event.into()).await.or_panic()?;
 

--- a/crates/amaru/src/stages/ledger.rs
+++ b/crates/amaru/src/stages/ledger.rs
@@ -1,4 +1,8 @@
-use amaru_kernel::{protocol_parameters::GlobalParameters, EraHistory, Hasher, MintedBlock, Point};
+use amaru_kernel::{
+    block::{BlockValidationResult, ValidateBlockEvent},
+    protocol_parameters::GlobalParameters,
+    EraHistory, Hasher, MintedBlock, Point, RawBlock,
+};
 use amaru_ledger::{
     context::{self, DefaultValidationContext},
     rules::{
@@ -8,7 +12,6 @@ use amaru_ledger::{
     },
     state::{self, BackwardError, VolatileState},
     store::{HistoricalStores, Store, StoreError},
-    BlockValidationResult, RawBlock, ValidateBlockEvent,
 };
 use anyhow::Context;
 use gasket::framework::{AsWorkError, WorkSchedule, WorkerError};
@@ -177,6 +180,7 @@ impl<S: Store + Send, HS: HistoricalStores + Send>
                 .map(|res| match res {
                     None => BlockValidationResult::BlockValidated {
                         point: point.clone(),
+                        block: block.to_vec(),
                         span: restore_span(span),
                     },
                     Some(_err) => BlockValidationResult::BlockValidationFailed {

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -25,7 +25,6 @@ dependencies = [
  "amaru-kernel",
  "amaru-ledger",
  "hex",
- "slot-arithmetic",
 ]
 
 [[package]]


### PR DESCRIPTION
This change "completes" the block diffusion pipeline handled by consensus logic and makes it possible for an Amaru node to use another Amaru node as an upstream peer, and therefore for an Amaru node to be used as a validating relay in the network.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new pipeline stage for storing raw blockchain blocks before validation, improving data handling and supporting pipelined processing.
  - Added support for storing and retrieving raw blocks in the consensus store, including RocksDB-backed storage.
  - Added new event types and results for block validation and rollback, with enhanced data tracking.

- **Bug Fixes**
  - Clarified and corrected the order and description of consensus pipeline stages in the documentation.

- **Refactor**
  - Updated imports and reorganized code to centralize block event types and raw block definitions.
  - Integrated the new store block stage into the pipeline, updating internal connections and naming for consistency.

- **Documentation**
  - Improved documentation to clarify the consensus pipeline and storage process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->