### PR TITLE
Polish C.I. build name so it fits in output

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run clippy
         run: cargo clippy-amaru
   build:
-    name: Build on ${{ matrix.environments.runner }} with target ${{ matrix.environments.target }}
+    name: Build for ${{ matrix.environments.target }} on ${{ matrix.environments.runner }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   sanity:
-    name: Sanity
+    name: Lint & coding practices
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
@@ -35,29 +35,41 @@ jobs:
       - name: Run clippy
         run: cargo clippy-amaru
   build:
-    name: Build for ${{ matrix.environments.target }} on ${{ matrix.environments.runner }}
+    name: Build ${{ matrix.environments.title }}
     strategy:
       fail-fast: false
       matrix:
         environments:
           - runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            title: x86_64/linux
+
+          - runner: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            title: aarch64/linux
+            command: test # This is a cross specific command. Do not change
+            setup: rustup target add aarch64-unknown-linux-musl
+            cross-compile: true
 
           - runner: macos-latest
             target: aarch64-apple-darwin
+            title: aarch64/macos
 
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
+            title: x86_64/windows
             command: test-amaru --profile dev-debug
 
           - runner: ubuntu-latest
             target: wasm32-unknown-unknown
+            title: wasm32
             packages: -p amaru-consensus -p amaru-ledger -p amaru-ouroboros -p slot-arithmetic
             command: build
             setup: rustup target add wasm32-unknown-unknown
 
           - runner: ubuntu-latest
             target: riscv32im-risc0-zkvm-elf
+            title: riscv32
             packages: -p amaru-ledger -p slot-arithmetic
             extra-args: +nightly -Zbuild-std=std,panic_abort
             command: build
@@ -66,12 +78,6 @@ jobs:
               /home/runner/.risc0/bin/rzup install
               rustup toolchain add nightly-x86_64-unknown-linux-gnu
               rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
-
-          - runner: ubuntu-latest
-            target: aarch64-unknown-linux-musl
-            command: test # This is a cross specific command. Do not change
-            setup: rustup target add aarch64-unknown-linux-musl
-            cross-compile: true
 
     timeout-minutes: 30
     runs-on: ${{ matrix.environments.runner }}
@@ -132,7 +138,7 @@ jobs:
         shell: bash
 
   coverage:
-    name: Coverage
+    name: Test coverage
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     env:
@@ -158,7 +164,7 @@ jobs:
           files: lcov.info
 
   snapshots:
-    name: Snapshots
+    name: End-to-end snapshot tests
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     strategy:


### PR DESCRIPTION
GitHub C.I. will cut _long_ build names. So the build with name `Build on ubuntu-latest with target aarch64-unknown-linux-musl` will show in the interface as
`Build on ubuntu-latest with t`. This make it harder to read the C.I. as almost all the builds appear to have the exact same prefix.

By switching the target and the host in the name of the build, the name becomes
`Build for aarch64-unknown-linux-musl on ubuntu-latest`. The prefix is then different for every build.

Not perfect but easier to navigate in the GitHub C.I. interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the display name format of build jobs in the CI workflow for improved clarity.
  * Added support for a new build target to enhance platform coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->