### PR TITLE
feat: add preview network to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -165,6 +165,7 @@ jobs:
           - name: preprod
             magic: 1
         cardano_node_version: [10.1.4]
+    continue-on-error: true 
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/NightlySynchronization.yml
+++ b/.github/workflows/NightlySynchronization.yml
@@ -15,7 +15,7 @@ jobs:
   sync_and_cache:
     strategy:
       matrix:
-        network: [ preprod ]
+        network: [ preprod, preview ]
         ogmios_version: [ v6.11.2 ]
         cardano_node_version: [ 10.1.4 ]
 


### PR DESCRIPTION
Added `preview` network to CI on top of `preprod`. Snapshots tests will be performed for both networks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated workflow configurations to add support for an additional network ("preview") in nightly synchronization processes.
  - Adjusted CI workflow to continue on errors during the snapshots job without failing the entire workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->