### PR TITLE
feat: document memory profiling via heaptrack

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "rustc --version",
 	"onCreateCommand": {
-		"installDependencies": "sudo apt update && sudo apt -y upgrade && sudo apt install -y clang"
+		"installDependencies": "sudo apt update && sudo apt -y upgrade && sudo apt install -y clang heaptrack heaptrack-gui"
 	},
 
 	// Configure tool-specific properties.
@@ -33,8 +33,11 @@
 				"rust-lang.rust-analyzer"
 			]
 		}
-	}
+	},
 
+	"containerEnv": {
+		"DISPLAY": "host.docker.internal:0"
+	}
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ lcov.info
 .aider*
 
 **/proptest-regressions/**
+
+heaptrack.*.gz

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,10 @@ debug = true
 lto = true
 codegen-units = 1
 
+[profile.profiling]
+inherits = "release"
+debug = true
+
 [workspace.metadata.cross.target.aarch64-unknown-linux-musl]
 pre-build = [
   "apt update",

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -1,0 +1,50 @@
+run inside devcontainer via vscode
+
+# Heapstack
+
+[Heapstack](https://github.com/KDE/heaptrack) is a heap memory profiler for Linux.
+
+## OSx
+
+Being Linux only, some steps are necessary to ensure heaptrack can be used on OSx.
+
+### Pre requisites
+
+[Devcontainer](https://containers.dev/) is leveraged to have amaru run in a pre-configured linux environment. Then [XQuartz](https://www.xquartz.org/) is used to display graphics directly on OSx host.
+
+First install XQuartz
+
+```
+brew install --cask xquartz
+```
+
+then run it `open -a XQuartz` and allow remote external connections in menu `Settings/Security` then restart.
+
+Finally, from within XQuartz integrated terminal, run `xhost +localhost`. *IMPORTANT* this has to be done each time XQuartz is restarted.
+
+### Using VSCode
+
+VSCode natively supports devcontainer so simply reopen your workspace in devcontainer. You will then get access to a regular VSCode instance as if it was running from within the docker instance.
+
+#### Generate a heaptrack snapshot
+
+```shell
+cargo build --profile profiling
+heaptrack ./target/profiling/amaru $YOUR_OPTIONS
+```
+
+#### Analyse heaptrack snapshot
+
+```shell
+heaptrack_gui SNAPSHOT_FILE
+```
+
+### Using another editor
+
+Use [Dev Container CLI](https://github.com/devcontainers/cli) to automate interactions with the docker image:
+
+```shell
+devcontainer up
+devcontainer exec --workspace-folder . cargo build --profile profiling
+devcontainer exec --workspace-folder . heaptrack ./target/profiling/amaru
+```


### PR DESCRIPTION
Make sure OSX and Linux users can profile heap memory via [heaptrack](https://github.com/KDE/heaptrack)