### PR TITLE
fix: introduce 'consensus' stake distribution for leader election.

### DIFF
--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -943,10 +943,11 @@ impl HasStakeDistribution for StakeDistributionObserver {
             .slot_to_epoch_unchecked_horizon(slot)
             .ok()?
             - 2;
+
         view.iter().find(|s| s.epoch == epoch).and_then(|s| {
             s.pools.get(pool).map(|st| PoolSummary {
                 vrf: st.parameters.vrf,
-                stake: st.stake,
+                stake: st.consensus_stake,
                 active_stake: s.active_stake,
             })
         })

--- a/crates/amaru-ledger/src/summary/mod.rs
+++ b/crates/amaru-ledger/src/summary/mod.rs
@@ -53,11 +53,16 @@ pub struct PoolState {
     /// Number of blocks produced during an epoch by the underlying pool.
     pub blocks_count: u64,
 
-    /// The stake used for verifying the leader-schedule.
-    pub stake: Lovelace,
+    /// The stake used for calculating rewards.
+    pub rewards_stake: Lovelace,
+
+    /// The stake used for verifying the leader-schedule. It includes proposal deposits
+    /// of proposals whose refund address is delegated to the underlying pool.
+    pub consensus_stake: Lovelace,
 
     /// The stake used when counting votes, which includes proposal deposits for proposals whose
-    /// refund address is delegated to the underlying pool.
+    /// refund address is delegated to the underlying pool EXCEPT in the last epoch of validity of
+    /// such proposals or, when the pool is retiring in the next epoch.
     pub voting_stake: Lovelace,
 
     /// The pool's margin, as define per its last registration certificate.
@@ -75,7 +80,7 @@ impl ::serde::Serialize for PoolState {
     fn serialize<S: ::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut s = serializer.serialize_struct("PoolState", 4)?;
         s.serialize_field("blocks_count", &self.blocks_count)?;
-        s.serialize_field("stake", &self.stake)?;
+        s.serialize_field("stake", &self.rewards_stake)?;
         s.serialize_field("voting_stake", &self.voting_stake)?;
         s.serialize_field("parameters", &self.parameters)?;
         s.end()

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -134,7 +134,7 @@ const EVENT_TARGET: &str = "amaru::ledger::state::rewards";
 
 impl PoolState {
     pub fn relative_stake(&self, total_stake: Lovelace) -> LovelaceRatio {
-        lovelace_ratio(self.stake, total_stake)
+        lovelace_ratio(self.rewards_stake, total_stake)
     }
 
     pub fn owner_stake(&self, accounts: &BTreeMap<StakeCredential, AccountState>) -> Lovelace {
@@ -153,10 +153,10 @@ impl PoolState {
         blocks_ratio: SafeRatio,
         active_stake: Lovelace,
     ) -> SafeRatio {
-        if self.stake.is_zero() {
+        if self.rewards_stake.is_zero() {
             SafeRatio::zero()
         } else {
-            blocks_ratio * BigUint::from(active_stake) / BigUint::from(self.stake)
+            blocks_ratio * BigUint::from(active_stake) / BigUint::from(self.rewards_stake)
         }
     }
 


### PR DESCRIPTION
Not quite the active stake. Not quite the voting stake. It's a new specimen.

TODO: 
- [ ] Open an issue in intersectMBO/cardano-ledger to describe the numerator/denominator discrepancy there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced a separate "consensus stake" metric alongside rewards stake.

- Refactor
  - Replaced pool "stake" with "rewards stake" for rewards, weighting and performance calculations.
  - Epoch calculation now uses the current horizon directly.
  - Refined deposit handling to separate expiring deposits for voting vs. rewards/consensus.

- Documentation
  - Clarified voting stake to exclude pools unregistering next epoch and deposits in their last valid epoch.

- Tests
  - Updated tests and models to reflect new stake metrics and calculations.

- Chores
  - Preserved external "stake" field in serialized output, now sourced from rewards stake.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->