### PR TITLE
small improvement to implementation of pure-stage

### DIFF
--- a/crates/amaru-consensus/src/consensus/mod.rs
+++ b/crates/amaru-consensus/src/consensus/mod.rs
@@ -60,8 +60,8 @@ pub fn build_stage_graph(
         select_chain_stage,
         (
             chain_selector,
-            outputs.without_state(),
-            upstream_errors_stage.without_state(),
+            outputs,
+            upstream_errors_stage.clone().without_state(),
         ),
     );
 
@@ -71,7 +71,7 @@ pub fn build_stage_graph(
             consensus,
             global_parameters.clone(),
             select_chain_stage.without_state(),
-            upstream_errors_stage.without_state(),
+            upstream_errors_stage.clone().without_state(),
         ),
     );
 

--- a/crates/pure-stage/src/simulation.rs
+++ b/crates/pure-stage/src/simulation.rs
@@ -116,7 +116,7 @@ pub(crate) fn airlock_effect<Out>(
 ///     (state, out)
 /// });
 /// let (output, mut rx) = network.output("output", 10);
-/// let stage = network.wire_up(stage, (1u32, output.without_state()));
+/// let stage = network.wire_up(stage, (1u32, output.clone()));
 ///
 /// let rt = tokio::runtime::Runtime::new().unwrap();
 /// let mut running = network.run(rt.handle().clone());

--- a/crates/pure-stage/src/simulation.rs
+++ b/crates/pure-stage/src/simulation.rs
@@ -132,7 +132,7 @@ pub(crate) fn airlock_effect<Out>(
 /// running.effect().assert_receive(&stage);
 ///
 /// running.resume_receive(&output).unwrap();
-/// let ext = running.effect().extract_external(&output, &OutputEffect::fake(output.name(), 2u32).0);
+/// let ext = running.effect().extract_external(&output, &OutputEffect::fake(output.name().clone(), 2u32).0);
 /// let result = rt.block_on(ext.run(Resources::default()));
 /// running.resume_external(&output, result).unwrap();
 /// running.effect().assert_receive(&output);
@@ -220,10 +220,7 @@ impl super::StageGraph for SimulationBuilder {
     {
         // THIS MUST MATCH THE TOKIO BUILDER
         let name = Name::from(&*format!("{}-{}", name.as_ref(), self.stages.len()));
-        let me = StageRef {
-            name: name.clone(),
-            _ph: PhantomData,
-        };
+        let me = StageRef::new(name.clone());
         let self_sender = self.inputs.sender(&me);
         let effects = Effects::new(me, self.effect.clone(), self.clock.clone(), self_sender);
         let transition: Transition =
@@ -272,17 +269,11 @@ impl super::StageGraph for SimulationBuilder {
         let data = self.stages.get_mut(&name).unwrap();
         data.state = InitStageState::Idle(Box::new(state));
 
-        StageStateRef {
-            name,
-            _ph: PhantomData,
-        }
+        StageStateRef::new(name)
     }
 
-    fn input<Msg: SendData, S>(&mut self, stage: S) -> Sender<Msg>
-    where
-        S: Into<StageRef<Msg>>,
-    {
-        self.inputs.sender(&stage.into())
+    fn input<Msg: SendData>(&mut self, stage: impl AsRef<StageRef<Msg>>) -> Sender<Msg> {
+        self.inputs.sender(stage.as_ref())
     }
 
     fn run(self, rt: Handle) -> Self::Running {

--- a/crates/pure-stage/src/simulation/inputs.rs
+++ b/crates/pure-stage/src/simulation/inputs.rs
@@ -47,7 +47,7 @@ impl Inputs {
 
     pub fn sender<Msg: SendData>(&self, stage: &StageRef<Msg>) -> Sender<Msg> {
         let tx_main = self.tx.clone();
-        let stage_name = stage.name();
+        let stage_name = stage.name().clone();
         Sender::new(Arc::new(move |msg| {
             let tx_main = tx_main.clone();
             let stage_name = stage_name.clone();

--- a/crates/pure-stage/src/simulation/running.rs
+++ b/crates/pure-stage/src/simulation/running.rs
@@ -231,18 +231,19 @@ impl SimulationRunning {
     ///
     /// Note that this method does not check if there is enough space in the
     /// mailbox, it will grow the mailbox beyond the `mailbox_size` limit.
-    pub fn enqueue_msg<Msg: SendData, S>(&mut self, sr: S, msg: impl IntoIterator<Item = Msg>)
-    where
-        S: Into<StageRef<Msg>>,
-    {
-        let data = self.stages.get_mut(&sr.into().name).unwrap();
+    pub fn enqueue_msg<Msg: SendData>(
+        &mut self,
+        sr: impl AsRef<StageRef<Msg>>,
+        msg: impl IntoIterator<Item = Msg>,
+    ) {
+        let data = self.stages.get_mut(sr.as_ref().name()).unwrap();
         data.mailbox
             .extend(msg.into_iter().map(|m| Box::new(m) as Box<dyn SendData>));
     }
 
     /// Retrieve the number of messages currently in the given stage’s mailbox.
-    pub fn mailbox_len<Msg>(&self, sr: &StageRef<Msg>) -> usize {
-        let data = self.stages.get(&sr.name).unwrap();
+    pub fn mailbox_len<Msg>(&self, sr: impl AsRef<StageRef<Msg>>) -> usize {
+        let data = self.stages.get(sr.as_ref().name()).unwrap();
         data.mailbox.len()
     }
 
@@ -254,7 +255,7 @@ impl SimulationRunning {
     /// Returns `None` if the stage is not suspended on [`Effect::Receive`], panics if the
     /// state type is incorrect.
     pub fn get_state<Msg, St: SendData>(&self, sr: &StageStateRef<Msg, St>) -> Option<&St> {
-        let data = self.stages.get(&sr.name).unwrap();
+        let data = self.stages.get(sr.name()).unwrap();
         match &data.state {
             StageState::Idle(state) => {
                 Some(state.cast_ref::<St>().expect("internal state type error"))
@@ -578,13 +579,13 @@ impl SimulationRunning {
     }
 
     /// Resume an [`Effect::Receive`].
-    pub fn resume_receive<Msg, S>(&mut self, at_stage: S) -> anyhow::Result<()>
-    where
-        S: Into<StageRef<Msg>>,
-    {
+    pub fn resume_receive<Msg>(
+        &mut self,
+        at_stage: impl AsRef<StageRef<Msg>>,
+    ) -> anyhow::Result<()> {
         let data = self
             .stages
-            .get_mut(&at_stage.into().name)
+            .get_mut(at_stage.as_ref().name())
             .expect("stage ref exists, so stage must exist");
         resume_receive_internal(
             &mut self.trace_buffer.lock(),
@@ -596,21 +597,15 @@ impl SimulationRunning {
     }
 
     /// Resume an [`Effect::Send`].
-    pub fn resume_send<Msg1, S1, Msg2: SendData, S2>(
+    pub fn resume_send<Msg1, Msg2: SendData>(
         &mut self,
-        from: S1,
-        to: S2,
+        from: impl AsRef<StageRef<Msg1>>,
+        to: impl AsRef<StageRef<Msg2>>,
         msg: Msg2,
-    ) -> anyhow::Result<()>
-    where
-        S1: Into<StageRef<Msg1>>,
-        S2: Into<StageRef<Msg2>>,
-    {
-        let from = from.into();
-        let to = to.into();
+    ) -> anyhow::Result<()> {
         let data = self
             .stages
-            .get_mut(&to.name)
+            .get_mut(to.as_ref().name())
             .expect("stage ref exists, so stage must exist");
         if post_message(data, self.mailbox_size, Box::new(msg)).is_err() {
             anyhow::bail!("mailbox is full while resuming send");
@@ -618,17 +613,21 @@ impl SimulationRunning {
 
         let data = self
             .stages
-            .get_mut(&from.name)
+            .get_mut(from.as_ref().name())
             .expect("stage ref exists, so stage must exist");
         let call = resume_send_internal(
             data,
             &mut |name, response| {
                 self.runnable.push_back((name, response));
             },
-            to.name(),
+            to.as_ref().name().clone(),
         )?;
 
-        self.handle_call_continuation(from.name(), to.name(), call);
+        self.handle_call_continuation(
+            from.as_ref().name().clone(),
+            to.as_ref().name().clone(),
+            call,
+        );
         Ok(())
     }
 
@@ -666,13 +665,14 @@ impl SimulationRunning {
     }
 
     /// Resume an [`Effect::Clock`].
-    pub fn resume_clock<Msg, S>(&mut self, at_stage: S, time: Instant) -> anyhow::Result<()>
-    where
-        S: Into<StageRef<Msg>>,
-    {
+    pub fn resume_clock<Msg>(
+        &mut self,
+        at_stage: impl AsRef<StageRef<Msg>>,
+        time: Instant,
+    ) -> anyhow::Result<()> {
         let data = self
             .stages
-            .get_mut(&at_stage.into().name)
+            .get_mut(at_stage.as_ref().name())
             .expect("stage ref exists, so stage must exist");
         resume_clock_internal(
             data,
@@ -710,13 +710,14 @@ impl SimulationRunning {
     /// Resume an [`Effect::Wait`].
     ///
     /// The given time is the clock when the stage wakes up.
-    pub fn resume_wait<Msg, S>(&mut self, at_stage: S, time: Instant) -> anyhow::Result<()>
-    where
-        S: Into<StageRef<Msg>>,
-    {
+    pub fn resume_wait<Msg>(
+        &mut self,
+        at_stage: impl AsRef<StageRef<Msg>>,
+        time: Instant,
+    ) -> anyhow::Result<()> {
         let data = self
             .stages
-            .get_mut(&at_stage.into().name)
+            .get_mut(at_stage.as_ref().name())
             .expect("stage ref exists, so stage must exist");
         resume_wait_internal(
             data,
@@ -730,17 +731,14 @@ impl SimulationRunning {
     /// Resume an [`Effect::Send`]’s second stage in case of a call.
     ///
     /// The message to be delivered to the stage must have been sent by the called stage already.
-    pub fn resume_call<Msg, S, Resp: SendData>(
+    pub fn resume_call<Msg, Resp: SendData>(
         &mut self,
-        at_stage: S,
+        at_stage: impl AsRef<StageRef<Msg>>,
         call: &CallRef<Resp>,
-    ) -> anyhow::Result<()>
-    where
-        S: Into<StageRef<Msg>>,
-    {
+    ) -> anyhow::Result<()> {
         let data = self
             .stages
-            .get_mut(&at_stage.into().name)
+            .get_mut(at_stage.as_ref().name())
             .expect("stage ref exists, so stage must exist");
         resume_call_internal(
             data,
@@ -752,18 +750,15 @@ impl SimulationRunning {
     }
 
     /// Resume an [`Effect::Respond`].
-    pub fn resume_respond<Msg, S, Resp: SendData>(
+    pub fn resume_respond<Msg, Resp: SendData>(
         &mut self,
-        at_stage: S,
+        at_stage: impl AsRef<StageRef<Msg>>,
         cr: &CallRef<Resp>,
         msg: Resp,
-    ) -> anyhow::Result<()>
-    where
-        S: Into<StageRef<Msg>>,
-    {
+    ) -> anyhow::Result<()> {
         let data = self
             .stages
-            .get_mut(&at_stage.into().name)
+            .get_mut(at_stage.as_ref().name())
             .expect("stage ref exists, so stage must exist");
         let res = resume_respond_internal(
             data,
@@ -796,17 +791,14 @@ impl SimulationRunning {
     }
 
     /// Resume an [`Effect::External`].
-    pub fn resume_external<Msg, S>(
+    pub fn resume_external<Msg>(
         &mut self,
-        at_stage: S,
+        at_stage: impl AsRef<StageRef<Msg>>,
         result: Box<dyn SendData>,
-    ) -> anyhow::Result<()>
-    where
-        S: Into<StageRef<Msg>>,
-    {
+    ) -> anyhow::Result<()> {
         let data = self
             .stages
-            .get_mut(&at_stage.into().name)
+            .get_mut(at_stage.as_ref().name())
             .expect("stage ref exists, so stage must exist");
         resume_external_internal(data, result, &mut |name, response| {
             self.runnable.push_back((name, response));
@@ -1069,7 +1061,7 @@ fn simulation_invariants() {
             }),
             // resume_call works because resume_send from the second item has already been called
             Box::new(|sim, stage, id| {
-                let data = sim.stages.get_mut(&stage.name).unwrap();
+                let data = sim.stages.get_mut(stage.name()).unwrap();
                 resume_call_internal(
                     data,
                     &mut |name, response| {

--- a/crates/pure-stage/src/simulation/running.rs
+++ b/crates/pure-stage/src/simulation/running.rs
@@ -1094,14 +1094,19 @@ fn simulation_invariants() {
         for (pred, op, name) in &ops {
             if pred(&effect).is_none() {
                 tracing::info!("op `{}` should not work", name);
-                op(&mut sim, &stage.without_state(), CallId::from_u64(0)).unwrap_err();
+                op(
+                    &mut sim,
+                    &stage.clone().without_state(),
+                    CallId::from_u64(0),
+                )
+                .unwrap_err();
                 sim.invariants();
             }
         }
         for (pred, op, name) in &ops {
             if let Some(id) = pred(&effect) {
                 tracing::info!("op `{}` should work", name);
-                op(&mut sim, &stage.without_state(), id).unwrap();
+                op(&mut sim, &stage.clone().without_state(), id).unwrap();
                 sim.invariants();
             }
         }

--- a/crates/pure-stage/src/stage_ref.rs
+++ b/crates/pure-stage/src/stage_ref.rs
@@ -96,7 +96,7 @@ impl<Msg, St> Clone for StageStateRef<Msg, St> {
     fn clone(&self) -> Self {
         Self {
             stage_ref: self.stage_ref.clone(),
-            _ph: self._ph.clone(),
+            _ph: self._ph,
         }
     }
 }

--- a/crates/pure-stage/src/stage_ref.rs
+++ b/crates/pure-stage/src/stage_ref.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::Name;
-use std::{fmt, marker::PhantomData};
+use std::{fmt, marker::PhantomData, ops::Deref};
 
 /// A handle to a stage during the building phase of a [`StageGraph`](crate::StageGraph).
 pub struct StageBuildRef<Msg, St, RefAux> {
@@ -35,7 +35,7 @@ impl<Msg, State, RefAux> StageBuildRef<Msg, State, RefAux> {
 /// A handle for sending messages to a stage via the [`Effects`](crate::Effects) argument to the stage transition function.
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct StageRef<Msg> {
-    pub name: Name,
+    name: Name,
     #[serde(skip)]
     pub(crate) _ph: PhantomData<Msg>,
 }
@@ -63,9 +63,22 @@ impl<Msg> fmt::Debug for StageRef<Msg> {
     }
 }
 
+impl<Msg> AsRef<StageRef<Msg>> for StageRef<Msg> {
+    fn as_ref(&self) -> &StageRef<Msg> {
+        self
+    }
+}
+
 impl<Msg> StageRef<Msg> {
-    pub fn name(&self) -> Name {
-        self.name.clone()
+    pub(crate) fn new(name: Name) -> Self {
+        Self {
+            name,
+            _ph: PhantomData,
+        }
+    }
+
+    pub fn name(&self) -> &Name {
+        &self.name
     }
 
     pub fn without_state(&self) -> StageRef<Msg> {
@@ -76,42 +89,20 @@ impl<Msg> StageRef<Msg> {
     }
 }
 
-impl<Msg, St> From<StageStateRef<Msg, St>> for StageRef<Msg> {
-    fn from(s: StageStateRef<Msg, St>) -> Self {
-        s.without_state()
-    }
-}
-
-impl<Msg, St> From<&StageStateRef<Msg, St>> for StageRef<Msg> {
-    fn from(s: &StageStateRef<Msg, St>) -> Self {
-        s.without_state()
-    }
-}
-
-impl<Msg> From<&StageRef<Msg>> for StageRef<Msg> {
-    fn from(s: &StageRef<Msg>) -> Self {
-        s.clone()
-    }
-}
-
 /// A handle for sending messages to a stage via the [`Effects`](crate::Effects) argument to the stage transition function.
-#[derive(serde::Serialize, serde::Deserialize)]
+///
+/// This is a variant that is mostly useful in tests because it allows extracting the current state of the stage.
+#[derive(Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct StageStateRef<Msg, St> {
-    pub name: Name,
+    stage_ref: StageRef<Msg>,
     #[serde(skip)]
-    pub(crate) _ph: PhantomData<(Msg, St)>,
+    pub(crate) _ph: PhantomData<St>,
 }
 
-impl<Msg, St> PartialEq for StageStateRef<Msg, St> {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
-    }
-}
-
-impl<Msg, St> Clone for StageStateRef<Msg, St> {
-    fn clone(&self) -> Self {
+impl<Msg, St> StageStateRef<Msg, St> {
+    pub(crate) fn new(name: Name) -> Self {
         Self {
-            name: self.name.clone(),
+            stage_ref: StageRef::new(name),
             _ph: PhantomData,
         }
     }
@@ -119,22 +110,27 @@ impl<Msg, St> Clone for StageStateRef<Msg, St> {
 
 impl<Msg, St> fmt::Debug for StageStateRef<Msg, St> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("StageImplRef")
-            .field("name", &self.name)
-            .finish()
+        self.stage_ref.fmt(f)
     }
 }
 
 impl<Msg, St> StageStateRef<Msg, St> {
-    pub fn name(&self) -> Name {
-        self.name.clone()
-    }
-
     pub fn without_state(&self) -> StageRef<Msg> {
-        StageRef {
-            name: self.name.clone(),
-            _ph: PhantomData,
-        }
+        self.stage_ref.clone()
+    }
+}
+
+impl<Msg, St> Deref for StageStateRef<Msg, St> {
+    type Target = StageRef<Msg>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.stage_ref
+    }
+}
+
+impl<Msg, St> AsRef<StageRef<Msg>> for StageStateRef<Msg, St> {
+    fn as_ref(&self) -> &StageRef<Msg> {
+        &self.stage_ref
     }
 }
 

--- a/crates/pure-stage/src/stage_ref.rs
+++ b/crates/pure-stage/src/stage_ref.rs
@@ -80,23 +80,25 @@ impl<Msg> StageRef<Msg> {
     pub fn name(&self) -> &Name {
         &self.name
     }
-
-    pub fn without_state(&self) -> StageRef<Msg> {
-        StageRef {
-            name: self.name.clone(),
-            _ph: PhantomData,
-        }
-    }
 }
 
 /// A handle for sending messages to a stage via the [`Effects`](crate::Effects) argument to the stage transition function.
 ///
 /// This is a variant that is mostly useful in tests because it allows extracting the current state of the stage.
-#[derive(Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct StageStateRef<Msg, St> {
     stage_ref: StageRef<Msg>,
     #[serde(skip)]
     pub(crate) _ph: PhantomData<St>,
+}
+
+impl<Msg, St> Clone for StageStateRef<Msg, St> {
+    fn clone(&self) -> Self {
+        Self {
+            stage_ref: self.stage_ref.clone(),
+            _ph: self._ph.clone(),
+        }
+    }
 }
 
 impl<Msg, St> StageStateRef<Msg, St> {
@@ -115,8 +117,8 @@ impl<Msg, St> fmt::Debug for StageStateRef<Msg, St> {
 }
 
 impl<Msg, St> StageStateRef<Msg, St> {
-    pub fn without_state(&self) -> StageRef<Msg> {
-        self.stage_ref.clone()
+    pub fn without_state(self) -> StageRef<Msg> {
+        self.stage_ref
     }
 }
 

--- a/crates/pure-stage/src/stagegraph.rs
+++ b/crates/pure-stage/src/stagegraph.rs
@@ -121,7 +121,7 @@ impl<Resp: SendData> CallRef<Resp> {
 /// let (output, mut rx) = network.output("output", 10);
 ///
 /// // phase 2: wire up stages by injecting targets into their state
-/// let stage = network.wire_up(stage, (1u32, output.without_state()));
+/// let stage = network.wire_up(stage, (1u32, output));
 ///
 /// // phase 3: populate the resources collection with the necessary resources (if used by external effects)
 /// network.resources().put(42u8);

--- a/crates/pure-stage/src/stagegraph.rs
+++ b/crates/pure-stage/src/stagegraph.rs
@@ -188,9 +188,7 @@ pub trait StageGraph {
     fn run(self, rt: Handle) -> Self::Running;
 
     /// Obtain a handle for sending messages to the given stage from outside the network.
-    fn input<Msg: SendData, S>(&mut self, stage: S) -> Sender<Msg>
-    where
-        S: Into<StageRef<Msg>>;
+    fn input<Msg: SendData>(&mut self, stage: impl AsRef<StageRef<Msg>>) -> Sender<Msg>;
 
     /// Utility function to create an output for the network.
     ///
@@ -209,7 +207,7 @@ pub trait StageGraph {
         let tx = MpscSender { sender };
 
         let output = self.stage(name, async |tx: MpscSender<Msg>, msg: Msg, eff| {
-            eff.external(OutputEffect::new(eff.me().name(), msg, tx.clone()))
+            eff.external(OutputEffect::new(eff.me().name().clone(), msg, tx.clone()))
                 .await;
             tx
         });

--- a/crates/pure-stage/tests/simulation.rs
+++ b/crates/pure-stage/tests/simulation.rs
@@ -42,7 +42,7 @@ fn basic() {
         state
     });
     let (output, mut rx) = network.output("output", 10);
-    let basic = network.wire_up(basic, State(1u32, output.without_state()));
+    let basic = network.wire_up(basic, State(1u32, output.clone()));
     let mut running = network.run(rt.handle().clone());
 
     // first check that the stages start out suspended on Receive
@@ -82,7 +82,7 @@ fn automatic() {
             state
         });
         let (output, rx) = network.output("output", 10);
-        let basic = network.wire_up(basic, State(1u32, output.without_state()));
+        let basic = network.wire_up(basic, State(1u32, output.clone()));
         (basic.without_state(), rx, output)
     }
 
@@ -157,7 +157,7 @@ fn automatic() {
 
     assert_eq!(
         replay.latest_state(in_ref.name()),
-        Some(&State(7, output.without_state()) as &dyn SendData)
+        Some(&State(7, output.clone()) as &dyn SendData)
     );
     assert_eq!(replay.is_running(in_ref.name()), false);
     assert_eq!(replay.is_idle(in_ref.name()), true);
@@ -178,7 +178,7 @@ fn breakpoint() {
         state
     });
     let (output, mut rx) = network.output("output", 10);
-    let basic = network.wire_up(basic, State(1u32, output.without_state()));
+    let basic = network.wire_up(basic, State(1u32, output.clone()));
     let mut running = network.run(rt.handle().clone());
 
     running.enqueue_msg(&basic, [1, 2, 3]);
@@ -205,7 +205,7 @@ fn overrides() {
         state
     });
     let (output, mut rx) = network.output("output", 10);
-    let basic = network.wire_up(basic, State(1u32, output.without_state()));
+    let basic = network.wire_up(basic, State(1u32, output.clone()));
     let mut running = network.run(rt.handle().clone());
 
     let count = Arc::new(AtomicUsize::new(0));

--- a/crates/pure-stage/tests/simulation.rs
+++ b/crates/pure-stage/tests/simulation.rs
@@ -58,7 +58,7 @@ fn basic() {
     running.resume_receive(&output).unwrap();
     let ext = running
         .effect()
-        .extract_external(&output, &OutputEffect::fake(output.name(), 2u32).0);
+        .extract_external(&output, &OutputEffect::fake(output.name().clone(), 2u32).0);
     let result = rt.block_on(ext.run(Resources::default()));
     // this check is also done when resuming, just want to show how to do it here
     assert_eq!(&*result, &() as &dyn SendData);
@@ -156,15 +156,15 @@ fn automatic() {
     replay.run_trace(trace).unwrap();
 
     assert_eq!(
-        replay.latest_state(&in_ref.name()),
+        replay.latest_state(in_ref.name()),
         Some(&State(7, output.without_state()) as &dyn SendData)
     );
-    assert_eq!(replay.is_running(&in_ref.name()), false);
-    assert_eq!(replay.is_idle(&in_ref.name()), true);
-    assert_eq!(replay.is_failed(&output.name()), false);
-    assert_eq!(replay.is_idle(&output.name()), true);
-    assert_eq!(replay.get_failure(&in_ref.name()), None);
-    assert_eq!(replay.get_failure(&output.name()), None);
+    assert_eq!(replay.is_running(in_ref.name()), false);
+    assert_eq!(replay.is_idle(in_ref.name()), true);
+    assert_eq!(replay.is_failed(output.name()), false);
+    assert_eq!(replay.is_idle(output.name()), true);
+    assert_eq!(replay.get_failure(in_ref.name()), None);
+    assert_eq!(replay.get_failure(output.name()), None);
     assert_eq!(replay.clock(), Instant::at_offset(Duration::from_secs(30)));
 }
 
@@ -186,8 +186,8 @@ fn breakpoint() {
         matches!(
             eff,
             Effect::Send { from, to, msg, .. }
-                if from == &basic.name &&
-                    to == &output.name &&
+                if from == basic.name() &&
+                    to == output.name() &&
                     *msg == Box::new(4u32) as Box<dyn SendData>
         )
     });
@@ -256,18 +256,18 @@ fn backpressure() {
     running.enqueue_msg(&sender, [1, 2, 3]);
     running.breakpoint("pressure", {
         let pressure = pressure.clone();
-        move |eff| matches!(eff, Effect::Clock { at_stage: a } if a == &pressure.name)
+        move |eff| matches!(eff, Effect::Clock { at_stage: a } if a == pressure.name())
     });
 
     let broken = running.run_until_blocked().assert_breakpoint("pressure");
     assert_eq!(
         broken,
         Effect::Clock {
-            at_stage: pressure.name(),
+            at_stage: pressure.name().clone(),
         }
     );
 
-    running.run_until_blocked().assert_busy([&pressure.name]);
+    running.run_until_blocked().assert_busy([pressure.name()]);
 
     running.handle_effect(broken);
     running.clear_breakpoint("pressure");

--- a/simulation/amaru-sim/src/echo/simulate.rs
+++ b/simulation/amaru-sim/src/echo/simulate.rs
@@ -59,7 +59,7 @@ pub fn spawn_echo_node() -> NodeHandle<EchoMessage> {
         },
     );
     let (output, rx) = network.output("output", 10);
-    let stage = network.wire_up(stage, State(0, output.without_state()));
+    let stage = network.wire_up(stage, State(0, output));
     let rt = tokio::runtime::Runtime::new().unwrap();
     let running = network.run(rt.handle().clone());
 

--- a/simulation/amaru-sim/src/simulator/run.rs
+++ b/simulation/amaru-sim/src/simulator/run.rs
@@ -198,8 +198,8 @@ fn spawn_node(
     );
 
     let (output, rx) = network.output("output", 10);
-    let receiver = network.wire_up(receiver, (receive_header_ref, output.without_state()));
-    network.wire_up(propagate_header_stage, (0, output.without_state()));
+    let receiver = network.wire_up(receiver, (receive_header_ref, output.clone()));
+    network.wire_up(propagate_header_stage, (0, output));
 
     network.resources().put(chain_ref);
     network.resources().put(global_parameters);


### PR DESCRIPTION
API stays basically the same, but passing references to stages actually only deals in references again.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a stage-state reference type for inspecting stage state and new constructors for safer stage creation.

- Refactor
  - Unified APIs to accept reference-like stage arguments and standardized access via a name() getter; adjusted ownership to avoid accidental moves while preserving behavior.
  - Updated wiring to pass cloned or stateful handles where appropriate.

- Documentation
  - Updated examples and tests to use new constructors and the name() accessor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->