### PR TITLE
refactor: split the stage api differently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "amaru-ouroboros-traits",
  "amaru-slot-arithmetic",
  "anyhow",
+ "async-trait",
  "either",
  "hex",
  "insta",
@@ -2534,6 +2535,7 @@ name = "pure-stage"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "cbor4ii",
  "either",
  "futures-util",

--- a/crates/amaru-consensus/Cargo.toml
+++ b/crates/amaru-consensus/Cargo.toml
@@ -42,6 +42,7 @@ amaru-ouroboros.workspace = true
 amaru-ouroboros-traits.workspace = true
 amaru-slot-arithmetic.workspace = true
 pure-stage.workspace = true
+async-trait = "0.1.89"
 
 [dev-dependencies]
 either.workspace = true

--- a/crates/amaru-consensus/src/consensus/mod.rs
+++ b/crates/amaru-consensus/src/consensus/mod.rs
@@ -12,11 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
-
-use crate::{ConsensusError, consensus::select_chain::SelectChain, is_header::IsHeader};
+use crate::consensus::receive_header::ReceiveHeader;
+use crate::consensus::select_chain::SelectChain;
+use crate::consensus::store_header::StoreHeader;
+use crate::consensus::upstream_errors::UpstreamErrors;
+use crate::consensus::validate_header::ValidateHeader;
+use crate::{ConsensusError, consensus::select_chain::SelectChainState, is_header::IsHeader};
 use amaru_kernel::{Header, Point, peer::Peer, protocol_parameters::GlobalParameters};
+use amaru_ouroboros_traits::HasStakeDistribution;
 use pure_stage::{StageGraph, StageRef};
+use std::fmt;
+use std::sync::Arc;
 use tracing::Span;
 
 pub mod headers_tree;
@@ -27,66 +33,39 @@ pub mod store_block;
 pub mod store_effects;
 pub mod store_header;
 pub mod tip;
+mod upstream_errors;
 pub mod validate_header;
 
 pub const EVENT_TARGET: &str = "amaru::consensus";
 
-pub fn build_stage_graph(
+pub fn build_consensus_stages(
     global_parameters: &GlobalParameters,
-    consensus: validate_header::ValidateHeader,
-    chain_selector: SelectChain,
+    ledger: Arc<dyn HasStakeDistribution>,
+    chain_selector: SelectChainState,
     network: &mut impl StageGraph,
-    outputs: StageRef<ValidateHeaderEvent>,
+    outputs: impl AsRef<StageRef<ValidateHeaderEvent>>,
 ) -> StageRef<ChainSyncEvent> {
-    let receive_header_stage = network.stage("receive_header", receive_header::stage);
-    let store_header_stage = network.stage("store_header", store_header::stage);
-    let validate_header_stage = network.stage("validate_header", validate_header::stage);
-    let select_chain_stage = network.stage("select_chain", select_chain::stage);
+    let upstream_errors = network.make_stage("upstream_errors");
+    let receive_header = network.make_stage("receive_header");
+    let store_header = network.make_stage("store_header");
+    let validate_header = network.make_stage("validate_header");
+    let select_chain = network.make_stage("select_chain");
 
-    // TODO: currently only validate_header errors, will need to grow into all error handling
-    let upstream_errors_stage = network.stage("upstream_errors", async |_, msg, eff| {
-        let ValidationFailed { peer, error } = msg;
-        tracing::error!(%peer, %error, "invalid header");
-
-        // TODO: implement specific actions once we have an upstream network
-
-        // termination here will tear down the entire stage graph
-        eff.terminate().await
-    });
-
-    let upstream_errors_stage = network.wire_up(upstream_errors_stage, ());
-
-    let select_chain_stage = network.wire_up(
-        select_chain_stage,
-        (
-            chain_selector,
-            outputs,
-            upstream_errors_stage.clone().without_state(),
-        ),
+    let upstream_errors = network.register(&upstream_errors, UpstreamErrors);
+    network.register(
+        &receive_header,
+        ReceiveHeader::new(&store_header, &upstream_errors),
     );
-
-    let validate_header_stage = network.wire_up(
-        validate_header_stage,
-        (
-            consensus,
-            global_parameters.clone(),
-            select_chain_stage.without_state(),
-            upstream_errors_stage.clone().without_state(),
-        ),
+    network.register(&store_header, StoreHeader::new(&validate_header));
+    network.register(
+        &validate_header,
+        ValidateHeader::new(global_parameters, ledger, &select_chain, &upstream_errors),
     );
-
-    let store_header_stage =
-        network.wire_up(store_header_stage, validate_header_stage.without_state());
-
-    let receive_header_stage = network.wire_up(
-        receive_header_stage,
-        (
-            store_header_stage.without_state(),
-            upstream_errors_stage.without_state(),
-        ),
+    network.register(
+        &select_chain,
+        SelectChain::new(chain_selector, outputs, &upstream_errors),
     );
-
-    receive_header_stage.without_state()
+    receive_header.without_state()
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/crates/amaru-consensus/src/consensus/upstream_errors.rs
+++ b/crates/amaru-consensus/src/consensus/upstream_errors.rs
@@ -1,0 +1,39 @@
+// Copyright 2024 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::consensus::ValidationFailed;
+use async_trait::async_trait;
+use pure_stage::Stage;
+
+#[derive(Clone)]
+pub struct UpstreamErrors;
+
+#[async_trait]
+impl Stage<ValidationFailed, ()> for UpstreamErrors {
+    fn initial_state(&self) {}
+
+    async fn run(
+        &self,
+        _state: (),
+        msg: ValidationFailed,
+        eff: pure_stage::Effects<ValidationFailed>,
+    ) -> () {
+        // TODO: currently only validate_header errors, will need to grow into all error handling
+        let ValidationFailed { peer, error } = msg;
+        tracing::error!(%peer, %error, "invalid header");
+        // TODO: implement specific actions once we have an upstream network
+        // termination here will tear down the entire stage graph
+        eff.terminate().await
+    }
+}

--- a/crates/pure-stage/Cargo.toml
+++ b/crates/pure-stage/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { workspace = true, features = ["rt", "time"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 typetag.workspace = true
+async-trait = "0.1.89"
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/pure-stage/src/lib.rs
+++ b/crates/pure-stage/src/lib.rs
@@ -35,8 +35,8 @@ pub use receiver::Receiver;
 pub use resources::Resources;
 pub use sender::Sender;
 pub use stage_ref::{StageBuildRef, StageRef};
-pub use stagegraph::{CallId, CallRef, StageGraph, StageGraphRunning};
+pub use stagegraph::{CallId, CallRef, Stage, StageGraph, StageGraphRunning};
 pub use time::{Clock, EPOCH, Instant};
-pub use types::{BoxFuture, Name, SendData};
+pub use types::{BoxFuture, MpscSender, Name, SendData};
 
 pub use typetag;


### PR DESCRIPTION
@rkuhn this is an exploration on how we could decouple the making of stage references from the registration of the transition function in order to create `Stage` components that are instantiated right away with their downstream references, instead of passing them as state. What do you think?