### PR TITLE
Polish diagnosis

### DIFF
--- a/cli-tests/test_crash_with_helpful_information.sh
+++ b/cli-tests/test_crash_with_helpful_information.sh
@@ -4,12 +4,19 @@ test_explains_snapshot_file_is_missing() {
 	assert_matches "data/preprod/snapshots.json.*NotFound" "$(bootstrap_amaru)"
 }
 
+skip_if "! ulimit -n" fd_limit
+test_explains_fd_limit_is_too_low() {
+	ulimit -n 256
+	assert_matches "Increase the limit for open files before starting Amaru" "$(start_amaru)"
+}
+
 setup() {
 	export AMARU_NETWORK=preprod
 	export CONFIG_FOLDER=data
 	export LEDGER_DIR=./ledger.${AMARU_NETWORK}.db
 	export CHAIN_DIR=./chain.${AMARU_NETWORK}.db
 	export BUILD_PROFILE=dev
+	export UNREACHABLE_PEER=127.0.0.1:65532
 }
 
 given_snapshots_file_is_missing() {
@@ -19,6 +26,14 @@ given_snapshots_file_is_missing() {
 bootstrap_amaru() {
 	cargo run --profile ${BUILD_PROFILE} -- bootstrap \
 		--config-dir ${CONFIG_FOLDER} \
+		--ledger-dir ${LEDGER_DIR} \
+		--chain-dir ${CHAIN_DIR} \
+		2>&1
+}
+
+start_amaru() {
+	cargo run --profile ${BUILD_PROFILE} -- daemon \
+		--peer-address ${UNREACHABLE_PEER} \
 		--ledger-dir ${LEDGER_DIR} \
 		--chain-dir ${CHAIN_DIR} \
 		2>&1


### PR DESCRIPTION
Very small adjustment to error message when fd limit is too low to, hopefully, make things a bit more obvious to users.

Also, adding a test to check the CLI actually outputs such a message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clearer startup message when the system’s open-file limit is too low, with more helpful guidance.
* **Refactor**
  * Standardized wording and labels in pre-flight checks for file descriptor limits to improve clarity and consistency.
* **Tests**
  * Added tests that simulate low open-file limits to verify the new startup guidance appears as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->