### PR TITLE
test: introduce a separate config for the simulated nodes

### DIFF
--- a/simulation/amaru-sim/src/simulator/mod.rs
+++ b/simulation/amaru-sim/src/simulator/mod.rs
@@ -20,6 +20,9 @@ pub mod simulate;
 mod simulate_config;
 pub use simulate_config::*;
 
+mod node_config;
+pub use node_config::*;
+
 mod args;
 pub use args::*;
 

--- a/simulation/amaru-sim/src/simulator/node_config.rs
+++ b/simulation/amaru-sim/src/simulator/node_config.rs
@@ -1,0 +1,67 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::simulator::Args;
+use pallas_crypto::hash::Hash;
+use std::path::PathBuf;
+
+/// Configuration for a single node
+#[derive(Debug, Clone)]
+pub struct NodeConfig {
+    pub stake_distribution_file: PathBuf,
+    pub consensus_context_file: PathBuf,
+    pub chain_dir: PathBuf,
+    pub block_tree_file: PathBuf,
+    pub start_header: Hash<32>,
+    pub number_of_upstream_peers: u8,
+    pub number_of_downstream_peers: u8,
+}
+
+impl Default for NodeConfig {
+    fn default() -> Self {
+        Self {
+            stake_distribution_file: PathBuf::from("./stake_distribution.json"),
+            consensus_context_file: PathBuf::from("./consensus_context.json"),
+            chain_dir: PathBuf::from("./chain.db/"),
+            block_tree_file: PathBuf::from("./chain.json"),
+            start_header: Hash::from([0; 32]),
+            number_of_upstream_peers: 2,
+            number_of_downstream_peers: 1,
+        }
+    }
+}
+
+impl NodeConfig {
+    pub fn from(args: Args) -> Self {
+        Self {
+            stake_distribution_file: args.stake_distribution_file,
+            consensus_context_file: args.consensus_context_file,
+            chain_dir: args.chain_dir,
+            block_tree_file: args.block_tree_file,
+            start_header: args.start_header,
+            number_of_upstream_peers: args.number_of_upstream_peers,
+            number_of_downstream_peers: args.number_of_downstream_peers,
+        }
+    }
+
+    pub fn with_number_of_upstream_peers(mut self, n: u8) -> Self {
+        self.number_of_upstream_peers = n;
+        self
+    }
+
+    pub fn with_number_of_downstream_peers(mut self, n: u8) -> Self {
+        self.number_of_downstream_peers = n;
+        self
+    }
+}

--- a/simulation/amaru-sim/src/simulator/run.rs
+++ b/simulation/amaru-sim/src/simulator/run.rs
@@ -17,7 +17,7 @@ use crate::simulator::bytes::Bytes;
 use crate::simulator::generate::generate_entries;
 use crate::simulator::ledger::{FakeStakeDistribution, populate_chain_store};
 use crate::simulator::simulate::simulate;
-use crate::simulator::{Args, Chain, History, NodeHandle, SimulateConfig};
+use crate::simulator::{Args, Chain, History, NodeConfig, NodeHandle, SimulateConfig};
 use crate::sync::ChainSyncMessage;
 use amaru::stages::build_stage_graph::build_stage_graph;
 use amaru_consensus::consensus::effects::{
@@ -60,21 +60,21 @@ use tracing::{Span, info};
 /// * Run the simulation.
 pub fn run(rt: Runtime, args: Args) {
     let trace_buffer = Arc::new(parking_lot::Mutex::new(TraceBuffer::new(42, 1_000_000_000)));
+    let node_config = NodeConfig::from(args.clone());
 
     let spawn = |node_id: String| {
         let mut network = SimulationBuilder::default().with_trace_buffer(trace_buffer.clone());
-        let (input, init_messages, output) = spawn_node(node_id, args.clone(), &mut network);
+        let (input, init_messages, output) = spawn_node(node_id, node_config.clone(), &mut network);
         let running = network.run(rt.handle().clone());
         NodeHandle::from_pure_stage(input, init_messages, output, running).unwrap()
     };
 
-    let config = SimulateConfig::from(args.clone());
+    let simulate_config = SimulateConfig::from(args.clone());
     simulate(
-        &config,
+        &simulate_config,
         spawn,
         generate_entries(
-            &config,
-            &args.block_tree_file,
+            &node_config,
             Instant::at_offset(Duration::from_secs(0)),
             200.0,
         ),
@@ -94,7 +94,7 @@ pub fn run(rt: Runtime, args: Args) {
 ///
 fn spawn_node(
     node_id: String,
-    args: Args,
+    node_config: NodeConfig,
     network: &mut SimulationBuilder,
 ) -> (
     StageRef<Envelope<ChainSyncMessage>>,
@@ -102,9 +102,8 @@ fn spawn_node(
     Receiver<Envelope<ChainSyncMessage>>,
 ) {
     info!("Spawning node!");
-    let config = SimulateConfig::from(args.clone());
-
-    let (network_name, select_chain, resource_header_store, resource_validation) = init_node(&args);
+    let (network_name, select_chain, resource_header_store, resource_validation) =
+        init_node(&node_config);
     let global_parameters: &GlobalParameters = network_name.into();
 
     // The receiver replies ok to init messages from the sender (via 'output', the only output of the graph)
@@ -171,7 +170,7 @@ fn spawn_node(
     let (output, rx1) = network.output("output", 10);
     let (sender, rx2) = mpsc::channel(10);
     let listener =
-        MockForwardEventListener::new(node_id, config.number_of_downstream_peers, sender);
+        MockForwardEventListener::new(node_id, node_config.number_of_downstream_peers, sender);
 
     let receiver = network.wire_up(receiver, (receive_header_ref, output.clone()));
 
@@ -198,7 +197,7 @@ fn spawn_node(
 }
 
 fn init_node(
-    args: &Args,
+    node_config: &NodeConfig,
 ) -> (
     NetworkName,
     SelectChain,
@@ -208,18 +207,18 @@ fn init_node(
     let network_name = NetworkName::Testnet(42);
     let chain_store = Arc::new(InMemConsensusStore::new());
     let stake_distribution =
-        Arc::new(FakeStakeDistribution::from_file(&args.stake_distribution_file).unwrap());
+        Arc::new(FakeStakeDistribution::from_file(&node_config.stake_distribution_file).unwrap());
 
     populate_chain_store(
         chain_store.clone(),
-        &args.start_header,
-        &args.consensus_context_file,
+        &node_config.start_header,
+        &node_config.consensus_context_file,
     )
     .unwrap_or_else(|e| panic!("cannot populate the chain store: {e:?}"));
 
     let select_chain = make_chain_selector(
         chain_store.clone(),
-        &(1..=args.number_of_upstream_peers)
+        &(1..=node_config.number_of_upstream_peers)
             .map(|i| Peer::new(&format!("c{}", i)))
             .collect::<Vec<_>>(),
     );

--- a/simulation/amaru-sim/src/simulator/simulate_config.rs
+++ b/simulation/amaru-sim/src/simulator/simulate_config.rs
@@ -21,8 +21,6 @@ pub struct SimulateConfig {
     pub number_of_tests: u32,
     pub seed: u64,
     pub number_of_nodes: u8,
-    pub number_of_upstream_peers: u8,
-    pub number_of_downstream_peers: u8,
     pub disable_shrinking: bool,
 }
 
@@ -32,8 +30,6 @@ impl Default for SimulateConfig {
             number_of_tests: 50,
             seed: rand::rng().random::<u64>(),
             number_of_nodes: 1,
-            number_of_upstream_peers: 2,
-            number_of_downstream_peers: 1,
             disable_shrinking: false,
         }
     }
@@ -46,8 +42,6 @@ impl SimulateConfig {
             number_of_tests: args.number_of_tests,
             seed: args.seed.unwrap_or(default.seed),
             number_of_nodes: args.number_of_nodes,
-            number_of_upstream_peers: args.number_of_upstream_peers,
-            number_of_downstream_peers: args.number_of_downstream_peers,
             disable_shrinking: args.disable_shrinking,
         }
     }
@@ -63,16 +57,6 @@ impl SimulateConfig {
 
     pub fn with_number_of_nodes(mut self, n: u8) -> Self {
         self.number_of_nodes = n;
-        self
-    }
-
-    pub fn with_number_of_upstream_peers(mut self, n: u8) -> Self {
-        self.number_of_upstream_peers = n;
-        self
-    }
-
-    pub fn with_number_of_downstream_peers(mut self, n: u8) -> Self {
-        self.number_of_downstream_peers = n;
         self
     }
 

--- a/simulation/amaru-sim/tests/simulation.rs
+++ b/simulation/amaru-sim/tests/simulation.rs
@@ -14,7 +14,7 @@
 
 use amaru_kernel::Hash;
 use amaru_sim::simulator::run::run;
-use amaru_sim::simulator::{Args, SimulateConfig};
+use amaru_sim::simulator::{Args, NodeConfig, SimulateConfig};
 use std::env;
 use std::str::FromStr;
 use tokio::runtime::Runtime;
@@ -22,22 +22,23 @@ use tracing_subscriber::EnvFilter;
 
 #[test]
 fn run_simulator() {
-    let defaults = SimulateConfig::default();
+    let simulate_config = SimulateConfig::default();
+    let node_config = NodeConfig::default();
     let args = Args {
         stake_distribution_file: "tests/data/stake-distribution.json".into(),
         consensus_context_file: "tests/data/consensus-context.json".into(),
         chain_dir: "./chain.db".into(),
         block_tree_file: "tests/data/chain.json".into(),
         start_header: Hash::from([0; 32]),
-        number_of_tests: get_env_var("AMARU_NUMBER_OF_TESTS", defaults.number_of_tests),
-        number_of_nodes: get_env_var("AMARU_NUMBER_OF_NODES", defaults.number_of_nodes),
+        number_of_tests: get_env_var("AMARU_NUMBER_OF_TESTS", simulate_config.number_of_tests),
+        number_of_nodes: get_env_var("AMARU_NUMBER_OF_NODES", simulate_config.number_of_nodes),
         number_of_upstream_peers: get_env_var(
             "AMARU_NUMBER_OF_UPSTREAM_PEERS",
-            defaults.number_of_upstream_peers,
+            node_config.number_of_upstream_peers,
         ),
         number_of_downstream_peers: get_env_var(
             "AMARU_NUMBER_OF_DOWNSTREAM_PEERS",
-            defaults.number_of_downstream_peers,
+            node_config.number_of_downstream_peers,
         ),
         disable_shrinking: is_true("AMARU_DISABLE_SHRINKING"),
         seed: get_optional_env_var("AMARU_TEST_SEED"),


### PR DESCRIPTION
The current simulation setup is a bit awkward since we:

 - Get arguments, `Args`
 - Extract a `SimulateConfig` from `Args`
 - But still pass `Args` down the line in addition to that config.

This PR extract another config data type, `NodeConfig` that contains the configuration that is relevant to a single simulated node, whereas `SimulateConfig` contains the configuration required for the simulation as a whole.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated per-node configuration with sensible defaults, including peer counts and file path settings.
  - Centralized chain/block file path handling within node configuration.

- **Refactor**
  - Simulator now uses the new node configuration across node spawning, initialization, and input generation.
  - Simulation configuration no longer includes peer count settings; those are managed per node.
  - Public API updated to accept the new node configuration where applicable.

- **Tests**
  - Updated simulation tests to initialize and use both simulation and per-node configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->