### PR TITLE
feat: add run_until_blocked_or_time to pure-stage

### DIFF
--- a/crates/pure-stage/Cargo.toml
+++ b/crates/pure-stage/Cargo.toml
@@ -25,6 +25,7 @@ typetag.workspace = true
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+tokio = { workspace = true, features = ["rt", "time", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/pure-stage/src/simulation/blocked.rs
+++ b/crates/pure-stage/src/simulation/blocked.rs
@@ -1,4 +1,4 @@
-use crate::{Effect, Name};
+use crate::{Effect, Instant, Name};
 
 /// Classification of why [`SimulationRunning::run_until_blocked`](crate::simulation::SimulationRunning::run_until_blocked) has stopped.
 #[derive(Debug, PartialEq)]
@@ -6,7 +6,7 @@ pub enum Blocked {
     /// All stages are suspended on [`Effect::Receive`].
     Idle,
     /// The simulation is waiting for a wakeup.
-    Sleeping,
+    Sleeping { next_wakeup: Instant },
     /// All stages are suspended on either [`Effect::Receive`] or [`Effect::Send`].
     Deadlock(Vec<Name>),
     /// The given breakpoint was hit.
@@ -26,9 +26,9 @@ impl Blocked {
     }
 
     /// Assert that the blocking reason is `Sleeping`.
-    pub fn assert_sleeping(&self) {
+    pub fn assert_sleeping(&self) -> Instant {
         match self {
-            Blocked::Sleeping => {}
+            Blocked::Sleeping { next_wakeup } => *next_wakeup,
             _ => panic!("expected sleeping, got {:?}", self),
         }
     }

--- a/crates/pure-stage/tests/simulation.rs
+++ b/crates/pure-stage/tests/simulation.rs
@@ -309,7 +309,15 @@ fn clock_manual() {
     running.run_until_sleeping_or_blocked().assert_sleeping();
     assert_eq!(running.get_state(&stage), None);
 
-    assert!(running.skip_to_next_wakeup());
+    let intermediate = running.now() + Duration::from_millis(100);
+    let target = intermediate + Duration::from_millis(900);
+
+    assert!(!running.skip_to_next_wakeup(Some(intermediate)));
+    assert_eq!(running.now(), intermediate);
+
+    assert!(running.skip_to_next_wakeup(None));
+    assert_eq!(running.now(), target);
+
     running.run_until_sleeping_or_blocked().assert_idle();
     let later = running.now();
 


### PR DESCRIPTION
also return next wakeup in `Blocked::Sleeping` and add `Running::next_wakeup()` accessor

Signed-off-by: Roland Kuhn <rk@rkuhn.info>
