### PR TITLE
add owners and relays to pool params generator

### DIFF
--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -73,8 +73,8 @@ pub use pallas_primitives::{
         TransactionOutput, Tx, UnitInterval, VKeyWitness, Value, Voter, VotingProcedure,
         VotingProcedures, VrfKeyhash, WitnessSet,
     },
-    AssetName, BigInt, Constr, DatumHash, MaybeIndefArray, PlutusData, PlutusScript, PolicyId,
-    PositiveCoin,
+    AssetName, BigInt, Constr, DatumHash, DnsName, IPv4, IPv6, MaybeIndefArray, PlutusData,
+    PlutusScript, PolicyId, Port, PositiveCoin,
 };
 pub use pallas_traverse::{ComputeHash, OriginalHash};
 pub use serde_json as json;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Made IPv4, IPv6, DnsName, and Port types available for use in the library.

* **Tests**
  * Enhanced test coverage for pool parameters by generating more realistic ownership and relay data, including various relay types and network address fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->