### PR TITLE
feat: improve snapshots logs

### DIFF
--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -41,7 +41,7 @@ use thiserror::Error;
 pub enum OpenErrorKind {
     #[error(transparent)]
     IO(#[from] io::Error),
-    #[error("no ledger stable snapshot found; at least one is expected")]
+    #[error("no ledger stable snapshot found; at least two are expected")]
     NoStableSnapshot,
 }
 

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -760,14 +760,14 @@ mod tests {
     #[test]
     fn pp_all_continuous() {
         let input = vec![vec![1, 2, 3]];
-        let expected = "[1-3]".to_string();
+        let expected = "[1..3]".to_string();
         assert_eq!(pretty_print_snapshot_ranges(&input), expected);
     }
 
     #[test]
     fn pp_mixed_groups() {
         let input = vec![vec![1, 2, 3], vec![5], vec![7, 8]];
-        let expected = "[1-3],5,[7-8]".to_string();
+        let expected = "[1..3],[5],[7..8]".to_string();
         assert_eq!(pretty_print_snapshot_ranges(&input), expected);
     }
 }

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -125,7 +125,7 @@ impl RocksDB {
     }
 
     pub fn new(dir: &Path) -> Result<Self, StoreError> {
-        assert_non_empty(dir)?;
+        assert_sufficient_snapshots(dir)?;
         let mut opts = default_opts_with_prefix();
         opts.create_if_missing(true);
         OptimisticTransactionDB::open(&opts, dir.join("live"))
@@ -207,7 +207,7 @@ pub struct ReadOnlyRocksDB {
 
 impl ReadOnlyRocksDB {
     pub fn new(dir: &Path) -> Result<Self, StoreError> {
-        assert_non_empty(dir)?;
+        assert_sufficient_snapshots(dir)?;
         let opts = default_opts_with_prefix();
         rocksdb::DB::open_for_read_only(&opts, dir.join("live"), false)
             .map(|db| ReadOnlyRocksDB { db })
@@ -597,9 +597,43 @@ impl ReadOnlyRocksDBSnapshot {
 // -------------------------------------------------------------------- Helpers
 // ----------------------------------------------------------------------------
 
-fn assert_non_empty(dir: &Path) -> Result<(), StoreError> {
+/// Splits a vector of numbers into groups of continuous numbers.
+/// e.g. `[1, 2, 3, 5, 6, 8]` becomes `[[1, 2, 3], [5, 6], [8]]`.
+fn split_continuous(input: Vec<u64>) -> Vec<Vec<u64>> {
+    input
+        .into_iter()
+        .fold(vec![], |mut acc, x| match acc.last() {
+            Some(last_group) if last_group.last().is_some_and(|&last| x == last + 1) => {
+                let mut new_acc = acc[..acc.len() - 1].to_vec();
+                let mut new_group = last_group.clone();
+                new_group.push(x);
+                new_acc.push(new_group);
+                new_acc
+            }
+            _ => {
+                acc.push(vec![x]);
+                acc
+            }
+        })
+}
+
+fn pretty_print_snapshot_ranges(ranges: &[Vec<u64>]) -> String {
+    ranges
+        .iter()
+        .map(|g| match g.len() {
+            0 => String::new(),
+            1 => g[0].to_string(),
+            #[allow(clippy::unwrap_used)] // Infallible error.
+            _ => format!("[{}-{}]", g.first().unwrap(), g.last().unwrap()),
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn assert_sufficient_snapshots(dir: &Path) -> Result<(), StoreError> {
     let snapshots = RocksDB::snapshots(dir)?;
-    info!(target: EVENT_TARGET, snapshots = snapshots.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(","), "new.known_snapshots");
+    let snapshots_ranges = split_continuous(snapshots.iter().map(|e| u64::from(*e)).collect());
+    info!(target: EVENT_TARGET, snapshots = pretty_print_snapshot_ranges(&snapshots_ranges), "new.known_snapshots");
     if snapshots.is_empty() {
         return Err(StoreError::Open(OpenErrorKind::NoStableSnapshot));
     }
@@ -707,5 +741,33 @@ mod tests {
 
         let ro_db = ReadOnlyRocksDB::new(dir.path()).inspect_err(|e| println!("{e:#?}"));
         assert!(matches!(ro_db, Ok(..)));
+    }
+
+    #[test]
+    fn split_all_continuous() {
+        let input = vec![1, 2, 3, 4, 5];
+        let expected = vec![vec![1, 2, 3, 4, 5]];
+        assert_eq!(split_continuous(input), expected);
+    }
+
+    #[test]
+    fn split_mixed_groups() {
+        let input = vec![1, 2, 3, 5, 6, 10];
+        let expected = vec![vec![1, 2, 3], vec![5, 6], vec![10]];
+        assert_eq!(split_continuous(input), expected);
+    }
+
+    #[test]
+    fn pp_all_continuous() {
+        let input = vec![vec![1, 2, 3]];
+        let expected = "[1-3]".to_string();
+        assert_eq!(pretty_print_snapshot_ranges(&input), expected);
+    }
+
+    #[test]
+    fn pp_mixed_groups() {
+        let input = vec![vec![1, 2, 3], vec![5], vec![7, 8]];
+        let expected = "[1-3],5,[7-8]".to_string();
+        assert_eq!(pretty_print_snapshot_ranges(&input), expected);
     }
 }

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -621,10 +621,10 @@ fn pretty_print_snapshot_ranges(ranges: &[Vec<u64>]) -> String {
     ranges
         .iter()
         .map(|g| match g.len() {
-            0 => String::new(),
-            1 => g[0].to_string(),
+            0 => "[]".to_string(),
+            1 => format!("[{}]", g[0]),
             #[allow(clippy::unwrap_used)] // Infallible error.
-            _ => format!("[{}-{}]", g.first().unwrap(), g.last().unwrap()),
+            _ => format!("[{}..{}]", g.first().unwrap(), g.last().unwrap()),
         })
         .collect::<Vec<_>>()
         .join(",")

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -634,7 +634,7 @@ fn assert_sufficient_snapshots(dir: &Path) -> Result<(), StoreError> {
     let snapshots = RocksDB::snapshots(dir)?;
     let snapshots_ranges = split_continuous(snapshots.iter().map(|e| u64::from(*e)).collect());
     info!(target: EVENT_TARGET, snapshots = pretty_print_snapshot_ranges(&snapshots_ranges), "new.known_snapshots");
-    if snapshots.is_empty() {
+    if snapshots_ranges.len() != 1 && snapshots_ranges[0].len() < 2 {
         return Err(StoreError::Open(OpenErrorKind::NoStableSnapshot));
     }
     Ok(())


### PR DESCRIPTION
Replace 

`2025-07-14T10:47:44.518912Z  INFO amaru::ledger::store: new.known_snapshots snapshots="[163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199,200,201,202,203,204]"`

with

`2025-07-14T10:53:27.296015Z  INFO amaru::ledger::store: new.known_snapshots snapshots="[163..221]"`

If non-continuous ranges are detected, will display `[163..211],[213],[215..221]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved logging of snapshot epochs by displaying them as continuous ranges for better readability.
  * Updated error messages to require at least two stable ledger snapshots for validation.

* **Bug Fixes**
  * Strengthened validation to ensure sufficient snapshots are present, providing clearer error messages when none are found.

* **Tests**
  * Added unit tests to verify accurate grouping and formatting of snapshot epochs in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->