### PR TITLE
Support arm

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,3 +10,6 @@ deny-amaru = "deny check licenses --config .cargo/deny.toml"
 
 [env]
 CLIPPY_CONF_DIR = ".cargo"
+
+[target.arm-unknown-linux-gnueabi]
+rustflags = ["-C", "link-arg=-latomic"]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,6 +78,11 @@ jobs:
             command: test
             cross-compile: true
 
+          - runner: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
+            command: test
+            cross-compile: true
+
     timeout-minutes: 30
     runs-on: ${{ matrix.environments.runner }}
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,6 +73,11 @@ jobs:
             setup: rustup target add aarch64-unknown-linux-musl
             cross-compile: true
 
+          - runner: ubuntu-latest
+            target: arm-unknown-linux-gnueabi #armv6 architecture
+            command: test
+            cross-compile: true
+
     timeout-minutes: 30
     runs-on: ${{ matrix.environments.runner }}
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run clippy
         run: cargo clippy-amaru
   build:
-    name: Build on ${{ matrix.environments.runner }} with target ${{ matrix.environments.target }}
+    name: Build for ${{ matrix.environments.target }} on ${{ matrix.environments.runner }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This P.R. adapts the C.I. to build and run tests on armv6 and armv7 architecture so that we ensure we support both of them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added cross-compilation testing for ARM architectures in the CI workflow.
  * Updated build job naming for improved clarity in CI.
  * Enhanced target-specific configuration for ARM builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->