### PR TITLE
pure-stage error handling

### DIFF
--- a/crates/amaru-consensus/src/lib.rs
+++ b/crates/amaru-consensus/src/lib.rs
@@ -28,7 +28,7 @@ pub mod consensus;
 
 pub type RawHeader = Vec<u8>;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum ConsensusError {
     #[error("cannot build a chain selector without a tip")]
     MissingTip,
@@ -63,7 +63,7 @@ pub enum ConsensusError {
     InvalidHeaderParent(Box<InvalidHeaderParentData>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InvalidHeaderParentData {
     peer: Peer,
     forwarded: Point,

--- a/crates/amaru/src/bin/amaru/cmd/daemon.rs
+++ b/crates/amaru/src/bin/amaru/cmd/daemon.rs
@@ -74,9 +74,9 @@ pub async fn run(
         clients.push((peer.clone(), Arc::new(Mutex::new(client))));
     }
 
-    let sync = bootstrap(config, clients)?;
-
     let exit = amaru::exit::hook_exit_token();
+
+    let sync = bootstrap(config, clients, exit.clone())?;
 
     run_pipeline(gasket::daemon::Daemon::new(sync), exit).await;
 

--- a/crates/amaru/src/bin/amaru/observability.rs
+++ b/crates/amaru/src/bin/amaru/observability.rs
@@ -284,7 +284,7 @@ fn teardown_open_telemetry(
 // -----------------------------------------------------------------------------
 // ENV FILTER
 // -----------------------------------------------------------------------------
-#[allow(clippy::panic)]
+#[allow(clippy::expect_used)]
 fn default_filter(var: &str, default: &str) -> EnvFilter {
     EnvFilter::try_from_env(var)
         .unwrap_or_else(|_| EnvFilter::from_str(default).expect("invalid default filter"))

--- a/crates/amaru/src/bin/amaru/panic.rs
+++ b/crates/amaru/src/bin/amaru/panic.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::process::exit;
+
 /// Installs a panic handler that prints some useful diagnostics and
 /// asks the user to report the issue.
 pub fn panic_handler() {
@@ -41,6 +43,9 @@ pub fn panic_handler() {
         };
         eprintln!("\n{}", indent(&error_message, 3));
         prev(info);
+        // Exit with a non-zero code to indicate that the process crashed
+        // otherwise it will just sit there and wait for ctrl-c without saying so.
+        exit(1);
     }));
 }
 

--- a/crates/amaru/src/bin/amaru/panic.rs
+++ b/crates/amaru/src/bin/amaru/panic.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::process::exit;
+use std::{io::Write, process::exit};
 
 /// Installs a panic handler that prints some useful diagnostics and
 /// asks the user to report the issue.
@@ -45,6 +45,7 @@ pub fn panic_handler() {
         prev(info);
         // Exit with a non-zero code to indicate that the process crashed
         // otherwise it will just sit there and wait for ctrl-c without saying so.
+        std::io::stderr().flush().ok();
         exit(1);
     }));
 }

--- a/crates/amaru/src/stages/pure_stage_util.rs
+++ b/crates/amaru/src/stages/pure_stage_util.rs
@@ -61,7 +61,7 @@ impl gasket::framework::Worker<PureStageSim> for Worker {
         // we cannot use pending(), though, because that prevents gasket from
         // shutting down the stage.
         select! {
-            _ = &mut stage.termination => {
+            _ = stage.termination.as_mut() => {
                 stage.exit.cancel();
                 Ok(WorkSchedule::Done)
             }

--- a/crates/ouroboros/src/praos/header.rs
+++ b/crates/ouroboros/src/praos/header.rs
@@ -57,6 +57,23 @@ pub enum AssertHeaderError {
     UnknownPool { pool: PoolId },
 }
 
+impl PartialEq for AssertHeaderError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::KnownLeaderVrf(l0), Self::KnownLeaderVrf(r0)) => l0 == r0,
+            (Self::VrfProof(l0), Self::VrfProof(r0)) => l0 == r0,
+            (Self::LeaderStake(l0), Self::LeaderStake(r0)) => l0 == r0,
+            (Self::KesSignature(l0), Self::KesSignature(r0)) => l0 == r0,
+            (Self::OperationalCertificate(l0), Self::OperationalCertificate(r0)) => l0 == r0,
+            (Self::TryFromSliceError(_), Self::TryFromSliceError(_)) => true,
+            (Self::UnknownPool { pool: l_pool }, Self::UnknownPool { pool: r_pool }) => {
+                l_pool == r_pool
+            }
+            _ => false,
+        }
+    }
+}
+
 pub type Assertion<'a> = Box<dyn Fn() -> Result<(), AssertHeaderError> + Send + Sync + 'a>;
 
 pub fn assert_all<'a>(
@@ -202,6 +219,37 @@ pub enum AssertVrfProofError {
         declared: Vec<u8>,
         computed: Vec<u8>,
     },
+}
+
+impl PartialEq for AssertVrfProofError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::MalformedProof(l0), Self::MalformedProof(r0)) => l0 == r0,
+            (Self::InvalidProof(l0), Self::InvalidProof(r0)) => l0 == r0,
+            (Self::TryFromSliceError(_), Self::TryFromSliceError(_)) => true,
+            (
+                Self::ProofMismatch {
+                    declared: l_declared,
+                    computed: l_computed,
+                },
+                Self::ProofMismatch {
+                    declared: r_declared,
+                    computed: r_computed,
+                },
+            ) => l_declared == r_declared && l_computed == r_computed,
+            (
+                Self::OutputMismatch {
+                    declared: l_declared,
+                    computed: l_computed,
+                },
+                Self::OutputMismatch {
+                    declared: r_declared,
+                    computed: r_computed,
+                },
+            ) => l_declared == r_declared && l_computed == r_computed,
+            _ => false,
+        }
+    }
 }
 
 impl AssertVrfProofError {

--- a/crates/pure-stage/src/effect.rs
+++ b/crates/pure-stage/src/effect.rs
@@ -429,7 +429,7 @@ impl StageEffect<Box<dyn SendData>> {
             ),
             StageEffect::Terminate => (
                 StageEffect::Terminate,
-                Effect::Failure { at_stage: at_name },
+                Effect::Terminate { at_stage: at_name },
             ),
         }
     }
@@ -467,7 +467,7 @@ pub enum Effect {
         #[serde(with = "crate::serde::serialize_external_effect")]
         effect: Box<dyn ExternalEffect>,
     },
-    Failure {
+    Terminate {
         at_stage: Name,
     },
 }
@@ -482,7 +482,7 @@ impl Effect {
             Effect::Wait { at_stage, .. } => at_stage,
             Effect::Respond { at_stage, .. } => at_stage,
             Effect::External { at_stage, .. } => at_stage,
-            Effect::Failure { at_stage, .. } => at_stage,
+            Effect::Terminate { at_stage, .. } => at_stage,
         }
     }
 
@@ -691,8 +691,8 @@ impl PartialEq for Effect {
                 }
                 _ => false,
             },
-            Effect::Failure { at_stage } => match other {
-                Effect::Failure {
+            Effect::Terminate { at_stage } => match other {
+                Effect::Terminate {
                     at_stage: other_at_stage,
                 } => at_stage == other_at_stage,
                 _ => false,

--- a/crates/pure-stage/src/effect.rs
+++ b/crates/pure-stage/src/effect.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use crate::{
-    serde::{to_cbor, SendDataValue},
+    serde::{never, to_cbor, SendDataValue},
     simulation::{airlock_effect, EffectBox},
     time::Clock,
     BoxFuture, CallId, CallRef, Instant, Name, Resources, SendData, Sender, StageRef,
@@ -91,7 +91,9 @@ impl<M: SendData, S> Effects<M, S> {
     pub fn self_sender(&self) -> Sender<M> {
         self.self_sender.clone()
     }
+}
 
+impl<M, S> Effects<M, S> {
     /// Send a message to the given stage, blocking the current stage until space has been
     /// made available in the target stage’s send queue.
     pub fn send<Msg: SendData, St>(
@@ -197,6 +199,26 @@ impl<M: SendData, S> Effects<M, S> {
                 _ => None,
             },
         )
+    }
+
+    /// Terminate this stage
+    ///
+    /// This will terminate this stage graph if done from a stage that was created before running the graph.
+    /// This future never resolves, so you can safely return the value to exit the transition function.
+    ///
+    /// Example:
+    ///
+    /// ```ignore
+    /// async |state, msg, eff| {
+    ///     if msg.is_fatal() {
+    ///         return eff.terminate().await;
+    ///     }
+    ///     // ...
+    ///     state
+    /// }
+    /// ```
+    pub fn terminate<T>(&self) -> BoxFuture<'static, T> {
+        airlock_effect(&self.effect, StageEffect::Terminate, |_eff| never())
     }
 }
 
@@ -342,6 +364,7 @@ pub(crate) enum StageEffect<T> {
     ),
     Respond(Name, CallId, Instant, oneshot::Sender<Box<dyn SendData>>, T),
     External(Box<dyn ExternalEffect>),
+    Terminate,
 }
 
 /// The response a stage receives from the execution of an effect.
@@ -404,6 +427,10 @@ impl StageEffect<Box<dyn SendData>> {
                     effect,
                 },
             ),
+            StageEffect::Terminate => (
+                StageEffect::Terminate,
+                Effect::Failure { at_stage: at_name },
+            ),
         }
     }
 }
@@ -442,8 +469,6 @@ pub enum Effect {
     },
     Failure {
         at_stage: Name,
-        #[serde(with = "crate::serde::serialize_error")]
-        error: anyhow::Error,
     },
 }
 
@@ -666,11 +691,10 @@ impl PartialEq for Effect {
                 }
                 _ => false,
             },
-            Effect::Failure { at_stage, error } => match other {
+            Effect::Failure { at_stage } => match other {
                 Effect::Failure {
                     at_stage: other_at_stage,
-                    error: other_error,
-                } => at_stage == other_at_stage && error.to_string() == other_error.to_string(),
+                } => at_stage == other_at_stage,
                 _ => false,
             },
         }

--- a/crates/pure-stage/src/lib.rs
+++ b/crates/pure-stage/src/lib.rs
@@ -36,7 +36,7 @@ pub use resources::Resources;
 pub use sender::Sender;
 pub use serde::Void;
 pub use stage_ref::{StageBuildRef, StageRef};
-pub use stagegraph::{CallId, CallRef, StageGraph};
+pub use stagegraph::{CallId, CallRef, StageGraph, StageGraphRunning};
 pub use time::{Clock, Instant, EPOCH};
 pub use types::{BoxFuture, Name, SendData};
 

--- a/crates/pure-stage/src/serde.rs
+++ b/crates/pure-stage/src/serde.rs
@@ -53,6 +53,11 @@ impl<T> std::fmt::Debug for NoDebug<T> {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Void {}
 
+#[allow(clippy::panic)]
+pub fn never() -> ! {
+    panic!("never")
+}
+
 /// `#[serde(with = "pure_stage::serde::serialize_error")]` for serializing [`anyhow::Error`].
 pub mod serialize_error {
     use super::*;

--- a/crates/pure-stage/src/serde.rs
+++ b/crates/pure-stage/src/serde.rs
@@ -53,9 +53,14 @@ impl<T> std::fmt::Debug for NoDebug<T> {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Void {}
 
+/// Diverging helper used in type contexts that expect `!`.
+/// Panics intentionally; for non-resolving futures, use `std::future::pending()`.
+#[cold]
+#[inline(never)]
+#[track_caller]
 #[allow(clippy::panic)]
 pub fn never() -> ! {
-    panic!("never")
+    panic!("unreachable: never")
 }
 
 /// `#[serde(with = "pure_stage::serde::serialize_error")]` for serializing [`anyhow::Error`].

--- a/crates/pure-stage/src/simulation.rs
+++ b/crates/pure-stage/src/simulation.rs
@@ -114,7 +114,7 @@ pub(crate) fn airlock_effect<Out>(
 /// let stage = network.stage("basic", async |(mut state, out), msg: u32, eff| {
 ///     state += msg;
 ///     eff.send(&out, state).await;
-///     Ok((state, out))
+///     (state, out)
 /// });
 /// let (output, mut rx) = network.output("output", 10);
 /// let stage = network.wire_up(stage, (1u32, output.without_state()));
@@ -215,7 +215,7 @@ impl super::StageGraph for SimulationBuilder {
     ) -> StageBuildRef<Msg, St, Self::RefAux<Msg, St>>
     where
         F: FnMut(St, Msg, Effects<Msg, St>) -> Fut + 'static + Send,
-        Fut: Future<Output = anyhow::Result<St>> + 'static + Send,
+        Fut: Future<Output = St> + 'static + Send,
         Msg: SendData + serde::de::DeserializeOwned,
         St: SendData,
     {
@@ -234,7 +234,7 @@ impl super::StageGraph for SimulationBuilder {
                     .cast_deserialize::<Msg>()
                     .expect("internal message type error");
                 let state = f(*state, msg, effects.clone());
-                Box::pin(async move { Ok(Box::new(state.await?) as Box<dyn SendData>) })
+                Box::pin(async move { Box::new(state.await) as Box<dyn SendData> })
             });
 
         if let Some(old) = self.stages.insert(

--- a/crates/pure-stage/src/simulation.rs
+++ b/crates/pure-stage/src/simulation.rs
@@ -36,7 +36,6 @@ use crate::{
 use either::Either;
 use parking_lot::Mutex;
 use std::{
-    any::Any,
     collections::{BTreeMap, VecDeque},
     future::{poll_fn, Future},
     marker::PhantomData,
@@ -229,7 +228,7 @@ impl super::StageGraph for SimulationBuilder {
         let effects = Effects::new(me, self.effect.clone(), self.clock.clone(), self_sender);
         let transition: Transition =
             Box::new(move |state: Box<dyn SendData>, msg: Box<dyn SendData>| {
-                let state = (state as Box<dyn Any>).downcast::<St>().unwrap();
+                let state = state.cast::<St>().expect("internal state type error");
                 let msg = msg
                     .cast_deserialize::<Msg>()
                     .expect("internal message type error");

--- a/crates/pure-stage/src/simulation/state.rs
+++ b/crates/pure-stage/src/simulation/state.rs
@@ -31,11 +31,7 @@ impl std::fmt::Debug for InitStageState {
 }
 
 pub type Transition = Box<
-    dyn FnMut(
-            Box<dyn SendData>,
-            Box<dyn SendData>,
-        ) -> BoxFuture<'static, anyhow::Result<Box<dyn SendData>>>
-        + Send,
+    dyn FnMut(Box<dyn SendData>, Box<dyn SendData>) -> BoxFuture<'static, Box<dyn SendData>> + Send,
 >;
 
 pub struct InitStageData {
@@ -46,7 +42,7 @@ pub struct InitStageData {
 
 pub enum StageState {
     Idle(Box<dyn SendData>),
-    Running(BoxFuture<'static, anyhow::Result<Box<dyn SendData>>>),
+    Running(BoxFuture<'static, Box<dyn SendData>>),
     Failed(String),
 }
 

--- a/crates/pure-stage/src/stagegraph.rs
+++ b/crates/pure-stage/src/stagegraph.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::{
-    types::MpscSender, Effects, Instant, Name, OutputEffect, Receiver, Resources, SendData, Sender,
-    StageBuildRef, StageRef, Void,
+    types::MpscSender, BoxFuture, Effects, Instant, Name, OutputEffect, Receiver, Resources,
+    SendData, Sender, StageBuildRef, StageRef, Void,
 };
 use std::{
     fmt::Debug,
@@ -131,7 +131,7 @@ impl<Resp: SendData> CallRef<Resp> {
 /// let mut running = network.run(rt.handle().clone());
 /// ```
 pub trait StageGraph {
-    type Running;
+    type Running: StageGraphRunning;
     type RefAux<Msg, State>;
 
     /// Create a stage from an asynchronous transition function (state × message → state) and
@@ -219,4 +219,9 @@ pub trait StageGraph {
     ///
     /// It is prudent to populate this collection before running the network.
     fn resources(&self) -> &Resources;
+}
+
+pub trait StageGraphRunning {
+    fn is_terminated(&self) -> bool;
+    fn termination(&self) -> BoxFuture<'static, ()>;
 }

--- a/crates/pure-stage/src/stagegraph.rs
+++ b/crates/pure-stage/src/stagegraph.rs
@@ -221,7 +221,13 @@ pub trait StageGraph {
     fn resources(&self) -> &Resources;
 }
 
+/// A trait for running stage graphs.
+///
+/// This trait is implemented by the return value of the [`StageGraph::run`] method.
 pub trait StageGraphRunning {
+    /// Returns true if the stage graph has observed a termination signal.
     fn is_terminated(&self) -> bool;
+
+    /// A future that resolves once the stage graph has terminated.
     fn termination(&self) -> BoxFuture<'static, ()>;
 }

--- a/crates/pure-stage/src/stagegraph.rs
+++ b/crates/pure-stage/src/stagegraph.rs
@@ -114,7 +114,7 @@ impl<Resp: SendData> CallRef<Resp> {
 /// let stage = network.stage("basic", async |(mut state, out), msg: u32, eff| {
 ///     state += msg;
 ///     eff.send(&out, state).await;
-///     Ok((state, out))
+///     (state, out)
 /// });
 /// // this is a feature of the SimulationBuilder
 /// let (output, mut rx) = network.output("output", 10);
@@ -164,7 +164,7 @@ pub trait StageGraph {
     ) -> StageBuildRef<Msg, St, Self::RefAux<Msg, St>>
     where
         F: FnMut(St, Msg, Effects<Msg, St>) -> Fut + 'static + Send,
-        Fut: Future<Output = anyhow::Result<St>> + 'static + Send,
+        Fut: Future<Output = St> + 'static + Send,
         Msg: SendData + serde::de::DeserializeOwned,
         St: SendData;
 
@@ -208,7 +208,7 @@ pub trait StageGraph {
         let output = self.stage(name, async |tx: MpscSender<Msg>, msg: Msg, eff| {
             eff.external(OutputEffect::new(eff.me().name(), msg, tx.clone()))
                 .await;
-            Ok(tx)
+            tx
         });
         let output = self.wire_up(output, tx);
 

--- a/crates/pure-stage/src/tokio.rs
+++ b/crates/pure-stage/src/tokio.rs
@@ -208,8 +208,7 @@ impl StageGraph for TokioBuilder {
         let handles2 = handles.clone();
         rt.spawn(async move {
             termination2.wait_for(|x| *x).await.ok();
-            let handles = std::mem::take(&mut *handles2.lock());
-            for handle in handles {
+            for handle in handles2.lock().iter() {
                 handle.abort();
             }
         });

--- a/crates/pure-stage/tests/tokio.rs
+++ b/crates/pure-stage/tests/tokio.rs
@@ -30,7 +30,7 @@ fn basic() {
     let mut graph = TokioBuilder::default();
     let double = graph.stage("double", async |to, msg: u32, eff| {
         eff.send(&to, msg * 2).await;
-        Ok(to)
+        to
     });
     let (out_ref, mut out_rx) = graph.output("output", 10);
     let double = graph.wire_up(double, out_ref);

--- a/simulation/amaru-sim/src/simulator/simulate.rs
+++ b/simulation/amaru-sim/src/simulator/simulate.rs
@@ -470,7 +470,7 @@ mod tests {
                         };
                         // println!(" ==> {:?}", reply);
                         eff.send(&state.1, reply).await;
-                        Ok(state)
+                        state
                     } else {
                         panic!("Got a message that wasn't an echo: {:?}", msg.body)
                     }


### PR DESCRIPTION
This PR improves several small things:

- pure_stage no longer handles errors from stages, only termination (which is an explicit effect)
- as soon as one stage terminates, the whole graph terminates
- graph termination can be observed/awaited from the outside
- the gasket adapter now uses this termination signal to trigger the exit hook CancellationToken (without that Amaru wouldn’t terminate in case of a header validation failure, just sit there and do nothing)
- any panic in Amaru will now actually terminate the process by calling `exit(1)` (previously it just sat there doing nothing)
- AMARU_LOG is no longer embezzled with a leading `none,gasket=error,` because that doesn’t really do much in my experiments
- default logging has been changed to `warn,amaru=debug`, which yields the same terminal output as before (in my testing) but allows external overrides with less surprises

Concerning the business logic, the `validate_header` stage now no longer handles validation errors by failing, instead it sends those errors to a new `errors_stage` that will tear down the system after logging the error. Eventually, this stage will instruct the upstream network handling to drop the peer.

This PR still has some compilation errors and clippy remarks to resolve and it needs to be rebased, hence the draft status. Please do start the review already because the actual changes are there (and you’ll probably have comments).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Graceful shutdown: stages and runtime expose termination signals; bootstrap accepts a cancellation token for clean exits.
  - Validation pipeline: improved header validation that logs invalid headers and emits upstream actions (kick/ban/log).

- Refactor
  - Stage and call APIs simplified to return plain values (no Result); termination flows replaced error-paths.

- Tests
  - Updated tests for new return semantics and termination-aware call patterns.

- Chores
  - Added equality derives and small public API exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->