### PR TITLE
chore: re-organize Makefile, split in different sections.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -266,7 +266,7 @@ jobs:
       - name: Run tests
         if: github.event_name == 'pull_request'
         run: |
-          make BUILD_PROFILE=test NETWORK=${{ matrix.network.name }} test-e2e
+          make BUILD_PROFILE=test AMARU_NETWORK=${{ matrix.network.name }} test-e2e
 
       - name: Teardown haskell node
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,26 @@ export AMARU_NETWORK AMARU_CONFIG_DIR AMARU_PEER_ADDRESS AMARU_LISTEN_ADDRESS AM
 .PHONY: help bootstrap start import-ledger-state import-headers import-nonces download-haskell-config coverage-html coverage-lconv check-llvm-cov fetch-chain-headers dev
 
 help:
-	@echo "\033[1;4mTargets:\033[00m"
-	@grep -E '^[a-zA-Z0-9 -]+:.*##'  Makefile | sort | while read -r l; do printf "  \033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 3- -d'#')\n"; done
+	@echo "\033[1;4mGetting Started:\033[00m"
+	@grep -E '^[a-z]+[^:]+:.*## &start '  Makefile | while read -r l; do printf "  \033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 3- -d'#' | sed 's/^ \&start//')\n"; done
+	@echo ""
+	@echo "\033[1;4mBuilding & Running:\033[00m"
+	@grep -E '^[a-z]+[^:]+:.*## &build '  Makefile | while read -r l; do printf "  \033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 3- -d'#' | sed 's/^ \&build//')\n"; done
+	@echo ""
+	@echo "\033[1;4mDev & Testing:\033[00m"
+	@grep -E '^[a-z]+[^:]+:.*## &test '  Makefile | while read -r l; do printf "  \033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 3- -d'#' | sed 's/^ \&test//')\n"; done
 	@echo ""
 	@echo "\033[1;4mConfiguration:\033[00m"
 	@grep -E '^[a-zA-Z0-9_]+ \?= '  Makefile | sort | while read -r l; do printf "  \033[36m$$(echo $$l | cut -f 1 -d'=')\033[00m=$$(echo $$l | cut -f 2- -d'=')\n"; done
 
-snapshots/$(AMARU_NETWORK): ## Download snapshots
+bootstrap: clear-dbs ## &start Bootstrap Amaru from scratch (snapshots + headers + ledger-state + nonces)
+	cargo run --profile $(BUILD_PROFILE) -- bootstrap \
+		--config-dir $(AMARU_CONFIG_DIR) \
+		--ledger-dir $(AMARU_LEDGER_DIR) \
+		--chain-dir $(AMARU_CHAIN_DIR) \
+		--network $(AMARU_NETWORK)
+
+snapshots/$(AMARU_NETWORK): ## &start Download initial snapshots
 	@if [ ! -f "${SNAPSHOTS_FILE}" ]; then echo "SNAPSHOTS_FILE not found: ${SNAPSHOTS_FILE}"; exit 1; fi;
 	mkdir -p "$@"
 	cat $(SNAPSHOTS_FILE) \
@@ -36,8 +49,11 @@ snapshots/$(AMARU_NETWORK): ## Download snapshots
 			curl --progress-bar -o - "$$u" | gunzip > "$@/$$p.cbor"; \
 		done
 
+import-headers: ## &start Import initial headers from $AMARU_PEER_ADDRESS
+	cargo run --profile $(BUILD_PROFILE) -- import-headers --config-dir "$(AMARU_CONFIG_DIR)"
+
 import-snapshots: import-ledger-state # 'backward-compatibility'; might remove after a while.
-import-ledger-state: snapshots/$(AMARU_NETWORK) ## Import snapshots for demo
+import-ledger-state: snapshots/$(AMARU_NETWORK) ## &start Import initial ledger-state snapshots
 	@SNAPSHOT_ARGS=""; \
 	CBOR_FILES=$$(find "$^" -maxdepth 1 -name '*.cbor'); \
 	if [ -z "$$CBOR_FILES" ]; then echo "No .cbor files found in $^"; exit 1; fi; \
@@ -49,10 +65,7 @@ import-ledger-state: snapshots/$(AMARU_NETWORK) ## Import snapshots for demo
 		--ledger-dir "$(AMARU_LEDGER_DIR)" \
 		$$SNAPSHOT_ARGS
 
-import-headers: ## Import headers from $AMARU_PEER_ADDRESS for demo
-	cargo run --profile $(BUILD_PROFILE) -- import-headers --config-dir "$(AMARU_CONFIG_DIR)"
-
-import-nonces: ## Import nonces for demo
+import-nonces: ## &start Import initial nonces
 	@if [ ! -f "$(NONCES_FILE)" ]; then echo "NONCES_FILE not found: $(NONCES_FILE)"; exit 1; fi; \
 	cargo run --profile $(BUILD_PROFILE) -- import-nonces \
 		--network $(AMARU_NETWORK) \
@@ -63,7 +76,7 @@ import-nonces: ## Import nonces for demo
 		--evolving $$(jq -r .evolving $(NONCES_FILE)) \
 		--tail $$(jq -r .tail $(NONCES_FILE))
 
-download-haskell-config: ## Download Cardano Haskell configuration for $AMARU_NETWORK
+download-haskell-config: ## &start Download Haskell node configuration files for $AMARU_NETWORK
 	mkdir -p $(HASKELL_NODE_CONFIG_DIR)
 	curl -fsSL -O --output-dir "$(HASKELL_NODE_CONFIG_DIR)" "$(HASKELL_NODE_CONFIG_SOURCE)/$(AMARU_NETWORK)/config.json"
 	curl -fsSL -O --output-dir "$(HASKELL_NODE_CONFIG_DIR)" "$(HASKELL_NODE_CONFIG_SOURCE)/$(AMARU_NETWORK)/topology.json"
@@ -72,64 +85,10 @@ download-haskell-config: ## Download Cardano Haskell configuration for $AMARU_NE
 	curl -fsSL -O --output-dir "$(HASKELL_NODE_CONFIG_DIR)" "$(HASKELL_NODE_CONFIG_SOURCE)/$(AMARU_NETWORK)/alonzo-genesis.json"
 	curl -fsSL -O --output-dir "$(HASKELL_NODE_CONFIG_DIR)" "$(HASKELL_NODE_CONFIG_SOURCE)/$(AMARU_NETWORK)/conway-genesis.json"
 
-clear-dbs: ## Clear the databases
-	@test -n "$(AMARU_LEDGER_DIR)" -a -n "$(AMARU_CHAIN_DIR)"
-	@rm -rf -- "$(AMARU_LEDGER_DIR)" "$(AMARU_CHAIN_DIR)"
+build: ## &build Compile for $BUILD_PROFILE
+	cargo build --profile $(BUILD_PROFILE)
 
-fetch-chain-headers: $(AMARU_CONFIG_DIR)/$(AMARU_NETWORK)/ ## Fetch chain headers from the network
-	cargo run --profile $(BUILD_PROFILE) -- fetch-chain-headers \
-		--peer-address $(AMARU_PEER_ADDRESS) \
-		--config-dir $(AMARU_CONFIG_DIR) \
-		--network $(AMARU_NETWORK)
-
-bootstrap: clear-dbs ## Bootstrap the node from scratch
-	cargo run --profile $(BUILD_PROFILE) -- bootstrap \
-		--config-dir $(AMARU_CONFIG_DIR) \
-		--ledger-dir $(AMARU_LEDGER_DIR) \
-		--chain-dir $(AMARU_CHAIN_DIR) \
-		--network $(AMARU_NETWORK)
-
-dev: start # 'backward-compatibility'; might remove after a while.
-start: ## Compile and run for development with default options
-	cargo run --profile $(BUILD_PROFILE) -- daemon
-
-fetch-data: ## Fetch data from the node
-	@npm --prefix data run fetch -- "$(AMARU_NETWORK)"
-
-generate-test-snapshots: ## Generate test snapshots for test-e2e
-	@npm --prefix conformance-tests run generate-all -- "$(AMARU_NETWORK)"
-	@./scripts/generate-snapshot-test-cases
-
-test-e2e: ## Run snapshot tests, assuming snapshots are available.
-	AMARU_NETWORK=$(AMARU_NETWORK) cargo test --profile $(BUILD_PROFILE) -p amaru -- --ignored
-
-test-e2e-from-scratch: bootstrap demo test-e2e ## Run end-to-end tests from scratch
-
-check-llvm-cov: ## Check if cargo-llvm-cov is installed, install if not
-	@if ! cargo llvm-cov --version >/dev/null 2>&1; then \
-		echo "cargo-llvm-cov not found. Installing..."; \
-		cargo install cargo-llvm-cov; \
-	else \
-		echo "cargo-llvm-cov is already installed"; \
-	fi
-
-coverage-html: check-llvm-cov ## Run test coverage for Amaru
-	cargo llvm-cov \
-		--no-cfg-coverage \
-		--html \
-		--output-dir $(COVERAGE_DIR) $(foreach package,$(COVERAGE_CRATES), --package $(package))
-
-coverage-lconv: ## Run test coverage for CI to upload to Codecov
-	cargo llvm-cov \
-		--all-features \
-		--workspace \
-		--lcov \
-		--output-path lcov.info
-
-demo: ## Synchronize Amaru until a target epoch $DEMO_TARGET_EPOCH
-		./scripts/demo $(BUILD_PROFILE) $(AMARU_PEER_ADDRESS) $(AMARU_LISTEN_ADDRESS) $(DEMO_TARGET_EPOCH) $(AMARU_NETWORK)
-
-build-examples: ## Build all examples
+build-examples: ## &build Build all examples
 	@for dir in $(wildcard examples/*/.); do \
 		if [ -f $$dir/Makefile ]; then \
 			echo "Building $$dir"; \
@@ -137,9 +96,57 @@ build-examples: ## Build all examples
 		fi; \
 	done
 
-all-ci-checks: ## Run all CI checks
+dev: start # 'backward-compatibility'; might remove after a while.
+start: ## &build Compile and run for $BUILD_PROFILE with default options
+	cargo run --profile $(BUILD_PROFILE) -- daemon
+
+demo: ## &build Synchronize Amaru until a target epoch $DEMO_TARGET_EPOCH on $AMARU_NETWORK
+		./scripts/demo $(BUILD_PROFILE) $(AMARU_PEER_ADDRESS) $(AMARU_LISTEN_ADDRESS) $(DEMO_TARGET_EPOCH) $(AMARU_NETWORK)
+
+clear-dbs: ## &build Clear the databases (!!)
+	@test -n "$(AMARU_LEDGER_DIR)" -a -n "$(AMARU_CHAIN_DIR)"
+	@rm -rf -- "$(AMARU_LEDGER_DIR)" "$(AMARU_CHAIN_DIR)"
+
+all-ci-checks: ## &test Run all CI checks
 	@cargo fmt-amaru
 	@cargo clippy-amaru
 	@cargo test-amaru
 	@$(MAKE) build-examples
 	@$(MAKE) coverage-lconv
+
+fetch-chain-headers: $(AMARU_CONFIG_DIR)/$(AMARU_NETWORK)/ ## &test Fetch chain headers from the network
+	cargo run --profile $(BUILD_PROFILE) -- fetch-chain-headers \
+		--peer-address $(AMARU_PEER_ADDRESS) \
+		--config-dir $(AMARU_CONFIG_DIR) \
+		--network $(AMARU_NETWORK)
+
+fetch-data: ## &test Fetch epoch data (dreps, pools, accounts, ...) from a Haskell node
+	@npm --prefix data run fetch -- "$(AMARU_NETWORK)"
+
+generate-test-snapshots: ## &test Generate test snapshots for test-e2e
+	@npm --prefix conformance-tests run generate-all -- "$(AMARU_NETWORK)"
+	@./scripts/generate-snapshot-test-cases
+
+test-e2e: ## &test Run snapshot tests, assuming snapshots are available
+	AMARU_NETWORK=$(AMARU_NETWORK) cargo test --profile $(BUILD_PROFILE) -p amaru -- --ignored
+
+check-llvm-cov: ## &test Check if cargo-llvm-cov is installed, install if not
+	@if ! cargo llvm-cov --version >/dev/null 2>&1; then \
+		echo "cargo-llvm-cov not found. Installing..."; \
+		cargo install cargo-llvm-cov; \
+	else \
+		echo "cargo-llvm-cov is already installed"; \
+	fi
+
+coverage-html: check-llvm-cov ## &test Run test coverage for Amaru
+	cargo llvm-cov \
+		--no-cfg-coverage \
+		--html \
+		--output-dir $(COVERAGE_DIR) $(foreach package,$(COVERAGE_CRATES), --package $(package))
+
+coverage-lconv: ## &test Run test coverage for CI to upload to Codecov
+	cargo llvm-cov \
+		--all-features \
+		--workspace \
+		--lcov \
+		--output-path lcov.info

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Amaru is a [Cardano](https://cardano.org) node client written in Rust. It is an 
 ### Installing
 
 ```console
-cargo build --release
+make build
 ```
 
 ### Running
@@ -23,7 +23,7 @@ cargo build --release
 on the selected network (e.g. [preprod](https://book.world.dev.cardano.org/env-preprod.html)).
 >
 > To run a local peer, refer to [Cardano's developers portal](https://developers.cardano.org/docs/get-started/cardano-node/running-cardano).
-> Make sure your peer listens to port `3001` or adapt the `PEER_ADDRESS` environment variable (e.g. `export PEER_ADDRESS=127.0.0.1:3002`)
+> Make sure your peer listens to port `3001` or adapt the `AMARU_PEER_ADDRESS` environment variable (e.g. `export AMARU_PEER_ADDRESS=127.0.0.1:3002`)
 
 1. Bootstrap the node:
 
@@ -40,9 +40,7 @@ docker-compose -f monitoring/jaeger/docker-compose.yml up
 3. Run Amaru:
 
 ```console
-cargo run --release -- daemon \
-  --peer-address=127.0.0.1:3001 \
-  --network=preprod
+make NETWORK=preprod start
 ```
 
 Replace `--peer-address` with your Cardano node peer address. It can be either
@@ -50,12 +48,10 @@ a local or remote node (i.e. any existing node relay), and you can even add
 multiple peers by replicating the option.
 
 > [!TIP]
-> To ensure logs are forwarded to telemetry backend, pass `--with-open-telemetry` as an option _before_ the `daemon` sub-command, eg.
+> To ensure logs are forwarded to telemetry backend, set `AMARU_WITH_OPEN_TELEMETRY=yes`:
 >
 > ```console
-> cargo run --release -- --with-open-telemetry daemon \
->  --peer-address=127.0.0.1:3001 \
->  --network=preprod
+> make NETWORK=preprod AMARU_WITH_OPEN_TELEMETRY=yes start
 > ```
 
 ### Monitoring

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ on the selected network (e.g. [preprod](https://book.world.dev.cardano.org/env-p
 1. Bootstrap the node:
 
 ```bash
-make NETWORK=preprod bootstrap
+make AMARU_NETWORK=preprod bootstrap
 ```
 
 2. _(Optional)_ Setup observability backends:
@@ -40,7 +40,7 @@ docker-compose -f monitoring/jaeger/docker-compose.yml up
 3. Run Amaru:
 
 ```console
-make NETWORK=preprod start
+make AMARU_NETWORK=preprod start
 ```
 
 Replace `--peer-address` with your Cardano node peer address. It can be either
@@ -51,7 +51,7 @@ multiple peers by replicating the option.
 > To ensure logs are forwarded to telemetry backend, set `AMARU_WITH_OPEN_TELEMETRY=yes`:
 >
 > ```console
-> make NETWORK=preprod AMARU_WITH_OPEN_TELEMETRY=yes start
+> make AMARU_NETWORK=preprod AMARU_WITH_OPEN_TELEMETRY=yes start
 > ```
 
 ### Monitoring

--- a/crates/amaru/build.rs
+++ b/crates/amaru/build.rs
@@ -18,9 +18,9 @@ use std::env;
 fn main() {
     built::write_built_file().expect("Failed to acquire build-time information");
 
-    // Set the NETWORK environment variable based on the value from the environment or default to "preprod"
-    // This is necessary for the tests to run correctly, as they rely on the NETWORK variable to be set at build time
-    let network = env::var("NETWORK").unwrap_or_else(|_| "preprod".into());
-    println!("cargo:rerun-if-env-changed=NETWORK");
-    println!("cargo:rustc-env=NETWORK={}", network);
+    // Set the AMARU_NETWORK environment variable based on the value from the environment or default to "preprod"
+    // This is necessary for the tests to run correctly, as they rely on the AMARU_NETWORK variable to be set at build time
+    let network = env::var("AMARU_NETWORK").unwrap_or_else(|_| "preprod".into());
+    println!("cargo:rerun-if-env-changed=AMARU_NETWORK");
+    println!("cargo:rustc-env=AMARU_NETWORK={}", network);
 }

--- a/crates/amaru/tests/summary.rs
+++ b/crates/amaru/tests/summary.rs
@@ -71,17 +71,17 @@ fn db(network: NetworkName, epoch: Epoch) -> Arc<impl Snapshot + Send + Sync> {
 
 include!(concat!(
     "snapshots/",
-    env!("NETWORK"),
+    env!("AMARU_NETWORK"),
     "/generated_compare_snapshot_test_cases.incl"
 ));
 
 #[expect(clippy::unwrap_used)]
 fn compare_snapshot(epoch: Epoch) {
     #[expect(clippy::expect_used)]
-    let network: NetworkName = env!("NETWORK")
+    let network: NetworkName = env!("AMARU_NETWORK")
         .to_string()
         .parse()
-        .expect("$NETWORK must be set to a valid network name");
+        .expect("$AMARU_NETWORK must be set to a valid network name");
 
     let snapshot = db(network, epoch);
 


### PR DESCRIPTION
While awaiting for other stuff to finish, I've been tweaking a bit the Makefile which has grown quite a bit. Also adjusted the README instruction accordingly, and to reflect some recent changes on ENV vars.

| before | after | 
| --- | --- | 
| <img width="690" height="610" alt="Screenshot 2025-09-13 at 17 49 24" src="https://github.com/user-attachments/assets/b51eba3a-1f0e-453b-bf84-9b684c555a1a" /> | <img width="737" height="709" alt="Screenshot 2025-09-13 at 17 49 41" src="https://github.com/user-attachments/assets/7a5bef8a-dd91-4bd9-8311-49304a771c43" /> | 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Make targets: build, build-examples, start, dev, demo, bootstrap, fetch-data, generate-test-snapshots, test-e2e; staged import targets for headers, ledger state, and nonces.
  - Categorized help output for easier discovery.

- Refactor
  - Reorganized bootstrap/snapshot and dev/runtime flow; removed legacy end-to-end entry.
  - CI/test orchestration consolidated (all-ci-checks).

- Documentation
  - Getting Started switched to Make targets; renamed env var to AMARU_PEER_ADDRESS and telemetry to AMARU_WITH_OPEN_TELEMETRY.
- Tests
  - CI and test tooling now use AMARU_NETWORK consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->