### PR TITLE
Rewrote the encoding for MemoizedTransactionOutput

### DIFF
--- a/crates/amaru-kernel/src/memoized/transaction_output.rs
+++ b/crates/amaru-kernel/src/memoized/transaction_output.rs
@@ -365,13 +365,11 @@ mod tests {
             script: None,
         };
 
-        // Encode
         let mut encoder = cbor::Encoder::new(Vec::new());
         let mut ctx = ();
         original.encode(&mut encoder, &mut ctx).unwrap();
         let encoded_bytes = encoder.writer().clone();
 
-        // Decode
         let mut decoder = cbor::Decoder::new(&encoded_bytes);
         let decoded: MemoizedTransactionOutput = decoder.decode_with(&mut ctx).unwrap();
 
@@ -396,13 +394,11 @@ mod tests {
             script: None,
         };
 
-        // Encode
         let mut encoder = cbor::Encoder::new(Vec::new());
         let mut ctx = ();
         original.encode(&mut encoder, &mut ctx).unwrap();
         let encoded_bytes = encoder.writer().clone();
 
-        // Decode
         let mut decoder = cbor::Decoder::new(&encoded_bytes);
         let decoded: MemoizedTransactionOutput = decoder.decode_with(&mut ctx).unwrap();
 

--- a/crates/amaru-kernel/src/memoized/transaction_output.rs
+++ b/crates/amaru-kernel/src/memoized/transaction_output.rs
@@ -80,11 +80,8 @@ impl<'b, C> cbor::Decode<'b, C> for MemoizedTransactionOutput {
                             }
                             1 => {
                                 d.tag()?;
-                                // Not sure why, but there is 1 extra byte when decoding
-                                // the PlutusData if this is not moved ahead one position
-                                // TODO: Determine why this is necessary
-                                d.set_position(d.position() + 1);
-                                let plutus_data: KeepRaw<'_, PlutusData> = d.decode_with(ctx)?;
+                                let plutus_data: KeepRaw<'_, PlutusData> =
+                                    cbor::decode(d.bytes()?)?;
                                 let memoized_data = MemoizedPlutusData::from(plutus_data);
                                 datum = MemoizedDatum::Inline(memoized_data);
                             }
@@ -367,7 +364,7 @@ mod tests {
             )
             .unwrap(),
             value: Value::Coin(1500000),
-            datum: datum,
+            datum,
             script: None,
         };
 
@@ -396,7 +393,7 @@ mod tests {
             )
             .unwrap(),
             value: Value::Coin(1500000),
-            datum: datum,
+            datum,
             script: None,
         };
 

--- a/crates/amaru-kernel/src/memoized/transaction_output.rs
+++ b/crates/amaru-kernel/src/memoized/transaction_output.rs
@@ -20,7 +20,6 @@ use crate::{
     PseudoScript, ScriptHash, Value,
 };
 
-use pallas_codec::minicbor::data::IanaTag;
 use pallas_primitives::{conway::NativeScript, KeepRaw, PlutusData};
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq)]
@@ -90,9 +89,9 @@ impl<'b, C> cbor::Decode<'b, C> for MemoizedTransactionOutput {
                                         datum = MemoizedDatum::Inline(memoized_data);
                                     }
                                     _ => {
-                                        return Err(cbor::decode::Error::message(format!(
-                                            "unknown tag for datum tag"
-                                        )));
+                                        return Err(cbor::decode::Error::message(
+                                            "unknown tag for datum tag",
+                                        ));
                                     }
                                 };
                             }
@@ -142,14 +141,14 @@ impl<'b, C> cbor::Decode<'b, C> for MemoizedTransactionOutput {
                                 };
                             }
                             _ => {
-                                return Err(cbor::decode::Error::message(format!(
-                                    "unknown tag for script tag"
-                                )));
+                                return Err(cbor::decode::Error::message(
+                                    "unknown tag for script tag",
+                                ));
                             }
                         }
                     }
                     _ => {
-                        return Err(cbor::decode::Error::message(format!("unknown key option")));
+                        return Err(cbor::decode::Error::message("unknown key option"));
                     }
                 }
             }

--- a/crates/amaru-kernel/src/memoized/transaction_output.rs
+++ b/crates/amaru-kernel/src/memoized/transaction_output.rs
@@ -348,33 +348,6 @@ mod tests {
     use pallas_crypto::hash::Hash;
 
     #[test]
-    fn test_encode_decode_legacy_output() {
-        let original = MemoizedTransactionOutput {
-            is_legacy: true,
-            address: Address::from_hex(
-                "61bbe56449ba4ee08c471d69978e01db384d31e29133af4546e6057335",
-            )
-            .unwrap(),
-            value: Value::Coin(1000000),
-            datum: MemoizedDatum::None,
-            script: None,
-        };
-
-        // Encode
-        let mut encoder = cbor::Encoder::new(Vec::new());
-        let mut ctx = ();
-        original.encode(&mut encoder, &mut ctx).unwrap();
-        let encoded_bytes = encoder.writer().clone();
-
-        // Decode
-        let mut decoder = cbor::Decoder::new(&encoded_bytes);
-        let decoded: MemoizedTransactionOutput = decoder.decode_with(&mut ctx).unwrap();
-
-        assert_eq!(original, decoded);
-        assert!(decoded.is_legacy);
-    }
-
-    #[test]
     fn test_encode_decode_output_with_datum_hash() {
         let hash_bytes = [1u8; 32];
         let datum_hash = Hash::<32>::from(hash_bytes);


### PR DESCRIPTION
This PR rewrites the encoding for MemoizedTransactionOutput to avoid encoding to MintedTransactionOutput and uses the original bytes to decode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction output decoding to support both current and legacy formats, improving compatibility and reliability.

* **Tests**
  * Added tests to verify encoding and decoding of transaction outputs with datum hashes in legacy and current formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->