### PR TITLE
doc: remove obsolete message from help

### DIFF
--- a/crates/amaru/src/bin/amaru/main.rs
+++ b/crates/amaru/src/bin/amaru/main.rs
@@ -33,8 +33,6 @@ enum Command {
     /// bootstrap configuration files in `data/${network name}/`
     /// directory to download snapshots, import those snapshots into
     /// the ledger, import nonces, and import headers.
-    ///
-    /// **NOTE**: Only `preprod` network is supported for now.
     Bootstrap(cmd::bootstrap::Args),
 
     FetchChainHeaders(cmd::fetch_chain_headers::Args),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Cleaned up and clarified internal documentation for a bootstrap command variant, removing a redundant note and extra spacing to improve readability.
  - No changes to behavior, flags, outputs, or user workflows; all commands function exactly as before.
  - No configuration, compatibility, or performance impact.
  - This update is purely editorial and does not affect public APIs or visible features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->