### PR TITLE
fix: use voting stake distribution for leader election.

### DIFF
--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -944,10 +944,13 @@ impl HasStakeDistribution for StakeDistributionObserver {
             .slot_to_epoch_unchecked_horizon(slot)
             .ok()?
             - 2;
+
         view.iter().find(|s| s.epoch == epoch).and_then(|s| {
             s.pools.get(pool).map(|st| PoolSummary {
                 vrf: st.parameters.vrf,
-                stake: st.stake,
+                // NOTE: The leader-election somehow uses the voting stake distribution that
+                // contains the proposal's deposit whose return addresses are delegated to pools.
+                stake: st.voting_stake,
                 active_stake: s.active_stake,
             })
         })


### PR DESCRIPTION
~Also adding the newly generated data for PreProd up to epoch 235; which were useful to pinpoint the issue. I'll add the corresponding snapshot tests in a separate PR / commit.~ (nevermind, will do separately also) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected epoch alignment for stake distribution, ensuring current data is used.
  * Pool summaries now display voting stake, matching leader selection metrics.

* **Documentation**
  * Clarified which stake source is used for leader selection.

* **Style**
  * Minor formatting cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->