### PR TITLE
feat: add flag for persisting pure-stage schedule on success

### DIFF
--- a/simulation/amaru-sim/src/simulator/generate.rs
+++ b/simulation/amaru-sim/src/simulator/generate.rs
@@ -319,8 +319,7 @@ pub fn generate_arrival_times<R: Rng>(
     let mut time: Instant = start_time;
     let mut arrival_times = Vec::new();
 
-    let exp =
-        Exp::new(1.0 / mean_millis).unwrap_or_else(|err| panic!("generate_arrival_times: {}", err));
+    let exp = Exp::new(1.0 / mean_millis).unwrap_or_else(|err| panic!("{}", err));
     for _ in 0..length {
         arrival_times.push(time);
         let delay = exp.sample(rng);

--- a/simulation/amaru-sim/src/simulator/mod.rs
+++ b/simulation/amaru-sim/src/simulator/mod.rs
@@ -81,9 +81,13 @@ pub struct Args {
     #[arg(long, default_value_t = Hash::from([0; 32]))]
     pub start_header: Hash<32>,
 
-    /// Seed
+    /// Seed for simulator.
     #[arg(long)]
     pub seed: Option<u64>,
+
+    /// Persist pure-stage's effect trace aka schdule even if the test passes.
+    #[arg(long)]
+    pub persist_on_success: bool,
 }
 
 pub fn run(rt: tokio::runtime::Runtime, args: Args) {
@@ -122,6 +126,7 @@ pub fn bootstrap(rt: tokio::runtime::Runtime, args: Args) {
         select_chain.clone(),
         &chain_data_path,
         args.seed,
+        args.persist_on_success,
     );
 }
 
@@ -132,6 +137,7 @@ fn run_simulator(
     select_chain: SelectChain,
     chain_data_path: &PathBuf,
     seed: Option<u64>,
+    persist_on_success: bool,
 ) {
     let number_of_nodes = 1;
     let trace_buffer = Arc::new(parking_lot::Mutex::new(TraceBuffer::new(42, 1_000_000_000)));
@@ -350,6 +356,7 @@ fn run_simulator(
         generate_inputs_strategy(chain_data_path, seed),
         chain_property(chain_data_path),
         trace_buffer,
+        persist_on_success,
     );
 }
 

--- a/simulation/amaru-sim/tests/simulation.rs
+++ b/simulation/amaru-sim/tests/simulation.rs
@@ -13,6 +13,7 @@ fn run_simulator() {
         block_tree_file: "tests/data/chain.json".into(),
         start_header: Hash::from([0; 32]),
         seed: Some(10244329322600784733),
+        persist_on_success: false,
     };
 
     tracing_subscriber::fmt()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new command-line option to control whether the simulation schedule is saved when tests pass.

- **Improvements**
  - Simulation schedules are now only persisted on test success if explicitly requested.
  - Schedule files now use a `.schedule` extension for improved clarity.

- **Bug Fixes**
  - Simplified an error message for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->