### PR TITLE
Can test the CLI of Amaru

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -319,3 +319,23 @@ jobs:
             cargo-x86_64-unknown-linux-gnu
       - name: Run amaru-consensus benches
         run: cargo bench -p amaru-consensus --features="test-utils profiling"
+
+  cli:
+    name: Test the CLI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.RUST_CACHE_PATH }}
+          key: cargo-x86_64-unknown-linux-gnu
+          restore-keys: |
+            cargo-x86_64-unknown-linux-gnu
+      - name: Install bash_unit
+        run: curl -s https://raw.githubusercontent.com/bash-unit/bash_unit/master/install.sh | bash
+      - name: Install expect
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y expect
+      - name: Run bash_unit
+        run: FORCE_COLOR=true ./bash_unit cli-tests/test_*

--- a/cli-tests/.gitignore
+++ b/cli-tests/.gitignore
@@ -1,0 +1,1 @@
+fixtures/*/snapshots/

--- a/cli-tests/README.md
+++ b/cli-tests/README.md
@@ -1,0 +1,23 @@
+# CLI Tests
+
+This directory is for testing the CLI of Amaru from the outside.
+
+As it mainly consists of running shell commands and checking the outcome, we
+use [bash_unit](https://github.com/bash-unit/bash_unit) for that.
+
+## How to run the test
+
+Ensure you have bash_unit installed. See
+[how to install bash_unit](https://github.com/bash-unit/bash_unit?tab=readme-ov-file#how-to-install-bash_unit).
+
+Run the following command:
+
+```
+#> bash_unit cli-tests/test_*
+```
+
+## How are the tests structured
+
+We often need some sort of setup specific to the kind of checks we want to make
+on the CLI. The `fixtures` subdirectory contains such setups and the tests `cd`
+into the appropriate directory depending on the test needs.

--- a/cli-tests/fixtures/missing_snapshots_file_setup/data/preprod/config.json
+++ b/cli-tests/fixtures/missing_snapshots_file_setup/data/preprod/config.json
@@ -1,0 +1,1 @@
+../../../../../data/preprod/config.json

--- a/cli-tests/fixtures/missing_snapshots_file_setup/data/preprod/dreps
+++ b/cli-tests/fixtures/missing_snapshots_file_setup/data/preprod/dreps
@@ -1,0 +1,1 @@
+../../../../../data/preprod/dreps

--- a/cli-tests/fixtures/missing_snapshots_file_setup/data/preprod/headers.json
+++ b/cli-tests/fixtures/missing_snapshots_file_setup/data/preprod/headers.json
@@ -1,0 +1,1 @@
+../../../../../data/preprod/headers.json

--- a/cli-tests/fixtures/missing_snapshots_file_setup/data/preprod/nonces.json
+++ b/cli-tests/fixtures/missing_snapshots_file_setup/data/preprod/nonces.json
@@ -1,0 +1,1 @@
+../../../../../data/preprod/nonces.json

--- a/cli-tests/fixtures/missing_snapshots_file_setup/data/preprod/pools
+++ b/cli-tests/fixtures/missing_snapshots_file_setup/data/preprod/pools
@@ -1,0 +1,1 @@
+../../../../../data/preprod/pools

--- a/cli-tests/fixtures/missing_snapshots_file_setup/data/preprod/pots
+++ b/cli-tests/fixtures/missing_snapshots_file_setup/data/preprod/pots
@@ -1,0 +1,1 @@
+../../../../../data/preprod/pots

--- a/cli-tests/fixtures/missing_snapshots_file_setup/data/preprod/rewards-provenance
+++ b/cli-tests/fixtures/missing_snapshots_file_setup/data/preprod/rewards-provenance
@@ -1,0 +1,1 @@
+../../../../../data/preprod/rewards-provenance

--- a/cli-tests/test_crash_with_helpful_information.sh
+++ b/cli-tests/test_crash_with_helpful_information.sh
@@ -1,0 +1,28 @@
+test_explains_snapshot_file_is_missing() {
+	given_snapshots_file_is_missing
+
+	assert_matches "data/preprod/snapshots.json.*NotFound" "$(bootstrap_amaru)"
+}
+
+setup() {
+	export NETWORK=preprod
+	export CONFIG_FOLDER=data
+	export LEDGER_DIR=./ledger.${NETWORK}.db
+	export CHAIN_DIR=./chain.${NETWORK}.db
+	export BUILD_PROFILE=dev
+	export AMARU_PEER_ADDRESS=127.0.0.1:3001
+}
+
+given_snapshots_file_is_missing() {
+	cd fixtures/missing_snapshots_file_setup
+}
+
+bootstrap_amaru() {
+	cargo run --profile ${BUILD_PROFILE} -- bootstrap \
+		--peer-address ${AMARU_PEER_ADDRESS} \
+		--config-dir ${CONFIG_FOLDER} \
+		--ledger-dir ${LEDGER_DIR} \
+		--chain-dir ${CHAIN_DIR} \
+		--network ${NETWORK} \
+		2>&1
+}

--- a/cli-tests/test_manage_colors_in_output.sh
+++ b/cli-tests/test_manage_colors_in_output.sh
@@ -1,0 +1,34 @@
+test_no_color_if_no_terminal() {
+	assert_fail "start_misconfigured_amaru_daemon | has_escape_sequence" \
+		"Found escape characters in output but we're not running in a terminal"
+}
+
+test_color_if_in_terminal() {
+	assert "emulate_terminal "$start_misconfigured_amaru_daemon_cmd" | has_escape_sequence" \
+		"No escape characters found in output but we're in a terminal and expecting some colors"
+}
+
+setup_suite() {
+	NETWORK=preprod
+	LEDGER_DIR=./ledger.${NETWORK}.db
+	CHAIN_DIR=./chain.${NETWORK}.db
+	BUILD_PROFILE=dev
+	UNREACHABLE_PEER=127.0.0.1:65532
+	export start_misconfigured_amaru_daemon_cmd="cargo run --color never --profile ${BUILD_PROFILE} -- daemon
+		--peer-address ${UNREACHABLE_PEER}
+		--ledger-dir ${LEDGER_DIR}
+		--chain-dir ${CHAIN_DIR}
+		--network ${NETWORK}"
+}
+
+emulate_terminal() {
+	expect -c "spawn -noecho $@; expect eof { exit 0 }"
+}
+
+has_escape_sequence() {
+	grep $'\033'
+}
+
+start_misconfigured_amaru_daemon() {
+	$start_misconfigured_amaru_daemon_cmd 2>&1 || true
+}


### PR DESCRIPTION
During a conversation with @KtorZ we were contemplating the idea of introducing tests of Amaru's CLI.

This PR implements several CLI tests. As these tests mainly consist of running a shell command which starts Amaru in various conditions and checking the outcome, we use [bash_unit](https://github.com/bash-unit/bash_unit) that is tailored to run tests written in bash (and which I maintain so I may be a bit biased here).

The `cli-tests` directory is introduced to contain this kind of tests:
*  `test_explains_snapshot_file_is_missing()` in `cli-tests/test_crash_with_helpful_information.sh` checks the output of amaru when bootstraped without snapshots is helpfull;
* `test_no_color_if_no_terminal` and `test_color_if_in_terminal` in `cli-tests/test_manage_colors_in_output.sh` check that Amaru is correctly managing colors depending on wether it's started in a terminal or not.

## How to run the test

Ensure you have bash_unit installed. See [how to install bash_unit](https://github.com/bash-unit/bash_unit/blob/main/README.adoc#how-to-install-bash_unit).

Run the following command:

```
#> bash_unit cli-tests/test_*
```

## How are the tests structured

We often need some sort of setup specific to the kind of checks we want to make on the CLI. The `fixtures` subdirectory contains such setups and the tests `cd` into them before starting Amaru.

## Integration with the CI

I've added a job to run this tests. I did my best to try to use rust compilation cache from the build stage but I'm not 100% sure I'm not missing something there.

This is what the test looks like when it fails: https://github.com/pgrange/amaru/actions/runs/16028793730/job/45223640352

This is what the test looks like when it succeeds:
https://github.com/pgrange/amaru/actions/runs/16028360576/job/45222108688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added CLI integration tests for missing snapshots error messaging and terminal-aware color output, with supporting fixtures.
- Chores
  - Extended continuous integration to run the CLI test suite on Linux with required tooling.
  - Ignored test snapshot directories to keep the repo clean.
- Documentation
  - Added instructions for running the CLI tests locally, including prerequisites and test structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->