### PR TITLE
pure-stage: add inputs, outputs, and externally defined effects

### DIFF
--- a/.cargo/clippy.toml
+++ b/.cargo/clippy.toml
@@ -1,5 +1,5 @@
 allow-expect-in-tests = true
 allow-panic-in-tests = true
 allow-unwrap-in-tests = true
-type-complexity-threshold = 400
+type-complexity-threshold = 600
 enum-variant-size-threshold = 1024

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2163,6 +2163,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "either",
+ "futures-util",
  "parking_lot",
  "thiserror 2.0.12",
  "tokio",

--- a/crates/pure-stage/Cargo.toml
+++ b/crates/pure-stage/Cargo.toml
@@ -13,9 +13,10 @@ rust-version.workspace = true
 [dependencies]
 anyhow.workspace = true
 either.workspace = true
+futures-util.workspace = true
 parking_lot.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["rt", "time"] }
+tokio = { workspace = true, features = ["rt", "time", "rt-multi-thread"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 

--- a/crates/pure-stage/src/lib.rs
+++ b/crates/pure-stage/src/lib.rs
@@ -1,15 +1,21 @@
-#![allow(clippy::panic, clippy::expect_used)]
-
 mod effect;
+mod output;
+mod receiver;
+mod sender;
 pub mod simulation;
-mod stage;
+mod stage_ref;
 mod stagegraph;
 mod time;
 pub mod tokio;
 mod types;
+mod util;
 
-pub use effect::Effect;
-pub use stage::{StageBuildRef, StageRef, Void};
-pub use stagegraph::{CallId, CallRef, Effects, StageGraph};
+pub use effect::{Effect, Effects, ExternalEffect, ExternalEffectAPI};
+pub use output::OutputEffect;
+pub use receiver::Receiver;
+pub use sender::Sender;
+pub use stage_ref::{StageBuildRef, StageRef};
+pub use stagegraph::{CallId, CallRef, StageGraph};
 pub use time::Instant;
-pub use types::{cast_msg, cast_msg_ref, cast_state, BoxFuture, Message, Name, State};
+pub use types::{BoxFuture, Message, Name, State};
+pub use util::Void;

--- a/crates/pure-stage/src/output.rs
+++ b/crates/pure-stage/src/output.rs
@@ -1,0 +1,61 @@
+use crate::{ExternalEffect, ExternalEffectAPI, Message, Name};
+use std::fmt;
+use tokio::sync::mpsc;
+
+#[derive(Clone)]
+pub struct OutputEffect<Msg: Message> {
+    pub name: Name,
+    pub msg: Msg,
+    sender: mpsc::Sender<Msg>,
+}
+
+impl<Msg: Message> OutputEffect<Msg> {
+    pub fn new(name: Name, msg: Msg, sender: mpsc::Sender<Msg>) -> Self {
+        Self { name, msg, sender }
+    }
+
+    /// Create a fake output effect for testing.
+    pub fn fake(name: Name, msg: Msg) -> (Self, mpsc::Receiver<Msg>) {
+        let (tx, rx) = mpsc::channel(1);
+        (
+            Self {
+                name,
+                msg,
+                sender: tx,
+            },
+            rx,
+        )
+    }
+}
+
+impl<Msg: Message + fmt::Debug> fmt::Debug for OutputEffect<Msg> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OutputEffect")
+            .field("name", &self.name)
+            .field("msg", &self.msg)
+            .field("type", &self.msg.type_name())
+            .finish()
+    }
+}
+
+impl<Msg: Message + PartialEq> ExternalEffect for OutputEffect<Msg> {
+    fn run(self: Box<Self>) -> crate::BoxFuture<'static, Box<dyn Message>> {
+        Box::pin(async move {
+            if let Err(e) = self.sender.send(self.msg).await {
+                tracing::debug!("output `{}` failed to send message: {:?}", self.name, e.0);
+            }
+            Box::new(()) as Box<dyn Message>
+        })
+    }
+
+    fn test_eq(&self, other: &dyn ExternalEffect) -> bool {
+        other
+            .cast_ref::<Self>()
+            .map(|other| self.name == other.name && self.msg == other.msg)
+            .unwrap_or(false)
+    }
+}
+
+impl<Msg: Message + PartialEq> ExternalEffectAPI for OutputEffect<Msg> {
+    type Response = ();
+}

--- a/crates/pure-stage/src/receiver.rs
+++ b/crates/pure-stage/src/receiver.rs
@@ -1,29 +1,27 @@
-use tokio::sync::mpsc::{error::TryRecvError, UnboundedReceiver};
+use futures_util::Stream;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::sync::mpsc;
 
 /// The message receptacle used by [`SimulationBuilder::output`](super::SimulationBuilder::output).
 ///
 /// It should be noted that [`Self::try_next`] returning `None` only means that the message
 /// queue is currently empty — it may be refilled by future simulation steps.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct Receiver<T> {
-    rx: Option<UnboundedReceiver<T>>,
+    rx: mpsc::Receiver<T>,
 }
 
 impl<T> Receiver<T> {
-    pub fn new(rx: UnboundedReceiver<T>) -> Self {
-        Self { rx: Some(rx) }
+    pub(crate) fn new(rx: mpsc::Receiver<T>) -> Self {
+        Self { rx }
     }
 
     /// Extract the next message if there is one.
     pub fn try_next(&mut self) -> Option<T> {
-        match self.rx.as_mut()?.try_recv() {
-            Ok(msg) => Some(msg),
-            Err(TryRecvError::Empty) => None,
-            Err(TryRecvError::Disconnected) => {
-                self.rx = None;
-                None
-            }
-        }
+        self.rx.try_recv().ok()
     }
 
     /// Produce an iterator over all messages currently enqueued.
@@ -37,5 +35,13 @@ impl<T> Receiver<T> {
             }
         }
         Iter(self)
+    }
+}
+
+impl<T> Stream for Receiver<T> {
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.rx.poll_recv(cx)
     }
 }

--- a/crates/pure-stage/src/sender.rs
+++ b/crates/pure-stage/src/sender.rs
@@ -1,0 +1,34 @@
+use crate::BoxFuture;
+use std::{fmt, sync::Arc};
+
+pub struct Sender<Msg> {
+    tx: Arc<dyn Fn(Msg) -> BoxFuture<'static, Result<(), Msg>> + Send + Sync>,
+}
+
+impl<Msg> Clone for Sender<Msg> {
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+        }
+    }
+}
+
+impl<Msg> fmt::Debug for Sender<Msg> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Sender")
+            .field("Msg", &std::any::type_name::<Msg>())
+            .finish()
+    }
+}
+
+impl<Msg> Sender<Msg> {
+    pub(crate) fn new(
+        tx: Arc<dyn Fn(Msg) -> BoxFuture<'static, Result<(), Msg>> + Send + Sync>,
+    ) -> Self {
+        Self { tx }
+    }
+
+    pub fn send(&self, msg: Msg) -> BoxFuture<'static, Result<(), Msg>> {
+        (self.tx)(msg)
+    }
+}

--- a/crates/pure-stage/src/simulation.rs
+++ b/crates/pure-stage/src/simulation.rs
@@ -1,9 +1,13 @@
-#![allow(clippy::wildcard_enum_match_arm, clippy::unwrap_used, clippy::panic)]
+#![allow(
+    clippy::wildcard_enum_match_arm,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::expect_used
+)]
 
 use crate::{
-    cast_msg,
     effect::{StageEffect, StageResponse},
-    BoxFuture, Effects, Instant, Message, Name, StageBuildRef, StageGraph, StageRef, State,
+    BoxFuture, Effects, Instant, Message, Name, Sender, StageBuildRef, StageRef, State,
 };
 use std::{
     any::Any,
@@ -17,16 +21,16 @@ use std::{
     task::Poll,
     time::Duration,
 };
-use tokio::sync::mpsc::unbounded_channel;
 
-pub use receiver::Receiver;
-pub use running::{Blocked, SimulationRunning};
+pub use running::{Blocked, OverrideResult, SimulationRunning};
 
 use either::Either;
+use inputs::Inputs;
 use parking_lot::Mutex;
 use state::{InitStageData, InitStageState, StageData, StageState, Transition};
+use tokio::runtime::Handle;
 
-mod receiver;
+mod inputs;
 mod running;
 mod state;
 
@@ -79,21 +83,19 @@ pub(crate) fn airlock_effect<Out>(
 ///
 /// Example:
 /// ```rust
-/// use pure_stage::{StageGraph, simulation::SimulationBuilder, StageRef};
+/// use pure_stage::{StageGraph, simulation::SimulationBuilder, OutputEffect, ExternalEffect};
 ///
 /// let mut network = SimulationBuilder::default();
-/// let stage = network.stage(
-///     "basic",
-///     async |(mut state, out), msg: u32, eff| {
-///         state += msg;
-///         eff.send(&out, state).await;
-///         Ok((state, out))
-///     },
-///     (1u32, StageRef::noop::<u32>()),
-/// );
-/// let (output, mut rx) = network.output("output");
-/// let stage = network.wire_up(stage, |state| state.1 = output.without_state());
-/// let mut running = network.run();
+/// let stage = network.stage("basic", async |(mut state, out), msg: u32, eff| {
+///     state += msg;
+///     eff.send(&out, state).await;
+///     Ok((state, out))
+/// });
+/// let (output, mut rx) = network.output("output", 10);
+/// let stage = network.wire_up(stage, (1u32, output.without_state()));
+///
+/// let rt = tokio::runtime::Runtime::new().unwrap();
+/// let mut running = network.run(rt.handle().clone());
 ///
 /// // first check that the stages start out suspended on Receive
 /// running.try_effect().unwrap_err().assert_idle();
@@ -106,6 +108,9 @@ pub(crate) fn airlock_effect<Out>(
 /// running.effect().assert_receive(&stage);
 ///
 /// running.resume_receive(&output).unwrap();
+/// let ext = running.effect().extract_external(&output, &OutputEffect::fake(output.name(), 2u32).0);
+/// let result = rt.block_on(ext.run());
+/// running.resume_external(&output, result).unwrap();
 /// running.effect().assert_receive(&output);
 ///
 /// assert_eq!(rx.drain().collect::<Vec<_>>(), vec![2]);
@@ -116,6 +121,7 @@ pub struct SimulationBuilder {
     clock: Arc<AtomicU64>,
     now: Arc<dyn Fn() -> Instant + Send + Sync>,
     mailbox_size: usize,
+    inputs: Inputs,
 }
 
 impl SimulationBuilder {
@@ -140,76 +146,8 @@ impl Default for SimulationBuilder {
             clock,
             now,
             mailbox_size: 10,
+            inputs: Inputs::new(10),
         }
-    }
-}
-
-impl SimulationBuilder {
-    /// Construct a stage that sends received messages to a [`Receiver`] that is also returned.
-    ///
-    /// Note that you can control the forwarding of these messages by delaying the resumption of
-    /// the [`Effect::Receive`] if you run in single-step mode. Otherwise, it is also possible
-    /// to have this stage interrupt the simulation when an incoming message fits a given predicate,
-    /// see [`output_interrupt`](Self::output_interrupt).
-    pub fn output<T: Message>(&mut self, name: impl AsRef<str>) -> (StageRef<T, ()>, Receiver<T>) {
-        let (tx, rx) = unbounded_channel();
-        let stage = self.stage(
-            &name,
-            move |_st, msg, _eff| {
-                let tx = tx.clone();
-                async move { tx.send(msg).map_err(|_| anyhow::anyhow!("channel closed")) }
-            },
-            (),
-        );
-        (self.wire_up(stage, |_| {}), Receiver::new(rx))
-    }
-
-    /// Construct a stage that sends received messages to a [`Receiver`] that is also returned.
-    ///
-    /// Note that you can control the forwarding of these messages by delaying the resumption of
-    /// the [`Effect::Receive`] if you run in single-step mode. Otherwise, it is also possible
-    /// to have this stage interrupt the simulation when an incoming message fits a given predicate.
-    ///
-    /// Example:
-    /// ```rust
-    /// # use pure_stage::{StageGraph, simulation::SimulationBuilder};
-    /// let mut network = SimulationBuilder::default();
-    /// let (output, mut rx) = network.output_interrupt("output", |msg| *msg == 2);
-    /// let mut running = network.run();
-    ///
-    /// running.enqueue_msg(&output, [1, 2, 3]);
-    ///
-    /// running.run_until_blocked().assert_interrupted("output");
-    /// assert_eq!(rx.drain().collect::<Vec<_>>(), vec![1]);
-    ///
-    /// running.resume_interrupt(&output);
-    /// assert_eq!(rx.drain().collect::<Vec<_>>(), vec![]);
-    ///
-    /// running.run_until_blocked().assert_idle();
-    /// assert_eq!(rx.drain().collect::<Vec<_>>(), vec![2, 3]);
-    /// ```
-    pub fn output_interrupt<T: Message>(
-        &mut self,
-        name: impl AsRef<str>,
-        interrupt: impl Fn(&T) -> bool + Send + 'static,
-    ) -> (StageRef<T, ()>, Receiver<T>) {
-        let (tx, rx) = unbounded_channel();
-        let stage = self.stage(
-            &name,
-            move |_st, msg, eff| {
-                let tx = tx.clone();
-                let interrupt = interrupt(&msg);
-                async move {
-                    if interrupt {
-                        eff.interrupt().await;
-                    }
-                    tx.send(msg).map_err(|_| anyhow::anyhow!("channel closed"))
-                }
-            },
-            (),
-        );
-        let stage = self.wire_up(stage, |_| {});
-        (stage, Receiver::new(rx))
     }
 }
 
@@ -221,22 +159,23 @@ impl super::StageGraph for SimulationBuilder {
         &mut self,
         name: impl AsRef<str>,
         mut f: F,
-        state: St,
     ) -> StageBuildRef<Msg, St, Self::RefAux<Msg, St>>
     where
         F: FnMut(St, Msg, Effects<Msg, St>) -> Fut + 'static + Send,
         Fut: Future<Output = anyhow::Result<St>> + 'static + Send,
     {
-        let name = Name::from(name.as_ref());
+        // THIS MUST MATCH THE TOKIO BUILDER
+        let name = Name::from(&*format!("{}-{}", name.as_ref(), self.stages.len()));
         let me = StageRef {
             name: name.clone(),
             _ph: PhantomData,
         };
-        let effects = Effects::new(me, self.effect.clone(), self.now.clone());
+        let self_sender = self.inputs.sender(&me);
+        let effects = Effects::new(me, self.effect.clone(), self.now.clone(), self_sender);
         let transition: Transition =
             Box::new(move |state: Box<dyn State>, msg: Box<dyn Message>| {
                 let state = (state as Box<dyn Any>).downcast::<St>().unwrap();
-                let msg = cast_msg::<Msg>(msg).unwrap();
+                let msg = *msg.cast::<Msg>().expect("internal message type error");
                 let state = f(*state, msg, effects.clone());
                 Box::pin(async move { Ok(Box::new(state.await?) as Box<dyn State>) })
             });
@@ -249,12 +188,15 @@ impl super::StageGraph for SimulationBuilder {
                 transition,
             },
         ) {
-            panic!("stage {name} already exists with state {:?}", old.state);
+            #[allow(clippy::panic)]
+            {
+                // names are unique by construction
+                panic!("stage {name} already exists with state {:?}", old.state);
+            }
         }
 
         StageBuildRef {
             name,
-            state,
             network: (),
             _ph: PhantomData,
         }
@@ -263,16 +205,14 @@ impl super::StageGraph for SimulationBuilder {
     fn wire_up<Msg: Message, St: State>(
         &mut self,
         stage: crate::StageBuildRef<Msg, St, Self::RefAux<Msg, St>>,
-        f: impl FnOnce(&mut St),
+        state: St,
     ) -> StageRef<Msg, St> {
         let StageBuildRef {
             name,
-            mut state,
             network: (),
             _ph,
         } = stage;
 
-        f(&mut state);
         let data = self.stages.get_mut(&name).unwrap();
         data.state = InitStageState::Idle(Box::new(state));
 
@@ -282,13 +222,18 @@ impl super::StageGraph for SimulationBuilder {
         }
     }
 
-    fn run(self) -> Self::Running {
+    fn sender<Msg: Message, St>(&mut self, stage: &StageRef<Msg, St>) -> Sender<Msg> {
+        self.inputs.sender(stage)
+    }
+
+    fn run(self, rt: Handle) -> Self::Running {
         let Self {
             stages: s,
             effect,
             clock,
             now,
             mailbox_size,
+            inputs,
         } = self;
         let mut stages = HashMap::new();
         for (
@@ -314,6 +259,6 @@ impl super::StageGraph for SimulationBuilder {
             };
             stages.insert(name, data);
         }
-        SimulationRunning::new(stages, effect, clock, now, mailbox_size)
+        SimulationRunning::new(stages, inputs, effect, clock, now, mailbox_size, rt)
     }
 }

--- a/crates/pure-stage/src/simulation/inputs.rs
+++ b/crates/pure-stage/src/simulation/inputs.rs
@@ -1,0 +1,73 @@
+use crate::{Message, Name, Sender, StageRef};
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot};
+
+#[derive(Debug)]
+pub struct Envelope {
+    pub name: Name,
+    pub msg: Box<dyn Message>,
+    pub tx: oneshot::Sender<()>,
+}
+
+impl Envelope {
+    fn new(name: Name, msg: Box<dyn Message>, tx: oneshot::Sender<()>) -> Self {
+        Self { name, msg, tx }
+    }
+}
+
+pub struct Inputs {
+    tx: mpsc::Sender<Envelope>,
+    rx: mpsc::Receiver<Envelope>,
+    peeked: Option<Envelope>,
+}
+
+impl Inputs {
+    pub fn new(buffer_size: usize) -> Self {
+        let (tx, rx) = mpsc::channel(buffer_size);
+        Self {
+            tx,
+            rx,
+            peeked: None,
+        }
+    }
+
+    pub fn sender<Msg: Message, St>(&self, stage: &StageRef<Msg, St>) -> Sender<Msg> {
+        let tx_main = self.tx.clone();
+        let stage_name = stage.name();
+        Sender::new(Arc::new(move |msg| {
+            let tx_main = tx_main.clone();
+            let stage_name = stage_name.clone();
+            Box::pin(async move {
+                let (tx, rx) = oneshot::channel();
+                tx_main
+                    .send(Envelope::new(stage_name.clone(), Box::new(msg), tx))
+                    .await
+                    .map_err(|e| {
+                        #[allow(clippy::expect_used)]
+                        *e.0.msg.cast::<Msg>().expect("message was just boxed")
+                    })?;
+                rx.await.ok();
+                Ok(())
+            })
+        }))
+    }
+
+    pub fn peek_name(&mut self) -> Option<&Name> {
+        if self.peeked.is_none() {
+            self.peeked = self.rx.try_recv().ok();
+        }
+        self.peeked.as_ref().map(|envelope| &envelope.name)
+    }
+
+    pub fn try_next(&mut self) -> Option<Envelope> {
+        if self.peeked.is_none() {
+            self.peeked = self.rx.try_recv().ok();
+        }
+        self.peeked.take()
+    }
+
+    pub fn put_back(&mut self, envelope: Envelope) {
+        assert!(self.peeked.is_none(), "cannot put back twice");
+        self.peeked = Some(envelope);
+    }
+}

--- a/crates/pure-stage/src/time.rs
+++ b/crates/pure-stage/src/time.rs
@@ -39,3 +39,18 @@ impl Instant {
         self.0.checked_sub(duration).map(Self)
     }
 }
+
+#[test]
+fn instant() {
+    let now = Instant::now();
+    let later = now.checked_add(Duration::from_secs(1)).unwrap();
+
+    assert_eq!(later.checked_since(now).unwrap(), Duration::from_secs(1));
+    assert_eq!(now.checked_since(later), None);
+
+    assert_eq!(later.saturating_since(now), Duration::from_secs(1));
+    assert_eq!(now.saturating_since(later), Duration::from_secs(0));
+
+    assert_eq!(now.checked_add(Duration::from_secs(1)).unwrap(), later);
+    assert_eq!(later.checked_sub(Duration::from_secs(1)).unwrap(), now);
+}

--- a/crates/pure-stage/src/util.rs
+++ b/crates/pure-stage/src/util.rs
@@ -1,0 +1,35 @@
+#![allow(dead_code)]
+
+/// Helper type to wrap futures/functions/etc. and thus avoid having to handroll
+/// a `Debug` implementation for a type containing the wrapped value.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct NoDebug<T>(T);
+impl<T> NoDebug<T> {
+    pub fn new(t: T) -> Self {
+        Self(t)
+    }
+
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+impl<T> std::ops::Deref for NoDebug<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl<T> std::ops::DerefMut for NoDebug<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+impl<T> std::fmt::Debug for NoDebug<T> {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
+    }
+}
+
+/// A type that is not inhabited.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Void {}

--- a/crates/pure-stage/tests/simulation.rs
+++ b/crates/pure-stage/tests/simulation.rs
@@ -1,37 +1,47 @@
 use pure_stage::{
-    simulation::{Blocked, SimulationBuilder},
-    CallRef, Name, StageGraph, StageRef,
+    simulation::{OverrideResult, SimulationBuilder},
+    CallRef, Effect, ExternalEffect, Message, OutputEffect, StageGraph,
 };
-use std::time::Duration;
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 use tracing_subscriber::EnvFilter;
 
 #[test]
 fn basic() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
     let mut network = SimulationBuilder::default();
-    let stage = network.stage(
-        "basic",
-        async |(mut state, out), msg: u32, eff| {
-            state += msg;
-            eff.send(&out, state).await;
-            Ok((state, out))
-        },
-        (1u32, StageRef::noop::<u32>()),
-    );
-    let (output, mut rx) = network.output("output");
-    let stage = network.wire_up(stage, |state| state.1 = output.without_state());
-    let mut running = network.run();
+    let basic = network.stage("basic", async |(mut state, out), msg: u32, eff| {
+        state += msg;
+        eff.send(&out, state).await;
+        Ok((state, out))
+    });
+    let (output, mut rx) = network.output("output", 10);
+    let basic = network.wire_up(basic, (1u32, output.without_state()));
+    let mut running = network.run(rt.handle().clone());
 
     // first check that the stages start out suspended on Receive
     running.try_effect().unwrap_err().assert_idle();
 
     // then insert some input and check reaction
-    running.enqueue_msg(&stage, [1]);
-    running.resume_receive(&stage).unwrap();
-    running.effect().assert_send(&stage, &output, 2u32);
-    running.resume_send(&stage, &output, 2u32).unwrap();
-    running.effect().assert_receive(&stage);
+    running.enqueue_msg(&basic, [1]);
+    running.resume_receive(&basic).unwrap();
+    running.effect().assert_send(&basic, &output, 2u32);
+    running.resume_send(&basic, &output, 2u32).unwrap();
+    running.effect().assert_receive(&basic);
 
     running.resume_receive(&output).unwrap();
+    let ext = running
+        .effect()
+        .extract_external(&output, &OutputEffect::fake(output.name(), 2u32).0);
+    let result = rt.block_on(ext.run());
+    // this check is also done when resuming, just want to show how to do it here
+    assert_eq!(&*result, &() as &dyn Message);
+    running.resume_external(&output, result).unwrap();
     running.effect().assert_receive(&output);
 
     assert_eq!(rx.drain().collect::<Vec<_>>(), vec![2]);
@@ -39,52 +49,76 @@ fn basic() {
 
 #[test]
 fn automatic() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
     let mut network = SimulationBuilder::default();
-    let stage = network.stage(
-        "basic",
-        async |(mut state, out), msg: u32, eff| {
-            state += msg;
-            eff.send(&out, state).await;
-            Ok((state, out))
-        },
-        (1u32, StageRef::noop::<u32>()),
-    );
-    let (output, mut rx) = network.output("output");
-    let stage = network.wire_up(stage, |state| state.1 = output.without_state());
-    let mut running = network.run();
+    let basic = network.stage("basic", async |(mut state, out), msg: u32, eff| {
+        state += msg;
+        eff.send(&out, state).await;
+        Ok((state, out))
+    });
+    let (output, mut rx) = network.output("output", 10);
+    let basic = network.wire_up(basic, (1u32, output.without_state()));
+    let mut running = network.run(rt.handle().clone());
 
-    running.enqueue_msg(&stage, [1, 2, 3]);
+    running.enqueue_msg(&basic, [1, 2, 3]);
     running.run_until_blocked().assert_idle();
     assert_eq!(rx.drain().collect::<Vec<_>>(), vec![2, 4, 7]);
 }
 
 #[test]
-fn interrupt() {
+fn breakpoint() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
     let mut network = SimulationBuilder::default();
-    let stage = network.stage(
-        "basic",
-        async |mut state, msg: u32, eff| {
-            state += msg;
-            if state > 5 {
-                eff.interrupt().await;
-            }
-            Ok(state)
-        },
-        1u32,
-    );
-    let stage = network.wire_up(stage, |_| {});
-    let mut running = network.run();
+    let basic = network.stage("basic", async |(mut state, out), msg: u32, eff| {
+        state += msg;
+        eff.send(&out, state).await;
+        Ok((state, out))
+    });
+    let (output, mut rx) = network.output("output", 10);
+    let basic = network.wire_up(basic, (1u32, output.without_state()));
+    let mut running = network.run(rt.handle().clone());
 
-    running.enqueue_msg(&stage, [1, 2, 3]);
-    running.run_until_blocked().assert_interrupted("basic");
-    assert_eq!(
-        running.run_until_blocked(),
-        Blocked::Busy(vec![Name::from("basic")])
-    );
+    running.enqueue_msg(&basic, [1, 2, 3]);
+    running.breakpoint("send4", move |eff| {
+        matches!(
+            eff,
+            Effect::Send { from, to, msg, .. }
+                if from == &basic.name &&
+                    to == &output.name &&
+                    *msg == Box::new(4u32) as Box<dyn Message>
+        )
+    });
+    running.run_until_blocked().assert_breakpoint("send4");
+    assert_eq!(rx.drain().collect::<Vec<_>>(), vec![2]);
+}
 
-    running.resume_interrupt(&stage).unwrap();
+#[test]
+fn overrides() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mut network = SimulationBuilder::default();
+    let basic = network.stage("basic", async |(mut state, out), msg: u32, eff| {
+        state += msg;
+        eff.send(&out, state).await;
+        Ok((state, out))
+    });
+    let (output, mut rx) = network.output("output", 10);
+    let basic = network.wire_up(basic, (1u32, output.without_state()));
+    let mut running = network.run(rt.handle().clone());
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let count2 = count.clone();
+    running.enqueue_msg(&basic, [1, 2, 3]);
+    running.override_external_effect(1, move |eff: Box<OutputEffect<u32>>| {
+        if eff.msg > 2 {
+            count2.fetch_add(1, Ordering::Relaxed);
+            OverrideResult::Handled(Box::new(()))
+        } else {
+            OverrideResult::NoMatch(eff)
+        }
+    });
     running.run_until_blocked().assert_idle();
-    assert_eq!(*running.get_state(&stage).unwrap(), 7);
+    assert_eq!(rx.drain().collect::<Vec<_>>(), vec![2, 7]);
+    assert_eq!(count.load(Ordering::Relaxed), 1);
 }
 
 #[test]
@@ -97,39 +131,43 @@ fn backpressure() {
 
     let mut network = SimulationBuilder::default().with_mailbox_size(1);
 
-    let sender = network.stage(
-        "sender",
-        async |target, msg: u32, eff| {
-            eff.send(&target, msg).await;
-            Ok(target)
-        },
-        StageRef::noop::<u32>(),
-    );
+    let sender = network.stage("sender", async |target, msg: u32, eff| {
+        eff.send(&target, msg).await;
+        Ok(target)
+    });
 
-    let pressure = network.stage(
-        "pressure",
-        async |mut state, msg: u32, eff| {
-            state += msg;
-            if msg == 1 {
-                // this will block the stage and lead to backpressure
-                eff.interrupt().await;
-            }
-            Ok(state)
-        },
-        1u32,
-    );
+    let pressure = network.stage("pressure", async |mut state, msg: u32, eff| {
+        state += msg;
+        // we need to place an effect that we can install a breakpoint on
+        // other than Receive, because that is automatically resumed upon sending
+        eff.clock().await;
+        Ok(state)
+    });
 
-    let sender = network.wire_up(sender, |state| *state = pressure.sender());
-    let pressure = network.wire_up(pressure, |_| {});
+    let sender = network.wire_up(sender, pressure.sender());
+    let pressure = network.wire_up(pressure, 1u32);
 
-    let mut running = network.run();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mut running = network.run(rt.handle().clone());
 
     running.enqueue_msg(&sender, [1, 2, 3]);
-    running.run_until_blocked().assert_interrupted("pressure");
-    // not resuming here so that "sender" will continue to run
-    running.run_until_blocked().assert_busy(["pressure"]);
+    running.breakpoint("pressure", {
+        let pressure = pressure.clone();
+        move |eff| matches!(eff, Effect::Clock { at_stage: a } if a == &pressure.name)
+    });
 
-    running.resume_interrupt(&pressure).unwrap();
+    let broken = running.run_until_blocked().assert_breakpoint("pressure");
+    assert_eq!(
+        broken,
+        Effect::Clock {
+            at_stage: pressure.name(),
+        }
+    );
+
+    running.run_until_blocked().assert_busy([&pressure.name]);
+
+    running.handle_effect(broken);
+    running.clear_breakpoint("pressure");
     running.run_until_blocked().assert_idle();
     assert_eq!(*running.get_state(&pressure).unwrap(), 7);
 }
@@ -137,24 +175,21 @@ fn backpressure() {
 #[test]
 fn clock() {
     let mut network = SimulationBuilder::default();
-    let stage = network.stage(
-        "basic",
-        async |_state, msg: u32, eff| {
-            let now = eff.clock().await;
-            let later = eff.wait(Duration::from_secs(1)).await;
-            Ok(Some((msg, now, later)))
-        },
-        None,
-    );
-    let stage = network.wire_up(stage, |_| {});
-    let mut running = network.run();
+    let basic = network.stage("basic", async |_state, msg: u32, eff| {
+        let now = eff.clock().await;
+        let later = eff.wait(Duration::from_secs(1)).await;
+        Ok(Some((msg, now, later)))
+    });
+    let basic = network.wire_up(basic, None);
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mut running = network.run(rt.handle().clone());
 
-    running.enqueue_msg(&stage, [42]);
+    running.enqueue_msg(&basic, [42]);
     let now = running.now();
     running.run_until_blocked().assert_idle();
     let later = running.now();
     assert_eq!(
-        running.get_state(&stage).unwrap(),
+        running.get_state(&basic).unwrap(),
         &Some((42u32, now, later))
     );
     assert_eq!(later.checked_since(now).unwrap(), Duration::from_secs(1));
@@ -163,17 +198,14 @@ fn clock() {
 #[test]
 fn clock_manual() {
     let mut network = SimulationBuilder::default();
-    let stage = network.stage(
-        "basic",
-        async |_state, msg: u32, eff| {
-            let now = eff.clock().await;
-            let later = eff.wait(Duration::from_secs(1)).await;
-            Ok(Some((msg, now, later)))
-        },
-        None,
-    );
-    let stage = network.wire_up(stage, |_| {});
-    let mut running = network.run();
+    let stage = network.stage("basic", async |_state, msg: u32, eff| {
+        let now = eff.clock().await;
+        let later = eff.wait(Duration::from_secs(1)).await;
+        Ok(Some((msg, now, later)))
+    });
+    let stage = network.wire_up(stage, None);
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mut running = network.run(rt.handle().clone());
 
     running.enqueue_msg(&stage, [42]);
     let now = running.now();
@@ -200,31 +232,24 @@ fn call() {
         .ok();
 
     let mut network = SimulationBuilder::default();
-    let caller = network.stage(
-        "caller",
-        async |(_state, target), msg: u32, eff| {
-            let state = eff
-                .call(&target, Duration::from_secs(2), move |cr| (msg + 1, cr))
-                .await
-                .ok_or_else(|| anyhow::anyhow!("call timed out"))?;
-            Ok((state, target))
-        },
-        (1u32, StageRef::noop::<(u32, CallRef<u32>)>()),
-    );
+    let caller = network.stage("caller", async |(_state, target), msg: u32, eff| {
+        let state = eff
+            .call(&target, Duration::from_secs(2), move |cr| (msg + 1, cr))
+            .await
+            .ok_or_else(|| anyhow::anyhow!("call timed out"))?;
+        Ok((state, target))
+    });
 
-    let callee = network.stage(
-        "callee",
-        async |state, msg: (u32, CallRef<u32>), eff| {
-            eff.wait(Duration::from_secs(1)).await;
-            eff.respond(msg.1, msg.0 * 2).await;
-            Ok(state)
-        },
-        (),
-    );
-    let caller = network.wire_up(caller, |state| state.1 = callee.sender());
-    let callee = network.wire_up(callee, |_| {});
+    let callee = network.stage("callee", async |state, msg: (u32, CallRef<u32>), eff| {
+        eff.wait(Duration::from_secs(1)).await;
+        eff.respond(msg.1, msg.0 * 2).await;
+        Ok(state)
+    });
+    let caller = network.wire_up(caller, (1u32, callee.sender()));
+    let callee = network.wire_up(callee, ());
 
-    let mut sim = network.run();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mut sim = network.run(rt.handle().clone());
 
     sim.enqueue_msg(&caller, [1]);
     sim.run_until_blocked().assert_idle();

--- a/crates/pure-stage/tests/tokio.rs
+++ b/crates/pure-stage/tests/tokio.rs
@@ -1,0 +1,51 @@
+use futures_util::StreamExt;
+use pure_stage::{tokio::TokioBuilder, StageGraph};
+use std::time::Duration;
+use tokio::time::timeout;
+
+#[test]
+fn basic() {
+    tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init()
+        .ok();
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    let mut graph = TokioBuilder::default();
+    let double = graph.stage("double", async |to, msg: u32, eff| {
+        eff.send(&to, msg * 2).await;
+        Ok(to)
+    });
+    let (out_ref, mut out_rx) = graph.output("output", 10);
+    let double = graph.wire_up(double, out_ref);
+
+    let send_double = graph.sender(&double);
+
+    let handle = rt.handle().clone();
+    rt.block_on(async move {
+        // running needs `tokio::spawn` to work
+        let graph = graph.run(handle);
+
+        for i in 0..10 {
+            tracing::info!("sending {}", i);
+            timeout(Duration::from_secs(1), send_double.send(i))
+                .await
+                .unwrap()
+                .unwrap();
+        }
+
+        for i in 0..10 {
+            tracing::info!("receiving {}", i);
+            assert_eq!(
+                timeout(Duration::from_secs(1), out_rx.next())
+                    .await
+                    .unwrap(),
+                Some(i * 2)
+            );
+        }
+
+        graph.abort();
+    });
+}


### PR DESCRIPTION
I rewrote the way outputs are done in terms of a mechanism that is more general and should be
adequate for the implementation of the storage effects (for headers, blocks, etc.). The idea is to
define an effect in terms of an async task while using nominal typing to allow overriding the effect
in simulation scenarios, including the ability to arbitrarily delay or alter what the effect does.

This PR also adds some docs and tests that were forgotten in the first pure-stage PR and makes the
use of names safe (uniqueness is internally guaranteed now) and more efficient (every project I work
on will sooner or later grow some `Arc<str>` or another) as names are notorious for blowing up
resource usage once going into producction use.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for external effects, enabling integration and testing of asynchronous operations outside the stage graph.
  - Introduced breakpoint and override mechanisms for advanced simulation control and effect interception.
  - Added sender and receiver abstractions for improved asynchronous message handling.
  - Added output stage creation with configurable send queue size for message forwarding.

- **Bug Fixes**
  - Improved casting and equality checks for messages and state objects, enhancing type safety and reliability.

- **Refactor**
  - Simplified and unified the API for stage creation, wiring, and running, now requiring explicit Tokio runtime handles.
  - Reorganized internal modules and refactored output, input, and effect handling for better maintainability.
  - Removed interrupt effect handling in favor of external effects and breakpoints.
  - Updated internal naming and state handling for stages to ensure uniqueness and clarity.

- **Tests**
  - Updated and expanded test suite to cover new features, including breakpoints, overrides, and asynchronous execution with Tokio.
  - Unified tests to use Tokio runtime explicitly and simplified wiring patterns.

- **Documentation**
  - Enhanced API documentation and updated code examples to reflect new patterns and features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->