### PR TITLE
Configure otlp endpoints

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -355,3 +355,11 @@ Coming soon.
 > The plan so far is to maximise compatibility with the existing Haskell node Prometheus metrics such that tools like [`gLiveView`](https://cardano-community.github.io/guild-operators/Scripts/gliveview/?h=gliveview) and [`nview`](https://github.com/blinklabs-io/nview) keep working out-of-the-box.
 >
 > We are planning, however, to add more metrics to Amaru.
+
+## Configuring OpenTelemetry
+
+Amaru provides a few options to configure OpenTelemetry:
+
+* `--amaru-service-name <STRING>` (environment variable `AMARU_SERVICE_NAME`): Sets the `service.name` key used to identify metrics and traces. This is useful when a single OTLP service stack collects telemetry from several Amaru instances
+* `--otlp_span_url <STRING>` (environment variable `AMARU_OTLP_SPAN_URL`): Sets the endpoint used to send spans, defaults to `http://localhost:4317`
+* `--otlp_metrics_url <STRING>` (environment variable `AMARU_OTLP_METRICS_URL`): Sets the endpoint used to send metrics, defaults to `http://localhost:4318/v1/metrics`

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -360,6 +360,6 @@ Coming soon.
 
 Amaru provides a few options to configure OpenTelemetry:
 
-* `--amaru-service-name <STRING>` (environment variable `AMARU_SERVICE_NAME`): Sets the `service.name` key used to identify metrics and traces. This is useful when a single OTLP service stack collects telemetry from several Amaru instances
-* `--otlp_span_url <STRING>` (environment variable `AMARU_OTLP_SPAN_URL`): Sets the endpoint used to send spans, defaults to `http://localhost:4317`
-* `--otlp_metrics_url <STRING>` (environment variable `AMARU_OTLP_METRICS_URL`): Sets the endpoint used to send metrics, defaults to `http://localhost:4318/v1/metrics`
+- `--amaru-service-name <STRING>` (environment variable `AMARU_SERVICE_NAME`): Sets the `service.name` key used to identify metrics and traces. This is useful when a single OTLP service stack collects telemetry from several Amaru instances
+- `--otlp_span_url <STRING>` (environment variable `AMARU_OTLP_SPAN_URL`): Sets the endpoint used to send spans, defaults to `http://localhost:4317`
+- `--otlp_metrics_url <STRING>` (environment variable `AMARU_OTLP_METRICS_URL`): Sets the endpoint used to send metrics, defaults to `http://localhost:4318/v1/metrics`


### PR DESCRIPTION
This PR allows one to configure where telemetry data is sent, while keeping current default of `localhost:4317` and `localhost:4318` for spans and metrics respectively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new CLI options and environment variables to configure OpenTelemetry span and metric endpoints, as well as the service name.
- **Documentation**
  - Updated documentation with instructions for configuring OpenTelemetry options, including new flags and environment variables for spans, metrics, and service naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->