### PR TITLE
fix: do not filter out pure_stage traces

### DIFF
--- a/crates/amaru/src/bin/amaru/observability.rs
+++ b/crates/amaru/src/bin/amaru/observability.rs
@@ -290,7 +290,7 @@ fn default_filter(var: &str, default: &str) -> EnvFilter {
     // which is a not so nice side-effects of the tracing library.
     EnvFilter::builder()
         .parse(format!(
-            "none,gasket=error,{}",
+            "none,pure_stage=info,gasket=error,{}",
             env::var(var).ok().as_deref().unwrap_or(default)
         ))
         .unwrap_or_else(|e| panic!("invalid {var} filters: {e}"))


### PR DESCRIPTION
Make sure `pure_stage` traces are not filtered out. Fixes regression with `demo` script and e2e tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated default logging configuration to surface info-level messages for the Pure Stage component, improving out-of-the-box observability.
  - Users may notice more informative logs from this component during normal operation, aiding monitoring and troubleshooting.
  - Existing environment variable overrides for logging continue to work as before; no other behavior or control-flow changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->