### PR TITLE
chore: upgrade pallas to newly released v0.32.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,9 +1996,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pallas-addresses"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bd039d7f1618d12ff348dd03eebe38c5d2a010325750e5341526c419b0f8e0"
+checksum = "45a7e0425ec22afe8e80c9f9dfb086cbad569fd2ba3e51d6ab8caa20423b7488"
 dependencies = [
  "base58",
  "bech32 0.9.1",
@@ -2012,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-codec"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1584d615857c0a44058fb612e892e9e0cc47b56c3c82cdf7347b5c1d1193598c"
+checksum = "e344b3e39ca3bd79bb7547b65b980869c3c377a00c48ece70430f4611c32a18b"
 dependencies = [
  "hex",
  "minicbor",
@@ -2024,9 +2024,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-crypto"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c1d642326ce402eb9191aeacc3dd0bf2b499848e97a56396c978a6eb9dd31a"
+checksum = "59c89ea16190a87a1d8bd36923093740a2b659ed6129f4636329319a70cc4db3"
 dependencies = [
  "cryptoxide",
  "hex",
@@ -2039,9 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-math"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95f16fb995f567d981aae17e2929f5c8ee0d97e41d402413bf0bd20df4ab41c"
+checksum = "c8d337797581aa82f57b90f6ea8610a080d272c9e27a7edb39d54f039deb0d92"
 dependencies = [
  "dashu-base",
  "dashu-int",
@@ -2051,9 +2051,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-network"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e44dd876dc70cbbfc865bb9143131f57edab2c45e873d915732b81982ddb67"
+checksum = "45b032abff3e307e21d99100a62b51084cc070d9e445ef95ed543a5225d865f5"
 dependencies = [
  "byteorder",
  "hex",
@@ -2069,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-primitives"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d30f5053073554d016a9f009c077f9a84275951a611cce54230de6c54d34d9b"
+checksum = "1912f4f4a0719e36ac061f7f3557b687e8ef7285b573608fb5c71eba64c1b04c"
 dependencies = [
  "base58",
  "bech32 0.9.1",
@@ -2085,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-traverse"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d2572d316883fe866ae648bc3c5357e70cbbe8de5d78b1246f6109520fa52f"
+checksum = "be7fbb1db75a0b6b32d1808b2cc5c7ba6dd261f289491bb86998b987b4716883"
 dependencies = [
  "hex",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,13 +38,13 @@ opentelemetry-otlp = { version = "0.30.0", features = [
     "reqwest-blocking-client",
 ] }
 opentelemetry_sdk = "0.30.0"
-pallas-addresses = "0.32.0"
-pallas-codec = "0.32.0" # When updating, double check that minicbor doesn't need to be updated too (see https://github.com/txpipe/pallas/blob/v0.32.0/pallas-codec/Cargo.toml#L22)
-pallas-crypto = "0.32.0"
-pallas-math = "0.32.0"
-pallas-network = "0.32.0"
-pallas-primitives = "0.32.0"
-pallas-traverse = "0.32.0"
+pallas-addresses = "0.32.1"
+pallas-codec = "0.32.1" # When updating, double check that minicbor doesn't need to be updated too (see https://github.com/txpipe/pallas/blob/v0.32.0/pallas-codec/Cargo.toml#L22)
+pallas-crypto = "0.32.1"
+pallas-math = "0.32.1"
+pallas-network = "0.32.1"
+pallas-primitives = "0.32.1"
+pallas-traverse = "0.32.1"
 parking_lot = "0.12.3"
 rayon = "1.10"
 rocksdb = { version = "0.23.0", default-features = false, features = [


### PR DESCRIPTION
this fixes #291 as pallas now can handle NodeToNodeVersionV14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions for several core libraries to improve stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->