### PR TITLE
fix: adjust testnet docker cluster to run antithesis

### DIFF
--- a/docker/start_amaru.sh
+++ b/docker/start_amaru.sh
@@ -26,10 +26,10 @@ fi
 
 # keep stack traces for troubleshooting purposes
 export RUST_BACKTRACE=full
-export AMARU_LOG=debug
-export AMARU_TRACE=gasket=error,debug
 
-exec cargo run --profile dev -- --with-json-traces daemon \
+export AMARU_LOG=gasket=error,amaru=debug,amaru::stages::consensus::forward_chain=info,info
+
+exec cargo run --profile dev -- daemon \
       --peer-address "${AMARU_PEER_ADDRESS}" \
       --ledger-dir "${AMARU_LEDGER_DIR}" \
       --chain-dir "${AMARU_CHAIN_DIR}"

--- a/docker/testnet/README.md
+++ b/docker/testnet/README.md
@@ -1,6 +1,5 @@
 # Amaru Testnet
 
-> [!WARNING]
 >
 > This is extremely rough on the edges and brittle. Most notably, the
 > configuration of the network is fixed (5 block producers, epoch

--- a/docker/testnet/docker-compose.yaml
+++ b/docker/testnet/docker-compose.yaml
@@ -16,13 +16,6 @@ x-cardano-node: &cardano-node
       +RTS -N -A16m -qg -qb -RTS
   restart:
     always
-  healthcheck:
-    test: ["CMD", "bash", "-c", "cardano-cli ping -j --magic 42 --host localhost --port 3001 --tip --quiet -c1" ]
-    interval: 1m30s
-    timeout: 10s
-    retries: 100
-    start_period: 40s
-    start_interval: 5s
   depends_on:
       amaru-loader:
         condition: service_completed_successfully


### PR DESCRIPTION
This PR does some adjustments to the `docker/testnet` configuration for the sake of running it in Antithesis using the [anti command-line interface](https://app.radicle.xyz/nodes/seed.hydra.bzh/rad:z2a7Te5b28CX5YyPQ7ihrdG2EEUsC/tree/cli/README.md) tool developed by the HAL Team at CF.

* Trim down logging (in our first run we generated 150GB of logs...)
* Add `testnet.yaml` (the `anti cli` requires this file to be present atm)
* Remove non standard markdown from `README.md` (the `anti cli` parses this file 🤷 )
* adjust image names to match [published packages](https://github.com/orgs/pragma-org/packages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified logging into a single environment variable and simplified daemon startup behavior.

* **Chores**
  * Updated testnet docker-compose by removing the healthcheck and adding runtime performance options to the node.
  * Minor script formatting cleanup.

* **Documentation**
  * Tidied warning formatting in the testnet README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->