### PR TITLE
feat: signal pure-stage termination to simulation

### DIFF
--- a/crates/pure-stage/src/simulation.rs
+++ b/crates/pure-stage/src/simulation.rs
@@ -32,6 +32,7 @@ use crate::{
     time::Clock,
     trace_buffer::TraceBuffer,
 };
+pub use blocked::{Blocked, SendBlock};
 use either::Either;
 use parking_lot::Mutex;
 use std::{
@@ -43,7 +44,6 @@ use std::{
 };
 use tokio::runtime::Handle;
 
-pub use blocked::Blocked;
 pub use replay::Replay;
 pub use running::{OverrideResult, SimulationRunning};
 


### PR DESCRIPTION
Also improve deadlock information

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Deadlock diagnostics now include sender, receiver, and call context for clearer insights.
  - Simulation can report a distinct “terminated” state when a stage ends.
  - Public exports updated to expose the new blocking detail type.

- Refactor
  - Blocking and effect handling streamlined to return explicit block reasons, enabling earlier exits and clearer reporting.
  - Public API shape adjusted to align with enhanced blocking and termination reporting; integrations may require minor updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->