### PR TITLE
fix: remove the pure-stage dependency in amaru-ledger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,6 @@ dependencies = [
  "hex",
  "num",
  "proptest",
- "pure-stage",
  "serde",
  "test-case",
  "thiserror 2.0.16",

--- a/crates/amaru-ledger/Cargo.toml
+++ b/crates/amaru-ledger/Cargo.toml
@@ -32,7 +32,6 @@ amaru-iter-borrow.workspace = true
 amaru-ouroboros-traits.workspace = true
 amaru-progress-bar.workspace = true
 amaru-slot-arithmetic.workspace = true
-pure-stage.workspace = true
 
 [dev-dependencies]
 # External dependencies ───────────────────────────────────────────────────────┐


### PR DESCRIPTION
This dependency is not needed and makes the build fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up build configuration by removing an unused internal dependency, reducing coupling and simplifying maintenance.
  * No changes to user-facing behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->