### PR TITLE
feat: allow chaindb to be concurrently opened for reading

### DIFF
--- a/crates/amaru-consensus/src/consensus/store.rs
+++ b/crates/amaru-consensus/src/consensus/store.rs
@@ -234,7 +234,7 @@ impl ChainStore<Header> for FakeStore {
     }
 
     fn store_block(&mut self, _hash: &Hash<32>, _block: &RawBlock) -> Result<(), StoreError> {
-        unimplemented!()
+        Ok(())
     }
 }
 

--- a/crates/amaru-consensus/src/consensus/store_block.rs
+++ b/crates/amaru-consensus/src/consensus/store_block.rs
@@ -54,7 +54,7 @@ impl StoreBlock {
 
 #[cfg(test)]
 mod tests {
-    use crate::consensus::store::StoreError;
+    use crate::consensus::store::{ReadOnlyChainStore, StoreError};
 
     use super::*;
     use amaru_kernel::{Hash, Point, RawBlock};
@@ -75,25 +75,25 @@ mod tests {
         }
     }
 
+    impl ReadOnlyChainStore<Header> for MockChainStore {
+        fn load_header(&self, _hash: &Hash<32>) -> Option<Header> {
+            unimplemented!()
+        }
+        fn load_block(&self, _hash: &Hash<32>) -> Result<RawBlock, StoreError> {
+            unimplemented!()
+        }
+        fn get_nonces(&self, _header: &Hash<32>) -> Option<amaru_ouroboros::Nonces> {
+            unimplemented!()
+        }
+    }
+
     impl ChainStore<Header> for MockChainStore {
         fn store_block(&mut self, point: &Hash<32>, block: &RawBlock) -> Result<(), StoreError> {
             self.stored_blocks.insert(*point, block.clone());
             Ok(())
         }
 
-        fn load_header(&self, _hash: &Hash<32>) -> Option<Header> {
-            unimplemented!()
-        }
-
         fn store_header(&mut self, _hash: &Hash<32>, _header: &Header) -> Result<(), StoreError> {
-            unimplemented!()
-        }
-
-        fn load_block(&self, _hash: &Hash<32>) -> Result<RawBlock, StoreError> {
-            unimplemented!()
-        }
-
-        fn get_nonces(&self, _header: &Hash<32>) -> Option<amaru_ouroboros::Nonces> {
             unimplemented!()
         }
 

--- a/crates/amaru-consensus/src/consensus/store_block.rs
+++ b/crates/amaru-consensus/src/consensus/store_block.rs
@@ -54,65 +54,17 @@ impl StoreBlock {
 
 #[cfg(test)]
 mod tests {
-    use crate::consensus::store::{ReadOnlyChainStore, StoreError};
+    use crate::consensus::store::FakeStore;
 
     use super::*;
-    use amaru_kernel::{Hash, Point, RawBlock};
-    use std::{collections::BTreeMap, sync::Arc};
+    use amaru_kernel::{Hash, Point};
+    use std::sync::Arc;
     use tokio::sync::Mutex;
     use tracing::Span;
 
-    // Mock implementation of ChainStore for testing
-    struct MockChainStore {
-        stored_blocks: BTreeMap<Hash<32>, RawBlock>,
-    }
-
-    impl MockChainStore {
-        fn new() -> Self {
-            Self {
-                stored_blocks: BTreeMap::new(),
-            }
-        }
-    }
-
-    impl ReadOnlyChainStore<Header> for MockChainStore {
-        fn load_header(&self, _hash: &Hash<32>) -> Option<Header> {
-            unimplemented!()
-        }
-        fn load_block(&self, _hash: &Hash<32>) -> Result<RawBlock, StoreError> {
-            unimplemented!()
-        }
-        fn get_nonces(&self, _header: &Hash<32>) -> Option<amaru_ouroboros::Nonces> {
-            unimplemented!()
-        }
-    }
-
-    impl ChainStore<Header> for MockChainStore {
-        fn store_block(&mut self, point: &Hash<32>, block: &RawBlock) -> Result<(), StoreError> {
-            self.stored_blocks.insert(*point, block.clone());
-            Ok(())
-        }
-
-        fn store_header(&mut self, _hash: &Hash<32>, _header: &Header) -> Result<(), StoreError> {
-            unimplemented!()
-        }
-
-        fn put_nonces(
-            &mut self,
-            _header: &Hash<32>,
-            _nonces: &amaru_ouroboros::Nonces,
-        ) -> Result<(), StoreError> {
-            unimplemented!()
-        }
-
-        fn era_history(&self) -> &amaru_kernel::EraHistory {
-            unimplemented!()
-        }
-    }
-
     #[tokio::test]
     async fn handle_event_returns_passed_event_when_forwarding_given_store_succeeds() {
-        let mock_store = Arc::new(Mutex::new(MockChainStore::new()));
+        let mock_store = Arc::new(Mutex::new(FakeStore::default()));
         let store_block = StoreBlock::new(mock_store.clone());
 
         let event = ValidateBlockEvent::Validated {
@@ -132,7 +84,7 @@ mod tests {
     #[allow(clippy::wildcard_enum_match_arm)]
     #[tokio::test]
     async fn handle_event_returns_passed_event_when_rollbacking() {
-        let mock_store = Arc::new(Mutex::new(MockChainStore::new()));
+        let mock_store = Arc::new(Mutex::new(FakeStore::default()));
         let store_block = StoreBlock::new(mock_store.clone());
 
         let expected_rollback_point = Point::Specific(100, Hash::from([2; 32]).to_vec());

--- a/crates/amaru/src/stages/consensus/forward_chain/test_infra.rs
+++ b/crates/amaru/src/stages/consensus/forward_chain/test_infra.rs
@@ -4,7 +4,7 @@ use super::{ForwardChainStage, ForwardEvent, PrettyPoint};
 use crate::stages::PallasPoint;
 use acto::{AcTokio, AcTokioRuntime, ActoCell, ActoInput, ActoRuntime};
 use amaru_consensus::{
-    consensus::store::{ChainStore, StoreError},
+    consensus::store::{ChainStore, ReadOnlyChainStore, StoreError},
     IsHeader, Nonces,
 };
 use amaru_kernel::{block::BlockValidationResult, from_cbor, Hash, Header, RawBlock, EMPTY_BLOCK};
@@ -71,18 +71,23 @@ impl TestStore {
     }
 }
 
-impl ChainStore<Header> for TestStore {
+impl ReadOnlyChainStore<Header> for TestStore {
     fn load_header(&self, hash: &Hash<32>) -> Option<Header> {
         self.0.get(hash).cloned()
     }
+    fn get_nonces(&self, _header: &Hash<32>) -> Option<Nonces> {
+        unimplemented!()
+    }
 
+    fn load_block(&self, _hash: &Hash<32>) -> Result<RawBlock, StoreError> {
+        unimplemented!()
+    }
+}
+
+impl ChainStore<Header> for TestStore {
     fn store_header(&mut self, hash: &Hash<32>, header: &Header) -> Result<(), StoreError> {
         self.0.insert(*hash, header.clone());
         Ok(())
-    }
-
-    fn get_nonces(&self, _header: &Hash<32>) -> Option<Nonces> {
-        unimplemented!()
     }
 
     fn put_nonces(&mut self, _header: &Hash<32>, _nonces: &Nonces) -> Result<(), StoreError> {
@@ -90,10 +95,6 @@ impl ChainStore<Header> for TestStore {
     }
 
     fn era_history(&self) -> &slot_arithmetic::EraHistory {
-        unimplemented!()
-    }
-
-    fn load_block(&self, _hash: &Hash<32>) -> Result<RawBlock, StoreError> {
         unimplemented!()
     }
 

--- a/simulation/amaru-sim/src/simulator/ledger.rs
+++ b/simulation/amaru-sim/src/simulator/ledger.rs
@@ -170,7 +170,7 @@ pub struct ConsensusContext {
 
 #[cfg(test)]
 mod test {
-    use amaru_consensus::consensus::store::ChainStore;
+    use amaru_consensus::consensus::store::ReadOnlyChainStore;
     use amaru_kernel::network::NetworkName;
     use amaru_kernel::Header;
     use amaru_stores::rocksdb::consensus::InMemConsensusStore;


### PR DESCRIPTION
This change introduces `open_for_read_only` to `RocksDBStore`, enabling concurrent read access without requiring a write lock.

This is particularly useful for tools like amaru-doctor, which need to inspect the chain database while amaru is actively running and modifying it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for opening consensus stores in read-only mode, including a dedicated read-only store type and method for opening databases without write access.

* **Refactor**
  * Separated store interfaces into distinct read-only and read-write traits, clarifying which operations are available for each mode.
  * Updated mock and test store implementations to align with the new trait hierarchy, improving modularity and clarity in test infrastructure.
  * Simplified test mocks by replacing custom mocks with standardized fake stores.

* **Tests**
  * Enhanced tests to verify concurrent access for both read-only and read-write stores and updated test imports to use the new read-only trait.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->