### PR TITLE
feat: adding custom testnet support

### DIFF
--- a/crates/amaru-kernel/src/network.rs
+++ b/crates/amaru-kernel/src/network.rs
@@ -306,6 +306,7 @@ impl From<NetworkName> for &EraHistory {
             NetworkName::Mainnet => todo!(),
             NetworkName::Preprod => &PREPROD_ERA_HISTORY,
             NetworkName::Preview => &PREVIEW_ERA_HISTORY,
+            // TODO: retrieve from DB
             NetworkName::Testnet(_) => &TESTNET_ERA_HISTORY,
         }
     }
@@ -385,6 +386,7 @@ impl From<NetworkName> for &GlobalParameters {
             NetworkName::Mainnet => todo!(),
             NetworkName::Preprod => &PREPROD_GLOBAL_PARAMETERS,
             NetworkName::Preview => &PREVIEW_GLOBAL_PARAMETERS,
+            // TODO: retrieve from DB
             NetworkName::Testnet(_) => &TESTNET_GLOBAL_PARAMETERS,
         }
     }

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -193,6 +193,7 @@ pub fn import_initial_snapshot(
     // Previous Protocol Params
     d.skip()?;
     // Future Protocol Params
+    // TODO if last snapshot, should be stored in live DB
     d.skip()?;
     // DRep Pulsing State
     d.skip()?;

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -114,19 +114,21 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
         era_history: EraHistory,
         global_parameters: GlobalParameters,
     ) -> Result<Self, StoreError> {
-        let stake_distributions =
-            initial_stake_distributions(&stable, &snapshots, &era_history, PROTOCOL_VERSION_9)?; // FIXME ProtocolVersion should be retrieved from the store
+        // TODO should consider for Epoch 0 and 1. For those 2 Epochs there is no staking rewards not distribution
+        //let stake_distributions =
+        //    initial_stake_distributions(&stable, &snapshots, &era_history, PROTOCOL_VERSION_9)?; // FIXME ProtocolVersion should be retrieved from the store
 
-        let protocol_parameters =
-            stable.get_protocol_parameters_for(&snapshots.most_recent_snapshot())?;
+        // TODO Should be retrieved from live DB
+        //let protocol_parameters =
+        //    stable.get_protocol_parameters_for(&snapshots.most_recent_snapshot())?;
 
         Ok(Self::new_with(
             stable,
             snapshots,
             era_history,
             global_parameters,
-            protocol_parameters,
-            stake_distributions,
+            ProtocolParameters::default(),
+            VecDeque::new(),
         ))
     }
 


### PR DESCRIPTION
This PR skeleton seeks to allow for custom testned definition. For now it merely details some potential ways to achieve this.

Amaru currently supports `preprod`, `preview` and `mainnet` network to various degrees. Adding custom network is currently undoable for a number of reasons:

* some necessary network specifics are hardcoded
* some data must be present at boot time
* some boot time computations depend on some asumptions

# Hardcoded

Some bits of logic is hardcoded for well-known networks:

* GlobalParameters
* EraHistory

For other networks it should be retrieved from the DB. Note that `GlobalParameters` can be updated through hard-forks, while `EraHistory` is append-only and new boundaries can also be appended through hard-forks. A dedicated DB might be introduced for that, as the current `ledger.db/*` DBs are per Epoch.

# Imported 

Some bits of data has to be imported (currently via the `bootstrap` command). `ProtocolParameters` can be modified through governance and can be changed on a per Epoch frequency.
It might make sense to leverage the `bootstrap` command for this, maybe supporting alternative data format. Note that `bootstrap` for now only loads past snapshots while here the `live` DB should be populated.

# First Epochs considerations

It is assumend that the 2 first Epoch (0 and 1) will not generate staking rewards. Those will only be generated starting Epoch 2.
