### PR TITLE
Fix cc members enactment

### DIFF
--- a/crates/amaru-kernel/src/constitutional_committee.rs
+++ b/crates/amaru-kernel/src/constitutional_committee.rs
@@ -15,12 +15,12 @@
 use crate::{RationalNumber, cbor, heterogeneous_array};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ConstitutionalCommittee {
+pub enum ConstitutionalCommitteeStatus {
     NoConfidence,
     Trusted { threshold: RationalNumber },
 }
 
-impl<C> cbor::encode::Encode<C> for ConstitutionalCommittee {
+impl<C> cbor::encode::Encode<C> for ConstitutionalCommitteeStatus {
     fn encode<W: cbor::encode::Write>(
         &self,
         e: &mut cbor::Encoder<W>,
@@ -41,7 +41,7 @@ impl<C> cbor::encode::Encode<C> for ConstitutionalCommittee {
     }
 }
 
-impl<'d, C> cbor::decode::Decode<'d, C> for ConstitutionalCommittee {
+impl<'d, C> cbor::decode::Decode<'d, C> for ConstitutionalCommitteeStatus {
     fn decode(d: &mut cbor::Decoder<'d>, ctx: &mut C) -> Result<Self, cbor::decode::Error> {
         heterogeneous_array(d, |d, assert_len| match d.u8()? {
             0 => {
@@ -62,13 +62,17 @@ impl<'d, C> cbor::decode::Decode<'d, C> for ConstitutionalCommittee {
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod tests {
-    use super::ConstitutionalCommittee::{self, *};
+    use super::ConstitutionalCommitteeStatus::{self, *};
     use crate::{prop_cbor_roundtrip, tests::any_rational_number};
     use proptest::prelude::*;
 
-    prop_cbor_roundtrip!(ConstitutionalCommittee, any_constitutional_committee());
+    prop_cbor_roundtrip!(
+        ConstitutionalCommitteeStatus,
+        any_constitutional_committee_status()
+    );
 
-    pub fn any_constitutional_committee() -> impl Strategy<Value = ConstitutionalCommittee> {
+    pub fn any_constitutional_committee_status()
+    -> impl Strategy<Value = ConstitutionalCommitteeStatus> {
         prop_oneof![
             Just(NoConfidence),
             any_rational_number().prop_map(|threshold| Trusted { threshold }),

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -861,7 +861,7 @@ fn import_constitutional_committee(
     let cc = match cc {
         StrictMaybe::Nothing => {
             info!(state = "no confidence", "constitutional committee");
-            amaru_kernel::ConstitutionalCommittee::NoConfidence
+            amaru_kernel::ConstitutionalCommitteeStatus::NoConfidence
         }
         StrictMaybe::Just(ConstitutionalCommittee { threshold, members }) => {
             info!(
@@ -873,7 +873,7 @@ fn import_constitutional_committee(
 
             cc_members = members;
 
-            amaru_kernel::ConstitutionalCommittee::Trusted { threshold }
+            amaru_kernel::ConstitutionalCommitteeStatus::Trusted { threshold }
         }
     };
 

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -28,7 +28,13 @@ use amaru_kernel::{
     protocol_parameters::ProtocolParameters,
 };
 use amaru_progress_bar::ProgressBar;
-use std::{collections::BTreeMap, fs, iter, path::PathBuf, rc::Rc, sync::LazyLock};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs, iter,
+    path::PathBuf,
+    rc::Rc,
+    sync::LazyLock,
+};
 use tracing::info;
 
 const BATCH_SIZE: usize = 5000;
@@ -877,7 +883,7 @@ fn import_constitutional_committee(
         }
     };
 
-    transaction.set_constitutional_committee(&cc)?;
+    transaction.update_constitutional_committee(&cc, BTreeMap::new(), BTreeSet::new())?;
 
     transaction.save(
         era_history,

--- a/crates/amaru-ledger/src/governance/ratification.rs
+++ b/crates/amaru-ledger/src/governance/ratification.rs
@@ -19,8 +19,8 @@ use crate::{
     summary::{SafeRatio, stake_distribution::StakeDistribution},
 };
 use amaru_kernel::{
-    Ballot, ComparableProposalId, DRep, Epoch, EraHistory, Lovelace, PoolId, StakeCredential,
-    UnitInterval, Vote, Voter, protocol_parameters::ProtocolParameters,
+    Ballot, ComparableProposalId, ConstitutionalCommitteeStatus, DRep, Epoch, EraHistory, Lovelace,
+    PoolId, StakeCredential, UnitInterval, Vote, Voter, protocol_parameters::ProtocolParameters,
 };
 use num::Zero;
 use std::{
@@ -228,7 +228,7 @@ impl<'distr> RatificationContext<'distr> {
                         self.constitutional_committee = None;
                         store_updates.push(Box::new(|db, _ctx| {
                             db.set_constitutional_committee(
-                                &amaru_kernel::ConstitutionalCommittee::NoConfidence,
+                                &ConstitutionalCommitteeStatus::NoConfidence,
                             )
                         }))
                     }
@@ -241,7 +241,7 @@ impl<'distr> RatificationContext<'distr> {
                         },
                         _parent,
                     ) => {
-                        let committee = amaru_kernel::ConstitutionalCommittee::Trusted {
+                        let committee = ConstitutionalCommitteeStatus::Trusted {
                             threshold: UnitInterval {
                                 numerator: threshold.numer().try_into().unwrap_or_else(|e| {
                                     unreachable!("threshold numerator larger than u64?!: {e}")

--- a/crates/amaru-ledger/src/governance/ratification.rs
+++ b/crates/amaru-ledger/src/governance/ratification.rs
@@ -231,7 +231,21 @@ impl<'distr> RatificationContext<'distr> {
                                 &ConstitutionalCommitteeStatus::NoConfidence,
                                 BTreeMap::new(),
                                 BTreeSet::new(),
-                            )
+                            )?;
+
+                            db.with_cc_members(|iterator| {
+                                // NOTE: CC members are not deleted when entering no confidence
+                                // mode. They are simply marked as inactive.
+                                //
+                                // In particular, their hot<->cold bindings are preserved.
+                                for (_, mut row) in iterator {
+                                    if let Some(cc_member) = row.borrow_mut() {
+                                        cc_member.valid_until = None;
+                                    }
+                                }
+                            })?;
+
+                            Ok(())
                         }))
                     }
 

--- a/crates/amaru-ledger/src/governance/ratification/constitutional_committee.rs
+++ b/crates/amaru-ledger/src/governance/ratification/constitutional_committee.rs
@@ -69,7 +69,7 @@ impl ConstitutionalCommittee {
         &mut self,
         threshold: SafeRatio,
         added: BTreeMap<StakeCredential, (Option<StakeCredential>, Epoch)>,
-        removed: BTreeSet<StakeCredential>,
+        removed: BTreeSet<&StakeCredential>,
     ) {
         self.threshold = threshold;
 
@@ -247,7 +247,7 @@ mod tests {
                 committee.update(
                     committee.threshold().clone(),
                     BTreeMap::new(),
-                    BTreeSet::from([any_active_member.clone()]),
+                    BTreeSet::from([any_active_member]),
                 );
             }
 
@@ -279,7 +279,7 @@ mod tests {
                         any_active_member.clone(),
                         any_member_state.clone(),
                     )]),
-                    BTreeSet::from([any_active_member.clone()]),
+                    BTreeSet::from([any_active_member]),
                 );
 
 

--- a/crates/amaru-ledger/src/governance/ratification/constitutional_committee.rs
+++ b/crates/amaru-ledger/src/governance/ratification/constitutional_committee.rs
@@ -22,6 +22,7 @@ use std::{
     rc::Rc,
     sync::LazyLock,
 };
+use tracing::warn;
 
 static ZERO: LazyLock<SafeRatio> = LazyLock::new(SafeRatio::zero);
 
@@ -139,6 +140,11 @@ impl ConstitutionalCommittee {
                 if self.active_members(current_epoch).len() < (min_committee_size as usize)
                     && protocol_version > PROTOCOL_VERSION_9
                 {
+                    warn!(
+                        members.active = self.active_members(current_epoch).len(),
+                        min_committee_size = min_committee_size,
+                        "no voting threshold because committee is too small"
+                    );
                     return None;
                 }
 

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -943,11 +943,10 @@ impl HasStakeDistribution for StakeDistributionObserver {
             .slot_to_epoch_unchecked_horizon(slot)
             .ok()?
             - 2;
-
         view.iter().find(|s| s.epoch == epoch).and_then(|s| {
             s.pools.get(pool).map(|st| PoolSummary {
                 vrf: st.parameters.vrf,
-                stake: st.consensus_stake,
+                stake: st.stake,
                 active_stake: s.active_stake,
             })
         })

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -31,7 +31,7 @@ use crate::{
     },
 };
 use amaru_kernel::{
-    ComparableProposalId, ConstitutionalCommittee, EraHistory, Hash, Lovelace,
+    ComparableProposalId, ConstitutionalCommitteeStatus, EraHistory, Hash, Lovelace,
     MemoizedTransactionOutput, MintedBlock, Point, PoolId, Slot, StakeCredential,
     StakeCredentialType, TransactionInput, expect_stake_credential,
     network::NetworkName,
@@ -831,8 +831,8 @@ fn new_ratification_context<'distr>(
     treasury: Lovelace,
 ) -> Result<RatificationContext<'distr>, StoreError> {
     let constitutional_committee = match snapshot.constitutional_committee()? {
-        ConstitutionalCommittee::NoConfidence => None,
-        ConstitutionalCommittee::Trusted { threshold } => {
+        ConstitutionalCommitteeStatus::NoConfidence => None,
+        ConstitutionalCommitteeStatus::Trusted { threshold } => {
             let members = snapshot
                 .iter_cc_members()?
                 .map(|(cold_credential, row)| {

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -33,7 +33,8 @@ use amaru_kernel::{
     protocol_parameters::ProtocolParameters,
 };
 use amaru_kernel::{
-    ComparableProposalId, Constitution, ConstitutionalCommittee, Epoch, MemoizedTransactionOutput,
+    ComparableProposalId, Constitution, ConstitutionalCommitteeStatus, Epoch,
+    MemoizedTransactionOutput,
 };
 use columns::*;
 use std::{borrow::BorrowMut, io, iter, ops::Deref};
@@ -158,7 +159,7 @@ pub trait ReadStore {
     fn pots(&self) -> Result<Pots>;
 
     /// Retrieve the state of the constitutional committee.
-    fn constitutional_committee(&self) -> Result<ConstitutionalCommittee>;
+    fn constitutional_committee(&self) -> Result<ConstitutionalCommitteeStatus>;
 
     /// Retrieve the current protocol's constitution
     fn constitution(&self) -> Result<Constitution>;
@@ -289,7 +290,8 @@ pub trait TransactionalContext<'a>: ReadStore {
     fn set_protocol_parameters(&self, protocol_parameters: &ProtocolParameters) -> Result<()>;
 
     /// Persist the constitutional committee state for the ongoing epoch.
-    fn set_constitutional_committee(&self, committee: &ConstitutionalCommittee) -> Result<()>;
+    fn set_constitutional_committee(&self, committee: &ConstitutionalCommitteeStatus)
+    -> Result<()>;
 
     /// Persist the latest proposal roots for the ongoing epoch.
     fn set_proposals_roots(&self, roots: &ProposalsRootsRc) -> Result<()>;

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -37,7 +37,12 @@ use amaru_kernel::{
     MemoizedTransactionOutput,
 };
 use columns::*;
-use std::{borrow::BorrowMut, io, iter, ops::Deref};
+use std::{
+    borrow::BorrowMut,
+    collections::{BTreeMap, BTreeSet},
+    io, iter,
+    ops::Deref,
+};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -290,8 +295,12 @@ pub trait TransactionalContext<'a>: ReadStore {
     fn set_protocol_parameters(&self, protocol_parameters: &ProtocolParameters) -> Result<()>;
 
     /// Persist the constitutional committee state for the ongoing epoch.
-    fn set_constitutional_committee(&self, committee: &ConstitutionalCommitteeStatus)
-    -> Result<()>;
+    fn update_constitutional_committee(
+        &self,
+        status: &ConstitutionalCommitteeStatus,
+        added: BTreeMap<StakeCredential, Epoch>,
+        removed: BTreeSet<StakeCredential>,
+    ) -> Result<()>;
 
     /// Persist the latest proposal roots for the ongoing epoch.
     fn set_proposals_roots(&self, roots: &ProposalsRootsRc) -> Result<()>;

--- a/crates/amaru-ledger/src/store/columns/cc_members.rs
+++ b/crates/amaru-ledger/src/store/columns/cc_members.rs
@@ -28,7 +28,7 @@ pub type Key = StakeCredential;
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct Row {
     pub hot_credential: Option<StakeCredential>,
-    pub valid_until: Epoch,
+    pub valid_until: Option<Epoch>,
 }
 
 impl<C> cbor::encode::Encode<C> for Row {
@@ -63,11 +63,11 @@ pub mod tests {
     prop_compose! {
         pub fn any_row()(
             hot_credential in option::of(any_stake_credential()),
-            valid_until in any::<u64>(),
+            valid_until in option::of(any::<u64>()),
         ) -> Row {
             Row {
                 hot_credential,
-                valid_until: Epoch::from(valid_until),
+                valid_until: valid_until.map(Epoch::from),
             }
         }
     }

--- a/crates/amaru-ledger/src/summary/mod.rs
+++ b/crates/amaru-ledger/src/summary/mod.rs
@@ -53,16 +53,11 @@ pub struct PoolState {
     /// Number of blocks produced during an epoch by the underlying pool.
     pub blocks_count: u64,
 
-    /// The stake used for calculating rewards.
-    pub rewards_stake: Lovelace,
-
-    /// The stake used for verifying the leader-schedule. It includes proposal deposits
-    /// of proposals whose refund address is delegated to the underlying pool.
-    pub consensus_stake: Lovelace,
+    /// The stake used for verifying the leader-schedule.
+    pub stake: Lovelace,
 
     /// The stake used when counting votes, which includes proposal deposits for proposals whose
-    /// refund address is delegated to the underlying pool EXCEPT in the last epoch of validity of
-    /// such proposals or, when the pool is retiring in the next epoch.
+    /// refund address is delegated to the underlying pool.
     pub voting_stake: Lovelace,
 
     /// The pool's margin, as define per its last registration certificate.
@@ -80,7 +75,7 @@ impl ::serde::Serialize for PoolState {
     fn serialize<S: ::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut s = serializer.serialize_struct("PoolState", 4)?;
         s.serialize_field("blocks_count", &self.blocks_count)?;
-        s.serialize_field("stake", &self.rewards_stake)?;
+        s.serialize_field("stake", &self.stake)?;
         s.serialize_field("voting_stake", &self.voting_stake)?;
         s.serialize_field("parameters", &self.parameters)?;
         s.end()

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -134,7 +134,7 @@ const EVENT_TARGET: &str = "amaru::ledger::state::rewards";
 
 impl PoolState {
     pub fn relative_stake(&self, total_stake: Lovelace) -> LovelaceRatio {
-        lovelace_ratio(self.rewards_stake, total_stake)
+        lovelace_ratio(self.stake, total_stake)
     }
 
     pub fn owner_stake(&self, accounts: &BTreeMap<StakeCredential, AccountState>) -> Lovelace {
@@ -153,10 +153,10 @@ impl PoolState {
         blocks_ratio: SafeRatio,
         active_stake: Lovelace,
     ) -> SafeRatio {
-        if self.rewards_stake.is_zero() {
+        if self.stake.is_zero() {
             SafeRatio::zero()
         } else {
-            blocks_ratio * BigUint::from(active_stake) / BigUint::from(self.rewards_stake)
+            blocks_ratio * BigUint::from(active_stake) / BigUint::from(self.stake)
         }
     }
 

--- a/crates/amaru-stores/src/in_memory/ledger/columns/cc_members.rs
+++ b/crates/amaru-stores/src/in_memory/ledger/columns/cc_members.rs
@@ -31,7 +31,7 @@ pub fn add(
         let row = cc_members.get(&key).cloned().or(match valid_until {
             Resettable::Set(valid_until) => Some(Row {
                 hot_credential: None,
-                valid_until,
+                valid_until: Some(valid_until),
             }),
             Resettable::Unchanged | Resettable::Reset => None,
         });

--- a/crates/amaru-stores/src/in_memory/mod.rs
+++ b/crates/amaru-stores/src/in_memory/mod.rs
@@ -17,7 +17,7 @@ use crate::in_memory::ledger::columns::{
 };
 use amaru_iter_borrow::IterBorrow;
 use amaru_kernel::{
-    ComparableProposalId, Constitution, ConstitutionalCommittee, EraHistory, Lovelace, Point,
+    ComparableProposalId, Constitution, ConstitutionalCommitteeStatus, EraHistory, Lovelace, Point,
     PoolId, Slot, StakeCredential, TransactionInput, protocol_parameters::ProtocolParameters,
 };
 use amaru_ledger::{
@@ -57,7 +57,7 @@ pub struct MemoryStore {
     cc_members: RefCell<BTreeMap<StakeCredential, cc_members_column::Row>>,
     votes: RefCell<BTreeMap<votes_column::Key, votes_column::Value>>,
     protocol_parameters: RefCell<Option<ProtocolParameters>>,
-    constitutional_committee: RefCell<ConstitutionalCommittee>,
+    constitutional_committee: RefCell<ConstitutionalCommitteeStatus>,
     era_history: EraHistory,
 }
 
@@ -76,7 +76,7 @@ impl MemoryStore {
             cc_members: RefCell::new(BTreeMap::new()),
             votes: RefCell::new(BTreeMap::new()),
             protocol_parameters: RefCell::new(None),
-            constitutional_committee: RefCell::new(ConstitutionalCommittee::NoConfidence),
+            constitutional_committee: RefCell::new(ConstitutionalCommitteeStatus::NoConfidence),
             era_history,
         }
     }
@@ -117,7 +117,7 @@ impl ReadStore for MemoryStore {
         })
     }
 
-    fn constitutional_committee(&self) -> Result<ConstitutionalCommittee, StoreError> {
+    fn constitutional_committee(&self) -> Result<ConstitutionalCommitteeStatus, StoreError> {
         Ok(self.constitutional_committee.borrow().clone())
     }
 
@@ -384,7 +384,7 @@ impl<'a> ReadStore for MemoryTransactionalContext<'a> {
         self.store.proposals_roots()
     }
 
-    fn constitutional_committee(&self) -> Result<ConstitutionalCommittee, StoreError> {
+    fn constitutional_committee(&self) -> Result<ConstitutionalCommitteeStatus, StoreError> {
         self.store.constitutional_committee()
     }
 
@@ -593,7 +593,7 @@ impl<'a> TransactionalContext<'a> for MemoryTransactionalContext<'a> {
 
     fn set_constitutional_committee(
         &self,
-        constitutional_committee: &ConstitutionalCommittee,
+        constitutional_committee: &ConstitutionalCommitteeStatus,
     ) -> Result<(), StoreError> {
         *self.store.constitutional_committee.borrow_mut() = constitutional_committee.clone();
         Ok(())

--- a/crates/amaru-stores/src/in_memory/mod.rs
+++ b/crates/amaru-stores/src/in_memory/mod.rs
@@ -36,7 +36,7 @@ use amaru_slot_arithmetic::Epoch;
 use std::{
     borrow::{Borrow, BorrowMut},
     cell::{RefCell, RefMut},
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     ops::{Deref, DerefMut},
 };
 
@@ -591,11 +591,13 @@ impl<'a> TransactionalContext<'a> for MemoryTransactionalContext<'a> {
         Ok(())
     }
 
-    fn set_constitutional_committee(
+    fn update_constitutional_committee(
         &self,
-        constitutional_committee: &ConstitutionalCommitteeStatus,
+        status: &ConstitutionalCommitteeStatus,
+        _added: BTreeMap<StakeCredential, Epoch>,
+        _removed: BTreeSet<StakeCredential>,
     ) -> Result<(), StoreError> {
-        *self.store.constitutional_committee.borrow_mut() = constitutional_committee.clone();
+        *self.store.constitutional_committee.borrow_mut() = status.clone();
         Ok(())
     }
 

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -15,9 +15,9 @@
 use ::rocksdb::{self, OptimisticTransactionDB, Options, SliceTransform, checkpoint};
 use amaru_iter_borrow::{self, IterBorrow, borrowable_proxy::BorrowableProxy};
 use amaru_kernel::{
-    CertificatePointer, ComparableProposalId, Constitution, ConstitutionalCommittee, EraHistory,
-    Lovelace, MemoizedTransactionOutput, Point, PoolId, StakeCredential, TransactionInput, cbor,
-    protocol_parameters::ProtocolParameters,
+    CertificatePointer, ComparableProposalId, Constitution, ConstitutionalCommitteeStatus,
+    EraHistory, Lovelace, MemoizedTransactionOutput, Point, PoolId, StakeCredential,
+    TransactionInput, cbor, protocol_parameters::ProtocolParameters,
 };
 use amaru_ledger::{
     governance::ratification::{ProposalsRoots, ProposalsRootsRc},
@@ -347,7 +347,7 @@ macro_rules! impl_ReadStore_body {
                 get_or_bail(|key| self.db.get(key), &KEY_PROTOCOL_PARAMETERS)
             }
 
-            fn constitutional_committee(&self) -> Result<ConstitutionalCommittee, StoreError> {
+            fn constitutional_committee(&self) -> Result<ConstitutionalCommitteeStatus, StoreError> {
                 get_or_bail(|key| self.db.get(key), &KEY_CONSTITUTIONAL_COMMITTEE)
             }
 
@@ -566,7 +566,7 @@ impl TransactionalContext<'_> for RocksDBTransactionalContext<'_> {
 
     fn set_constitutional_committee(
         &self,
-        constitutional_committee: &ConstitutionalCommittee,
+        constitutional_committee: &ConstitutionalCommitteeStatus,
     ) -> Result<(), StoreError> {
         self.db
             .put(

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::rocksdb::common::as_key;
 use ::rocksdb::{self, OptimisticTransactionDB, Options, SliceTransform, checkpoint};
 use amaru_iter_borrow::{self, IterBorrow, borrowable_proxy::BorrowableProxy};
 use amaru_kernel::{
@@ -32,6 +33,7 @@ use rocksdb::{
     DB, DBAccess, DBIteratorWithThreadMode, Direction, IteratorMode, ReadOptions, Transaction,
 };
 use std::{
+    collections::{BTreeMap, BTreeSet},
     fmt, fs,
     ops::Deref,
     path::{Path, PathBuf},
@@ -564,16 +566,36 @@ impl TransactionalContext<'_> for RocksDBTransactionalContext<'_> {
         Ok(())
     }
 
-    fn set_constitutional_committee(
+    fn update_constitutional_committee(
         &self,
-        constitutional_committee: &ConstitutionalCommitteeStatus,
+        status: &ConstitutionalCommitteeStatus,
+        added: BTreeMap<StakeCredential, Epoch>,
+        removed: BTreeSet<StakeCredential>,
     ) -> Result<(), StoreError> {
         self.db
-            .put(
-                KEY_CONSTITUTIONAL_COMMITTEE,
-                as_value(constitutional_committee),
-            )
+            .put(KEY_CONSTITUTIONAL_COMMITTEE, as_value(status))
             .map_err(|err| StoreError::Internal(err.into()))?;
+
+        for cold_cred in removed {
+            let key = as_key(&cc_members::PREFIX, cold_cred);
+            self.db
+                .delete(key)
+                .map_err(|err| StoreError::Internal(err.into()))?;
+        }
+
+        for (cold_cred, valid_until) in added.into_iter() {
+            let key = as_key(&cc_members::PREFIX, &cold_cred);
+            self.db
+                .put(
+                    key,
+                    as_value(scolumns::cc_members::Row {
+                        hot_credential: None,
+                        valid_until,
+                    }),
+                )
+                .map_err(|err| StoreError::Internal(err.into()))?;
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
- :round_pushpin: **Revert "fix: introduce 'consensus' stake distribution for leader election."**
  This reverts commit 01f24ddcc2833d318ae1d522c20dd99f3e2c478b.

- :round_pushpin: **chore: rename kernel's 'ConstitutionalCommittee' -> 'ConstitutionalCommitteeStatus'**
    There's already another object called ConstitutionCommittee, and this is confusing.

- :round_pushpin: **fix: update stored constitutional committee members on ratified cc changes.**
    The enact step was so far only updating the cc status; but completely overlooked the addition of the actual members. This is now properly handled.

- :round_pushpin: **fix: preserve hot<->cold cc relationships irrespective of cc status.**
    There are two things at play here:

  1. When removing CC members (which includes, when entering a state of
     no confidence); we shouldn't forget any of the cold -> hot
     delegations. Yes, this is technically a resource leak (since we can
     have orphan relations that never get cleaned up).

  2. It is actually allowed to define such a cold -> hot relations for
     unelected CC members, so long as they appear in an ongoing
     proposal. So it is important to also ensure that any previously
     defined relation is preserved when finally electing a CC (instead
     of blindly overwriting whatever is stored at the CC key)...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Consolidated pool stake fields into a single "stake" used across summaries and calculations; serialization updated accordingly.
  - Renamed constitutional committee representation to a "status" model and switched to delta-based membership updates (add/remove).
  - Committee member expiry is now optional; members without expiry are excluded from active set.

- Bug Fixes
  - No-confidence now preserves members as inactive (not deleted).

- Chores
  - Added warnings when active committee is undersized on newer protocol versions.
  - Storage backends updated to the new status/update flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->