### PR TITLE
fix: make sure build.rs is called when NETWORK changes

### DIFF
--- a/crates/amaru/build.rs
+++ b/crates/amaru/build.rs
@@ -21,5 +21,6 @@ fn main() {
     // Set the NETWORK environment variable based on the value from the environment or default to "preprod"
     // This is necessary for the tests to run correctly, as they rely on the NETWORK variable to be set at build time
     let network = env::var("NETWORK").unwrap_or_else(|_| "preprod".into());
+    println!("cargo:rerun-if-env-changed=NETWORK");
     println!("cargo:rustc-env=NETWORK={}", network);
 }


### PR DESCRIPTION
`build.rs` execution is cached. Make sure it's being run again when `NETWORK` env variable changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved build reliability by re-running the build when the NETWORK environment variable changes, ensuring configuration updates are picked up without manual clean builds.
  - Default network remains unchanged; no impact on runtime behavior or public interfaces.
  - Enhances developer experience and CI consistency. End users see no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->