### PR TITLE
Notify when node is caught-up with its peer(s)

### DIFF
--- a/crates/amaru-consensus/src/consensus/mod.rs
+++ b/crates/amaru-consensus/src/consensus/mod.rs
@@ -45,8 +45,8 @@ pub fn build_stage_graph(
 
     // TODO: currently only validate_header errors, will need to grow into all error handling
     let upstream_errors_stage = network.stage("upstream_errors", async |_, msg, eff| {
-        let ValidationFailed { peer, point, error } = msg;
-        tracing::error!(%peer, %point, %error, "invalid header");
+        let ValidationFailed { peer, error } = msg;
+        tracing::error!(%peer, %error, "invalid header");
 
         // TODO: implement specific actions once we have an upstream network
 
@@ -92,13 +92,12 @@ pub fn build_stage_graph(
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ValidationFailed {
     pub peer: Peer,
-    pub point: Point,
     pub error: ConsensusError,
 }
 
 impl ValidationFailed {
-    pub fn new(peer: Peer, point: Point, error: ConsensusError) -> Self {
-        Self { peer, point, error }
+    pub fn new(peer: Peer, error: ConsensusError) -> Self {
+        Self { peer, error }
     }
 }
 
@@ -187,14 +186,6 @@ impl DecodedChainSyncEvent {
             DecodedChainSyncEvent::RollForward { peer, .. } => peer.clone(),
             DecodedChainSyncEvent::Rollback { peer, .. } => peer.clone(),
             DecodedChainSyncEvent::CaughtUp { peer, .. } => peer.clone(),
-        }
-    }
-
-    pub fn point(&self) -> Point {
-        match self {
-            DecodedChainSyncEvent::RollForward { point, .. } => point.clone(),
-            DecodedChainSyncEvent::Rollback { rollback_point, .. } => rollback_point.clone(),
-            DecodedChainSyncEvent::CaughtUp { .. } => todo!(),
         }
     }
 }

--- a/crates/amaru-consensus/src/consensus/mod.rs
+++ b/crates/amaru-consensus/src/consensus/mod.rs
@@ -117,6 +117,11 @@ pub enum ChainSyncEvent {
         #[serde(skip, default = "Span::none")]
         span: Span,
     },
+    CaughtUp {
+        peer: Peer,
+        #[serde(skip, default = "Span::none")]
+        span: Span,
+    },
 }
 
 impl fmt::Debug for ChainSyncEvent {
@@ -145,6 +150,10 @@ impl fmt::Debug for ChainSyncEvent {
                 .field("peer", &peer.name)
                 .field("rollback_point", &rollback_point.to_string())
                 .finish(),
+            ChainSyncEvent::CaughtUp { peer, .. } => f
+                .debug_struct("CaughtUp")
+                .field("peer", &peer.name)
+                .finish(),
         }
     }
 }
@@ -165,6 +174,11 @@ pub enum DecodedChainSyncEvent {
         #[serde(skip, default = "Span::none")]
         span: Span,
     },
+    CaughtUp {
+        peer: Peer,
+        #[serde(skip, default = "Span::none")]
+        span: Span,
+    },
 }
 
 impl DecodedChainSyncEvent {
@@ -172,6 +186,7 @@ impl DecodedChainSyncEvent {
         match self {
             DecodedChainSyncEvent::RollForward { peer, .. } => peer.clone(),
             DecodedChainSyncEvent::Rollback { peer, .. } => peer.clone(),
+            DecodedChainSyncEvent::CaughtUp { peer, .. } => peer.clone(),
         }
     }
 
@@ -179,6 +194,7 @@ impl DecodedChainSyncEvent {
         match self {
             DecodedChainSyncEvent::RollForward { point, .. } => point.clone(),
             DecodedChainSyncEvent::Rollback { rollback_point, .. } => rollback_point.clone(),
+            DecodedChainSyncEvent::CaughtUp { .. } => todo!(),
         }
     }
 }
@@ -205,6 +221,10 @@ impl fmt::Debug for DecodedChainSyncEvent {
                 .debug_struct("Rollback")
                 .field("peer", &peer.name)
                 .field("rollback_point", &rollback_point.to_string())
+                .finish(),
+            DecodedChainSyncEvent::CaughtUp { peer, .. } => f
+                .debug_struct("CaughtUp")
+                .field("peer", &peer.name)
                 .finish(),
         }
     }

--- a/crates/amaru-consensus/src/consensus/receive_header.rs
+++ b/crates/amaru-consensus/src/consensus/receive_header.rs
@@ -97,6 +97,10 @@ pub async fn stage(
             )
             .await
         }
+        ChainSyncEvent::CaughtUp { peer, span } => {
+            eff.send(&downstream, DecodedChainSyncEvent::CaughtUp { peer, span })
+                .await
+        }
     }
     (downstream, errors)
 }

--- a/crates/amaru-consensus/src/consensus/receive_header.rs
+++ b/crates/amaru-consensus/src/consensus/receive_header.rs
@@ -66,8 +66,7 @@ pub async fn stage(
                 Ok(header) => header,
                 Err(error) => {
                     tracing::error!(%error, %point, %peer, "Failed to decode header");
-                    eff.send(&errors, ValidationFailed::new(peer, point.clone(), error))
-                        .await;
+                    eff.send(&errors, ValidationFailed::new(peer, error)).await;
                     return (downstream, errors);
                 }
             };

--- a/crates/amaru-consensus/src/consensus/select_chain.rs
+++ b/crates/amaru-consensus/src/consensus/select_chain.rs
@@ -44,15 +44,20 @@ impl SyncTracker {
     pub fn new(peers: &[Peer]) -> Self {
         let peers_state = peers
             .iter()
-            .map(|p| ((*p).clone(), SyncState::Syncing))
+            .map(|p| (p.clone(), SyncState::Syncing))
             .collect();
         Self { peers_state }
     }
 
     pub fn caught_up(&mut self, peer: &Peer) {
         if let Some(s) = self.peers_state.get_mut(peer) {
-            *s = SyncState::CaughtUp;
-            info!(%peer, "caught-up");
+            match s {
+                SyncState::Syncing => {
+                    *s = SyncState::CaughtUp;
+                    info!(%peer, "caught-up");
+                }
+                SyncState::CaughtUp => (),
+            }
         } else {
             warn!("unknown caught-up peer {}", peer);
         }

--- a/crates/amaru-consensus/src/consensus/select_chain.rs
+++ b/crates/amaru-consensus/src/consensus/select_chain.rs
@@ -25,7 +25,7 @@ use pure_stage::{Effects, StageRef, Void};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Display, Formatter};
-use tracing::{Level, Span, debug, error, instrument, trace};
+use tracing::{Level, Span, debug, info, instrument, trace, warn};
 
 pub const DEFAULT_MAXIMUM_FRAGMENT_LENGTH: usize = 2160;
 
@@ -52,8 +52,9 @@ impl SyncTracker {
     pub fn caught_up(&mut self, peer: &Peer) {
         if let Some(s) = self.peers_state.get_mut(peer) {
             *s = SyncState::CaughtUp;
+            info!(%peer, "caught-up");
         } else {
-            error!("unknown caught-up peer {}", peer);
+            warn!("unknown caught-up peer {}", peer);
         }
     }
 

--- a/crates/amaru-consensus/src/consensus/select_chain.rs
+++ b/crates/amaru-consensus/src/consensus/select_chain.rs
@@ -311,19 +311,14 @@ pub async fn stage(
     adopt_current_span(&msg);
     let peer = msg.peer();
 
-    let point = msg.point();
     let events = match select_chain.handle_chain_sync(msg).await {
         Ok(events) => events,
         Err(e) => {
-            eff.send(&errors, ValidationFailed::new(peer, point, e))
-                .await;
+            eff.send(&errors, ValidationFailed::new(peer, e)).await;
             return (select_chain, downstream, errors);
         }
     };
 
-    if events.is_empty() {
-        tracing::info!(%peer, %point, "no events to send");
-    }
     for event in events {
         eff.send(&downstream, event).await;
     }

--- a/crates/amaru-consensus/src/consensus/store_header.rs
+++ b/crates/amaru-consensus/src/consensus/store_header.rs
@@ -47,6 +47,7 @@ pub async fn stage(
             eff.send(&downstream, msg).await
         }
         DecodedChainSyncEvent::Rollback { .. } => eff.send(&downstream, msg).await,
+        DecodedChainSyncEvent::CaughtUp { .. } => eff.send(&downstream, msg).await,
     }
     downstream
 }

--- a/crates/amaru-consensus/src/consensus/validate_header.rs
+++ b/crates/amaru-consensus/src/consensus/validate_header.rs
@@ -123,7 +123,7 @@ impl ValidateHeader {
     )]
     pub async fn handle_roll_forward<M, S>(
         &mut self,
-        eff: &Effects<M, S>,
+        eff: &mut Effects<M, S>,
         peer: Peer,
         point: Point,
         header: Header,
@@ -151,7 +151,7 @@ impl ValidateHeader {
 
     pub async fn validate_header<M, S>(
         &mut self,
-        eff: &Effects<M, S>,
+        eff: &mut Effects<M, S>,
         chain_sync: DecodedChainSyncEvent,
         global_parameters: &GlobalParameters,
     ) -> Result<DecodedChainSyncEvent, ConsensusError> {
@@ -226,11 +226,8 @@ pub async fn stage(
             Ok(nonces) => nonces,
             Err(error) => {
                 tracing::error!(%peer, %error, "evolve nonce failed");
-                eff.send(
-                    &errors,
-                    ValidationFailed::new(peer.clone(), point.clone(), error.into()),
-                )
-                .await;
+                eff.send(&errors, ValidationFailed::new(peer.clone(), error.into()))
+                    .await;
                 return false;
             }
         };
@@ -245,11 +242,8 @@ pub async fn stage(
             &global,
         ) {
             tracing::info!(%peer, %error, "invalid header");
-            eff.send(
-                &errors,
-                ValidationFailed::new(peer.clone(), point.clone(), error),
-            )
-            .await;
+            eff.send(&errors, ValidationFailed::new(peer.clone(), error))
+                .await;
             false
         } else {
             true

--- a/crates/amaru-consensus/src/span.rs
+++ b/crates/amaru-consensus/src/span.rs
@@ -45,6 +45,7 @@ mod impls {
             match self {
                 ChainSyncEvent::RollForward { span, .. } => span.context(),
                 ChainSyncEvent::Rollback { span, .. } => span.context(),
+                ChainSyncEvent::CaughtUp { span, .. } => span.context(),
             }
         }
     }
@@ -54,6 +55,7 @@ mod impls {
             match self {
                 DecodedChainSyncEvent::RollForward { span, .. } => span.context(),
                 DecodedChainSyncEvent::Rollback { span, .. } => span.context(),
+                DecodedChainSyncEvent::CaughtUp { span, .. } => span.context(),
             }
         }
     }

--- a/crates/amaru/src/bin/amaru/cmd/import_headers.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_headers.rs
@@ -21,12 +21,7 @@ use amaru_stores::rocksdb::consensus::RocksDBStore;
 use clap::Parser;
 use gasket::framework::*;
 use pallas_network::miniprotocols::chainsync::{HeaderContent, NextResponse};
-use std::{
-    error::Error,
-    path::PathBuf,
-    sync::{Arc, RwLock},
-    time::Duration,
-};
+use std::{error::Error, path::PathBuf, time::Duration};
 use tokio::time::timeout;
 use tracing::info;
 
@@ -109,7 +104,6 @@ pub(crate) async fn import_headers(
         Peer::new(peer_address),
         peer_client.chainsync,
         vec![point.clone()],
-        Arc::new(RwLock::new(true)),
     );
 
     client.find_intersection().await?;

--- a/crates/amaru/src/stages/mod.rs
+++ b/crates/amaru/src/stages/mod.rs
@@ -413,7 +413,7 @@ fn make_chain_selector(
         tree.initialize_peer(peer, &root_hash)?;
     }
 
-    Ok(SelectChain::new(tree, &peers.iter().collect()))
+    Ok(SelectChain::new(tree, peers))
 }
 
 pub trait PallasPoint {

--- a/simulation/amaru-sim/src/simulator/mod.rs
+++ b/simulation/amaru-sim/src/simulator/mod.rs
@@ -367,5 +367,5 @@ fn make_chain_selector(
         tree.initialize_peer(peer, &root_hash)
             .expect("the root node is guaranteed to already be in the tree")
     }
-    SelectChain::new(tree)
+    SelectChain::new(tree, &peers.iter().collect())
 }

--- a/simulation/amaru-sim/src/simulator/mod.rs
+++ b/simulation/amaru-sim/src/simulator/mod.rs
@@ -367,5 +367,5 @@ fn make_chain_selector(
         tree.initialize_peer(peer, &root_hash)
             .expect("the root node is guaranteed to already be in the tree")
     }
-    SelectChain::new(tree, &peers.iter().collect())
+    SelectChain::new(tree, peers)
 }


### PR DESCRIPTION
Following-up on work to better handle waiting for more blocks to come by decoupling PeerClient in its constituent mini-protocols, this PR  handles caught-up logic in a more robust way by sending downstream messages when our peer asks for waiting. A node is now considered caught-up once _all_ its peers are caught-up. 
It also removes the `point` from `ValidationFailed` as it's not always possible now to retrieve a `point` from all propagated events and this information should be in the error anyhow.

This PR does not attempt to handle disconnections nor fall back from `CaughtUp` state to `Syncing`, this will be handled separately, but it does address some of the concerns of #335.  

Here are how logs look like: 

```
2025-09-01T15:56:37.804758Z DEBUG amaru::consensus: new_tip hash=9b14c160e5fad961c18c0c3e7f0ec73c7d918651dd4b87473ace00bb6a807869 slot=90086104
2025-09-01T15:56:37.804792Z DEBUG amaru::consensus: new_tip hash=8246b637be26a6e61e1ad53acab9820e2f8005fb8cfaaba05c30c45e456266c8 slot=90086105
2025-09-01T15:56:37.804826Z DEBUG amaru::consensus: new_tip hash=9b6baefd6438f088700abe34ccb2b90da3b1f1bf144287382bbd6182f34099fd slot=90086180
2025-09-01T15:56:37.804838Z  INFO amaru_consensus::consensus::select_chain: caught-up peer=localhost:3001
2025-09-01T15:57:42.096002Z DEBUG amaru::consensus: new_tip hash=0903e0933d4f57fa5e0faeb38910e9d6d9e6d169dd2ddd05487635cfd304bdba slot=90086262
2025-09-01T15:57:53.109177Z DEBUG amaru::consensus: new_tip hash=91c74842b4e5934f7969f2ac80bf4bff03e3dca851bde35b9434c03f34105c12 slot=90086273
2025-09-01T15:58:38.271418Z DEBUG amaru::consensus: new_tip hash=f391dcc54325cd2b2c8b73d9c5f77d47638e5745d4b6558541bfd7ca7d3a4eea slot=90086318
2025-09-01T15:58:52.102944Z DEBUG amaru::consensus: new_tip hash=433c11009b61d4ba22dd2dcab2e388eac145dba71348bd92ab479be50a276351 slot=90086332
2025-09-01T15:58:57.308605Z DEBUG amaru::consensus: new_tip hash=544c23c36b48599e6bbf3d1c57a5d508380590c7422ef333f4dfe5c91e226b17 slot=90086337
2025-09-01T15:59:01.204670Z DEBUG amaru::consensus: new_tip hash=4a03133394ab5ed90f743cb6895a0569950d61dd8e564fe4f611b8cdecc3b08c slot=90086341
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chain sync now emits a per-peer "Caught up" event that flows through stages and downstream.

* **Bug Fixes / Improvements**
  * Enhanced chain-event logging (adds slot and fork length) and simplified validation error reporting.

* **Refactor**
  * Removed legacy "catching up" flag; stage/client initialization and event forwarding streamlined; select-chain now tracks per-peer sync state.

* **Tests**
  * Added unit tests for per-peer sync tracking and caught-up detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->