### PR TITLE
feat: split chain sync and block fetch clients

### DIFF
--- a/crates/amaru-network/src/chain_sync_client.rs
+++ b/crates/amaru-network/src/chain_sync_client.rs
@@ -175,8 +175,7 @@ impl ChainSyncClient {
         }
     }
 
-    pub async fn has_agency(&self) -> bool {
-        let client = &self.chain_sync;
-        client.has_agency()
+    pub fn has_agency(&self) -> bool {
+        self.chain_sync.has_agency()
     }
 }

--- a/crates/amaru-network/src/chain_sync_client.rs
+++ b/crates/amaru-network/src/chain_sync_client.rs
@@ -43,7 +43,7 @@ pub fn to_traverse(header: &HeaderContent) -> Result<MultiEraHeader<'_>, ChainSy
 
 /// Handles chain synchronization network operations
 pub struct ChainSyncClient {
-    peer: Peer,
+    pub peer: Peer,
     chain_sync: Client<HeaderContent>,
     intersection: Vec<Point>,
     is_catching_up: Arc<RwLock<bool>>,
@@ -156,7 +156,7 @@ impl ChainSyncClient {
         client
             .request_next()
             .await
-            .inspect_err(|err| tracing::error!(reason = %err, "request next failed; retrying"))
+            .inspect_err(|err| tracing::error!(reason = %err, "request next failed"))
             .map_err(ChainSyncClientError::NetworkError)
     }
 
@@ -168,9 +168,9 @@ impl ChainSyncClient {
 
         match client.recv_while_must_reply().await {
             Ok(result) => Ok(result),
-            Err(e) => {
-                tracing::error!(reason = %e, "failed while awaiting for next block");
-                Err(ChainSyncClientError::NetworkError(e))
+            Err(err) => {
+                tracing::error!(reason = %err, "failed while awaiting for next block");
+                Err(ChainSyncClientError::NetworkError(err))
             }
         }
     }

--- a/crates/amaru-network/src/chain_sync_client.rs
+++ b/crates/amaru-network/src/chain_sync_client.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{point::to_network_point, session::PeerSession};
+use crate::point::to_network_point;
 use amaru_consensus::{RawHeader, consensus::ChainSyncEvent};
-use amaru_kernel::Point;
-use pallas_network::miniprotocols::chainsync::{ClientError, HeaderContent, NextResponse, Tip};
+use amaru_kernel::{Point, peer::Peer};
+use pallas_network::miniprotocols::chainsync::{
+    Client, ClientError, HeaderContent, NextResponse, Tip,
+};
 use pallas_traverse::MultiEraHeader;
 use std::sync::{Arc, RwLock};
 use tracing::{Level, Span, instrument};
@@ -41,19 +43,22 @@ pub fn to_traverse(header: &HeaderContent) -> Result<MultiEraHeader<'_>, ChainSy
 
 /// Handles chain synchronization network operations
 pub struct ChainSyncClient {
-    peer_session: PeerSession,
+    peer: Peer,
+    chain_sync: Client<HeaderContent>,
     intersection: Vec<Point>,
     is_catching_up: Arc<RwLock<bool>>,
 }
 
 impl ChainSyncClient {
     pub fn new(
-        peer_session: PeerSession,
+        peer: Peer,
+        chain_sync: Client<HeaderContent>,
         intersection: Vec<Point>,
         is_catching_up: Arc<RwLock<bool>>,
     ) -> Self {
         Self {
-            peer_session,
+            peer,
+            chain_sync,
             intersection,
             is_catching_up,
         }
@@ -86,13 +91,12 @@ impl ChainSyncClient {
         skip_all,
         name = "chainsync_client.find_intersection",
         fields(
-            peer = self.peer_session.peer.name,
+            peer = self.peer.name,
             intersection.slot = %self.intersection.last().map(|p| p.slot_or_default()).unwrap_or_default(),
         ),
     )]
-    pub async fn find_intersection(&self) -> Result<(), ChainSyncClientError> {
-        let mut peer_client = self.peer_session.peer_client.lock().await;
-        let client = (*peer_client).chainsync();
+    pub async fn find_intersection(&mut self) -> Result<(), ChainSyncClientError> {
+        let client = &mut self.chain_sync;
         let (point, _) = client
             .find_intersect(
                 self.intersection
@@ -114,7 +118,7 @@ impl ChainSyncClient {
         &mut self,
         header: &HeaderContent,
     ) -> Result<ChainSyncEvent, ChainSyncClientError> {
-        let peer = &self.peer_session.peer;
+        let peer = &self.peer;
         let header = to_traverse(header)?;
         let point = Point::Specific(header.slot(), header.hash().to_vec());
 
@@ -135,7 +139,7 @@ impl ChainSyncClient {
         rollback_point: Point,
         _tip: Tip,
     ) -> Result<ChainSyncEvent, ChainSyncClientError> {
-        let peer = &self.peer_session.peer;
+        let peer = &self.peer;
         Ok(ChainSyncEvent::Rollback {
             peer: peer.clone(),
             rollback_point,
@@ -147,8 +151,7 @@ impl ChainSyncClient {
         &mut self,
     ) -> Result<NextResponse<HeaderContent>, ChainSyncClientError> {
         self.catching_up();
-        let mut peer_client = self.peer_session.lock().await;
-        let client = (*peer_client).chainsync();
+        let client = &mut self.chain_sync;
 
         client
             .request_next()
@@ -161,8 +164,7 @@ impl ChainSyncClient {
         &mut self,
     ) -> Result<NextResponse<HeaderContent>, ChainSyncClientError> {
         self.no_longer_catching_up();
-        let mut peer_client = self.peer_session.lock().await;
-        let client = (*peer_client).chainsync();
+        let client = &mut self.chain_sync;
 
         match client.recv_while_must_reply().await {
             Ok(result) => Ok(result),
@@ -174,8 +176,7 @@ impl ChainSyncClient {
     }
 
     pub async fn has_agency(&self) -> bool {
-        let mut peer_client = self.peer_session.lock().await;
-        let client = (*peer_client).chainsync();
+        let client = &self.chain_sync;
         client.has_agency()
     }
 }

--- a/crates/amaru/src/bin/amaru/cmd/daemon.rs
+++ b/crates/amaru/src/bin/amaru/cmd/daemon.rs
@@ -18,8 +18,7 @@ use amaru_kernel::{default_chain_dir, default_ledger_dir, network::NetworkName};
 use clap::{ArgAction, Parser};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use pallas_network::facades::PeerClient;
-use std::{path::PathBuf, sync::Arc, time::Duration};
-use tokio::sync::Mutex;
+use std::{path::PathBuf, time::Duration};
 use tokio_util::sync::CancellationToken;
 use tracing::trace;
 
@@ -81,10 +80,10 @@ pub async fn run(
 
     let metrics = metrics.map(track_system_metrics).transpose()?;
 
-    let mut clients: Vec<(String, Arc<Mutex<PeerClient>>)> = vec![];
+    let mut clients: Vec<(String, PeerClient)> = vec![];
     for peer in &config.upstream_peers {
         let client = connect_to_peer(peer, &config.network).await?;
-        clients.push((peer.clone(), Arc::new(Mutex::new(client))));
+        clients.push((peer.clone(), client));
     }
 
     let exit = amaru::exit::hook_exit_token();

--- a/crates/amaru/src/bin/amaru/cmd/import_headers.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_headers.rs
@@ -105,12 +105,9 @@ pub(crate) async fn import_headers(
     let mut db = RocksDBStore::new(chain_db_dir, era_history)?;
 
     let peer_client = connect_to_peer(peer_address, &network_name).await?;
-
-    let peer_session = (Peer::new(peer_address), peer_client.chainsync);
-
     let mut client = ChainSyncClient::new(
-        peer_session.0,
-        peer_session.1,
+        Peer::new(peer_address),
+        peer_client.chainsync,
         vec![point.clone()],
         Arc::new(RwLock::new(true)),
     );

--- a/crates/amaru/src/bin/amaru/cmd/import_headers.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_headers.rs
@@ -122,7 +122,7 @@ pub(crate) async fn import_headers(
     let mut progress: Option<Box<dyn ProgressBar>> = None;
 
     loop {
-        let what = if client.has_agency().await {
+        let what = if client.has_agency() {
             request_next_block(&mut client, &mut db, &mut count, &mut progress, max).await?
         } else {
             await_for_next_block(&mut client, &mut db, &mut count, &mut progress, max).await?

--- a/crates/amaru/src/stages/consensus/fetch_block.rs
+++ b/crates/amaru/src/stages/consensus/fetch_block.rs
@@ -29,19 +29,16 @@ pub type DownstreamPort = gasket::messaging::OutputPort<ValidateBlockEvent>;
 #[derive(Stage)]
 #[stage(name = "stage.fetch", unit = "ValidateHeaderEvent", worker = "Worker")]
 pub struct BlockFetchStage {
-    pub peer_sessions: BTreeMap<Peer, Client>,
+    pub clients: BTreeMap<Peer, Client>,
     pub upstream: UpstreamPort,
     pub downstream: DownstreamPort,
 }
 
 impl BlockFetchStage {
-    pub fn new(sessions: Vec<(Peer, Client)>) -> Self {
-        let peer_sessions = sessions
-            .into_iter()
-            .map(|(peer, client)| (peer.clone(), client))
-            .collect::<BTreeMap<_, _>>();
+    pub fn new(clients: Vec<(Peer, Client)>) -> Self {
+        let clients = clients.into_iter().collect::<BTreeMap<_, _>>();
         Self {
-            peer_sessions,
+            clients,
             upstream: Default::default(),
             downstream: Default::default(),
         }
@@ -92,7 +89,7 @@ impl BlockFetchStage {
         // the block should be fetched from any other valid peer
         // which is known to have it
         let client = self
-            .peer_sessions
+            .clients
             .get_mut(peer)
             .ok_or_else(|| ConsensusError::UnknownPeer(peer.clone()))?;
         let new_point: pallas_network::miniprotocols::Point = match point.clone() {

--- a/crates/amaru/src/stages/consensus/fetch_block.rs
+++ b/crates/amaru/src/stages/consensus/fetch_block.rs
@@ -19,8 +19,8 @@ use amaru_consensus::{
     ConsensusError, IsHeader, consensus::ValidateHeaderEvent, span::adopt_current_span,
 };
 use amaru_kernel::{Point, block::ValidateBlockEvent, peer::Peer};
-use amaru_network::session::PeerSession;
 use gasket::framework::*;
+use pallas_network::miniprotocols::blockfetch::Client;
 use tracing::{error, instrument};
 
 pub type UpstreamPort = gasket::messaging::InputPort<ValidateHeaderEvent>;
@@ -29,16 +29,16 @@ pub type DownstreamPort = gasket::messaging::OutputPort<ValidateBlockEvent>;
 #[derive(Stage)]
 #[stage(name = "stage.fetch", unit = "ValidateHeaderEvent", worker = "Worker")]
 pub struct BlockFetchStage {
-    pub peer_sessions: BTreeMap<Peer, PeerSession>,
+    pub peer_sessions: BTreeMap<Peer, Client>,
     pub upstream: UpstreamPort,
     pub downstream: DownstreamPort,
 }
 
 impl BlockFetchStage {
-    pub fn new(sessions: &[PeerSession]) -> Self {
+    pub fn new(sessions: Vec<(Peer, Client)>) -> Self {
         let peer_sessions = sessions
-            .iter()
-            .map(|p| (p.peer.clone(), p.clone()))
+            .into_iter()
+            .map(|(peer, client)| (peer.clone(), client))
             .collect::<BTreeMap<_, _>>();
         Self {
             peer_sessions,
@@ -87,16 +87,14 @@ impl BlockFetchStage {
         Ok(())
     }
 
-    async fn fetch_block(&self, peer: &Peer, point: &Point) -> Result<Vec<u8>, ConsensusError> {
+    async fn fetch_block(&mut self, peer: &Peer, point: &Point) -> Result<Vec<u8>, ConsensusError> {
         // FIXME: should not crash if the peer is not found
         // the block should be fetched from any other valid peer
         // which is known to have it
-        let peer_session = self
+        let client = self
             .peer_sessions
-            .get(peer)
+            .get_mut(peer)
             .ok_or_else(|| ConsensusError::UnknownPeer(peer.clone()))?;
-        let mut session = peer_session.peer_client.lock().await;
-        let client = (*session).blockfetch();
         let new_point: pallas_network::miniprotocols::Point = match point.clone() {
             Point::Origin => pallas_network::miniprotocols::Point::Origin,
             Point::Specific(slot, hash) => {

--- a/crates/amaru/src/stages/mod.rs
+++ b/crates/amaru/src/stages/mod.rs
@@ -166,10 +166,7 @@ pub fn bootstrap(
 
     let global_parameters: &GlobalParameters = config.network.into();
 
-    let peers: Vec<Peer> = clients
-        .iter()
-        .map(|c| Peer::new(&c.0.to_string()))
-        .collect();
+    let peers: Vec<Peer> = clients.iter().map(|c| Peer::new(&c.0)).collect();
 
     let is_catching_up = Arc::new(RwLock::new(true));
 

--- a/crates/amaru/src/stages/pull.rs
+++ b/crates/amaru/src/stages/pull.rs
@@ -82,7 +82,7 @@ impl gasket::framework::Worker<Stage> for Worker {
 
     async fn schedule(&mut self, stage: &mut Stage) -> Result<WorkSchedule<WorkUnit>, WorkerError> {
         if self.initialised {
-            if stage.client.has_agency().await {
+            if stage.client.has_agency() {
                 // should request next block
                 Ok(WorkSchedule::Unit(WorkUnit::Pull))
             } else {

--- a/crates/amaru/src/stages/pull.rs
+++ b/crates/amaru/src/stages/pull.rs
@@ -14,12 +14,10 @@
 
 use crate::send;
 use amaru_consensus::consensus::ChainSyncEvent;
-use amaru_kernel::Point;
-use amaru_network::{
-    chain_sync_client::ChainSyncClient, point::from_network_point, session::PeerSession,
-};
+use amaru_kernel::{Point, peer::Peer};
+use amaru_network::{chain_sync_client::ChainSyncClient, point::from_network_point};
 use gasket::framework::*;
-use pallas_network::miniprotocols::chainsync::{HeaderContent, NextResponse, Tip};
+use pallas_network::miniprotocols::chainsync::{Client, HeaderContent, NextResponse, Tip};
 use std::sync::{Arc, RwLock};
 use tracing::{Level, instrument};
 
@@ -28,6 +26,7 @@ pub type DownstreamPort = gasket::messaging::OutputPort<ChainSyncEvent>;
 pub enum WorkUnit {
     Pull,
     Await,
+    Intersect,
 }
 
 #[derive(Stage)]
@@ -39,17 +38,18 @@ pub struct Stage {
 
 impl Stage {
     pub fn new(
-        peer_session: PeerSession,
+        peer: Peer,
+        chain_sync: Client<HeaderContent>,
         intersection: Vec<Point>,
         is_catching_up: Arc<RwLock<bool>>,
     ) -> Self {
         Self {
-            client: ChainSyncClient::new(peer_session, intersection, is_catching_up),
+            client: ChainSyncClient::new(peer, chain_sync, intersection, is_catching_up),
             downstream: Default::default(),
         }
     }
 
-    pub async fn find_intersection(&self) -> Result<(), WorkerError> {
+    pub async fn find_intersection(&mut self) -> Result<(), WorkerError> {
         self.client.find_intersection().await.or_panic()
     }
 
@@ -68,25 +68,29 @@ impl Stage {
     }
 }
 
-pub struct Worker {}
+pub struct Worker {
+    initialised: bool,
+}
 
 #[async_trait::async_trait(?Send)]
 impl gasket::framework::Worker<Stage> for Worker {
-    async fn bootstrap(stage: &Stage) -> Result<Self, WorkerError> {
-        stage.find_intersection().await?;
-
-        let worker = Self {};
+    async fn bootstrap(_stage: &Stage) -> Result<Self, WorkerError> {
+        let worker = Self { initialised: false };
 
         Ok(worker)
     }
 
     async fn schedule(&mut self, stage: &mut Stage) -> Result<WorkSchedule<WorkUnit>, WorkerError> {
-        if stage.client.has_agency().await {
-            // should request next block
-            Ok(WorkSchedule::Unit(WorkUnit::Pull))
+        if self.initialised {
+            if stage.client.has_agency().await {
+                // should request next block
+                Ok(WorkSchedule::Unit(WorkUnit::Pull))
+            } else {
+                // should await for next block
+                Ok(WorkSchedule::Unit(WorkUnit::Await))
+            }
         } else {
-            // should await for next block
-            Ok(WorkSchedule::Unit(WorkUnit::Await))
+            Ok(WorkSchedule::Unit(WorkUnit::Intersect))
         }
     }
 
@@ -99,6 +103,11 @@ impl gasket::framework::Worker<Stage> for Worker {
         let next = match unit {
             WorkUnit::Pull => stage.client.request_next().await.or_panic()?,
             WorkUnit::Await => stage.client.await_next().await.or_panic()?,
+            WorkUnit::Intersect => {
+                stage.find_intersection().await?;
+                self.initialised = true;
+                return Ok(());
+            }
         };
 
         match next {

--- a/crates/amaru/src/stages/pull.rs
+++ b/crates/amaru/src/stages/pull.rs
@@ -19,7 +19,7 @@ use amaru_network::{chain_sync_client::ChainSyncClient, point::from_network_poin
 use gasket::framework::*;
 use pallas_network::miniprotocols::chainsync::{Client, HeaderContent, NextResponse, Tip};
 use std::sync::{Arc, RwLock};
-use tracing::{Level, instrument};
+use tracing::{Level, debug, instrument};
 
 pub type DownstreamPort = gasket::messaging::OutputPort<ChainSyncEvent>;
 
@@ -105,6 +105,7 @@ impl gasket::framework::Worker<Stage> for Worker {
             WorkUnit::Await => stage.client.await_next().await.or_panic()?,
             WorkUnit::Intersect => {
                 stage.find_intersection().await?;
+                debug!("chain_sync {}: intersection found", stage.client.peer);
                 self.initialised = true;
                 return Ok(());
             }


### PR DESCRIPTION
This PR avoids the `pull` stage from starving the `block_fetch` stage because of the need to hold a lock on a shared client. It turns out each mini protocol client can be unbundled and used as a standalone client without the need to explicit locking.

Kudos to @rkuhn 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an initial intersection step in the pull stage for smoother first-time synchronization.

- Performance
  - Reduced internal locking and indirection by using direct per-peer clients, improving chain sync and block fetch throughput.

- Reliability
  - Added timeout-driven retries during header import to recover from slow/unresponsive peers.
  - More consistent agency handling and improved tracing for easier diagnostics.

- Refactor
  - Simplified peer handling and updated startup/bootstrap flow to accept direct peer connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->