### PR TITLE
chore: run cargo machete to remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,6 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "pallas-crypto",
  "pallas-network",
  "proptest",
  "pure-stage",
@@ -169,7 +168,6 @@ dependencies = [
  "sha3",
  "test-case",
  "thiserror 2.0.16",
- "tracing",
 ]
 
 [[package]]
@@ -186,7 +184,6 @@ dependencies = [
  "hex",
  "num",
  "proptest",
- "pure-stage",
  "serde",
  "test-case",
  "thiserror 2.0.16",
@@ -212,30 +209,14 @@ name = "amaru-network"
 version = "0.1.0"
 dependencies = [
  "amaru-kernel",
- "amaru-ouroboros",
  "amaru-ouroboros-traits",
- "amaru-slot-arithmetic",
  "anyhow",
  "async-trait",
- "hex",
- "insta",
- "minicbor",
- "pallas-crypto",
- "pallas-math",
  "pallas-network",
  "pallas-traverse",
- "proptest",
- "pure-stage",
- "rand 0.9.2",
- "rand_distr",
- "rayon",
- "serde",
- "serde_json",
- "tempfile",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/amaru-kernel/Cargo.toml
+++ b/crates/amaru-kernel/Cargo.toml
@@ -31,7 +31,6 @@ serde = { workspace = true, features = ["derive", "rc"] }
 serde_json.workspace = true
 sha3.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
 proptest = { workspace = true, optional = true }
 
 # Internal dependencies ───────────────────────────────────────────────────────┐

--- a/crates/amaru-ledger/Cargo.toml
+++ b/crates/amaru-ledger/Cargo.toml
@@ -32,7 +32,6 @@ amaru-iter-borrow.workspace = true
 amaru-ouroboros-traits.workspace = true
 amaru-progress-bar.workspace = true
 amaru-slot-arithmetic.workspace = true
-pure-stage.workspace = true
 
 [dev-dependencies]
 # External dependencies ───────────────────────────────────────────────────────┐

--- a/crates/amaru-network/Cargo.toml
+++ b/crates/amaru-network/Cargo.toml
@@ -15,32 +15,14 @@ rust-version.workspace = true
 [dependencies]
 async-trait.workspace = true
 anyhow.workspace = true
-hex.workspace = true
-pallas-crypto.workspace = true
-pallas-math.workspace = true
 pallas-network.workspace = true
 pallas-traverse.workspace = true
-rayon.workspace = true
-serde.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 
 amaru-kernel.workspace = true
-amaru-ouroboros.workspace = true
 amaru-ouroboros-traits.workspace = true
-amaru-slot-arithmetic.workspace = true
-pure-stage.workspace = true
 
 [dev-dependencies]
-amaru-slot-arithmetic = { workspace = true, features = ["test-utils"] }
-hex.workspace = true
-insta.workspace = true
-minicbor.workspace = true
-proptest.workspace = true
-rand.workspace = true
-rand_distr.workspace = true
-serde_json.workspace = true
-tempfile.workspace = true
 tokio = { workspace = true, features = ["rt", "macros"] }
-tracing-subscriber.workspace = true

--- a/crates/amaru-stores/Cargo.toml
+++ b/crates/amaru-stores/Cargo.toml
@@ -38,3 +38,6 @@ amaru-ledger = { workspace = true, features = ["test-utils"] }
 [features]
 default = ["rocksdb"]
 rocksdb = ["dep:rocksdb", "dep:rand"]
+
+[package.metadata.cargo-machete]
+ignored = ["rand"]

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -28,7 +28,6 @@ minicbor.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
-pallas-crypto.workspace = true
 pallas-network.workspace = true
 reqwest.workspace = true
 serde.workspace = true
@@ -36,10 +35,10 @@ serde_json.workspace = true
 sysinfo.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = [
-    "fs",
-    "rt",
-    "rt-multi-thread",
-    "signal",
+  "fs",
+  "rt",
+  "rt-multi-thread",
+  "signal",
 ] }
 tokio-util.workspace = true
 tracing-opentelemetry.workspace = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Streamlined project dependencies by removing unused workspace entries to simplify builds and reduce overhead.
  - Updated build metadata to improve tooling analysis without affecting runtime behavior.
  - No changes to public APIs or runtime functionality.

- Style
  - Minor formatting cleanups in configuration files for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->