### PR TITLE
fix: cli_test updated, no need for a peer to bootstrap

### DIFF
--- a/cli-tests/test_crash_with_helpful_information.sh
+++ b/cli-tests/test_crash_with_helpful_information.sh
@@ -10,7 +10,6 @@ setup() {
 	export LEDGER_DIR=./ledger.${NETWORK}.db
 	export CHAIN_DIR=./chain.${NETWORK}.db
 	export BUILD_PROFILE=dev
-	export AMARU_PEER_ADDRESS=127.0.0.1:3001
 }
 
 given_snapshots_file_is_missing() {
@@ -19,7 +18,6 @@ given_snapshots_file_is_missing() {
 
 bootstrap_amaru() {
 	cargo run --profile ${BUILD_PROFILE} -- bootstrap \
-		--peer-address ${AMARU_PEER_ADDRESS} \
 		--config-dir ${CONFIG_FOLDER} \
 		--ledger-dir ${LEDGER_DIR} \
 		--chain-dir ${CHAIN_DIR} \


### PR DESCRIPTION
[PR 320](https://github.com/pragma-org/amaru/pull/320) has been merged just after [PR 410](https://github.com/pragma-org/amaru/pull/410) but the cli parameters were incompatible between one another.

This fixes the cli test to adapt to this new cli args.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified CLI crash information test by removing the need to set a manual peer address, relying on defaults to reduce setup friction and flakiness.

* **Chores**
  * Cleaned up test bootstrap configuration by removing redundant parameters, aligning with default networking behavior for a more consistent test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->