### PR TITLE
feat: first stab at experimenting with profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "tracy-client",
 ]
 
 [[package]]
@@ -1082,6 +1083,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1699,19 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "lru-slab"
@@ -2705,6 +2733,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,6 +3356,27 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tracy-client"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d90a2c01305b02b76fdd89ac8608bae27e173c829a35f7d76a345ab5d33836db"
+dependencies = [
+ "loom",
+ "once_cell",
+ "tracy-client-sys",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
+dependencies = [
+ "cc",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ tracing-subscriber = { version = "0.3.18", features = [
     "std",
     "json",
 ] }
+tracy-client = "=0.18.0" # Works with tracy 0.11.1, latest published on brew
 typetag = "0.2.20"
 
 amaru-consensus = { path = "crates/amaru-consensus" }

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ bootstrap: clear-dbs ## Bootstrap the node from scratch
 		--network $(NETWORK)
 
 dev: ## Compile and run for development with default options
-	cargo run --profile $(BUILD_PROFILE) -- daemon \
+	cargo run --profile $(BUILD_PROFILE) $(EXTRA_CARGO_FLAGS) -- --with-open-telemetry daemon \
 		--ledger-dir $(LEDGER_DIR) \
 		--chain-dir $(CHAIN_DIR) \
 		--peer-address $(AMARU_PEER_ADDRESS) \

--- a/PROFILING.md
+++ b/PROFILING.md
@@ -1,0 +1,10 @@
+
+Install tracy
+
+```shell
+brew install tracy
+```
+
+```shell
+BUILD_PROFILE=dev-debug make dev
+```

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -42,6 +42,7 @@ tracing-subscriber.workspace = true
 tracing.workspace = true
 anyhow.workspace = true
 progress-bar = { workspace = true, features = ["terminal"] }
+tracy-client = { workspace = true, optional = true }
 
 amaru-consensus.workspace = true
 amaru-kernel.workspace = true
@@ -61,3 +62,7 @@ once_cell.workspace = true
 [build-dependencies]
 built = { workspace = true, features = ["git2"] }
 amaru-kernel.workspace = true
+
+[features]
+default = []
+tracy = ["tracy-client"]

--- a/crates/amaru/src/bin/amaru/main.rs
+++ b/crates/amaru/src/bin/amaru/main.rs
@@ -21,6 +21,9 @@ mod metrics;
 mod observability;
 mod panic;
 
+#[cfg(feature = "tracy")]
+use tracy_client::{span, Client};
+
 #[derive(Debug, Subcommand)]
 enum Command {
     /// Bootstrap the node with needed data.
@@ -85,6 +88,11 @@ const DEFAULT_OTLP_METRIC_URL: &str = "http://localhost:4318/v1/metrics";
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     panic_handler();
+
+    #[cfg(feature = "tracy")]
+    Client::start();
+    #[cfg(feature = "tracy")]
+    let _span = span!("Main");
 
     let args = Cli::parse();
 

--- a/crates/amaru/src/stages/ledger.rs
+++ b/crates/amaru/src/stages/ledger.rs
@@ -20,6 +20,9 @@ use gasket::framework::{WorkSchedule, WorkerError};
 use std::sync::{Arc, RwLock};
 use tracing::{error, info, instrument, trace, Level, Span};
 
+#[cfg(feature = "tracy")]
+use tracy_client::span;
+
 pub type UpstreamPort = gasket::messaging::InputPort<ValidateBlockEvent>;
 pub type DownstreamPort = gasket::messaging::OutputPort<BlockValidationResult>;
 
@@ -202,6 +205,9 @@ impl<S: Store + Send, HS: HistoricalStores + Send>
         unit: &ValidateBlockEvent,
         stage: &mut ValidateBlockStage<S, HS>,
     ) -> Result<(), WorkerError> {
+        #[cfg(feature = "tracy")]
+        let _span = span!("Block");
+
         adopt_current_span(unit);
         let result = match unit {
             ValidateBlockEvent::Validated { point, block, span } => {


### PR DESCRIPTION
Experiment with profiling.

# Samply

Investigate [samply](https://github.com/mstange/samply)

# Tracy

First stab at experimenting [tracy](https://github.com/wolfpld/tracy) using [rust_tracy_client](https://github.com/nagisa/rust_tracy_client). On OSX only shows global CPU usage and Tracy spans eventually added.

# Others

* https://rumcajs.dev/posts/memory-analysis-in-rust/

Run `BUILD_PROFILE=dev-debug make dev` and then connect using [tracy](https://github.com/wolfpld/tracy).

Check if [tracing_tracy]( https://docs.rs/tracing-tracy/latest/tracing_tracy/) is useful. See https://github.com/zorp-corp/nockchain/pull/45

With Rust memory isn't monitored by default. Is there an alternative?

## Stack sampling

Stack sampling doesn't work on OSX. On Linux you need the following:

```shell
echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
echo 1 | sudo tee /proc/sys/kernel/yama/perf_event_paranoid
```