### PR TITLE
feat: add a command to dump the state of the chain store

### DIFF
--- a/crates/amaru/src/bin/amaru/cmd/dump_chain_db.rs
+++ b/crates/amaru/src/bin/amaru/cmd/dump_chain_db.rs
@@ -1,0 +1,104 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use amaru_kernel::network::NetworkName;
+use amaru_kernel::string_utils::ListToString;
+use amaru_kernel::{Header, to_cbor};
+use amaru_ouroboros_traits::{ChainStore, IsHeader};
+use amaru_stores::rocksdb::consensus::RocksDBStore;
+use clap::{Parser, arg};
+use std::fmt::Display;
+use std::sync::Arc;
+use std::{error::Error, path::PathBuf};
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// Network for which we are importing headers.
+    ///
+    /// Should be one of 'mainnet', 'preprod', 'preview' or 'testnet:<magic>' where
+    /// `magic` is a 32-bits unsigned value denoting a particular testnet.
+    #[arg(
+        long,
+        value_name = "NETWORK",
+        env = "AMARU_NETWORK",
+        default_value_t = NetworkName::Preprod,
+    )]
+    network: NetworkName,
+
+    /// The path to the chain database to dump
+    #[arg(long, value_name = "DIR", default_value = "chain.db")]
+    chain_dir: PathBuf,
+}
+
+pub async fn run(args: Args) -> Result<(), Box<dyn Error>> {
+    let chain_dir = args.chain_dir;
+    let era_history = args.network.into();
+    let db: Arc<dyn ChainStore<Header>> = Arc::new(RocksDBStore::new(&chain_dir, era_history)?);
+
+    print_iterator(
+        "headers",
+        db.load_headers().map(|header| {
+            (
+                format!("\n{}", header.hash()),
+                hex::encode(to_cbor(&header)),
+            )
+        }),
+    );
+    print_iterator(
+        "parent -> children relationships\n",
+        db.load_parents_children()
+            .map(|(parent, children)| (parent, children.list_to_string(", "))),
+    );
+    print_iterator(
+        "nonces\n",
+        db.load_nonces()
+            .map(|(hash, nonces)| (hash, hex::encode(to_cbor(&nonces)))),
+    );
+    print_iterator(
+        "blocks\n",
+        db.load_blocks()
+            .map(|(hash, block)| (hash, hex::encode(block.to_vec()))),
+    );
+    print_best_chain(db);
+    Ok(())
+}
+
+#[expect(clippy::print_stdout)]
+pub fn print_best_chain(db: Arc<dyn ChainStore<Header>>) {
+    println!();
+    let best_chain = db.retrieve_best_chain();
+    println!(
+        "The best chain is:\n  {}",
+        best_chain.list_to_string("\n  ")
+    );
+
+    println!();
+    println!("The best chain length is: {}", best_chain.len());
+    println!("The best chain anchor is: {}", db.get_anchor_hash());
+    println!("The best chain tip is: {}", db.get_best_chain_hash());
+}
+
+#[expect(clippy::print_stdout)]
+pub fn print_iterator<K: Display, V: Display>(title: &str, iterator: impl Iterator<Item = (K, V)>) {
+    println!("\n{}", title.to_ascii_uppercase());
+    let mut count = 0;
+    for (k, v) in iterator {
+        println!("{}: {}", k, v);
+        count += 1;
+    }
+    // remove newlines
+    let mut lower = title.to_lowercase().clone();
+    lower.retain(|c| c != '\n');
+    println!("=> Found {} {}", count, lower);
+}

--- a/crates/amaru/src/bin/amaru/cmd/mod.rs
+++ b/crates/amaru/src/bin/amaru/cmd/mod.rs
@@ -18,6 +18,7 @@ use pallas_network::facades::PeerClient;
 pub(crate) mod bootstrap;
 pub(crate) mod convert_ledger_state;
 pub(crate) mod daemon;
+pub(crate) mod dump_chain_db;
 pub(crate) mod fetch_chain_headers;
 pub(crate) mod import_headers;
 pub(crate) mod import_ledger_state;

--- a/crates/amaru/src/bin/amaru/main.rs
+++ b/crates/amaru/src/bin/amaru/main.rs
@@ -63,6 +63,16 @@ enum Command {
 
     /// Import VRF nonces intermediate states
     ImportNonces(cmd::import_nonces::Args),
+
+    /// Dump the content of the chain database for troubleshooting purposes.
+    /// This command dumps the _whole_ content of the chain database in a human-readable format:
+    ///  - Headers (hash + hex-encoded body)
+    ///  - Parent-child relationships between headers
+    ///  - Nonces
+    ///  - Blocks
+    ///  - Best chain anchor, tip and length
+    ///
+    DumpChainDB(cmd::dump_chain_db::Args),
 }
 
 #[derive(Debug, Parser)]
@@ -79,13 +89,16 @@ struct Cli {
     #[clap(long, action, env("AMARU_WITH_JSON_TRACES"))]
     with_json_traces: bool,
 
-    #[arg(long, value_name = "STRING", env("AMARU_SERVICE_NAME"), default_value_t = DEFAULT_SERVICE_NAME.to_string())]
+    #[arg(long, value_name = "STRING", env("AMARU_SERVICE_NAME"), default_value_t = DEFAULT_SERVICE_NAME.to_string()
+    )]
     service_name: String,
 
-    #[arg(long, value_name = "URL", env("AMARU_OTLP_SPAN_URL"), default_value_t = DEFAULT_OTLP_SPAN_URL.to_string())]
+    #[arg(long, value_name = "URL", env("AMARU_OTLP_SPAN_URL"), default_value_t = DEFAULT_OTLP_SPAN_URL.to_string()
+    )]
     otlp_span_url: String,
 
-    #[arg(long, value_name = "URL", env("AMARU_OTLP_METRIC_URL"), default_value_t = DEFAULT_OTLP_METRIC_URL.to_string())]
+    #[arg(long, value_name = "URL", env("AMARU_OTLP_METRIC_URL"), default_value_t = DEFAULT_OTLP_METRIC_URL.to_string()
+    )]
     otlp_metric_url: String,
 }
 
@@ -138,6 +151,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Command::Bootstrap(args) => cmd::bootstrap::run(args).await,
         Command::FetchChainHeaders(args) => cmd::fetch_chain_headers::run(args).await,
         Command::ConvertLedgerState(args) => cmd::convert_ledger_state::run(args).await,
+        Command::DumpChainDB(args) => cmd::dump_chain_db::run(args).await,
     };
 
     // TODO: we might also want to integrate this into a graceful shutdown system, and into a panic hook


### PR DESCRIPTION
This command prints:

 - The headers: hash + encoded body
 - The nonces
 - The blocks
 - The current best chain anchor
 - The current best chain tip
 - The current best chain length

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “dump-chain-db” CLI subcommand to inspect the chain database.
  - Outputs headers, parent/child relationships, nonces, blocks, and a best chain summary (tip, length, anchor).
  - Supports selecting the network and chain directory via flags or environment variables.
  - Provides human-readable and hex-encoded views to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->