### PR TITLE
allow passing explicit seed to simulation tests

### DIFF
--- a/simulation/amaru-sim/src/simulator/generate.rs
+++ b/simulation/amaru-sim/src/simulator/generate.rs
@@ -297,9 +297,12 @@ pub fn generate_inputs<R: Rng>(rng: &mut R, file_path: &PathBuf) -> Result<Vec<C
 
 pub fn generate_inputs_strategy(
     file_path: &PathBuf,
+    seed: Option<u64>,
 ) -> impl Strategy<Value = Vec<ChainSyncMessage>> + use<'_> {
-    any::<u64>().prop_map(|seed| {
+    any::<u64>().prop_map(move |s| {
+        let seed = seed.unwrap_or(s);
         let mut rng = StdRng::seed_from_u64(seed);
+        println!("seed {}", seed);
         generate_inputs(&mut rng, file_path).unwrap()
     })
 }

--- a/simulation/amaru-sim/src/simulator/mod.rs
+++ b/simulation/amaru-sim/src/simulator/mod.rs
@@ -78,6 +78,10 @@ pub struct Args {
     /// Default to genesis hash, eg. all-zero hash.
     #[arg(long, default_value_t = Hash::from([0; 32]))]
     pub start_header: Hash<32>,
+
+    /// Seed
+    #[arg(long)]
+    pub seed: Option<u64>,
 }
 
 pub fn run(rt: tokio::runtime::Runtime, args: Args) {
@@ -117,6 +121,7 @@ pub fn bootstrap(rt: tokio::runtime::Runtime, args: Args) {
         global_parameters.clone(),
         &mut consensus,
         &chain_data_path,
+        args.seed,
     );
 }
 
@@ -125,6 +130,7 @@ fn run_simulator(
     global: GlobalParameters,
     validate_header: &mut ValidateHeader,
     chain_data_path: &PathBuf,
+    seed: Option<u64>,
 ) {
     let config_without_shrink = Config {
         max_shrink_iters: 0,
@@ -310,7 +316,7 @@ fn run_simulator(
         config_without_shrink,
         number_of_nodes,
         spawn,
-        generate_inputs_strategy(chain_data_path),
+        generate_inputs_strategy(chain_data_path, seed),
         chain_property(chain_data_path),
     );
 }

--- a/simulation/amaru-sim/tests/simulation.rs
+++ b/simulation/amaru-sim/tests/simulation.rs
@@ -9,6 +9,7 @@ fn run_simulator() {
         chain_dir: ".".into(),
         block_tree_file: "tests/data/chain.json".into(),
         start_header: Hash::from([0; 32]),
+        seed: Some(10244329322600784733)
     };
 
     tracing_subscriber::fmt()


### PR DESCRIPTION
this requires some work to allow passing arguments through `cargo test`