### PR TITLE
Isolate Pallas in Kernel

### DIFF
--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -747,10 +747,7 @@ pub trait OriginalSize {
     fn original_size(&self) -> usize;
 }
 
-impl<T> OriginalSize for T
-where
-    T: cbor::Encode<()>,
-{
+impl<T> OriginalSize for KeepRaw<'_, T> {
     fn original_size(&self) -> usize {
         to_cbor(self).len()
     }

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -718,10 +718,6 @@ impl HasLovelace for MemoizedTransactionOutput {
         self.value.lovelace()
     }
 }
-// This is a useful trait to have instead of writing `to_cbor(x).len()` everywhere
-// But this necessarily re-serializes objects that aren't wrapped in a `KeepRaw`.
-// This is not what we should do, we should instead rely on the original bytes.
-// However, everywhere this logic was used had a FIXME, so just moving the logic is OK here.
 pub trait OriginalSize {
     fn original_size(&self) -> usize;
 }

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -141,10 +141,6 @@ impl PartialOrd for RedeemersKeyAdapter {
 }
 
 impl RedeemersKeyAdapter {
-    pub fn unwrap(self) -> PallasRedeemersKey {
-        self.inner
-    }
-
     fn tag_rank(&self) -> u8 {
         match self.tag {
             RedeemerTag::Spend => 0,
@@ -154,6 +150,12 @@ impl RedeemersKeyAdapter {
             RedeemerTag::Vote => 4,
             RedeemerTag::Propose => 5,
         }
+    }
+}
+
+impl From<RedeemersKeyAdapter> for PallasRedeemersKey {
+    fn from(value: RedeemersKeyAdapter) -> Self {
+        value.inner
     }
 }
 

--- a/crates/amaru-ledger/src/rules/block/body_size.rs
+++ b/crates/amaru-ledger/src/rules/block/body_size.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{MintedBlock, OriginalSize};
+use amaru_kernel::{to_cbor, MintedBlock};
 
 use super::InvalidBlockDetails;
 
@@ -35,10 +35,10 @@ pub fn block_body_size_valid(block: &MintedBlock<'_>) -> Result<(), InvalidBlock
 
 // FIXME: Do not re-serialize block here, but rely on the original bytes.
 fn calculate_block_body_size(block: &MintedBlock<'_>) -> usize {
-    block.transaction_bodies.original_size()
-        + block.transaction_witness_sets.original_size()
-        + block.auxiliary_data_set.original_size()
-        + block.invalid_transactions.original_size()
+    to_cbor(&block.transaction_bodies).len()
+        + to_cbor(&block.transaction_witness_sets).len()
+        + to_cbor(&block.auxiliary_data_set).len()
+        + to_cbor(&block.invalid_transactions).len()
 }
 
 #[cfg(test)]

--- a/crates/amaru-ledger/src/rules/block/body_size.rs
+++ b/crates/amaru-ledger/src/rules/block/body_size.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{to_cbor, MintedBlock};
+use amaru_kernel::{MintedBlock, OriginalSize};
 
 use super::InvalidBlockDetails;
 
@@ -35,15 +35,10 @@ pub fn block_body_size_valid(block: &MintedBlock<'_>) -> Result<(), InvalidBlock
 
 // FIXME: Do not re-serialize block here, but rely on the original bytes.
 fn calculate_block_body_size(block: &MintedBlock<'_>) -> usize {
-    let tx_bodies_raw = to_cbor(&block.transaction_bodies);
-    let tx_witness_sets_raw = to_cbor(&block.transaction_witness_sets);
-    let auxiliary_data_raw = to_cbor(&block.auxiliary_data_set);
-    let invalid_transactions_raw = to_cbor(&block.invalid_transactions);
-
-    tx_bodies_raw.len()
-        + tx_witness_sets_raw.len()
-        + auxiliary_data_raw.len()
-        + invalid_transactions_raw.len()
+    block.transaction_bodies.original_size()
+        + block.transaction_witness_sets.original_size()
+        + block.auxiliary_data_set.original_size()
+        + block.invalid_transactions.original_size()
 }
 
 #[cfg(test)]

--- a/crates/amaru-ledger/src/rules/transaction/scripts.rs
+++ b/crates/amaru-ledger/src/rules/transaction/scripts.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::context::{UtxoSlice, WitnessSlice};
 use amaru_kernel::{
     display_collection, get_provided_scripts, script_purpose_to_string, DatumHash, HasRedeemerKeys,


### PR DESCRIPTION
It's very difficult to [migrate to Pallas v1-alpha](https://github.com/pragma-org/amaru/pull/266) for us right now due to several complexities (discussed [here](https://discord.com/channels/1202416088776712253/1384269156626595840/1384350668751503420)).

In an attempt to make such a transition easier–and to ensure a separation of responsibilities–we're working to isolate Pallas logic in the Kernel. Most importantly, any logic that matches on CBOR specific structures or works with the raw bytes of CBOR should belong in the Kernel. This makes the transition much easier and keeps our ledger rules focused on the validation logic instead of (de)serialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new redeemer key type with custom ordering for consistent handling of redeemer keys.
  - Added a unified method to extract redeemer keys from redeemers.
  - Provided a method to retrieve the original CBOR-encoded byte size of objects.

- **Refactor**
  - Simplified redeemer processing logic for transactions, improving clarity and removing duplicate handling.
  - Streamlined block body size calculation by removing intermediate variables.
  - Refined minimum value calculation by directly accessing protocol parameters and clarifying comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->