### PR TITLE
feat: nicer debug representation for Point

### DIFF
--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -132,8 +132,9 @@ pub mod serde_utils;
 #[cfg(any(test, feature = "test-utils"))]
 pub mod tests {
     pub use crate::{
-        anchor::tests::*, ballot::tests::*, certificate_pointer::tests::*, pool_params::tests::*,
-        proposal_id::tests::*, proposal_pointer::tests::*, transaction_pointer::tests::*,
+        anchor::tests::*, ballot::tests::*, certificate_pointer::tests::*, point::tests::*,
+        pool_params::tests::*, proposal_id::tests::*, proposal_pointer::tests::*,
+        transaction_pointer::tests::*,
     };
 }
 
@@ -145,6 +146,10 @@ pub const PROTOCOL_VERSION_9: ProtocolVersion = (9, 0);
 pub const PROTOCOL_VERSION_10: ProtocolVersion = (10, 0);
 
 pub const EMPTY_BLOCK: Vec<u8> = vec![];
+
+pub const HEADER_HASH_SIZE: usize = 32;
+
+pub const ORIGIN_HASH: Hash<HEADER_HASH_SIZE> = Hash::new([0; HEADER_HASH_SIZE]);
 
 // Re-exports & extra aliases
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
We use the same representation for Debug and Display as there's no sense in displaying an array of bytes in Debug mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced constants for header hash size and a default origin hash value.

* **Bug Fixes**
  * Improved debug output formatting for points to enhance readability.

* **Tests**
  * Expanded and restructured tests with property-based and parameterized tests for points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->