### PR TITLE
fix: adjust the comment on evolve_nonce to leave implementation detai…

### DIFF
--- a/crates/amaru-consensus/src/consensus/store.rs
+++ b/crates/amaru-consensus/src/consensus/store.rs
@@ -46,6 +46,12 @@ impl<H: IsHeader> Praos<H> for PraosChainStore<H> {
         self.store.get_nonces(header).map(|nonces| nonces.active)
     }
 
+    /// Evolve the given nonce by combining it in an arbitrary way with other data. When
+    /// `within_stability_window` is false, this also modifies the candidate nonce for the next
+    /// epoch.
+    ///
+    /// Once the stability window has been reached, the candidate is fixed for the epoch and will
+    /// be used once crossing the epoch boundary to produce the next epoch nonce.
     fn evolve_nonce(&self, header: &H) -> Result<Nonces, Self::Error> {
         let (epoch, is_within_stability_window) = nonce::randomness_stability_window(
             header,

--- a/crates/amaru-ouroboros-traits/src/praos/mod.rs
+++ b/crates/amaru-ouroboros-traits/src/praos/mod.rs
@@ -97,11 +97,6 @@ pub trait Praos<H: IsHeader>: Send + Sync {
     /// So, nonces aren't bound to epochs, but to headers.
     fn get_nonce(&self, header: &Hash<32>) -> Option<Nonce>;
 
-    /// Evolve the given nonce by combining it in an arbitrary way with other data. When
-    /// `within_stability_window` is false, this also modifies the candidate nonce for the next
-    /// epoch.
-    ///
-    /// Once the stability window has been reached, the candidate is fixed for the epoch and will
-    /// be used once crossing the epoch boundary to produce the next epoch nonce.
+    /// Evolve the given nonce by combining it in an arbitrary way with other data.
     fn evolve_nonce(&self, header: &H) -> Result<Nonces, Self::Error>;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified how nonce evolution relates to stability windows and epoch boundaries in the consensus component.
  - Simplified and unified the evolve_nonce description in the PRAOS trait to a concise, generic explanation.
  - No functional or behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->