### PR TITLE
feat: allow fetch to work with custom network and without pre-defined config.

### DIFF
--- a/data/fetch.mjs
+++ b/data/fetch.mjs
@@ -23,6 +23,8 @@ const network = (process.argv[2] ?? "").toLowerCase();
 
 const includeSnapshots = (process.argv[3] ?? "false").toLowerCase() == "true";
 
+const ogmiosUrl = process.env.OGMIOS_URL ?? "ws://127.0.0.1:1337"
+
 if (!["preview", "preprod", "mainnet", "custom"].includes(network)) {
   console.log(`Missing or invalid network.
 Usage:
@@ -156,7 +158,7 @@ async function fetchContinuously() {
       }
 
       done(true);
-    });
+    }, ogmiosUrl);
 
     if (exit === undefined) {
       process.stderr.cursorTo(0, 0);


### PR DESCRIPTION
When set to 'custom', fetch will simply adapt to whatever network is available, and fetch snapshots on epoch boundaries (auto-magically detected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Support for a “custom” network and OGMIOS_URL override.
  * Optional per-network ledger snapshot dumping.

* Improvements
  * Automatic live fetching when no config is present.
  * Faster concurrent fetching (up to 10 simultaneous fetches).
  * Spinner progress indicator and TTY-aware progress logging.
  * Network-specific configuration and storage to avoid refetching.
  * Safer handling when crossing epoch boundaries.

* Reliability
  * Improved retry and error handling for transient connection/data issues.

* Refactor
  * Clear separation between config-driven and continuous fetching flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->