### PR TITLE
fix: use test build profile throughout CI, to ensure meaningful cache hit.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,16 +42,20 @@ jobs:
         environments:
           - runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+
           - runner: macos-latest
             target: aarch64-apple-darwin
+
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
             command: test --profile dev-debug
+
           - runner: ubuntu-latest
             target: wasm32-unknown-unknown
             packages: -p amaru-consensus -p amaru-ledger -p amaru-ouroboros -p slot-arithmetic
             command: build
             setup: rustup target add wasm32-unknown-unknown
+
           - runner: ubuntu-latest
             target: riscv32im-risc0-zkvm-elf
             packages: -p amaru-ledger -p slot-arithmetic
@@ -62,11 +66,13 @@ jobs:
               /home/runner/.risc0/bin/rzup install
               rustup toolchain add nightly-x86_64-unknown-linux-gnu
               rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+
           - runner: ubuntu-24.04
             target: aarch64-unknown-linux-musl
             command: test
             setup: rustup target add aarch64-unknown-linux-musl
             cross-compile: true
+
     timeout-minutes: 30
     runs-on: ${{ matrix.environments.runner }}
     steps:
@@ -209,7 +215,7 @@ jobs:
 
       - name: Build Amaru
         run: |
-          cargo test --release --no-run -p amaru
+          cargo test --no-run -p amaru
 
       - name: Cache Amaru's ledger.db
         id: cache-ledger-db
@@ -227,13 +233,13 @@ jobs:
       - name: Full bootstrap amaru
         if: steps.cache-ledger-db.outputs.cache-hit == ''
         run: |
-          make bootstrap
+          make BUILD_PROFILE=test bootstrap
 
       - name: Light bootstrap amaru
         if: steps.cache-ledger-db.outputs.cache-hit != ''
         run: |
-          make import-headers
-          make import-nonces
+          make BUILD_PROFILE=test import-headers
+          make BUILD_PROFILE=test import-nonces
 
       - uses: actions/cache/save@v4
         if: github.event_name == 'push' || steps.cache-ledger-db.outputs.cache-hit == ''
@@ -245,11 +251,11 @@ jobs:
         timeout-minutes: 30
         shell: bash
         run: |
-          make demo
+          make BUILD_PROFILE=test demo
 
       - name: Run tests
         run: |
-          make test-e2e
+          make BUILD_PROFILE=test test-e2e
 
       - name: Teardown haskell node
         shell: bash
@@ -294,15 +300,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.RUST_CACHE_PATH }}
+          key: cargo-x86_64-unknown-linux-gnu
+          restore-keys: |
+            cargo-x86_64-unknown-linux-gnu
+
       - name: Build amaru
-        run: cargo build
+        run: cargo build --profile test
         working-directory: simulation/amaru-sim
 
       - name: Setup GHC and cabal
-        uses: haskell-actions/setup@v2  
-        with:  
-          ghc-version: '9.6.7'  
-          cabal-version: '3.14'  
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: '9.6.7'
+          cabal-version: '3.14'
 
       - name: Build moskstraumen
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,6 @@ dependencies = [
  "amaru",
  "amaru-consensus",
  "amaru-kernel",
- "amaru-ledger",
  "amaru-ouroboros",
  "amaru-stores",
  "anyhow",

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ coverage-lconv: ## Run test coverage for CI to upload to Codecov
 
 demo: ## Synchronize Amaru until a target epoch $DEMO_TARGET_EPOCH
 	LEDGER_DIR=$(LEDGER_DIR) CHAIN_DIR=$(CHAIN_DIR) \
-		./scripts/demo.sh $(AMARU_PEER_ADDRESS) $(LISTEN_ADDRESS) $(DEMO_TARGET_EPOCH) $(NETWORK)
+		./scripts/demo.sh $(BUILD_PROFILE) $(AMARU_PEER_ADDRESS) $(LISTEN_ADDRESS) $(DEMO_TARGET_EPOCH) $(NETWORK)
 
 build-examples: ## Build all examples
 	@for dir in $(wildcard examples/*/.); do \

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -7,22 +7,27 @@ exitWithUsage () {
   exit 1
 }
 
-PEER_ADDRESS=$1
+BUILD_PROFILE=$1
+if [ -z "$BUILD_PROFILE" ]; then
+  exitWithUsage
+fi
+
+PEER_ADDRESS=$2
 if [ -z "$PEER_ADDRESS" ]; then
   exitWithUsage
 fi
 
-LISTEN_ADDRESS=$2
+LISTEN_ADDRESS=$3
 if [ -z "$LISTEN_ADDRESS" ]; then
   exitWithUsage
 fi
 
-TARGET_EPOCH=$3
+TARGET_EPOCH=$4
 if [ -z "$TARGET_EPOCH" ]; then
   exitWithUsage
 fi
 
-NETWORK=${4:-preprod}
+NETWORK=${5:-preprod}
 
 LEDGER_DIR=${LEDGER_DIR:-./ledger.db}
 
@@ -30,7 +35,7 @@ CHAIN_DIR=${CHAIN_DIR:-./chain.db}
 
 echo -e "      \033[1;32mTarget\033[00m epoch $TARGET_EPOCH"
 set -eo pipefail
-AMARU_TRACE="amaru=info" cargo run --release -- --with-json-traces daemon \
+AMARU_TRACE="amaru=info" cargo run --profile $BUILD_PROFILE -- --with-json-traces daemon \
            --peer-address="${PEER_ADDRESS}" \
            --listen-address="${LISTEN_ADDRESS}" \
            --network="${NETWORK}" \

--- a/simulation/amaru-sim/Cargo.toml
+++ b/simulation/amaru-sim/Cargo.toml
@@ -10,10 +10,8 @@ homepage.workspace = true
 documentation.workspace = true
 rust-version.workspace = true
 
-[package.metadata.cargo-machete]
-ignored = ["amaru-consensus", "amaru-kernel", "amaru-ledger", "amaru-ouroboros", "hex", "pallas-codec", "pallas-crypto", "pallas-primitives"]
-
 [dependencies]
+anyhow.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 futures-util.workspace = true
@@ -24,23 +22,21 @@ pallas-crypto.workspace = true
 pallas-primitives.workspace = true
 proptest = {workspace = true, features = ["std"] }
 pure-stage.workspace = true
+rand.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "signal", "io-util"] }
 tokio-stream.workspace = true
 tokio-util.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
-serde.workspace = true
-serde_json.workspace = true
 
 amaru = { path = "../../crates/amaru" }
 amaru-kernel = { path = "../../crates/amaru-kernel" }
 amaru-consensus = { path = "../../crates/amaru-consensus" }
-amaru-ledger = { path = "../../crates/amaru-ledger" }
 amaru-ouroboros = { path = "../../crates/ouroboros" }
 amaru-stores = { path = "../../crates/amaru-stores" }
 slot-arithmetic = { path = "../../crates/slot-arithmetic" }
-anyhow.workspace = true
-rand.workspace = true
 
 [dev-dependencies]
 insta = { workspace = true, features = ["json"] }


### PR DESCRIPTION
We only populate caches when merging on `main`, and those caches are prepared with a test profile. The simulation and e2e snapshots tests currently causes a full rebuild, adding 7-8 extra minutes on all CI checks. That's unfortunate and this commit shall fix this.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow for improved build profile handling, caching, and formatting.
  - Modified Makefile and demo script to support dynamic build profiles.
  - Cleaned up and reorganized simulation project dependencies for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->