### PR TITLE
Improve startup error message when missing bootstrapped db

### DIFF
--- a/crates/amaru/src/stages/mod.rs
+++ b/crates/amaru/src/stages/mod.rs
@@ -167,7 +167,14 @@ pub fn bootstrap(
         config.network,
         era_history.clone(),
         global_parameters.clone(),
-    )?;
+    )
+    .map_err(|e| -> Box<dyn Error> {
+        format!(
+            "Failed to create ledger. Have you bootstrapped your node? Error: {}",
+            e
+        )
+        .into()
+    })?;
 
     let (chain_syncs, block_fetchs): (
         Vec<(Peer, Client<HeaderContent>)>,


### PR DESCRIPTION
This PR resolves https://github.com/pragma-org/amaru/issues/417 by adding additional context and a suggestion to the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Enhanced IO error messages to include the related file or directory path, making storage-related failures easier to diagnose.
  - Improved snapshot listing and pruning error reporting with path context.
  - Added clearer, user-facing guidance when ledger creation fails during bootstrap, preserving the original error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->