### PR TITLE
chore: remove unused pub fns

### DIFF
--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -825,25 +825,6 @@ impl HasExUnits for MintedBlock<'_> {
     }
 }
 
-/// Calculate the total ex units in a witness set
-pub fn to_ex_units(witness_set: WitnessSet) -> ExUnits {
-    match witness_set.redeemer {
-        Some(redeemers) => match redeemers {
-            Redeemers::List(redeemers) => redeemers
-                .iter()
-                .fold(ExUnits { mem: 0, steps: 0 }, |acc, redeemer| {
-                    sum_ex_units(acc, redeemer.ex_units)
-                }),
-            Redeemers::Map(redeemers_map) => redeemers_map
-                .into_iter()
-                .fold(ExUnits { mem: 0, steps: 0 }, |acc, (_, redeemer)| {
-                    sum_ex_units(acc, redeemer.ex_units)
-                }),
-        },
-        None => ExUnits { mem: 0, steps: 0 },
-    }
-}
-
 /// Collect provided scripts and compute each ScriptHash in a witness set
 pub fn get_provided_scripts<'a>(
     witness_set: &'a MintedWitnessSet<'_>,

--- a/crates/slot-arithmetic/src/lib.rs
+++ b/crates/slot-arithmetic/src/lib.rs
@@ -379,29 +379,6 @@ impl EraHistory {
         Err(TimeHorizonError::PastTimeHorizon)
     }
 
-    pub fn slot_to_absolute_time(
-        &self,
-        slot: Slot,
-        system_start: u64,
-    ) -> Result<u64, TimeHorizonError> {
-        self.slot_to_relative_time(slot).map(|t| system_start + t)
-    }
-
-    pub fn relative_time_to_slot(&self, time: u64) -> Result<Slot, TimeHorizonError> {
-        for era in &self.eras {
-            if era.start.time_ms > time {
-                return Err(TimeHorizonError::InvalidEraHistory);
-            }
-            if era.end.time_ms >= time {
-                let time_elapsed = time - era.start.time_ms;
-                let slots_elapsed = time_elapsed / era.params.slot_length;
-                let slot = era.start.slot.offset_by(slots_elapsed);
-                return Ok(slot);
-            }
-        }
-        Err(TimeHorizonError::PastTimeHorizon)
-    }
-
     pub fn slot_to_epoch(&self, slot: Slot) -> Result<Epoch, TimeHorizonError> {
         for era in &self.eras {
             if era.start.slot > slot {


### PR DESCRIPTION
Remove unused pub functions as detected by [cargo-workspace-unused-pub](https://github.com/cpg314/cargo-workspace-unused-pub)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed several public methods related to execution unit calculation and slot/time conversions, resulting in a simplified interface for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->