### PR TITLE
chore: separate long running tests from regular PR ones

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -250,6 +250,12 @@ jobs:
           path: ./ledger.${{ matrix.network.name }}.db
           key: ${{ runner.OS }}-ledger-cache-v6-${{ steps.timestamp.outputs.value }}
 
+      - name: Run node
+        if: github.event_name == 'pull_request'
+        timeout-minutes: 30
+        shell: bash
+        run: make BUILD_PROFILE=test demo
+
       - name: Install Cardano CLI
         if: github.event_name != 'pull_request'
         run: |
@@ -266,16 +272,14 @@ jobs:
           ls $PWD/cardano-cli-bin/
           chmod +x cardano-cli-bin/cardano-cli
 
-      - name: Run node
+      - name: Run node until latest epoch (main branch only)
+        if: github.event_name != 'pull_request'
         timeout-minutes: 30
         shell: bash
         run: |
           set -eux
 
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-            # If this is a push event, we want to test all revolut epochs
-            export DEMO_TARGET_EPOCH=$(sudo $PWD/cardano-cli-bin/cardano-cli query tip --socket-path ${{ runner.temp }}/ipc/node.socket --testnet-magic ${{ matrix.network.magic }} | jq '.epoch - 1')
-          fi
+          export DEMO_TARGET_EPOCH=$(sudo $PWD/cardano-cli-bin/cardano-cli query tip --socket-path ${{ runner.temp }}/ipc/node.socket --testnet-magic ${{ matrix.network.magic }} | jq '.epoch - 1')
           make BUILD_PROFILE=test demo
 
       - name: Run tests


### PR DESCRIPTION
Make it clear that long running tests only run on main branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CI workflow to run a simplified node demo during pull requests and a full node run for main branch updates, improving clarity and reliability of automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->