### PR TITLE
fix: do not depend on risc0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -53,16 +53,13 @@ jobs:
             setup: rustup target add wasm32-unknown-unknown
 
           - runner: ubuntu-latest
-            target: riscv32im-risc0-zkvm-elf
-            title: riscv32
-            packages: -p amaru-ledger -p amaru-slot-arithmetic -p pure-stage
+            target: riscv32gc-unknown-linux-gnu
+            title: riscv32gc
+            packages: -p amaru-ledger -p amaru-slot-arithmetic
             extra-args: +nightly -Zbuild-std=std,panic_abort
             command: build
-            setup: |
-              curl -L https://risczero.com/install | bash
-              /home/runner/.risc0/bin/rzup install
-              rustup toolchain add nightly-x86_64-unknown-linux-gnu
-              rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+            setup: rustup component add rust-src --toolchain nightly
+
     runs-on: ${{ matrix.environments.runner }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -54,7 +54,7 @@ jobs:
 
           - runner: ubuntu-latest
             target: riscv32gc-unknown-linux-gnu
-            title: riscv32gc
+            title: riscv32
             packages: -p amaru-ledger -p amaru-slot-arithmetic
             extra-args: +nightly -Zbuild-std=std,panic_abort
             command: build


### PR DESCRIPTION
Update `riscv` compilation to move away from `risc0` specifics to more generic `riscv32gc-unknown-linux-gnu`. `risc0` proved to be flaky and regularly break the build. 

Note that there are a bunch of different targets considered by `riscv` zkvm implementers so it makes sense to move to a more standard one. `risc0` itself is [planning](https://github.com/rust-lang/rust/issues/135376#issuecomment-3276097710) to move to `riscv32gc-unknown-linux-gnu` soon. Also note that `riscv32gc-unknown-linux-gnu` is a [tier 2.5](https://rust-lang.github.io/rustup-components-history/) target while the risc0 one is tier3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI configuration for riscv32 builds to use a more standard target, improving compatibility across environments.
  - Simplified toolchain setup to reduce build time and lower flakiness in nightly builds.
  - Streamlined package selection in the riscv32 job to speed up the pipeline and cut unnecessary steps.
  - No changes to user-facing features or public APIs; these updates only enhance build reliability and developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->