### PR TITLE
feat: don't persist empty schedules

### DIFF
--- a/simulation/amaru-sim/src/simulator/simulate.rs
+++ b/simulation/amaru-sim/src/simulator/simulate.rs
@@ -324,19 +324,14 @@ fn persist_schedule(
 
     let now = SystemTime::now();
 
-    let dir_str: &str = dir
-        .as_os_str()
-        .to_str()
-        .ok_or(anyhow::anyhow!("invalid bytes in dir"))?;
-
-    let path = PathBuf::from(format!(
-        "{}/{}-{}.schedule",
-        dir_str,
+    let filename = format!(
+        "{}-{}.schedule",
         prefix,
         now.duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_secs()
-    ));
+    );
+    let path = dir.join(filename);
 
     let mut file = File::create(&path)?;
     for bytes in trace_buffer.lock().iter() {


### PR DESCRIPTION
There's a test that we expect to fail and which has a trace buffer of size 0, running this test used to cause failure schedule to be persisted.

Fixes #288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented creation of empty schedule files when there is no trace data to save.  
- **New Features**
  - Schedule files are now saved with unique timestamped filenames in specified directories.  
  - Users receive clear feedback on the success or failure of schedule file saving operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->