### PR TITLE
chore: use expect for warnings and remove unused ones

### DIFF
--- a/crates/amaru-consensus/benches/headers_tree.rs
+++ b/crates/amaru-consensus/benches/headers_tree.rs
@@ -26,7 +26,7 @@
 /// This way of profiling was chosen to be able to isolate exactly the code we want to benchmark
 /// and not the generation of the tree and actions.
 ///
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 #[cfg(all(unix, feature = "profiling", feature = "test-utils"))]
 fn main() {
     use pprof::{ProfilerGuardBuilder, flamegraph::Options};

--- a/crates/amaru-consensus/src/consensus/headers_tree/headers_tree.rs
+++ b/crates/amaru-consensus/src/consensus/headers_tree/headers_tree.rs
@@ -41,7 +41,6 @@ type HeaderHash = Hash<HEADER_HASH_SIZE>;
 ///  - tree: a tree representation of the headers to be able to traverse from root to leaves.
 ///  - peers: a map of the latest tip for each peer.
 ///
-#[allow(dead_code)]
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HeadersTree<H> {
     /// Maximum size allowed for a given chain
@@ -140,7 +139,6 @@ impl<H: IsHeader + Clone + PartialEq + Eq> HeadersTree<H> {
     }
 }
 
-#[allow(dead_code)]
 impl<H: IsHeader + Clone + Debug + PartialEq + Eq> HeadersTree<H> {
     /// Initialize a HeadersTree as a tree rooted in the Genesis header
     pub fn new(max_length: usize, root: &Option<H>) -> HeadersTree<H> {
@@ -446,7 +444,7 @@ impl<H: IsHeader + Clone + PartialEq + Eq> HeadersTree<H> {
 
     /// Return the header for a given hash, panicking if it does not exist.
     /// This function should only with precaution, when we are sure the header exists.
-    #[allow(clippy::panic)]
+    #[expect(clippy::panic)]
     fn unsafe_get_header(&self, hash: &HeaderHash) -> &H {
         self.get_header(hash)
             .unwrap_or_else(|| panic!("A header must exist for hash {}", hash))
@@ -528,7 +526,6 @@ impl<H: IsHeader + Clone + PartialEq + Eq> HeadersTree<H> {
 
     /// Return the header hash that is the least common parent between 2 headers in the tree
     /// This implementation avoids materializing the full set of ancestors for both headers.
-    #[allow(clippy::panic)]
     fn find_intersection_hash(&self, hash1: &HeaderHash, hash2: &HeaderHash) -> HeaderHash {
         if hash1 == hash2 {
             return *hash1;

--- a/crates/amaru-consensus/src/consensus/headers_tree/mod.rs
+++ b/crates/amaru-consensus/src/consensus/headers_tree/mod.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #[cfg(any(test, feature = "test-utils"))]
-#[allow(clippy::module_inception, clippy::unwrap_used)]
+#[expect(clippy::module_inception, clippy::unwrap_used)]
 pub mod data_generation;
 
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 pub mod headers_tree;
 mod tree;
 

--- a/crates/amaru-consensus/src/consensus/mod.rs
+++ b/crates/amaru-consensus/src/consensus/mod.rs
@@ -158,7 +158,6 @@ impl fmt::Debug for ChainSyncEvent {
 }
 
 #[derive(Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[allow(clippy::large_enum_variant)]
 pub enum DecodedChainSyncEvent {
     RollForward {
         peer: Peer,
@@ -222,7 +221,6 @@ impl fmt::Debug for DecodedChainSyncEvent {
 }
 
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-#[allow(clippy::large_enum_variant)]
 pub enum ValidateHeaderEvent {
     Validated {
         peer: Peer,

--- a/crates/amaru-consensus/src/consensus/store_block.rs
+++ b/crates/amaru-consensus/src/consensus/store_block.rs
@@ -77,7 +77,6 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    #[allow(clippy::wildcard_enum_match_arm)]
     #[tokio::test]
     async fn handle_event_returns_passed_event_when_rollbacking() {
         let mock_store = Arc::new(Mutex::new(FakeStore::default()));

--- a/crates/amaru-consensus/src/consensus/store_effects.rs
+++ b/crates/amaru-consensus/src/consensus/store_effects.rs
@@ -35,7 +35,7 @@ impl StoreHeaderEffect {
 }
 
 impl ExternalEffect for StoreHeaderEffect {
-    #[allow(clippy::expect_used)]
+    #[expect(clippy::expect_used)]
     fn run(
         self: Box<Self>,
         resources: Resources,
@@ -70,7 +70,7 @@ impl EvolveNonceEffect {
 }
 
 impl ExternalEffect for EvolveNonceEffect {
-    #[allow(clippy::expect_used)]
+    #[expect(clippy::expect_used)]
     fn run(
         self: Box<Self>,
         resources: Resources,

--- a/crates/amaru-kernel/src/account.rs
+++ b/crates/amaru-kernel/src/account.rs
@@ -17,7 +17,6 @@ use crate::{DRep, Lovelace, PoolId, Set, StrictMaybe, cbor};
 #[derive(Debug)]
 pub struct Account {
     pub rewards_and_deposit: StrictMaybe<(Lovelace, Lovelace)>,
-    #[allow(dead_code)]
     pub pointers: Set<(u64, u64, u64)>,
     pub pool: StrictMaybe<PoolId>,
     pub drep: StrictMaybe<DRep>,

--- a/crates/amaru-kernel/src/anchor.rs
+++ b/crates/amaru-kernel/src/anchor.rs
@@ -23,7 +23,7 @@ pub mod tests {
     prop_compose! {
         pub fn any_anchor()(
             url in {
-                #[allow(clippy::unwrap_used)]
+                #[expect(clippy::unwrap_used)]
                 string::string_regex(
                     r"(https:)?[a-zA-Z0-9]{2,}(\.[a-zA-Z0-9]{2,})(\.[a-zA-Z0-9]{2,})?"
                 ).unwrap()

--- a/crates/amaru-kernel/src/drep_state.rs
+++ b/crates/amaru-kernel/src/drep_state.rs
@@ -19,7 +19,6 @@ pub struct DRepState {
     pub expiry: Epoch,
     pub anchor: StrictMaybe<Anchor>,
     pub deposit: Lovelace,
-    #[allow(dead_code)]
     pub delegators: Set<StakeCredential>,
 }
 

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -372,7 +372,7 @@ pub fn output_stake_credential(output: &MemoizedTransactionOutput) -> Option<Sta
 
 // TODO: Required because Pallas doesn't export any contructors for StakeAddress directly. Should
 // be fixed there.
-#[allow(clippy::expect_used)]
+#[expect(clippy::expect_used)]
 pub fn new_stake_address(network: Network, payload: StakePayload) -> StakeAddress {
     let fake_payment_part = ShelleyPaymentPart::Key(Hash::new([
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -449,7 +449,7 @@ pub fn reward_account_to_stake_credential(account: &RewardAccount) -> Option<Sta
 
 /// An 'unsafe' version of `reward_account_to_stake_credential` that panics when the given
 /// RewardAccount isn't a `StakeCredential`.
-#[allow(clippy::panic)]
+#[expect(clippy::panic)]
 pub fn expect_stake_credential(account: &RewardAccount) -> StakeCredential {
     reward_account_to_stake_credential(account)
         .unwrap_or_else(|| panic!("unexpected malformed reward account: {:?}", account))
@@ -618,7 +618,7 @@ pub trait HasNetwork {
 }
 
 impl HasNetwork for Address {
-    #[allow(clippy::unwrap_used)]
+    #[expect(clippy::unwrap_used)]
     fn has_network(&self) -> Network {
         match self {
             Address::Byron(address) => address.has_network(),
@@ -644,7 +644,7 @@ impl HasNetwork for ByronAddress {
         As a result, since we are only checking the network of a Byron address for validation, we will mirror the Haskell node logic and disregard the discriminant when fetching the network from an address.
         (https://github.com/IntersectMBO/cardano-ledger/blob/2d1e94cf96d00ba0da53883c388fa0aba6d74624/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs#L152)
     */
-    #[allow(clippy::unwrap_used)]
+    #[expect(clippy::unwrap_used)]
     fn has_network(&self) -> Network {
         // Unwrap is safe, we know that there is a valid address payload if it is a Byron address.
         let x: AddressPayload = from_cbor(&self.payload.0).unwrap();

--- a/crates/amaru-kernel/src/memoized/script.rs
+++ b/crates/amaru-kernel/src/memoized/script.rs
@@ -70,15 +70,15 @@ pub fn encode_script<W: cbor::encode::Write>(
             bytes
         }
         MemoizedScript::PlutusV1Script(plutus) => {
-            #[allow(clippy::unwrap_used)] // Infallible error.
+            #[expect(clippy::unwrap_used)] // Infallible error.
             cbor::to_vec((1, Into::<&ByteSlice>::into(plutus.as_ref()))).unwrap()
         }
         MemoizedScript::PlutusV2Script(plutus) => {
-            #[allow(clippy::unwrap_used)] // Infallible error.
+            #[expect(clippy::unwrap_used)] // Infallible error.
             cbor::to_vec((2, Into::<&ByteSlice>::into(plutus.as_ref()))).unwrap()
         }
         MemoizedScript::PlutusV3Script(plutus) => {
-            #[allow(clippy::unwrap_used)] // Infallible error.
+            #[expect(clippy::unwrap_used)] // Infallible error.
             cbor::to_vec((3, Into::<&ByteSlice>::into(plutus.as_ref()))).unwrap()
         }
     };

--- a/crates/amaru-kernel/src/memoized/transaction_output.rs
+++ b/crates/amaru-kernel/src/memoized/transaction_output.rs
@@ -313,7 +313,6 @@ fn from_legacy_value(value: AlonzoValue) -> Result<Value, String> {
     }
 }
 
-#[allow(dead_code)] // not dead, used in a serde macro field.
 fn serialize_address<S: serde::ser::Serializer>(
     addr: &Address,
     serializer: S,
@@ -329,7 +328,6 @@ fn deserialize_address<'de, D: serde::de::Deserializer<'de>>(
 }
 
 // FIXME: Eventually allow serializing complete values, not just coins.
-#[allow(dead_code)] // not dead, used in a serde macro field.
 fn serialize_value<S: serde::ser::Serializer>(
     value: &Value,
     serializer: S,

--- a/crates/amaru-kernel/src/network.rs
+++ b/crates/amaru-kernel/src/network.rs
@@ -434,7 +434,6 @@ impl From<NetworkName> for &EraHistory {
     }
 }
 
-#[allow(clippy::todo)]
 impl From<NetworkName> for &GlobalParameters {
     fn from(value: NetworkName) -> Self {
         match value {
@@ -590,7 +589,6 @@ pub mod tests {
         }
 
         #[test]
-        #[allow(clippy::disallowed_methods)]
         fn can_compute_slot_to_epoch_for_preprod() {
             let era_history = &*PREPROD_ERA_HISTORY;
             assert_eq!(

--- a/crates/amaru-kernel/src/proposal_state.rs
+++ b/crates/amaru-kernel/src/proposal_state.rs
@@ -19,7 +19,6 @@ pub struct ProposalState {
     pub id: ProposalId,
     pub procedure: Proposal,
     pub proposed_in: Epoch,
-    #[allow(dead_code)]
     pub expires_after: Epoch,
 }
 

--- a/crates/amaru-kernel/src/reward.rs
+++ b/crates/amaru-kernel/src/reward.rs
@@ -16,9 +16,7 @@ use crate::{Lovelace, PoolId, RewardKind, cbor};
 
 #[derive(Debug)]
 pub struct Reward {
-    #[allow(dead_code)]
     pub kind: RewardKind,
-    #[allow(dead_code)]
     pub pool: PoolId,
     pub amount: Lovelace,
 }

--- a/crates/amaru-kernel/src/reward_kind.rs
+++ b/crates/amaru-kernel/src/reward_kind.rs
@@ -21,7 +21,7 @@ pub enum RewardKind {
 }
 
 impl<'b, C> cbor::decode::Decode<'b, C> for RewardKind {
-    #[allow(clippy::panic)]
+    #[expect(clippy::panic)]
     fn decode(d: &mut cbor::Decoder<'b>, _ctx: &mut C) -> Result<Self, cbor::decode::Error> {
         Ok(match d.u8()? {
             0 => RewardKind::Member,

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -613,7 +613,7 @@ fn import_proposals(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn import_stake_pools<S: Store>(
     db: &S,
     point: &Point,
@@ -1024,7 +1024,7 @@ fn decode_seggregated_parameters(
 
 // TODO: Move to Pallas
 #[derive(Debug)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 struct GovActionState {
     id: ProposalId,
     committee_votes: BTreeMap<StakeCredential, Vote>,
@@ -1056,7 +1056,7 @@ impl<'d, C> cbor::decode::Decode<'d, C> for GovActionState {
 #[derive(Debug)]
 enum ConstitutionalCommitteeAuthorization {
     DelegatedToHotCredential(StakeCredential),
-    Resigned(#[allow(dead_code)] StrictMaybe<Anchor>),
+    Resigned(#[expect(dead_code)] StrictMaybe<Anchor>),
 }
 
 impl<'d, C> cbor::decode::Decode<'d, C> for ConstitutionalCommitteeAuthorization {

--- a/crates/amaru-ledger/src/context/assert.rs
+++ b/crates/amaru-ledger/src/context/assert.rs
@@ -59,7 +59,7 @@ impl From<AssertPreparationContext> for AssertValidationContext {
 impl PreparationContext<'_> for AssertPreparationContext {}
 
 impl PrepareUtxoSlice<'_> for AssertPreparationContext {
-    #[allow(clippy::panic)]
+    #[expect(clippy::panic)]
     fn require_input(&mut self, input: &TransactionInput) {
         if !self.utxo.contains_key(input) {
             panic!("unknown required input: {input:?}");

--- a/crates/amaru-ledger/src/context/default/validation.rs
+++ b/crates/amaru-ledger/src/context/default/validation.rs
@@ -218,7 +218,6 @@ impl CommitteeSlice for DefaultValidationContext {
 }
 
 impl ProposalsSlice for DefaultValidationContext {
-    #[allow(clippy::unwrap_used)]
     fn acknowledge(&mut self, id: ProposalId, pointer: ProposalPointer, proposal: Proposal) {
         self.state
             .proposals

--- a/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
+++ b/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
@@ -313,7 +313,6 @@ impl ProposalsForest {
                     }
                 }
 
-                #[allow(clippy::map_entry)]
                 if self.proposals.contains_key(&id) {
                     Ok((id, BTreeSet::new()))
                 } else {
@@ -1217,7 +1216,7 @@ mod tests {
                                 .map(|(k, v)| (k, u64::from(v)))
                                 .collect::<Vec<(_, _)>>(),
                         ),
-                        #[allow(clippy::unwrap_used)]
+                        #[expect(clippy::unwrap_used)]
                         RationalNumber {
                             numerator: threshold.numer().try_into().unwrap(),
                             denominator: threshold.denom().try_into().unwrap(),
@@ -1280,7 +1279,7 @@ mod tests {
                                 .chain(protocol_parameters.1)
                                 .chain(orphan)
                                 .for_each(|(id, pointer, action)| {
-                                    #[allow(clippy::unwrap_used)]
+                                    #[expect(clippy::unwrap_used)]
                                     forest
                                         .insert(&ERA_HISTORY, id.clone(), pointer, action.clone())
                                         .unwrap();
@@ -1293,7 +1292,7 @@ mod tests {
                                 .chain(constitution.1)
                                 .chain(orphan)
                                 .for_each(|(id, pointer, action)| {
-                                    #[allow(clippy::unwrap_used)]
+                                    #[expect(clippy::unwrap_used)]
                                     forest
                                         .insert(&ERA_HISTORY, id.clone(), pointer, action.clone())
                                         .unwrap();

--- a/crates/amaru-ledger/src/governance/ratification/proposals_tree.rs
+++ b/crates/amaru-ledger/src/governance/ratification/proposals_tree.rs
@@ -193,7 +193,7 @@ impl<T: Eq + Ord> Sibling<T> {
         }
     }
 
-    #[allow(dead_code)] // Actually used in tests.
+    #[cfg(test)]
     pub fn id(&self) -> Rc<T> {
         self.id.clone()
     }
@@ -332,7 +332,7 @@ mod tests {
         #[test]
         #[should_panic]
         fn prop_cannot_insert_already_existing_element((mut tree, next, any_parent) in any_proposals_tree()) {
-            #[allow(unused_must_use)]
+            #[expect(unused_must_use)]
             tree.insert(Rc::new(next - 1), any_parent);
         }
     }

--- a/crates/amaru-ledger/src/rules/block/header_size.rs
+++ b/crates/amaru-ledger/src/rules/block/header_size.rs
@@ -20,7 +20,7 @@ pub fn block_header_size_valid(
     header: &[u8],
     protocol_params: &ProtocolParameters,
 ) -> Result<(), InvalidBlockDetails> {
-    #[allow(clippy::unnecessary_fallible_conversions)]
+    #[expect(clippy::unnecessary_fallible_conversions)]
     let max_header_size = protocol_params
         .max_block_header_size
         .try_into()

--- a/crates/amaru-ledger/src/rules/transaction.rs
+++ b/crates/amaru-ledger/src/rules/transaction.rs
@@ -78,7 +78,7 @@ pub enum InvalidTransaction {
     Metadata(#[from] InvalidTransactionMetadata),
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub fn execute<C>(
     context: &mut C,
     network: &Network,

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -157,7 +157,7 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
         ))
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new_with(
         stable: S,
         snapshots: HS,
@@ -233,8 +233,8 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
 
     /// Inspect the tip of this ledger state. This corresponds to the point of the latest block
     /// applied to the ledger.
-    #[allow(clippy::panic)]
-    #[allow(clippy::unwrap_used)]
+    #[expect(clippy::panic)]
+    #[expect(clippy::unwrap_used)]
     pub fn tip(&'_ self) -> Cow<'_, Point> {
         if let Some(st) = self.volatile.view_back() {
             return Cow::Borrowed(&st.anchor.0);
@@ -249,8 +249,9 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
         )
     }
 
-    #[allow(clippy::unwrap_used)]
-    #[instrument(level = Level::TRACE, skip_all, fields(point.slot = %now_stable.anchor.0.slot_or_default()))]
+    #[expect(clippy::unwrap_used)]
+    #[instrument(level = Level::TRACE, skip_all, fields(point.slot = %now_stable.anchor.0.slot_or_default())
+    )]
     fn apply_block(&mut self, now_stable: AnchoredVolatileState) -> Result<(), StateError> {
         let stable_tip_slot = now_stable.anchor.0.slot_or_default();
 
@@ -419,7 +420,7 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
         Ok(protocol_parameters)
     }
 
-    #[allow(clippy::unwrap_used)]
+    #[expect(clippy::unwrap_used)]
     #[instrument(level = Level::TRACE, skip_all)]
     fn compute_rewards(&mut self) -> Result<RewardsSummary, StateError> {
         let mut stake_distributions = self.stake_distributions.lock().unwrap();
@@ -450,7 +451,6 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
     /// Roll the ledger forward with the given block by applying transactions one by one, in
     /// sequence. The update stops at the first invalid transaction, if any. Otherwise, it updates
     /// the internal state of the ledger.
-    #[allow(clippy::unwrap_used)]
     #[instrument(level = Level::TRACE, skip_all)]
     pub fn forward(&mut self, next_state: AnchoredVolatileState) -> Result<(), StateError> {
         // Persist the next now-immutable block, which may not quite exist when we just
@@ -498,8 +498,9 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
         })
     }
 
-    #[allow(clippy::unwrap_used)]
-    #[instrument(level = Level::TRACE, skip_all, name="state.resolve_inputs", fields(resolved_from_context, resolved_from_volatile, resolved_from_db))]
+    #[expect(clippy::unwrap_used)]
+    #[instrument(level = Level::TRACE, skip_all, name="state.resolve_inputs", fields(resolved_from_context, resolved_from_volatile, resolved_from_db)
+    )]
     pub fn resolve_inputs<'a>(
         &'_ self,
         ongoing_state: &VolatileState,
@@ -932,10 +933,9 @@ pub struct StakeDistributionObserver {
 }
 
 impl HasStakeDistribution for StakeDistributionObserver {
-    #[allow(clippy::unwrap_used)]
+    #[expect(clippy::unwrap_used)]
     fn get_pool(&self, slot: Slot, pool: &PoolId) -> Option<PoolSummary> {
         let view = self.view.lock().unwrap();
-        #[allow(clippy::disallowed_methods)]
         let epoch = self
             .era_history
             // NOTE: This function is called by the consensus when validating block headers. So in

--- a/crates/amaru-ledger/src/state/volatile_db.rs
+++ b/crates/amaru-ledger/src/state/volatile_db.rs
@@ -184,7 +184,7 @@ pub struct StoreUpdate<W, A, R> {
 }
 
 impl AnchoredVolatileState {
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn into_store_update(
         self,
         epoch: Epoch,
@@ -320,7 +320,7 @@ fn remove_dreps(
     mut deregistrations: BTreeMap<StakeCredential, CertificatePointer>,
 ) -> impl Iterator<Item = (dreps::Key, CertificatePointer)> {
     iterator.map(move |credential| {
-        #[allow(clippy::expect_used)]
+        #[expect(clippy::expect_used)]
         let pointer = deregistrations
             .remove(&credential)
             .expect("every 'unregistered' drep must have a matching deregistration");

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -214,7 +214,7 @@ pub trait HistoricalStores {
 
     /// The least recent snapshot. Note that we never starts from genesis; so there's always a
     /// snapshot available.
-    #[allow(clippy::panic)]
+    #[expect(clippy::panic)]
     fn least_recent_snapshot(&self) -> Epoch {
         self.snapshots()
             .unwrap_or_default()
@@ -225,7 +225,7 @@ pub trait HistoricalStores {
 
     /// The most recent snapshot. Note that we never starts from genesis; so there's always a
     /// snapshot available.
-    #[allow(clippy::panic)]
+    #[expect(clippy::panic)]
     fn most_recent_snapshot(&self) -> Epoch {
         self.snapshots()
             .unwrap_or_default()
@@ -262,7 +262,7 @@ pub trait TransactionalContext<'a>: ReadStore {
 
     /// Add or remove entries to/from the store. The exact semantic of 'add' and 'remove' depends
     /// on the column type. All updates are atomatic and attached to the given `Point`.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn save(
         &self,
         era_history: &EraHistory,

--- a/crates/amaru-ledger/src/store/columns/mod.rs
+++ b/crates/amaru-ledger/src/store/columns/mod.rs
@@ -24,7 +24,7 @@ pub mod slots;
 pub mod utxo;
 pub mod votes;
 
-#[allow(clippy::panic)]
+#[expect(clippy::panic)]
 pub fn unsafe_decode<T: for<'d> cbor::Decode<'d, ()>>(bytes: Vec<u8>) -> T {
     cbor::decode(&bytes).unwrap_or_else(|e| {
         panic!(

--- a/crates/amaru-ledger/src/store/columns/pools.rs
+++ b/crates/amaru-ledger/src/store/columns/pools.rs
@@ -179,7 +179,7 @@ impl Row {
         )
     }
 
-    #[allow(clippy::panic)]
+    #[expect(clippy::panic)]
     pub fn extend(mut bytes: Vec<u8>, future_params: (Option<PoolParams>, Epoch)) -> Vec<u8> {
         let tail = bytes.split_off(bytes.len() - 1);
         assert_eq!(tail, vec![0xFF], "invalid pool tail");

--- a/crates/amaru-ledger/src/store/columns/utxo.rs
+++ b/crates/amaru-ledger/src/store/columns/utxo.rs
@@ -112,7 +112,7 @@ pub mod tests {
                 fields: MaybeIndefArray::Def(vec![PlutusData::BigInt(big_int)]),
             });
 
-            #[allow(clippy::expect_used)]
+            #[expect(clippy::expect_used)]
             let memoized =
                 MemoizedPlutusData::new(pd).expect("PlutusData encoding should never fail");
 

--- a/crates/amaru-ledger/src/summary/governance.rs
+++ b/crates/amaru-ledger/src/summary/governance.rs
@@ -73,7 +73,6 @@ impl GovernanceSummary {
 
         db.iter_proposals()?
             .try_for_each(|(_, row)| -> Result<(), Error> {
-                #[allow(clippy::disallowed_methods)]
                 let epoch = era_history
                     .slot_to_epoch_unchecked_horizon(row.proposed_in.transaction.slot)
                     .map_err(|e| Error::EraHistoryError(row.proposed_in.transaction.slot, e))?;

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -597,7 +597,7 @@ impl RewardsSummary {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn apply_leader_rewards(
         accounts: &mut BTreeMap<StakeCredential, Lovelace>,
         blocks_per_pool: &mut BTreeMap<PoolId, u64>,

--- a/crates/amaru-ledger/src/summary/stake_distribution.rs
+++ b/crates/amaru-ledger/src/summary/stake_distribution.rs
@@ -454,7 +454,7 @@ pub mod tests {
         ) -> DRepState {
             // Ensure registered at is always strictly after previous de-registrations.
             let (registered_at, previous_deregistration) = if previous_deregistration > Some(registered_at) {
-                #[allow(clippy::unwrap_used)]
+                #[expect(clippy::unwrap_used)]
                 // NOTE: .unwrap can't fail because of the 'if' guard.
                 (previous_deregistration.unwrap(), Some(registered_at))
             } else if previous_deregistration == Some(registered_at) {

--- a/crates/amaru-stores/src/in_memory/mod.rs
+++ b/crates/amaru-stores/src/in_memory/mod.rs
@@ -154,7 +154,6 @@ impl ReadStore for MemoryStore {
         Ok((&*self.pots.borrow()).into())
     }
 
-    #[allow(refining_impl_trait)]
     fn iter_utxos(
         &self,
     ) -> Result<
@@ -175,7 +174,6 @@ impl ReadStore for MemoryStore {
         Ok(utxo_vec.into_iter())
     }
 
-    #[allow(refining_impl_trait)]
     fn iter_block_issuers(
         &self,
     ) -> Result<
@@ -197,7 +195,6 @@ impl ReadStore for MemoryStore {
         Ok(block_issuer_vec.into_iter())
     }
 
-    #[allow(refining_impl_trait)]
     fn iter_pools(
         &self,
     ) -> Result<
@@ -219,7 +216,6 @@ impl ReadStore for MemoryStore {
         Ok(pool_vec.into_iter())
     }
 
-    #[allow(refining_impl_trait)]
     fn iter_accounts(
         &self,
     ) -> Result<
@@ -241,7 +237,6 @@ impl ReadStore for MemoryStore {
         Ok(accounts_vec.into_iter())
     }
 
-    #[allow(refining_impl_trait)]
     fn iter_dreps(
         &self,
     ) -> Result<
@@ -263,7 +258,6 @@ impl ReadStore for MemoryStore {
         Ok(dreps_vec.into_iter())
     }
 
-    #[allow(refining_impl_trait)]
     fn iter_proposals(
         &self,
     ) -> Result<
@@ -285,7 +279,6 @@ impl ReadStore for MemoryStore {
         Ok(proposals_vec.into_iter())
     }
 
-    #[allow(refining_impl_trait)]
     fn iter_cc_members(
         &self,
     ) -> Result<
@@ -307,7 +300,6 @@ impl ReadStore for MemoryStore {
         Ok(cc_members_vec.into_iter())
     }
 
-    #[allow(refining_impl_trait)]
     fn iter_votes(
         &self,
     ) -> Result<
@@ -419,7 +411,6 @@ impl<'a> ReadStore for MemoryTransactionalContext<'a> {
         self.store.pots()
     }
 
-    #[allow(refining_impl_trait)]
     fn iter_utxos(
         &self,
     ) -> Result<
@@ -434,7 +425,6 @@ impl<'a> ReadStore for MemoryTransactionalContext<'a> {
         self.store.iter_utxos()
     }
 
-    #[allow(refining_impl_trait)]
     fn iter_block_issuers(
         &self,
     ) -> Result<
@@ -449,7 +439,6 @@ impl<'a> ReadStore for MemoryTransactionalContext<'a> {
         self.store.iter_block_issuers()
     }
 
-    #[allow(refining_impl_trait)]
     fn iter_pools(
         &self,
     ) -> Result<
@@ -464,7 +453,6 @@ impl<'a> ReadStore for MemoryTransactionalContext<'a> {
         self.store.iter_pools()
     }
 
-    #[allow(refining_impl_trait)]
     fn iter_accounts(
         &self,
     ) -> Result<
@@ -479,7 +467,6 @@ impl<'a> ReadStore for MemoryTransactionalContext<'a> {
         self.store.iter_accounts()
     }
 
-    #[allow(refining_impl_trait)]
     fn iter_dreps(
         &self,
     ) -> Result<
@@ -494,7 +481,6 @@ impl<'a> ReadStore for MemoryTransactionalContext<'a> {
         self.store.iter_dreps()
     }
 
-    #[allow(refining_impl_trait)]
     fn iter_proposals(
         &self,
     ) -> Result<
@@ -509,7 +495,6 @@ impl<'a> ReadStore for MemoryTransactionalContext<'a> {
         self.store.iter_proposals()
     }
 
-    #[allow(refining_impl_trait)]
     fn iter_cc_members(
         &self,
     ) -> Result<
@@ -524,7 +509,6 @@ impl<'a> ReadStore for MemoryTransactionalContext<'a> {
         self.store.iter_cc_members()
     }
 
-    #[allow(refining_impl_trait)]
     fn iter_votes(
         &self,
     ) -> Result<

--- a/crates/amaru-stores/src/rocksdb/common.rs
+++ b/crates/amaru-stores/src/rocksdb/common.rs
@@ -32,7 +32,7 @@ pub fn as_value<T: cbor::Encode<()> + std::fmt::Debug>(value: T) -> Vec<u8> {
 }
 
 /// A simple helper function to encode any (serialisable) value to CBOR bytes.
-#[allow(clippy::panic)]
+#[expect(clippy::panic)]
 pub fn as_bytes<T: cbor::Encode<()> + std::fmt::Debug>(prefix: &[u8], value: T) -> Vec<u8> {
     let mut buffer = Vec::from(prefix);
     cbor::encode(value, &mut buffer)

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/dreps.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/dreps.rs
@@ -29,7 +29,6 @@ use tracing::error;
 pub const PREFIX: [u8; PREFIX_LEN] = [0x64, 0x72, 0x65, 0x70];
 
 /// Register a new DRep.
-#[allow(clippy::unwrap_used)]
 pub fn add<DB>(
     db: &Transaction<'_, DB>,
     valid_until_on_update: Epoch,

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/proposals.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/proposals.rs
@@ -25,7 +25,6 @@ pub use amaru_ledger::store::{
 pub const PREFIX: [u8; PREFIX_LEN] = [0x70, 0x72, 0x6F, 0x70];
 
 /// Register a new Proposal.
-#[allow(clippy::unwrap_used)]
 pub fn add<DB>(
     db: &Transaction<'_, DB>,
     rows: impl Iterator<Item = (Key, Value)>,

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/utxo.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/utxo.rs
@@ -23,7 +23,7 @@ use rocksdb::Transaction;
 /// Name prefixed used for storing UTxO entries. UTF-8 encoding for "utxo"
 pub const PREFIX: [u8; PREFIX_LEN] = [0x75, 0x74, 0x78, 0x6f];
 
-#[allow(clippy::panic)]
+#[expect(clippy::panic)]
 pub fn get(
     db_get: impl Fn(&[u8]) -> Result<Option<Vec<u8>>, rocksdb::Error>,
     key: &Key,

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/votes.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/votes.rs
@@ -27,7 +27,6 @@ pub const PREFIX: [u8; PREFIX_LEN] = [0x76, 0x6f, 0x74, 0x65];
 
 /// Register a series of new votes. Returns the credentials (script or key) of all dreps found
 /// amongst the voters.
-#[allow(clippy::unwrap_used)]
 pub fn add<DB>(
     db: &Transaction<'_, DB>,
     rows: impl Iterator<Item = (Key, Value)>,

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -230,7 +230,8 @@ impl Snapshot for RocksDBSnapshot {
 impl Store for RocksDB {
     type Transaction<'a> = RocksDBTransactionalContext<'a>;
 
-    #[instrument(level = Level::INFO, target = EVENT_TARGET, name = "snapshot", skip_all, fields(epoch))]
+    #[instrument(level = Level::INFO, target = EVENT_TARGET, name = "snapshot", skip_all, fields(epoch)
+    )]
     fn next_snapshot(&'_ self, epoch: Epoch) -> Result<(), StoreError> {
         let path = self.dir.join(epoch.to_string());
 
@@ -249,7 +250,7 @@ impl Store for RocksDB {
         Ok(())
     }
 
-    #[allow(clippy::panic)] // Expected
+    #[expect(clippy::panic)] // Expected
     fn create_transaction(&self) -> RocksDBTransactionalContext<'_> {
         if self.ongoing_transaction.get() {
             // Thats a bug in the code, we should never have two transactions at the same time
@@ -851,7 +852,7 @@ fn pretty_print_snapshot_ranges(ranges: &[Vec<u64>]) -> String {
         .map(|g| match g.len() {
             0 => "[]".to_string(),
             1 => format!("[{}]", g[0]),
-            #[allow(clippy::unwrap_used)] // Infallible error.
+            #[expect(clippy::unwrap_used)] // Infallible error.
             _ => format!("[{}..{}]", g.first().unwrap(), g.last().unwrap()),
         })
         .collect::<Vec<_>>()
@@ -898,8 +899,8 @@ where
         .map_err(StoreError::Undecodable)
 }
 
-#[allow(clippy::panic)]
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::panic)]
+#[expect(clippy::unwrap_used)]
 pub fn iter<'a, 'b, K, V, DB, F>(
     db_iter_opt: F,
     prefix: [u8; PREFIX_LEN],
@@ -940,7 +941,7 @@ where
 }
 
 /// An generic column iterator, provided that rows from the column are (de)serialisable.
-#[allow(clippy::panic)]
+#[expect(clippy::panic)]
 fn with_prefix_iterator<
     K: Clone + fmt::Debug + for<'d> cbor::Decode<'d, ()> + cbor::Encode<()>,
     V: Clone + fmt::Debug + for<'d> cbor::Decode<'d, ()> + cbor::Encode<()>,

--- a/crates/amaru-stores/src/rocksdb/transaction.rs
+++ b/crates/amaru-stores/src/rocksdb/transaction.rs
@@ -39,7 +39,7 @@ impl OngoingTransaction {
     }
 
     pub(crate) fn set(&self, value: bool) {
-        #[allow(clippy::panic)]
+        #[expect(clippy::panic)]
         if self.get() == value {
             // This is a bug, we should never set the same value twice. Crash the process.
             panic!("Ongoing transaction was already set to {}", value);

--- a/crates/amaru/build.rs
+++ b/crates/amaru/build.rs
@@ -14,7 +14,7 @@
 
 use std::env;
 
-#[allow(clippy::expect_used)]
+#[expect(clippy::expect_used)]
 fn main() {
     built::write_built_file().expect("Failed to acquire build-time information");
 

--- a/crates/amaru/src/bin/amaru/cmd/import_headers.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_headers.rs
@@ -58,7 +58,8 @@ pub struct Args {
     ///
     /// This is the "intersection" point which will be given to the peer as a starting point
     /// to import the chain database.
-    #[arg(long, value_name = "POINT", verbatim_doc_comment, value_parser = |s: &str| Point::try_from(s))]
+    #[arg(long, value_name = "POINT", verbatim_doc_comment, value_parser = |s: &str| Point::try_from(s)
+    )]
     starting_point: Point,
 
     /// Number of headers to import.
@@ -158,7 +159,7 @@ async fn await_for_next_block(
     }
 }
 
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 fn handle_response(
     next: NextResponse<HeaderContent>,
     db: &mut RocksDBStore,
@@ -189,7 +190,6 @@ fn handle_response(
                 Ok(Continue)
             }
         }
-        #[allow(clippy::unwrap_used)]
         NextResponse::RollBackward(point, tip) => {
             info!(?point, ?tip, "roll_backward");
             if progress.is_none() {

--- a/crates/amaru/src/bin/amaru/cmd/import_ledger_state.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_ledger_state.rs
@@ -122,7 +122,7 @@ async fn import_all(
     Ok(())
 }
 
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 async fn import_one(
     network: NetworkName,
     snapshot: &PathBuf,

--- a/crates/amaru/src/bin/amaru/cmd/import_nonces.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_nonces.rs
@@ -111,7 +111,6 @@ pub(crate) async fn import_nonces(
 
     let epoch = {
         let slot = initial_nonce.at.slot_or_default();
-        #[allow(clippy::disallowed_methods)]
         // NOTE: The slot definitely exists and is within one of the known eras.
         era_history.slot_to_epoch_unchecked_horizon(slot)?
     };

--- a/crates/amaru/src/bin/amaru/observability.rs
+++ b/crates/amaru/src/bin/amaru/observability.rs
@@ -52,7 +52,7 @@ type JsonLayer<S> = Layered<JsonFilter<S>, S>;
 
 type JsonFilter<S> = Filtered<Layer<S, JsonFields, Format<Json>>, EnvFilter, S>;
 
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 #[derive(Default)]
 pub enum TracingSubscriber<S> {
     #[default]
@@ -68,8 +68,8 @@ impl TracingSubscriber<Registry> {
         Self::Registry(tracing_subscriber::registry())
     }
 
-    #[allow(clippy::panic)]
-    #[allow(clippy::wildcard_enum_match_arm)]
+    #[expect(clippy::panic)]
+    #[expect(clippy::wildcard_enum_match_arm)]
     pub fn with_open_telemetry(&mut self, layer: OpenTelemetryFilter<Registry>) {
         match std::mem::take(self) {
             Self::Registry(registry) => {
@@ -79,8 +79,8 @@ impl TracingSubscriber<Registry> {
         }
     }
 
-    #[allow(clippy::panic)]
-    #[allow(clippy::wildcard_enum_match_arm)]
+    #[expect(clippy::panic)]
+    #[expect(clippy::wildcard_enum_match_arm)]
     pub fn with_json<F, G>(&mut self, layer_json: F, layer_both: G)
     where
         F: FnOnce() -> JsonFilter<Registry>,
@@ -207,7 +207,7 @@ pub struct OpenTelemetryConfig {
     pub metric_url: String,
 }
 
-#[allow(clippy::panic)]
+#[expect(clippy::panic)]
 pub fn setup_open_telemetry(
     config: &OpenTelemetryConfig,
     subscriber: &mut TracingSubscriber<Registry>,
@@ -281,7 +281,7 @@ fn teardown_open_telemetry(
 // -----------------------------------------------------------------------------
 // ENV FILTER
 // -----------------------------------------------------------------------------
-#[allow(clippy::expect_used)]
+#[expect(clippy::expect_used)]
 fn default_filter(var: &str, default: &str) -> EnvFilter {
     match EnvFilter::try_from_env(var) {
         Ok(filter) => filter,

--- a/crates/amaru/src/exit.rs
+++ b/crates/amaru/src/exit.rs
@@ -20,7 +20,7 @@ use tracing::{trace, warn};
 
 #[inline]
 #[cfg(unix)]
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 async fn wait_for_exit_signal() {
     let mut sigterm =
         tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).unwrap();

--- a/crates/amaru/src/stages/consensus/forward_chain.rs
+++ b/crates/amaru/src/stages/consensus/forward_chain.rs
@@ -69,7 +69,7 @@ impl ForwardChainStage {
         max_peers: usize,
         our_tip: Tip,
     ) -> Self {
-        #[allow(clippy::expect_used)]
+        #[expect(clippy::expect_used)]
         let runtime =
             AcTokio::new("consensus.forward", 1).expect("failed to create AcTokio runtime");
         Self {
@@ -85,7 +85,6 @@ impl ForwardChainStage {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
 pub enum Unit {
     Peer(RefCell<Option<PeerServer>>),
     Block(BlockValidationResult),
@@ -183,7 +182,6 @@ impl Drop for Worker {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 enum ClientOp {
     /// the tip to go back to
@@ -360,7 +358,6 @@ impl gasket::framework::Worker<ForwardChainStage> for Worker {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
 enum ClientMsg {
     /// A new peer has connected to us.
     ///

--- a/crates/amaru/src/stages/consensus/forward_chain/client_protocol.rs
+++ b/crates/amaru/src/stages/consensus/forward_chain/client_protocol.rs
@@ -82,7 +82,6 @@ pub async fn client_protocols(
     Ok(())
 }
 
-#[allow(clippy::large_enum_variant)]
 pub enum ChainSyncMsg {
     /// An operation coming in from the ledger
     Op(ClientOp),

--- a/crates/amaru/src/stages/consensus/forward_chain/test_infra.rs
+++ b/crates/amaru/src/stages/consensus/forward_chain/test_infra.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![expect(dead_code)]
 // Copyright 2025 PRAGMA
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -349,7 +349,6 @@ impl Client {
 }
 
 #[derive(Clone)]
-#[allow(clippy::large_enum_variant)]
 pub enum ClientMsg {
     Forward(Header, Tip),
     Backward(Point, Tip),

--- a/crates/amaru/src/stages/mod.rs
+++ b/crates/amaru/src/stages/mod.rs
@@ -151,7 +151,6 @@ impl From<MaxExtraLedgerSnapshots> for u64 {
     }
 }
 
-#[allow(clippy::todo)]
 pub fn bootstrap(
     config: Config,
     clients: Vec<(String, PeerClient)>,
@@ -296,7 +295,7 @@ pub fn bootstrap(
 
 type ChainStoreResult = (Tip, Option<Header>, Arc<Mutex<dyn ChainStore<Header>>>);
 
-#[allow(clippy::todo, clippy::panic)]
+#[expect(clippy::panic)]
 fn make_chain_store(
     config: &Config,
     era_history: &EraHistory,
@@ -309,7 +308,6 @@ fn make_chain_store(
 
     let (our_tip, header) = if let amaru_kernel::Point::Specific(_slot, hash) = &tip {
         let tip_hash = &Hash::from(&**hash);
-        #[allow(clippy::expect_used)]
         let header: Header = chain_store.load_header(tip_hash).unwrap_or_else(|| {
             panic!(
                 "Tip {} not found in chain database '{}'",

--- a/crates/amaru/tests/iter/borrow.rs
+++ b/crates/amaru/tests/iter/borrow.rs
@@ -48,7 +48,7 @@ impl<'b, C> cbor::decode::Decode<'b, C> for Fruit {
 }
 
 /// A simple helper function to encode any (serialisable) value to CBOR bytes.
-#[allow(clippy::panic)]
+#[expect(clippy::panic)]
 fn to_cbor<T: cbor::Encode<()> + std::fmt::Debug>(value: T) -> Vec<u8> {
     let mut buffer = Vec::new();
     cbor::encode(&value, &mut buffer)
@@ -111,7 +111,6 @@ fn db_iterator_mutate() {
 
     // Simulate a series of operation on the "fruit" table, deferring updates to a separate
     // 'handler' function.
-    #[allow(clippy::panic)]
     {
         let batch = db.transaction();
         let mut iterator: KeyValueIterator<'_, 6, String, Fruit> = new(batch

--- a/crates/amaru/tests/summary.rs
+++ b/crates/amaru/tests/summary.rs
@@ -36,8 +36,8 @@ use test_case::test_case;
 pub static CONNECTIONS: LazyLock<Mutex<BTreeMap<Epoch, Arc<RocksDBSnapshot>>>> =
     LazyLock::new(|| Mutex::new(BTreeMap::new()));
 
-#[allow(clippy::panic)]
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::panic)]
+#[expect(clippy::unwrap_used)]
 /// Get a read-only handle on a snapshot. This allows to run all test cases in parallel without
 /// conflicts (a single scenario typically need 2 snapshots, so two tests may need access to the
 /// same snapshot at the same time).
@@ -76,9 +76,9 @@ include!(concat!(
     "/generated_compare_snapshot_test_cases.incl"
 ));
 
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 fn compare_snapshot(epoch: Epoch) {
-    #[allow(clippy::expect_used)]
+    #[expect(clippy::expect_used)]
     let network: NetworkName = env!("NETWORK")
         .to_string()
         .parse()

--- a/crates/iter-borrow/src/lib.rs
+++ b/crates/iter-borrow/src/lib.rs
@@ -140,7 +140,7 @@ pub mod borrowable_proxy {
     where
         F: FnOnce(T),
     {
-        #[allow(clippy::unwrap_used)]
+        #[expect(clippy::unwrap_used)]
         fn borrow(&self) -> &T {
             self.item.as_ref().unwrap()
         }
@@ -151,7 +151,7 @@ pub mod borrowable_proxy {
     where
         F: FnOnce(T),
     {
-        #[allow(clippy::unwrap_used)]
+        #[expect(clippy::unwrap_used)]
         fn borrow_mut(&mut self) -> &mut T {
             self.borrowed = true;
             self.item.as_mut().unwrap()

--- a/crates/minicbor-extra/src/lib.rs
+++ b/crates/minicbor-extra/src/lib.rs
@@ -18,7 +18,7 @@ use std::convert::Infallible;
 pub use decode::*;
 pub mod decode;
 
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 /// Encode any serialisable value `T` into bytes.
 pub fn to_cbor<T: cbor::Encode<()>>(value: &T) -> Vec<u8> {
     let mut buffer = Vec::new();

--- a/crates/ouroboros-traits/src/has_stake_distribution/mock.rs
+++ b/crates/ouroboros-traits/src/has_stake_distribution/mock.rs
@@ -28,7 +28,7 @@ pub struct MockLedgerState {
 }
 
 impl MockLedgerState {
-    #[allow(clippy::unwrap_used)]
+    #[expect(clippy::unwrap_used)]
     pub fn new(vrf_vkey_hash: &str, stake: Lovelace, active_stake: Lovelace) -> Self {
         Self {
             vrf_vkey_hash: vrf_vkey_hash.parse().unwrap(),

--- a/crates/ouroboros/src/praos/header.rs
+++ b/crates/ouroboros/src/praos/header.rs
@@ -28,7 +28,7 @@ use thiserror::Error;
 /// FIXME: Ideally, we should replace the use of dashu in pallas-math with num-bigint
 /// since it has become our weapong of choice within Amaru. Mixing maths libraries is
 /// a recipe for mistakes.
-#[allow(clippy::expect_used)]
+#[expect(clippy::expect_used)]
 static CERTIFIED_NATURAL_MAX: LazyLock<FixedDecimal> = LazyLock::new(|| {
     FixedDecimal::from_str(
         "1157920892373161954235709850086879078532699846656405640394575840079131296399360000000000000000000000000000000000",

--- a/crates/ouroboros/src/vrf/mod.rs
+++ b/crates/ouroboros/src/vrf/mod.rs
@@ -194,11 +194,10 @@ pub enum ProofFromBytesError {
     DecompressionFailed,
 }
 
-#[allow(clippy::expect_used)]
 impl TryFrom<&[u8; Self::SIZE]> for Proof {
     type Error = ProofFromBytesError;
 
-    #[allow(clippy::wildcard_enum_match_arm)]
+    #[expect(clippy::wildcard_enum_match_arm)]
     fn try_from(slice: &[u8; Self::SIZE]) -> Result<Self, Self::Error> {
         Ok(Proof(VrfProof03::from_bytes(slice).map_err(
             |e| match e {

--- a/crates/ouroboros/tests/validation.rs
+++ b/crates/ouroboros/tests/validation.rs
@@ -184,7 +184,7 @@ where
 
 #[derive(Debug, Serialize, Deserialize)]
 enum Mutation {
-    #[allow(clippy::enum_variant_names)]
+    #[expect(clippy::enum_variant_names)]
     NoMutation,
     MutateKESKey,
     MutateColdKey,

--- a/crates/progress-bar/src/terminal_progress_bar.rs
+++ b/crates/progress-bar/src/terminal_progress_bar.rs
@@ -20,7 +20,7 @@ pub struct TerminalProgressBar {
     inner: indicatif::ProgressBar,
 }
 
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 pub fn new_terminal_progress_bar(size: usize, template: &str) -> Box<dyn ProgressBar> {
     Box::new(TerminalProgressBar {
         inner: indicatif::ProgressBar::new(size as u64)

--- a/crates/pure-stage/src/effect.rs
+++ b/crates/pure-stage/src/effect.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::expect_used)]
+#![expect(clippy::expect_used)]
 // Copyright 2025 PRAGMA
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -255,7 +255,7 @@ impl dyn ExternalEffect {
 
     pub fn cast<T: ExternalEffect>(self: Box<Self>) -> anyhow::Result<Box<T>> {
         if (&*self as &dyn Any).is::<T>() {
-            #[allow(clippy::expect_used)]
+            #[expect(clippy::expect_used)]
             Ok(Box::new(
                 *(self as Box<dyn Any>)
                     .downcast::<T>()
@@ -383,7 +383,7 @@ impl StageEffect<Box<dyn SendData>> {
     /// - the marker we remember in the running simulation
     /// - the effect we emit to the outside world
     pub fn split(self, at_name: Name) -> (StageEffect<()>, Effect) {
-        #[allow(clippy::panic)]
+        #[expect(clippy::panic)]
         match self {
             StageEffect::Receive => (StageEffect::Receive, Effect::Receive { at_stage: at_name }),
             StageEffect::Send(name, msg, call_param) => {
@@ -472,7 +472,7 @@ pub enum Effect {
     },
 }
 
-#[allow(clippy::wildcard_enum_match_arm, clippy::panic)]
+#[expect(clippy::wildcard_enum_match_arm, clippy::panic)]
 impl Effect {
     pub fn at_stage(&self) -> &Name {
         match self {
@@ -496,7 +496,7 @@ impl Effect {
         }
     }
 
-    #[allow(clippy::unwrap_used)]
+    #[expect(clippy::unwrap_used)]
     pub fn assert_send<Msg1, Msg2: SendData + PartialEq, St1, St2>(
         &self,
         at_stage: &StageRef<Msg1, St1>,
@@ -614,7 +614,7 @@ impl Effect {
                 at_stage: a,
                 effect: e,
             } if a == at_stage.name => {
-                #[allow(clippy::unwrap_used)]
+                #[expect(clippy::unwrap_used)]
                 let e = e.cast::<Eff>().unwrap();
                 assert_eq!(&*e, effect);
                 e
@@ -628,7 +628,7 @@ impl Effect {
 }
 
 impl PartialEq for Effect {
-    #[allow(clippy::wildcard_enum_match_arm)]
+    #[expect(clippy::wildcard_enum_match_arm)]
     fn eq(&self, other: &Self) -> bool {
         match self {
             Effect::Receive { at_stage } => match other {

--- a/crates/pure-stage/src/logging/layer.rs
+++ b/crates/pure-stage/src/logging/layer.rs
@@ -38,7 +38,7 @@
 // NOTE: This is a work in progress.
 // ********************************************************
 
-#![allow(unused)]
+#![expect(unused)]
 
 use cbor4ii::{
     core::{
@@ -63,7 +63,7 @@ impl CborVisitor {
     }
 }
 
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used)]
 impl tracing::field::Visit for CborVisitor {
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
         let mut buf = Vec::new();
@@ -164,7 +164,7 @@ where
         }
     }
 
-    #[allow(clippy::expect_used)]
+    #[expect(clippy::expect_used)]
     fn on_enter(&self, id: &tracing::span::Id, ctx: Context<'_, S>) {
         if let Some(span) = ctx.span(id) {
             let ext = span.extensions();
@@ -199,7 +199,7 @@ where
         }
     }
 
-    #[allow(clippy::expect_used)]
+    #[expect(clippy::expect_used)]
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
         let mut visitor = CborVisitor::default();
         event.record(&mut visitor);
@@ -226,7 +226,7 @@ impl CborEmitter for Arc<Mutex<Vec<u8>>> {
     }
 }
 
-#[allow(clippy::disallowed_types)]
+#[expect(clippy::disallowed_types)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/pure-stage/src/resources.rs
+++ b/crates/pure-stage/src/resources.rs
@@ -15,7 +15,7 @@
 use parking_lot::{
     MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock, RwLockReadGuard, RwLockWriteGuard,
 };
-#[allow(clippy::disallowed_types)]
+#[expect(clippy::disallowed_types)]
 use std::{
     any::{Any, TypeId, type_name},
     collections::HashMap,
@@ -46,7 +46,7 @@ use std::{
 /// use [`SyncWrapper`](https://docs.rs/sync_wrapper/latest/sync_wrapper/struct.SyncWrapper.html)
 /// or a mutex.
 #[derive(Default, Clone)]
-#[allow(clippy::disallowed_types)]
+#[expect(clippy::disallowed_types)]
 pub struct Resources(Arc<RwLock<HashMap<TypeId, Box<dyn Any + Send + Sync>>>>);
 
 impl Resources {

--- a/crates/pure-stage/src/serde.rs
+++ b/crates/pure-stage/src/serde.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code, clippy::borrowed_box)]
+#![expect(dead_code, clippy::borrowed_box)]
 // Copyright 2025 PRAGMA
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,7 +58,7 @@ pub enum Void {}
 #[cold]
 #[inline(never)]
 #[track_caller]
-#[allow(clippy::panic)]
+#[expect(clippy::panic)]
 pub fn never() -> ! {
     panic!("unreachable: never")
 }
@@ -222,7 +222,7 @@ pub fn to_cbor<T: serde::Serialize>(value: &T) -> Vec<u8> {
         static BUFFER: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
     }
     BUFFER.with_borrow_mut(|buffer| {
-        #[allow(clippy::expect_used)]
+        #[expect(clippy::expect_used)]
         to_writer(&mut *buffer, value).expect("serialization should not fail");
         let ret = Vec::from(buffer.as_slice());
         buffer.clear();

--- a/crates/pure-stage/src/simulation.rs
+++ b/crates/pure-stage/src/simulation.rs
@@ -1,4 +1,9 @@
-#![allow(
+#![expect(
+    clippy::wildcard_enum_match_arm,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::expect_used
+)]
 // Copyright 2025 PRAGMA
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,12 +17,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-    clippy::wildcard_enum_match_arm,
-    clippy::unwrap_used,
-    clippy::panic,
-    clippy::expect_used
-)]
 
 //! This module contains the [`SimulationBuilder`] and [`SimulationRunning`] types, which are
 //! used to build and run a simulation.
@@ -244,7 +243,7 @@ impl super::StageGraph for SimulationBuilder {
                 transition,
             },
         ) {
-            #[allow(clippy::panic)]
+            #[expect(clippy::panic)]
             {
                 // names are unique by construction
                 panic!("stage {name} already exists with state {:?}", old.state);

--- a/crates/pure-stage/src/simulation/inputs.rs
+++ b/crates/pure-stage/src/simulation/inputs.rs
@@ -57,7 +57,7 @@ impl Inputs {
                     .send(Envelope::new(stage_name, Box::new(msg), tx))
                     .await
                     .map_err(|e| {
-                        #[allow(clippy::expect_used)]
+                        #[expect(clippy::expect_used)]
                         *e.0.msg.cast::<Msg>().expect("message was just boxed")
                     })?;
                 rx.await.ok();

--- a/crates/pure-stage/src/simulation/replay.rs
+++ b/crates/pure-stage/src/simulation/replay.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)]
+#![expect(clippy::disallowed_types)]
 // Copyright 2025 PRAGMA
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/crates/pure-stage/src/simulation/running.rs
+++ b/crates/pure-stage/src/simulation/running.rs
@@ -73,7 +73,7 @@ pub struct SimulationRunning {
 }
 
 impl SimulationRunning {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(super) fn new(
         stages: BTreeMap<Name, StageData>,
         inputs: Inputs,
@@ -154,7 +154,7 @@ impl SimulationRunning {
                 if effect.is::<T>() {
                     // if this casting turns out to be a significant cost, we can split the
                     // overrides by TypeId and run each in an appropriately typed closure
-                    #[allow(clippy::expect_used)]
+                    #[expect(clippy::expect_used)]
                     match transform(effect.cast::<T>().expect("checked above")) {
                         OverrideResult::NoMatch(effect) => {
                             OverrideResult::NoMatch(effect as Box<dyn ExternalEffect>)
@@ -854,7 +854,6 @@ impl PartialOrd for Sleeping {
 
 struct OverrideExternalEffect {
     remaining: usize,
-    #[allow(clippy::type_complexity)]
     transform: Box<
         dyn FnMut(
                 Box<dyn ExternalEffect>,
@@ -1002,7 +1001,7 @@ fn simulation_invariants() {
         .unwrap();
     let mut sim = network.run(rt.handle().clone());
 
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     let ops: [(
         Box<dyn Fn(&Effect) -> Option<CallId>>,
         Box<dyn Fn(&mut SimulationRunning, &StageRef<Msg, bool>, CallId) -> anyhow::Result<()>>,

--- a/crates/pure-stage/src/time.rs
+++ b/crates/pure-stage/src/time.rs
@@ -117,7 +117,7 @@ impl Instant {
 impl std::ops::Add<Duration> for Instant {
     type Output = Instant;
 
-    #[allow(clippy::expect_used)]
+    #[expect(clippy::expect_used)]
     fn add(self, duration: Duration) -> Self {
         Instant(
             self.0
@@ -130,7 +130,7 @@ impl std::ops::Add<Duration> for Instant {
 impl std::ops::Sub<Duration> for Instant {
     type Output = Instant;
 
-    #[allow(clippy::expect_used)]
+    #[expect(clippy::expect_used)]
     fn sub(self, duration: Duration) -> Self {
         Instant(
             self.0

--- a/crates/pure-stage/src/tokio.rs
+++ b/crates/pure-stage/src/tokio.rs
@@ -134,7 +134,7 @@ impl StageGraph for TokioBuilder {
         }
     }
 
-    #[allow(clippy::expect_used)]
+    #[expect(clippy::expect_used)]
     fn wire_up<Msg: SendData, St: SendData>(
         &mut self,
         stage: StageBuildRef<Msg, St, Self::RefAux<Msg, St>>,
@@ -184,7 +184,6 @@ impl StageGraph for TokioBuilder {
         }
     }
 
-    #[allow(clippy::expect_used)]
     fn input<Msg: SendData, St>(&mut self, stage: &StageRef<Msg, St>) -> Sender<Msg> {
         mk_sender(&stage.name, &self.inner)
     }
@@ -224,7 +223,7 @@ impl StageGraph for TokioBuilder {
     }
 }
 
-#[allow(clippy::expect_used)]
+#[expect(clippy::expect_used)]
 fn mk_sender<Msg: SendData>(stage_name: &Name, inner: &TokioInner) -> Sender<Msg> {
     let tx = inner
         .senders
@@ -252,19 +251,19 @@ async fn interpreter<St>(
         if let Poll::Ready(state) = poll {
             return Some(state);
         }
-        #[allow(clippy::panic)]
+        #[expect(clippy::panic)]
         let Some(Left(eff)) = effect.lock().take() else {
             panic!("stage `{name}` used .await on something that was not a stage effect");
         };
         let resp = match eff {
             StageEffect::Receive => {
-                #[allow(clippy::panic)]
+                #[expect(clippy::panic)]
                 {
                     panic!("effect Receive cannot be explicitly awaited (stage `{name}`)")
                 }
             }
             StageEffect::Send(target, msg, call) => {
-                #[allow(clippy::expect_used)]
+                #[expect(clippy::expect_used)]
                 let tx = inner
                     .senders
                     .get(&target)
@@ -290,7 +289,7 @@ async fn interpreter<St>(
                 StageResponse::WaitResponse(now())
             }
             StageEffect::Call(..) => {
-                #[allow(clippy::panic)]
+                #[expect(clippy::panic)]
                 {
                     panic!("StageEffect::Call cannot be explicitly awaited (stage `{name}`")
                 }

--- a/crates/pure-stage/src/trace_buffer.rs
+++ b/crates/pure-stage/src/trace_buffer.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::borrowed_box)]
+#![expect(clippy::borrowed_box)]
 // Copyright 2025 PRAGMA
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -136,7 +136,7 @@ impl TraceBuffer {
 
         self.used_size += msg.len();
 
-        #[allow(clippy::expect_used)]
+        #[expect(clippy::expect_used)]
         while self.used_size > self.max_size && self.messages.len() > self.min_entries {
             self.used_size -= self
                 .messages
@@ -174,7 +174,7 @@ impl TraceBuffer {
     }
 
     /// Hydrate the trace buffer (stored in CBOR format) into a vector of entries.
-    #[allow(clippy::expect_used)]
+    #[expect(clippy::expect_used)]
     pub fn hydrate(&self) -> Vec<TraceEntry> {
         self.messages
             .iter()

--- a/crates/pure-stage/src/types.rs
+++ b/crates/pure-stage/src/types.rs
@@ -78,7 +78,7 @@ impl dyn SendData {
 
     fn try_cast<T: SendData>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
         if (&*self as &dyn Any).is::<T>() {
-            #[allow(clippy::expect_used)]
+            #[expect(clippy::expect_used)]
             Ok(Box::new(
                 *(self as Box<dyn Any>)
                     .downcast::<T>()
@@ -222,14 +222,14 @@ impl<T> DerefMut for MpscSender<T> {
     }
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct MpscReceiver<T> {
     #[serde(skip, default = "dummy_receiver")]
     pub receiver: mpsc::Receiver<T>,
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 fn dummy_receiver<T>() -> mpsc::Receiver<T> {
     mpsc::channel(1).1
 }

--- a/crates/pure-stage/tests/simulation.rs
+++ b/crates/pure-stage/tests/simulation.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::bool_assert_comparison)]
+#![expect(clippy::bool_assert_comparison)]
 // Copyright 2025 PRAGMA
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/crates/slot-arithmetic/src/lib.rs
+++ b/crates/slot-arithmetic/src/lib.rs
@@ -190,7 +190,7 @@ pub struct Bound {
     pub epoch: Epoch,
 }
 
-#[allow(dead_code)]
+#[cfg(test)]
 impl Bound {
     fn genesis() -> Bound {
         Bound {
@@ -453,7 +453,7 @@ pub struct EpochBounds {
 // the current tip. Returns number of milliseconds elapsed since the system start time.
 impl EraHistory {
     pub fn new(eras: &[Summary], stability_window: Slot) -> EraHistory {
-        #[allow(clippy::panic)]
+        #[expect(clippy::panic)]
         if eras.is_empty() {
             panic!("EraHistory cannot be empty");
         }
@@ -619,7 +619,6 @@ fn slot_to_epoch(slot: &Slot, era: &Summary) -> Result<Epoch, EraHistoryError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
     use proptest::prelude::*;

--- a/crates/tracing-json/src/lib.rs
+++ b/crates/tracing-json/src/lib.rs
@@ -47,7 +47,7 @@ struct JsonVisitor {
 }
 
 impl JsonVisitor {
-    #[allow(clippy::unwrap_used)]
+    #[expect(clippy::unwrap_used)]
     fn add_field(&mut self, json_path: &str, value: json::Value) {
         let steps = json_path.split('.').collect::<Vec<_>>();
 

--- a/examples/ledger-in-nodejs/src/lib.rs
+++ b/examples/ledger-in-nodejs/src/lib.rs
@@ -15,7 +15,7 @@
 use amaru_examples_shared::{forward_ledger, RAW_BLOCK_CONWAY_3};
 
 #[unsafe(no_mangle)]
-#[allow(clippy::missing_safety_doc)]
+#[expect(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn ledger() {
     forward_ledger(RAW_BLOCK_CONWAY_3);
 }

--- a/simulation/amaru-sim/src/simulator/data_generation/chain.rs
+++ b/simulation/amaru-sim/src/simulator/data_generation/chain.rs
@@ -21,7 +21,6 @@ use std::{fmt, fs};
 /// A chain represents a tree of blocks read from a JSON file.
 /// Each block may have multiple children, representing forks in the chain.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct Chain {
     pub block: Block,
     pub children: Vec<Chain>,

--- a/simulation/amaru-sim/src/simulator/ledger.rs
+++ b/simulation/amaru-sim/src/simulator/ledger.rs
@@ -119,7 +119,7 @@ pub struct IndividualStake {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub enum PopulateError {
     IoError(StoreError),
     SerdeError(serde_json::Error),
@@ -161,7 +161,7 @@ pub(crate) fn populate_chain_store(
 #[serde(rename_all = "camelCase")]
 // NOTE: we allow non snake case here because of the way the field name and KES
 // acronym is usually encoded in Haskell-land.
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 pub struct ConsensusContext {
     active_slot_coeff: f64,
     nonce: Hash<32>,

--- a/simulation/amaru-sim/src/simulator/simulate.rs
+++ b/simulation/amaru-sim/src/simulator/simulate.rs
@@ -256,7 +256,7 @@ mod tests {
 
     // This shows how we can test external binaries. The test is disabled because building and
     // locating a binary on CI, across all platforms, is annoying.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     #[ignore]
     fn blackbox_test_echo() {
         let config = SimulateConfig::default()

--- a/simulation/amaru-sim/src/simulator/world/mod.rs
+++ b/simulation/amaru-sim/src/simulator/world/mod.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 mod node_handle;
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 mod world;
 
 pub use node_handle::*;


### PR DESCRIPTION
`expect` raises a warning when the annotation is not necessary anymore.