### PR TITLE
feat: do not panic when block validation fails

### DIFF
--- a/crates/amaru/src/stages/consensus/forward_chain.rs
+++ b/crates/amaru/src/stages/consensus/forward_chain.rs
@@ -318,7 +318,7 @@ impl gasket::framework::Worker<ForwardChainStage> for Worker {
                     target: EVENT_TARGET,
                     parent: span,
                     slot = ?point.slot_or_default(),
-                    hash = %Hash::<32>::from(point),
+                    hash = ?Hash::<32>::from(point),
                     "block_validation_failed"
                 );
 

--- a/crates/amaru/src/stages/ledger.rs
+++ b/crates/amaru/src/stages/ledger.rs
@@ -114,10 +114,7 @@ impl<S: Store + Send, HS: HistoricalStores + Send> ValidateBlockStage<S, HS> {
         let protocol_version = block.header.header_body.protocol_version;
         match rules::validate_block(&mut context, self.state.protocol_parameters(), &block) {
             BlockValidation::Err(err) => return Err(err),
-            BlockValidation::Invalid(err) => {
-                error!("Block invalid: {:?}", err);
-                return Ok(Some(err));
-            }
+            BlockValidation::Invalid(err) => Ok(Some(err)),
             BlockValidation::Valid(()) => {
                 let state: VolatileState = context.into();
                 let issuer = Hasher::<224>::hash(&block.header.header_body.issuer_vkey[..]);
@@ -175,20 +172,20 @@ impl<S: Store + Send, HS: HistoricalStores + Send>
         stage: &mut ValidateBlockStage<S, HS>,
     ) -> Result<(), WorkerError> {
         let result = match unit {
-            ValidateBlockEvent::Validated { point, block, span } => stage
-                .roll_forward(point.clone(), block.to_vec())
-                .map(|res| match res {
-                    None => BlockValidationResult::BlockValidated {
-                        point: point.clone(),
-                        block: block.to_vec(),
-                        span: restore_span(span),
-                    },
-                    Some(_err) => BlockValidationResult::BlockValidationFailed {
-                        point: point.clone(),
-                        span: restore_span(span),
-                    },
-                })
-                .or_panic()?,
+            ValidateBlockEvent::Validated { point, block, span } => {
+                let point = point.clone();
+                let block = block.to_vec();
+                let span = restore_span(span);
+
+                match stage.roll_forward(point.clone(), block.clone()) {
+                    Ok(None) => BlockValidationResult::BlockValidated { point, block, span },
+                    Ok(Some(_)) => BlockValidationResult::BlockValidationFailed { point, span },
+                    Err(err) => {
+                        error!(?err, "Failed to validate block");
+                        BlockValidationResult::BlockValidationFailed { point, span }
+                    }
+                }
+            }
             ValidateBlockEvent::Rollback {
                 rollback_point,
                 span,


### PR DESCRIPTION
Let `amaru` continue validating after a block validation fails.

This currently does not work and still panics higher up in the stack due to a mishandling in the consensus layer. This will be addressed in a subsequent PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling and logging during block validation to provide clearer feedback when issues occur.
  - Enhanced log output formatting for hash values to aid in debugging.

- **Refactor**
  - Streamlined control flow for block validation processes, making error handling more explicit and robust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->