### PR TITLE
feat: make sure AMARU_NETWORK can be used with all commands

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -177,7 +177,7 @@ jobs:
         shell: bash
         run: |
           docker pull ghcr.io/intersectmbo/cardano-node:${{ matrix.cardano_node_version }}
-          make HASKELL_NODE_CONFIG_DIR=cardano-node-config NETWORK=${{ matrix.network.name }} download-haskell-config
+          make HASKELL_NODE_CONFIG_DIR=cardano-node-config AMARU_NETWORK=${{ matrix.network.name }} download-haskell-config
           docker run -d --name cardano-node \
             -v ${{ runner.temp }}/db-${{ matrix.network.name }}:/db \
             -v ${{ runner.temp }}/ipc:/ipc \
@@ -217,13 +217,13 @@ jobs:
       - name: Full bootstrap amaru
         if: steps.cache-ledger-db.outputs.cache-hit == ''
         run: |
-          make BUILD_PROFILE=test NETWORK=${{ matrix.network.name }} bootstrap
+          make BUILD_PROFILE=test AMARU_NETWORK=${{ matrix.network.name }} bootstrap
 
       - name: Light bootstrap amaru
         if: steps.cache-ledger-db.outputs.cache-hit != ''
         run: |
-          make BUILD_PROFILE=test NETWORK=${{ matrix.network.name }} import-headers
-          make BUILD_PROFILE=test NETWORK=${{ matrix.network.name }} import-nonces
+          make BUILD_PROFILE=test AMARU_NETWORK=${{ matrix.network.name }} import-headers
+          make BUILD_PROFILE=test AMARU_NETWORK=${{ matrix.network.name }} import-nonces
 
       - uses: actions/cache/save@v4
         if: github.event_name == 'push' || steps.cache-ledger-db.outputs.cache-hit == ''

--- a/.github/workflows/nightly-synchronization.yml
+++ b/.github/workflows/nightly-synchronization.yml
@@ -50,12 +50,12 @@ jobs:
       shell: bash
       working-directory: ${{ runner.temp }}/db-${{ matrix.network }}
       run: |
-        if [ "$NETWORK" == "preprod" ]; then
+        if [ "$AMARU_NETWORK" == "preprod" ]; then
           rm -f immutable/00*.chunk immutable/01*.chunk immutable/02*.chunk immutable/030*.chunk
         fi
 
-        if [ "$NETWORK" == "preview" ]; then
+        if [ "$AMARU_NETWORK" == "preview" ]; then
           rm -f immutable/0*.chunk immutable/10*.chunk immutable/11*.chunk
         fi
       env:
-        NETWORK: ${{ matrix.network }}
+        AMARU_NETWORK: ${{ matrix.network }}

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,7 @@ bootstrap: clear-dbs ## &start Bootstrap Amaru from scratch (snapshots + headers
 	cargo run --profile $(BUILD_PROFILE) -- bootstrap \
 		--config-dir $(AMARU_CONFIG_DIR) \
 		--ledger-dir $(AMARU_LEDGER_DIR) \
-		--chain-dir $(AMARU_CHAIN_DIR) \
-		--network $(AMARU_NETWORK)
+		--chain-dir $(AMARU_CHAIN_DIR)
 
 snapshots/$(AMARU_NETWORK): ## &start Download initial snapshots
 	@if [ ! -f "${SNAPSHOTS_FILE}" ]; then echo "SNAPSHOTS_FILE not found: ${SNAPSHOTS_FILE}"; exit 1; fi;
@@ -61,14 +60,12 @@ import-ledger-state: snapshots/$(AMARU_NETWORK) ## &start Import initial ledger-
 		SNAPSHOT_ARGS="$$SNAPSHOT_ARGS --snapshot $$SNAPSHOT"; \
 	done; \
 	cargo run --profile $(BUILD_PROFILE) -- import-ledger-state \
-		--network $(AMARU_NETWORK) \
 		--ledger-dir "$(AMARU_LEDGER_DIR)" \
 		$$SNAPSHOT_ARGS
 
 import-nonces: ## &start Import initial nonces
 	@if [ ! -f "$(NONCES_FILE)" ]; then echo "NONCES_FILE not found: $(NONCES_FILE)"; exit 1; fi; \
 	cargo run --profile $(BUILD_PROFILE) -- import-nonces \
-		--network $(AMARU_NETWORK) \
 		--chain-dir $(AMARU_CHAIN_DIR) \
 		--at $$(jq -r .at $(NONCES_FILE)) \
 		--active $$(jq -r .active $(NONCES_FILE)) \
@@ -117,8 +114,7 @@ all-ci-checks: ## &test Run all CI checks
 fetch-chain-headers: $(AMARU_CONFIG_DIR)/$(AMARU_NETWORK)/ ## &test Fetch chain headers from the network
 	cargo run --profile $(BUILD_PROFILE) -- fetch-chain-headers \
 		--peer-address $(AMARU_PEER_ADDRESS) \
-		--config-dir $(AMARU_CONFIG_DIR) \
-		--network $(AMARU_NETWORK)
+		--config-dir $(AMARU_CONFIG_DIR)
 
 fetch-data: ## &test Fetch epoch data (dreps, pools, accounts, ...) from a Haskell node
 	@npm --prefix data run fetch -- "$(AMARU_NETWORK)"

--- a/cli-tests/test_crash_with_helpful_information.sh
+++ b/cli-tests/test_crash_with_helpful_information.sh
@@ -5,10 +5,10 @@ test_explains_snapshot_file_is_missing() {
 }
 
 setup() {
-	export NETWORK=preprod
+	export AMARU_NETWORK=preprod
 	export CONFIG_FOLDER=data
-	export LEDGER_DIR=./ledger.${NETWORK}.db
-	export CHAIN_DIR=./chain.${NETWORK}.db
+	export LEDGER_DIR=./ledger.${AMARU_NETWORK}.db
+	export CHAIN_DIR=./chain.${AMARU_NETWORK}.db
 	export BUILD_PROFILE=dev
 }
 
@@ -21,6 +21,5 @@ bootstrap_amaru() {
 		--config-dir ${CONFIG_FOLDER} \
 		--ledger-dir ${LEDGER_DIR} \
 		--chain-dir ${CHAIN_DIR} \
-		--network ${NETWORK} \
 		2>&1
 }

--- a/cli-tests/test_manage_colors_in_output.sh
+++ b/cli-tests/test_manage_colors_in_output.sh
@@ -10,14 +10,14 @@ test_color_if_in_terminal() {
 
 setup_suite() {
 	AMARU_NETWORK=preprod
-	LEDGER_DIR=./ledger.${NETWORK}.db
-	CHAIN_DIR=./chain.${NETWORK}.db
+	LEDGER_DIR=./ledger.${AMARU_NETWORK}.db
+	CHAIN_DIR=./chain.${AMARU_NETWORK}.db
 	BUILD_PROFILE=dev
 	UNREACHABLE_PEER=127.0.0.1:65532
 	export start_misconfigured_amaru_daemon_cmd="cargo run --color never --profile ${BUILD_PROFILE} -- daemon
 		--peer-address ${UNREACHABLE_PEER}
 		--ledger-dir ${LEDGER_DIR}
-		--chain-dir ${CHAIN_DIR}
+		--chain-dir ${CHAIN_DIR}"
 }
 
 emulate_terminal() {

--- a/cli-tests/test_manage_colors_in_output.sh
+++ b/cli-tests/test_manage_colors_in_output.sh
@@ -9,7 +9,7 @@ test_color_if_in_terminal() {
 }
 
 setup_suite() {
-	NETWORK=preprod
+	AMARU_NETWORK=preprod
 	LEDGER_DIR=./ledger.${NETWORK}.db
 	CHAIN_DIR=./chain.${NETWORK}.db
 	BUILD_PROFILE=dev
@@ -18,7 +18,6 @@ setup_suite() {
 		--peer-address ${UNREACHABLE_PEER}
 		--ledger-dir ${LEDGER_DIR}
 		--chain-dir ${CHAIN_DIR}
-		--network ${NETWORK}"
 }
 
 emulate_terminal() {

--- a/crates/amaru/src/bin/amaru/cmd/bootstrap.rs
+++ b/crates/amaru/src/bin/amaru/cmd/bootstrap.rs
@@ -54,6 +54,7 @@ pub struct Args {
     #[arg(
         long,
         value_name = "NETWORK",
+        env = "AMARU_NETWORK",
         default_value_t = DEFAULT_NETWORK,
     )]
     network: NetworkName,

--- a/crates/amaru/src/bin/amaru/cmd/convert_ledger_state.rs
+++ b/crates/amaru/src/bin/amaru/cmd/convert_ledger_state.rs
@@ -35,7 +35,13 @@ pub struct Args {
     target_dir: Option<PathBuf>,
 
     /// Network to convert snapshots for.
-    #[arg(long, value_name = "NETWORK_NAME", verbatim_doc_comment)]
+    #[arg(
+        long,
+        value_name = "NETWORK_NAME",
+        env = "AMARU_NETWORK",
+        default_value_t = NetworkName::Preprod,
+        verbatim_doc_comment
+    )]
     network: NetworkName,
 }
 

--- a/crates/amaru/src/bin/amaru/cmd/fetch_chain_headers.rs
+++ b/crates/amaru/src/bin/amaru/cmd/fetch_chain_headers.rs
@@ -40,6 +40,7 @@ pub struct Args {
     #[arg(
         long,
         value_name = "NETWORK",
+        env = "AMARU_NETWORK",
         default_value_t = DEFAULT_NETWORK,
     )]
     network: NetworkName,

--- a/crates/amaru/src/bin/amaru/cmd/import_ledger_state.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_ledger_state.rs
@@ -54,6 +54,7 @@ pub struct Args {
     #[arg(
         long,
         value_name = "NETWORK",
+        env = "AMARU_NETWORK",
         default_value_t = NetworkName::Preprod,
     )]
     network: NetworkName,

--- a/crates/amaru/src/bin/amaru/cmd/import_nonces.rs
+++ b/crates/amaru/src/bin/amaru/cmd/import_nonces.rs
@@ -56,6 +56,7 @@ pub struct Args {
     #[arg(
         long,
         value_name = "NETWORK",
+        env = "AMARU_NETWORK",
         default_value_t = NetworkName::Preprod,
     )]
     network: NetworkName,

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,7 @@ This directory contains development related docker informations.
 
 ```bash
 cd docker/cluster
-echo NETWORK=preprod >.env
+echo AMARU_NETWORK=preprod >.env
 docker compose up --build
 ```
 
@@ -46,7 +46,7 @@ the network and start the cluster:
 
 ```bash
 cd docker/cluster
-echo NETWORK=preprod >.env
+echo AMARU_NETWORK=preprod >.env
 docker compose up --build
 ```
 

--- a/docker/cluster/docker-compose.yml
+++ b/docker/cluster/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       cardano:
         condition: service_healthy
     environment:
-      - NETWORK
+      - AMARU_NETWORK
       - LEDGER_DIR
       - CONFIG_FOLDER
       - CHAIN_DIR
@@ -24,7 +24,7 @@ services:
       amaru:
         condition: service_started
     environment:
-      - NETWORK
+      - AMARU_NETWORK
       - LEDGER_DIR
       - CONFIG_FOLDER
       - CHAIN_DIR
@@ -35,7 +35,7 @@ services:
   cardano:
     image: ghcr.io/blinklabs-io/cardano-node
     environment:
-      - NETWORK
+      - AMARU_NETWORK
     volumes:
       - cardano_data:/data/db
     healthcheck:

--- a/docker/start_amaru.sh
+++ b/docker/start_amaru.sh
@@ -14,7 +14,7 @@ LEDGER_DIR="${LEDGER_DIR:-${DATA_DIR}/ledger.db}"
 CHAIN_DIR="${CHAIN_DIR:-${DATA_DIR}/chain.db}"
 CONFIG_FOLDER="${CONFIG_FOLDER:-data}"
 
-[[ -z "${NETWORK:-}" ]] && usage "Set NETWORK (via .env, compose, or shell) to a value supported by Amaru"
+[[ -z "${AMARU_NETWORK:-}" ]] && usage "Set NETWORK (via .env, compose, or shell) to a value supported by Amaru"
 
 if ! [ -d "${LEDGER_DIR}" ]
 then
@@ -28,5 +28,4 @@ fi
 exec cargo run --profile dev -- daemon \
       --peer-address "${PEER_ADDRESS}" \
       --ledger-dir "${LEDGER_DIR}" \
-      --chain-dir "${CHAIN_DIR}" \
-      --network "${NETWORK}"
+      --chain-dir "${CHAIN_DIR}"

--- a/docker/start_amaru.sh
+++ b/docker/start_amaru.sh
@@ -14,15 +14,14 @@ LEDGER_DIR="${LEDGER_DIR:-${DATA_DIR}/ledger.db}"
 CHAIN_DIR="${CHAIN_DIR:-${DATA_DIR}/chain.db}"
 CONFIG_FOLDER="${CONFIG_FOLDER:-data}"
 
-[[ -z "${AMARU_NETWORK:-}" ]] && usage "Set NETWORK (via .env, compose, or shell) to a value supported by Amaru"
+[[ -z "${AMARU_NETWORK:-}" ]] && usage "Set AMARU_NETWORK (via .env, compose, or shell) to a value supported by Amaru"
 
 if ! [ -d "${LEDGER_DIR}" ]
 then
     cargo run --profile dev -- bootstrap \
       --config-dir "${CONFIG_FOLDER}" \
       --ledger-dir "${LEDGER_DIR}" \
-      --chain-dir "${CHAIN_DIR}" \
-      --network "${NETWORK}"
+      --chain-dir "${CHAIN_DIR}"
 fi
 
 exec cargo run --profile dev -- daemon \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI commands now read network from AMARU_NETWORK environment variable when flag is omitted.
* **Chores**
  * Standardized AMARU_NETWORK across CI workflows, scripts, and Docker.
* **Tests**
  * Updated tests to use AMARU_NETWORK and simplified invocations by removing explicit network flags.
* **Documentation**
  * Docker docs updated to instruct setting AMARU_NETWORK in .env.
* **Refactor**
  * Removed redundant explicit network flags, relying on environment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->