### PR TITLE
Governance ratification tweaks & refactors

### DIFF
--- a/crates/amaru-ledger/src/governance/ratification.rs
+++ b/crates/amaru-ledger/src/governance/ratification.rs
@@ -574,7 +574,7 @@ pub mod tests {
     mod internal {
         use super::*;
         use amaru_kernel::tests::any_proposal_pointer;
-        use proptest::prelude::*;
+        use proptest::{prelude::*, test_runner::RngSeed};
 
         proptest! {
             #[test]
@@ -588,6 +588,7 @@ pub mod tests {
         }
 
         proptest! {
+            #![proptest_config(ProptestConfig { rng_seed: RngSeed::Fixed(42), ..ProptestConfig::default() })]
             #[test]
             #[should_panic]
             fn prop_proposal_pointer_sometimes_min_epoch(pointer in any_proposal_pointer(u64::MAX)) {
@@ -597,6 +598,7 @@ pub mod tests {
         }
 
         proptest! {
+            #![proptest_config(ProptestConfig { rng_seed: RngSeed::Fixed(42), ..ProptestConfig::default() })]
             #[test]
             #[should_panic]
             fn prop_proposal_pointer_sometimes_max_epoch(pointer in any_proposal_pointer(u64::MAX)) {

--- a/crates/amaru-ledger/src/governance/ratification/constitutional_committee.rs
+++ b/crates/amaru-ledger/src/governance/ratification/constitutional_committee.rs
@@ -204,7 +204,7 @@ mod tests {
         Epoch, Hash, StakeCredential, Vote, PROTOCOL_VERSION_10, PROTOCOL_VERSION_9,
     };
     use num::{One, Zero};
-    use proptest::{collection, prelude::*, sample};
+    use proptest::{collection, prelude::*, sample, test_runner::RngSeed};
     use std::{
         collections::{BTreeMap, BTreeSet},
         rc::Rc,
@@ -303,6 +303,7 @@ mod tests {
     }
 
     proptest! {
+        #![proptest_config(ProptestConfig { rng_seed: RngSeed::Fixed(42), ..ProptestConfig::default() })]
         #[test]
         #[should_panic]
         fn prop_tally_is_sometimes_greater_than_0((epoch, votes, committee) in any_tally()) {
@@ -377,6 +378,7 @@ mod tests {
     }
 
     proptest! {
+        #![proptest_config(ProptestConfig { rng_seed: RngSeed::Fixed(42), ..ProptestConfig::default() })]
         #[test]
         #[should_panic]
         fn prop_tally_sometimes_see_inactive_members((epoch, _, committee) in any_tally()) {

--- a/crates/amaru-ledger/src/governance/ratification/dreps.rs
+++ b/crates/amaru-ledger/src/governance/ratification/dreps.rs
@@ -240,7 +240,7 @@ mod tests {
         DRep, Epoch, Vote, PROTOCOL_VERSION_10, PROTOCOL_VERSION_9,
     };
     use num::{One, Zero};
-    use proptest::{collection, prelude::*, sample};
+    use proptest::{collection, prelude::*, sample, test_runner::RngSeed};
     use std::{collections::BTreeMap, rc::Rc};
 
     proptest! {
@@ -312,6 +312,7 @@ mod tests {
     }
 
     proptest! {
+        #![proptest_config(ProptestConfig { rng_seed: RngSeed::Fixed(42), ..ProptestConfig::default() })]
         #[test]
         #[should_panic]
         fn prop_generated_dreps_are_sometimes_expired((epoch, _, _, stake_distribution) in any_tally()) {

--- a/crates/amaru-ledger/src/governance/ratification/proposal_enum.rs
+++ b/crates/amaru-ledger/src/governance/ratification/proposal_enum.rs
@@ -196,7 +196,7 @@ impl fmt::Display for OrphanProposal {
             OrphanProposal::TreasuryWithdrawal(withdrawals) => {
                 let total = withdrawals
                     .iter()
-                    .fold(0, |total, (_, single)| total + single)
+                    .fold(0_u64, |total, (_, single)| total.saturating_add(*single))
                     / 1_000_000;
                 write!(f, "withdrawal={total}₳")
             }
@@ -266,8 +266,9 @@ pub mod tests {
     pub fn any_orphan_proposal() -> impl Strategy<Value = OrphanProposal> {
         let any_nice_poll = Just(OrphanProposal::NicePoll);
 
-        let any_treasury_withdrawal = collection::btree_map(any_stake_credential(), 1_u64.., 1..3)
-            .prop_map(OrphanProposal::TreasuryWithdrawal);
+        let any_treasury_withdrawal =
+            collection::btree_map(any_stake_credential(), 1..(u64::MAX / 3), 1..3)
+                .prop_map(OrphanProposal::TreasuryWithdrawal);
 
         prop_oneof![any_nice_poll, any_treasury_withdrawal]
     }

--- a/crates/amaru-ledger/src/governance/ratification/proposal_enum.rs
+++ b/crates/amaru-ledger/src/governance/ratification/proposal_enum.rs
@@ -124,6 +124,10 @@ impl ProposalEnum {
         matches!(self, Self::ConstitutionalCommittee(ChangeMembers { .. }, _))
     }
 
+    pub fn is_orphan(&self) -> bool {
+        matches!(self, Self::Orphan(..))
+    }
+
     pub fn is_nice_poll(&self) -> bool {
         matches!(self, Self::Orphan(OrphanProposal::NicePoll))
     }

--- a/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
+++ b/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
@@ -815,7 +815,7 @@ mod tests {
         ComparableProposalId, Epoch, GovAction, KeyValuePairs, Lovelace, Nullable, ProposalId,
         ProposalPointer, RationalNumber, Set,
     };
-    use proptest::{collection, prelude::*};
+    use proptest::{collection, prelude::*, test_runner::RngSeed};
     use std::{cmp::Ordering, collections::BTreeSet, rc::Rc, sync::LazyLock};
 
     const MAX_TREE_SIZE: usize = 8;
@@ -876,6 +876,7 @@ mod tests {
     }
 
     proptest! {
+        #![proptest_config(ProptestConfig { rng_seed: RngSeed::Fixed(14), ..ProptestConfig::default() })]
         #[test]
         #[should_panic]
         fn prop_compass_sometimes_yield_constitutional_committee(
@@ -889,6 +890,7 @@ mod tests {
     }
 
     proptest! {
+        #![proptest_config(ProptestConfig { rng_seed: RngSeed::Fixed(42), ..ProptestConfig::default() })]
         #[test]
         #[should_panic]
         fn prop_compass_sometimes_yield_treasury_withdrawals(
@@ -904,6 +906,7 @@ mod tests {
     }
 
     proptest! {
+        #![proptest_config(ProptestConfig { rng_seed: RngSeed::Fixed(42), ..ProptestConfig::default() })]
         #[test]
         #[should_panic]
         fn prop_compass_sometimes_yield_parameter_changes(

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -874,7 +874,6 @@ fn new_ratification_context<'distr>(
         // beginning of epoch `e + 1`. So, the epoch we consider for DRep mandates and proposal
         // expiry is the one from after the snapshot.
         epoch: snapshot.epoch() + 1,
-        total_withdrawn: 0,
         treasury,
         stake_distribution,
         protocol_parameters,


### PR DESCRIPTION
- :round_pushpin: **chore: internalize in forest checks on withdrawals w.r.t treasury**
    This alleviates a bit the ratification plumbing, and moves some of the pre-conditions to ratification closer to the other similar conditions. Doing so also allow to include this particular behaviour as part of the proposals forest testing, by also covering withdrawals.

- :round_pushpin: **chore: internalize cc validity check in proposals forest's compass**
    For the same reason as the withdrawals; those checks are better all done in one place. It also allows testing them better and makes the encapsulation clearer.

- :round_pushpin: **feat: lazily compute governance approvals**
    CC acceptance is by far the least expensive, and there's no need to compute the other if this one is false. Same for SPOs; which should be in general smaller than dreps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Treasury-aware proposal processing prevents overdrawn withdrawals and tracks remaining balance during ratification.
  * Protocol-parameter checks (e.g., maximum committee term length) enforced when navigating proposals.
  * Proposal orphan detection exposed for richer proposal handling.
  * Streamlined acceptance flow yields clearer outcomes from committee, pool, and DRep checks.

* **Bug Fixes**
  * Large treasury withdrawal totals display safely using saturating arithmetic.
  * Treasury updates now avoid underflow and remain consistent across steps.

* **Refactor**
  * Removed per-withdrawal cumulative state and adjusted proposal APIs.

* **Tests**
  * Property tests made deterministic by seeding RNGs and updated expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->