### PR TITLE
feat: set service name at start of daemon

### DIFF
--- a/crates/amaru-consensus/src/consensus/chain_selection.rs
+++ b/crates/amaru-consensus/src/consensus/chain_selection.rs
@@ -162,6 +162,7 @@ impl<H: IsHeader> From<Option<H>> for Tip<H> {
         }
     }
 }
+
 /// Current state of chain selection process
 ///
 /// Chain selection is parameterised by the header type `H`, in

--- a/crates/amaru/src/bin/amaru/main.rs
+++ b/crates/amaru/src/bin/amaru/main.rs
@@ -58,11 +58,18 @@ enum Command {
 struct Cli {
     #[command(subcommand)]
     command: Command,
+
     #[clap(long, action, env("AMARU_WITH_OPEN_TELEMETRY"))]
     with_open_telemetry: bool,
+
     #[clap(long, action, env("AMARU_WITH_JSON_TRACES"))]
     with_json_traces: bool,
+
+    #[arg(long, value_name = "STRING", default_value_t = DEFAULT_SERVICE_NAME.to_string())]
+    service_name: String,
 }
+
+const DEFAULT_SERVICE_NAME: &str = "amaru";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -73,7 +80,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut subscriber = observability::TracingSubscriber::new();
 
     let observability::OpenTelemetryHandle { metrics, teardown } = if args.with_open_telemetry {
-        observability::setup_open_telemetry(&mut subscriber)
+        observability::setup_open_telemetry(&args.service_name, &mut subscriber)
     } else {
         observability::OpenTelemetryHandle::default()
     };

--- a/crates/amaru/src/bin/amaru/observability.rs
+++ b/crates/amaru/src/bin/amaru/observability.rs
@@ -16,8 +16,6 @@ use tracing_subscriber::{
     EnvFilter, Registry,
 };
 
-const SERVICE_NAME: &str = "amaru";
-
 const AMARU_LOG_VAR: &str = "AMARU_LOG";
 
 const DEFAULT_AMARU_LOG_FILTER: &str = "amaru=debug";
@@ -182,12 +180,15 @@ impl Default for OpenTelemetryHandle {
 }
 
 #[allow(clippy::panic)]
-pub fn setup_open_telemetry(subscriber: &mut TracingSubscriber<Registry>) -> OpenTelemetryHandle {
+pub fn setup_open_telemetry(
+    service_name: &String,
+    subscriber: &mut TracingSubscriber<Registry>,
+) -> OpenTelemetryHandle {
     use opentelemetry::KeyValue;
     use opentelemetry_sdk::{metrics::Temporality, Resource};
 
     let resource = Resource::builder()
-        .with_attribute(KeyValue::new("service.name", SERVICE_NAME))
+        .with_attribute(KeyValue::new("service.name", service_name.to_string()))
         .build();
 
     // Traces & span
@@ -221,7 +222,7 @@ pub fn setup_open_telemetry(subscriber: &mut TracingSubscriber<Registry>) -> Ope
     opentelemetry::global::set_meter_provider(metrics_provider.clone());
 
     // Subscriber
-    let opentelemetry_tracer = opentelemetry_provider.tracer(SERVICE_NAME);
+    let opentelemetry_tracer = opentelemetry_provider.tracer(service_name.to_string());
     let opentelemetry_layer = tracing_opentelemetry::layer()
         .with_tracer(opentelemetry_tracer)
         .with_filter(default_filter(AMARU_TRACE_VAR, DEFAULT_AMARU_TRACE_FILTER));

--- a/crates/amaru/src/stages/common.rs
+++ b/crates/amaru/src/stages/common.rs
@@ -32,7 +32,7 @@ macro_rules! send {
     }
 }
 
-/// Generic scheduling function for the common case where we immediately dispatch
+/// Generic scheduling macro for the common case where we immediately dispatch
 /// received message to be processed.
 ///
 /// Mostly useful to add more context to errors and reduce boilerplate.

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -68,6 +68,7 @@ name = "amaru-ouroboros-traits"
 version = "0.1.0"
 dependencies = [
  "amaru-kernel",
+ "serde",
  "slot-arithmetic",
 ]
 


### PR DESCRIPTION
Currently, the otel property 'service.name' is hardcoded to 'amaru' which is confusing when one wants to monitor several amaru services. This change provides a dead simple solution allowing the process name to be set at start time and defaulting to 'amaru'. A possibly more robust solution would use host name resolution but this is not needed atm.