### PR TITLE
chore: make sure cross compiles aarch64 on osx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,3 +148,11 @@ debug = true
 [profile.release]
 lto = true
 codegen-units = 1
+
+[workspace.metadata.cross.target.aarch64-unknown-linux-musl]
+pre-build = [
+    "apt update",
+    "apt install -y libclang-dev"
+]
+[workspace.metadata.cross.target.aarch64-unknown-linux-musl.env]
+passthrough = ["LIBCLANG_PATH=/usr/lib/llvm-10/lib"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for the aarch64-unknown-linux-musl target to improve environment setup during cross-compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->