### PR TITLE
chore: make sure all crates are considered

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,7 @@
 fmt-amaru = "fmt --all -- --check"
 clippy-amaru = "clippy --workspace --all-targets --all-features -- -D warnings"
 check-amaru = "check --workspace --all-targets --all-features"
+build-amaru = "build --workspace --all-targets --all-features"
 test-amaru = "test --workspace --all-targets --all-features"
 deny-amaru = "deny check licenses --config .cargo/deny.toml"
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
 
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
-            command: test --profile dev-debug
+            command: test-amaru --profile dev-debug
 
           - runner: ubuntu-latest
             target: wasm32-unknown-unknown
@@ -69,7 +69,7 @@ jobs:
 
           - runner: ubuntu-24.04
             target: aarch64-unknown-linux-musl
-            command: test
+            command: test # This is a cross specific command. Do not change
             setup: rustup target add aarch64-unknown-linux-musl && sudo apt-get install -y pkg-config libssl-dev
             cross-compile: true
 
@@ -97,7 +97,7 @@ jobs:
           key: cargo-${{ matrix.environments.target }}
           restore-keys: |
             cargo-${{ matrix.environments.target }}
-      - name: Run tests
+      - name: Run build
         run: |
           set +e
           EXTRA_ARGS="${{ matrix.environments.extra-args || '' }}"


### PR DESCRIPTION
`cargo build` doesn't consider all crates by default. Create a `build-amaru` that aligns with `test-amaru`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a new build alias for streamlined workspace builds.
  - Updated CI workflow to use the new build alias for certain targets and adjusted step names for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->