### PR TITLE
Temporarily reduce chain selection header tree's size.

### DIFF
--- a/crates/amaru/src/stages/mod.rs
+++ b/crates/amaru/src/stages/mod.rs
@@ -379,10 +379,19 @@ fn make_ledger(
 fn make_chain_selector(
     header: &Option<Header>,
     peers: &Vec<PeerSession>,
-    consensus_security_parameter: usize,
+    _consensus_security_parameter: usize,
 ) -> Result<Arc<Mutex<HeadersTree<Header>>>, ConsensusError> {
     // TODO: initialize the headers tree from the ChainDB store
-    let mut tree = HeadersTree::new(consensus_security_parameter, header);
+    //
+    // FIXME: Use the actual *consensus_security_param*; for now, this is artifically disabled
+    // because the introduction of the new chain selection algorithm makes synchronizing unbearably
+    // slow. The culprit seems to be around the `header_exists` function, which gets worse with the
+    // capacity of the tree.
+    //
+    // In *practice* (and good network conditions), that tree can actually be pretty small.
+    // Although in reality and to be "immune" to deep forks, it must be set to `k` (a.k.a the
+    // consensus security param).
+    let mut tree = HeadersTree::new(100, header);
 
     let root_hash = match header {
         Some(h) => h.hash(),


### PR DESCRIPTION
The header trees's capacity was *rightfully* configured to be based on the `consensus_security_param`; Yet the introduction of the chain selection algorithm in #372 makes synchronizing unbearably slow (from ~5min to >30min). 

The culprit seems to be around the `header_exists` function, which gets worse with the capacity of the tree. The function in itself takes a significant time (initially fast, but rapidly growing and remaining around ~5ms on my machine, out of ~5ms for the entire `roll_forward` call), because it has to traverse all candidate headers in the tree. Hence, because the tree starts originally empty; the problem only manifests after it's been filled to its capacity and, when the capacity is large enough. 

In *practice* (and good network conditions), that capacity can actually be pretty small. Although in reality and to be "immune" to deep forks, it must be set to `k` (a.k.a the consensus security param). So, we discussed reverting the entire PR, I believe this change instead is _okay_ for the sake of getting the workflow back to where it was; while the algorithm is being reworked to needs less traversal here (in particular, I don't fully understand the choice of an `IndexTree` over a `BTreeMap` 🤔?).




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized chain selection by using a consistent internal threshold, improving synchronization reliability.

* **Refactor**
  * Simplified configuration by removing an unused tuning parameter to reduce ambiguity.

* **Documentation**
  * Added clarifying comments explaining the temporary configuration choice and its implications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->