### PR TITLE
feat: suggest hook to sign-off commit messages

### DIFF
--- a/scripts/hooks/prepare-commit-message
+++ b/scripts/hooks/prepare-commit-message
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Automatically adds 'Signed-off-by:' to the commit message
+# based on git configuration
+
+NAME=$(git config user.name)
+EMAIL=$(git config user.email)
+
+if [ -z "$NAME" ]; then
+    echo "empty git config user.name"
+    exit 1
+fi
+
+if [ -z "$EMAIL" ]; then
+    echo "empty git config user.email"
+    exit 1
+fi
+
+git interpret-trailers --if-exists doNothing --trailer \
+    "Signed-off-by: $NAME <$EMAIL>" \
+    --in-place "$1"


### PR DESCRIPTION
Perhaps it's just me, but I am using several computers and ensuring proper configuration of Amaru repository on each computer would be easier if I shared those hooks. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically appends a "Signed-off-by:" line to commit messages using your Git user name and email.
  * Provides an error message if your Git user name or email is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->