### PR TITLE
wip: thread stage graph TraceBuffer through simulation test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
  "pallas-codec",
  "pallas-crypto",
  "pallas-primitives",
+ "parking_lot",
  "proptest",
  "pure-stage",
  "rand 0.9.1",

--- a/simulation/amaru-sim/Cargo.toml
+++ b/simulation/amaru-sim/Cargo.toml
@@ -20,6 +20,7 @@ hex.workspace = true
 pallas-codec.workspace = true
 pallas-crypto.workspace = true
 pallas-primitives.workspace = true
+parking_lot.workspace = true
 proptest = {workspace = true, features = ["std"] }
 pure-stage.workspace = true
 rand.workspace = true

--- a/simulation/amaru-sim/src/simulator/mod.rs
+++ b/simulation/amaru-sim/src/simulator/mod.rs
@@ -38,7 +38,7 @@ use clap::Parser;
 use generate::{generate_inputs_strategy, parse_json, read_chain_json};
 use ledger::{populate_chain_store, FakeStakeDistribution};
 use proptest::test_runner::Config;
-use pure_stage::{simulation::SimulationBuilder, StageRef};
+use pure_stage::{simulation::SimulationBuilder, trace_buffer::TraceBuffer, StageRef};
 use pure_stage::{StageGraph, Void};
 use simulate::{pure_stage_node_handle, simulate, Trace};
 use std::{path::PathBuf, sync::Arc};
@@ -132,9 +132,11 @@ fn run_simulator(
         ..Config::default()
     };
     let number_of_nodes = 1;
+    let trace_buffer = Arc::new(parking_lot::Mutex::new(TraceBuffer::new(42, 1_000_000_000)));
+    let buffer = trace_buffer.clone();
     let spawn = move || {
         println!("*** Spawning node!");
-        let mut network = SimulationBuilder::default();
+        let mut network = SimulationBuilder::default().with_trace_buffer(buffer.clone());
         let init_st = ValidateHeader {
             ledger: validate_header.ledger.clone(),
             store: validate_header.store.clone(),
@@ -312,6 +314,7 @@ fn run_simulator(
         spawn,
         generate_inputs_strategy(chain_data_path),
         chain_property(chain_data_path),
+        trace_buffer
     );
 }
 


### PR DESCRIPTION
we want to
1. remove duplication
2. write the trace file in a temporary file
3. copy the file locally if test fails
3. (optional) allow to keep the trace buffer file based on configuration of the test