### PR TITLE
chore: use ubuntu-latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,7 +67,7 @@ jobs:
               rustup toolchain add nightly-x86_64-unknown-linux-gnu
               rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
 
-          - runner: ubuntu-24.04
+          - runner: ubuntu-latest
             target: aarch64-unknown-linux-musl
             command: test
             setup: rustup target add aarch64-unknown-linux-musl


### PR DESCRIPTION
Align all ubuntu images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build environment for certain jobs to use the latest available Ubuntu runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->