### PR TITLE
chore: clarify IncompatibleVersion error message

### DIFF
--- a/crates/amaru/src/bin/amaru/cmd/daemon.rs
+++ b/crates/amaru/src/bin/amaru/cmd/daemon.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::metrics::track_system_metrics;
+use crate::{cmd::connect_to_peer, metrics::track_system_metrics};
 use amaru::stages::{bootstrap, Config, StorePath};
 use amaru_kernel::{default_chain_dir, default_ledger_dir, network::NetworkName};
 use clap::{ArgAction, Parser};
@@ -70,9 +70,7 @@ pub async fn run(
 
     let mut clients: Vec<(String, Arc<Mutex<PeerClient>>)> = vec![];
     for peer in &config.upstream_peers {
-        let client =
-            PeerClient::connect(peer.clone(), config.network.to_network_magic() as u64).await
-            .inspect_err(|e| tracing::error!("failed to connect to peer {}: {}", peer, e))?;
+        let client = connect_to_peer(peer, &config.network).await?;
         clients.push((peer.clone(), Arc::new(Mutex::new(client))));
     }
 

--- a/crates/amaru/src/bin/amaru/cmd/import_headers.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_headers.rs
@@ -1,3 +1,4 @@
+use crate::cmd::connect_to_peer;
 use amaru::stages::{pull, PeerSession};
 use amaru_consensus::{consensus::store::ChainStore, peer::Peer, IsHeader};
 use amaru_kernel::{default_chain_dir, from_cbor, network::NetworkName, Header, Point};
@@ -5,10 +6,7 @@ use amaru_stores::rocksdb::consensus::RocksDBStore;
 use clap::Parser;
 use gasket::framework::*;
 use indicatif::{ProgressBar, ProgressStyle};
-use pallas_network::{
-    facades::PeerClient,
-    miniprotocols::chainsync::{self, HeaderContent, NextResponse},
-};
+use pallas_network::miniprotocols::chainsync::{self, HeaderContent, NextResponse};
 use std::{error::Error, path::PathBuf, sync::Arc, time::Duration};
 use tokio::{sync::Mutex, time::timeout};
 use tracing::info;
@@ -88,8 +86,7 @@ pub(crate) async fn import_headers(
     let mut db = RocksDBStore::new(chain_db_dir, era_history)?;
 
     let peer_client = Arc::new(Mutex::new(
-        PeerClient::connect(peer_address, network_name.to_network_magic() as u64).await
-        .inspect_err(|e|tracing::error!("failed to connect to peer {}: {}", peer_address, e))?
+        connect_to_peer(peer_address, &network_name).await?,
     ));
 
     let peer_session = PeerSession {

--- a/crates/amaru/src/bin/amaru/cmd/mod.rs
+++ b/crates/amaru/src/bin/amaru/cmd/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use amaru_kernel::{network::NetworkName, Nonce, Point};
+use pallas_network::facades::PeerClient;
 
 pub(crate) mod bootstrap;
 pub(crate) mod daemon;
@@ -24,6 +25,15 @@ pub(crate) const DEFAULT_NETWORK: NetworkName = NetworkName::Preprod;
 
 /// Default address to listen on for incoming connections.
 pub(crate) const DEFAULT_LISTEN_ADDRESS: &str = "0.0.0.0:3000";
+
+/// Establish a connection to another peer. The connection are discriminated by network types.
+pub(crate) async fn connect_to_peer(
+    peer_address: &str,
+    network: &NetworkName,
+) -> Result<PeerClient, pallas_network::facades::Error> {
+    PeerClient::connect(peer_address, network.to_network_magic() as u64).await
+        .inspect_err(|reason| tracing::error!(peer = %peer_address, reason = %reason, "failed to connect to peer"))
+}
 
 /// Utility function to parse a point from a string.
 ///


### PR DESCRIPTION
When trying to connect to a cardano node using an incompatible protocol version the error message was not explicit:
```
Error: IncompatibleVersion
```

This commit changes that to:
```
failed to connect to peer <peer>: handshake version not accepted
```

It would be even better if we could share the versions supported by the remote node but we need to make pallas-network share this information with us so that's probably the best we can do right now.

Also note that, in the daemon, the first node with which we fail to connect will make the whole process to stop. Not sure this is intentional but that's what we had before so I keep it that way for now.

I'm not super happy with tracing errors and then returning them. I considered handling errors globally in the `main` function and I think this is what we should do but, at this point, doing so reduces the information that we can share and so make diagnosis a bit difficult. Such an approach would need to define amaru specific global errors that can be handled at a very high level but still carry enough information to be usefull... next time ;)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when connecting to peers by adding explicit error logging for connection failures.
- **New Features**
  - Enhanced peer connection process with a new asynchronous connection method for better reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->