### PR TITLE
feat: add CODEOWNERS file to trigger antithesis run

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# this should contain all the github handles allowed to trigger antithesis tests
+antithesis: @abailly


### PR DESCRIPTION
the antithesis CLI built by HAL Team to mediate execution of tests on the antithesis platform requires the presence of this file to allow tests trigger by identified users. Checkout https://github.com/cardano-foundation/antithesis/ for more details.