### PR TITLE
chore: add a make command to update the license header in source files

### DIFF
--- a/crates/amaru-kernel/src/macros.rs
+++ b/crates/amaru-kernel/src/macros.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /// Generate a roundtrip property to assert that Cbor encoder and decoder for a given type can
 /// safely be called in sequence and yield the original input.
 ///

--- a/crates/amaru-kernel/src/protocol_parameters.rs
+++ b/crates/amaru-kernel/src/protocol_parameters.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::{cbor, Coin, EpochInterval, ExUnits, Lovelace, RationalNumber};
 use pallas_codec::minicbor::{data::Tag, Decoder};
 use pallas_primitives::{conway::CostModels, CostModel};

--- a/crates/amaru-ledger/src/context/default/mod.rs
+++ b/crates/amaru-ledger/src/context/default/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod preparation;
 mod validation;
 

--- a/crates/amaru-ledger/src/rules/transaction/mint.rs
+++ b/crates/amaru-ledger/src/rules/transaction/mint.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::context::{UtxoSlice, WitnessSlice};
 use amaru_kernel::{MemoizedDatum, Multiasset, NonZeroInt, RequiredScript, ScriptPurpose};
 

--- a/crates/amaru-mempool/src/strategies/mod.rs
+++ b/crates/amaru-mempool/src/strategies/mod.rs
@@ -1,2 +1,16 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod dummy;
 pub use dummy::*;

--- a/crates/amaru-stores/src/in_memory/ledger/columns/accounts.rs
+++ b/crates/amaru-stores/src/in_memory/ledger/columns/accounts.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::in_memory::MemoryStore;
 use amaru_kernel::StakeCredential;
 use amaru_ledger::store::{

--- a/crates/amaru-stores/src/in_memory/ledger/columns/cc_members.rs
+++ b/crates/amaru-stores/src/in_memory/ledger/columns/cc_members.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::in_memory::MemoryStore;
 use amaru_ledger::store::{
     columns::cc_members::{Key, Value},

--- a/crates/amaru-stores/src/in_memory/ledger/columns/dreps.rs
+++ b/crates/amaru-stores/src/in_memory/ledger/columns/dreps.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::in_memory::MemoryStore;
 use amaru_kernel::{CertificatePointer, Point, StakeCredential};
 use amaru_ledger::store::{

--- a/crates/amaru-stores/src/in_memory/ledger/columns/pools.rs
+++ b/crates/amaru-stores/src/in_memory/ledger/columns/pools.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::in_memory::MemoryStore;
 use amaru_ledger::store::{
     columns::pools::{Key, Row, Value},

--- a/crates/amaru-stores/src/in_memory/ledger/columns/proposals.rs
+++ b/crates/amaru-stores/src/in_memory/ledger/columns/proposals.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::in_memory::MemoryStore;
 use amaru_kernel::ComparableProposalId;
 use amaru_ledger::store::{

--- a/crates/amaru-stores/src/in_memory/ledger/columns/utxo.rs
+++ b/crates/amaru-stores/src/in_memory/ledger/columns/utxo.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::in_memory::MemoryStore;
 use amaru_kernel::TransactionInput;
 use amaru_ledger::store::{

--- a/crates/amaru-stores/src/in_memory/ledger/mod.rs
+++ b/crates/amaru-stores/src/in_memory/ledger/mod.rs
@@ -1,1 +1,15 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub mod columns;

--- a/crates/amaru-stores/src/in_memory/mod.rs
+++ b/crates/amaru-stores/src/in_memory/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use amaru_kernel::{
     protocol_parameters::ProtocolParameters, ComparableProposalId, EraHistory, Lovelace, Point,
     PoolId, ProposalId, Slot, StakeCredential, TransactionInput,

--- a/crates/amaru/src/bin/amaru/cmd/import_headers.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_headers.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::cmd::connect_to_peer;
 use amaru::stages::{pull, PeerSession};
 use amaru_consensus::{consensus::store::ChainStore, peer::Peer, IsHeader};

--- a/crates/amaru/src/bin/amaru/observability.rs
+++ b/crates/amaru/src/bin/amaru/observability.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{metrics::SdkMeterProvider, trace::SdkTracerProvider};

--- a/crates/amaru/src/point.rs
+++ b/crates/amaru/src/point.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use amaru_kernel::Point;
 
 /// Convert an Amaru's point into a pallas_network's Point.

--- a/crates/amaru/src/stages/consensus/forward_chain/client_protocol.rs
+++ b/crates/amaru/src/stages/consensus/forward_chain/client_protocol.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::point::from_network_point;
 
 use super::{

--- a/crates/amaru/src/stages/consensus/forward_chain/client_state.rs
+++ b/crates/amaru/src/stages/consensus/forward_chain/client_state.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::{hash_point, ClientOp};
 use crate::stages::AsTip;
 use amaru_consensus::{consensus::store::ChainStore, IsHeader};

--- a/crates/amaru/src/stages/consensus/forward_chain/test_infra.rs
+++ b/crates/amaru/src/stages/consensus/forward_chain/test_infra.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use super::{ForwardChainStage, ForwardEvent, PrettyPoint};
 use crate::stages::PallasPoint;
 use acto::{AcTokio, AcTokioRuntime, ActoCell, ActoInput, ActoRuntime};

--- a/crates/amaru/src/stages/consensus/forward_chain/test_infra.rs
+++ b/crates/amaru/src/stages/consensus/forward_chain/test_infra.rs
@@ -1,4 +1,18 @@
 #![allow(dead_code)]
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 
 use super::{ForwardChainStage, ForwardEvent, PrettyPoint};
 use crate::stages::PallasPoint;

--- a/crates/amaru/src/stages/consensus/forward_chain/tests.rs
+++ b/crates/amaru/src/stages/consensus/forward_chain/tests.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::{
     client_state::find_headers_between,
     test_infra::{

--- a/crates/amaru/src/stages/ledger.rs
+++ b/crates/amaru/src/stages/ledger.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::{schedule, send, stages::common::adopt_current_span};
 use amaru_consensus::IsHeader;
 use amaru_kernel::{

--- a/crates/amaru/tests/iter/mod.rs
+++ b/crates/amaru/tests/iter/mod.rs
@@ -1,1 +1,15 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod borrow;

--- a/crates/amaru/tests/lib.rs
+++ b/crates/amaru/tests/lib.rs
@@ -1,2 +1,16 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod iter;
 // Do not add top level modules here, or tests will be run twice

--- a/crates/ouroboros-traits/src/lib.rs
+++ b/crates/ouroboros-traits/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub mod has_stake_distribution;
 pub use has_stake_distribution::*;
 

--- a/crates/ouroboros/src/praos/mod.rs
+++ b/crates/ouroboros/src/praos/mod.rs
@@ -1,2 +1,16 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub mod header;
 pub mod nonce;

--- a/crates/pure-stage/src/effect.rs
+++ b/crates/pure-stage/src/effect.rs
@@ -1,4 +1,18 @@
 #![allow(clippy::expect_used)]
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 
 use crate::{
     serde::{to_cbor, SendDataValue},

--- a/crates/pure-stage/src/effect.rs
+++ b/crates/pure-stage/src/effect.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use crate::{
     serde::{to_cbor, SendDataValue},
     simulation::{airlock_effect, EffectBox},

--- a/crates/pure-stage/src/lib.rs
+++ b/crates/pure-stage/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod effect;
 mod logging;
 mod output;

--- a/crates/pure-stage/src/logging.rs
+++ b/crates/pure-stage/src/logging.rs
@@ -1,1 +1,15 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod layer;

--- a/crates/pure-stage/src/logging/layer.rs
+++ b/crates/pure-stage/src/logging/layer.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! This module implements a tracing layer that serializes all events and spans into CBOR.
 //!
 //! ## Background

--- a/crates/pure-stage/src/output.rs
+++ b/crates/pure-stage/src/output.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::{types::MpscSender, ExternalEffect, ExternalEffectAPI, Name, SendData};
 use std::fmt;
 use tokio::sync::mpsc;

--- a/crates/pure-stage/src/receiver.rs
+++ b/crates/pure-stage/src/receiver.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use futures_util::Stream;
 use std::{
     pin::Pin,

--- a/crates/pure-stage/src/sender.rs
+++ b/crates/pure-stage/src/sender.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::BoxFuture;
 use std::{fmt, sync::Arc};
 

--- a/crates/pure-stage/src/serde.rs
+++ b/crates/pure-stage/src/serde.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 //! This module contains some serialization and deserialization code for the Pure Stage library.
 
 use cbor4ii::serde::to_writer;

--- a/crates/pure-stage/src/serde.rs
+++ b/crates/pure-stage/src/serde.rs
@@ -1,4 +1,18 @@
 #![allow(dead_code, clippy::borrowed_box)]
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 
 //! This module contains some serialization and deserialization code for the Pure Stage library.
 

--- a/crates/pure-stage/src/simulation.rs
+++ b/crates/pure-stage/src/simulation.rs
@@ -1,4 +1,18 @@
 #![allow(
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
     clippy::wildcard_enum_match_arm,
     clippy::unwrap_used,
     clippy::panic,

--- a/crates/pure-stage/src/simulation/blocked.rs
+++ b/crates/pure-stage/src/simulation/blocked.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::{Effect, Instant, Name};
 
 /// Classification of why [`SimulationRunning::run_until_blocked`](crate::simulation::SimulationRunning::run_until_blocked) has stopped.

--- a/crates/pure-stage/src/simulation/inputs.rs
+++ b/crates/pure-stage/src/simulation/inputs.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::{Name, SendData, Sender, StageRef};
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};

--- a/crates/pure-stage/src/simulation/replay.rs
+++ b/crates/pure-stage/src/simulation/replay.rs
@@ -1,4 +1,18 @@
 #![allow(clippy::disallowed_types)]
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 
 use crate::{
     serde::to_cbor,

--- a/crates/pure-stage/src/simulation/replay.rs
+++ b/crates/pure-stage/src/simulation/replay.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use crate::{
     serde::to_cbor,
     simulation::{

--- a/crates/pure-stage/src/simulation/resume.rs
+++ b/crates/pure-stage/src/simulation/resume.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::{
     effect::StageEffect,
     simulation::state::{StageData, StageState},

--- a/crates/pure-stage/src/simulation/running.rs
+++ b/crates/pure-stage/src/simulation/running.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::{
     inputs::Inputs, EffectBox, Instant, StageData, StageEffect, StageResponse, StageState,
 };

--- a/crates/pure-stage/src/simulation/state.rs
+++ b/crates/pure-stage/src/simulation/state.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use super::StageEffect;
 use crate::{BoxFuture, Name, SendData};
 use std::{collections::VecDeque, fmt};

--- a/crates/pure-stage/src/stage_ref.rs
+++ b/crates/pure-stage/src/stage_ref.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::{Name, Void};
 use std::{fmt, marker::PhantomData};
 

--- a/crates/pure-stage/src/stagegraph.rs
+++ b/crates/pure-stage/src/stagegraph.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::{
     types::MpscSender, Effects, Instant, Name, OutputEffect, Receiver, SendData, Sender,
     StageBuildRef, StageRef, Void,

--- a/crates/pure-stage/src/time.rs
+++ b/crates/pure-stage/src/time.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::{
     sync::{
         atomic::{AtomicU64, Ordering},

--- a/crates/pure-stage/src/tokio.rs
+++ b/crates/pure-stage/src/tokio.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! This module contains the Tokio-based [`StageGraph`] implementation, to be used in production.
 //!
 //! It is good practice to perform the stage contruction and wiring in a function that takes an

--- a/crates/pure-stage/src/trace_buffer.rs
+++ b/crates/pure-stage/src/trace_buffer.rs
@@ -1,4 +1,18 @@
 #![allow(clippy::borrowed_box)]
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 
 //! This module contains the [`TraceBuffer`] type, which is used to record the trace of a simulation.
 

--- a/crates/pure-stage/src/trace_buffer.rs
+++ b/crates/pure-stage/src/trace_buffer.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 //! This module contains the [`TraceBuffer`] type, which is used to record the trace of a simulation.
 
 use crate::{effect::StageResponse, serde::to_cbor, Effect, Instant, Name, SendData};

--- a/crates/pure-stage/src/types.rs
+++ b/crates/pure-stage/src/types.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::serde::{to_cbor, SendDataValue};
 use anyhow::Context;
 use cbor4ii::serde::from_slice;

--- a/crates/pure-stage/tests/simulation.rs
+++ b/crates/pure-stage/tests/simulation.rs
@@ -1,4 +1,18 @@
 #![allow(clippy::bool_assert_comparison)]
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 
 use pure_stage::{
     simulation::{OverrideResult, SimulationBuilder},

--- a/crates/pure-stage/tests/simulation.rs
+++ b/crates/pure-stage/tests/simulation.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use pure_stage::{
     simulation::{OverrideResult, SimulationBuilder},
     trace_buffer::TraceBuffer,

--- a/crates/pure-stage/tests/tokio.rs
+++ b/crates/pure-stage/tests/tokio.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use futures_util::StreamExt;
 use pure_stage::{tokio::TokioBuilder, StageGraph};
 use std::time::Duration;

--- a/crates/tracing-json/src/lib.rs
+++ b/crates/tracing-json/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use assert_json_diff::assert_json_eq;
 use serde_json as json;
 use std::sync::{Arc, RwLock};

--- a/examples/ledger-in-nodejs/src/lib.rs
+++ b/examples/ledger-in-nodejs/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use amaru_examples_shared::{forward_ledger, RAW_BLOCK_CONWAY_3};
 
 #[no_mangle]

--- a/examples/shared/src/lib.rs
+++ b/examples/shared/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use amaru_kernel::{
     cbor, from_cbor, network::NetworkName, protocol_parameters::GlobalParameters, to_cbor, Bytes,
     EraHistory, Hash, Hasher, MemoizedTransactionOutput, MintedBlock, Point,

--- a/examples/shared/src/main.rs
+++ b/examples/shared/src/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use amaru_examples_shared::{forward_ledger, RAW_BLOCK_CONWAY_3};
 
 fn main() {

--- a/simulation/amaru-sim/tests/simulation.rs
+++ b/simulation/amaru-sim/tests/simulation.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::env;
 
 use amaru_kernel::Hash;


### PR DESCRIPTION
I noticed that some source files had no license headers and I suspect that some others might not be up to date.

There are a few options for maintaining source file headers in the Rust ecosystem but not necessarily full-featured or well-maintained ([here](https://github.com/grtlr/cargo-license-template) is an example of an archived attempt), and I eventually chose [licensesnip](https://github.com/notken12/licensesnip).

I integrated `licensesnip` both as a `make` task: `make update-source-headers` (there's also `make check-source-headers`) and a commit hook.

_One caveat_: there's no way to leave an existing license header as it is with `licensesnip` if its year doesn't match with today's year. This is why I updated all existing headers even if some of them correspond to files that haven't been touched since 2024. Please tell me if you think that is an issue.

A follow-up question: do we really need license headers in every file? There is already a license file at the top of the project and the license is also mentioned in `Cargo.toml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Apache 2.0 license headers to all relevant source and test files across the project. No changes were made to code logic, functionality, or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->