### PR TITLE
feat: move the select_chain stage to the end of the stage graph

### DIFF
--- a/crates/amaru-consensus/src/consensus/effects/consensus_effects.rs
+++ b/crates/amaru-consensus/src/consensus/effects/consensus_effects.rs
@@ -212,7 +212,7 @@ pub mod tests {
         fn rollback(
             &self,
             _peer: &Peer,
-            _rollback_header: &Header,
+            _point: &Point,
         ) -> BoxFuture<'static, anyhow::Result<(), ProcessingFailed>> {
             Box::pin(async { Ok(()) })
         }

--- a/crates/amaru-consensus/src/consensus/effects/ledger_effects.rs
+++ b/crates/amaru-consensus/src/consensus/effects/ledger_effects.rs
@@ -14,10 +14,10 @@
 
 use crate::consensus::errors::ProcessingFailed;
 use amaru_kernel::peer::Peer;
-use amaru_kernel::{Header, Point, PoolId, RawBlock};
+use amaru_kernel::{Point, PoolId, RawBlock};
 use amaru_metrics::ledger::LedgerMetrics;
 use amaru_ouroboros_traits::{
-    BlockValidationError, CanValidateBlocks, HasStakeDistribution, IsHeader, PoolSummary,
+    BlockValidationError, CanValidateBlocks, HasStakeDistribution, PoolSummary,
 };
 use amaru_slot_arithmetic::Slot;
 use pure_stage::{BoxFuture, Effects, ExternalEffect, ExternalEffectAPI, Resources, SendData};
@@ -36,7 +36,7 @@ pub trait LedgerOps: HasStakeDistribution {
     fn rollback(
         &self,
         peer: &Peer,
-        rollback_header: &Header,
+        point: &Point,
     ) -> BoxFuture<'_, anyhow::Result<(), ProcessingFailed>>;
 }
 
@@ -64,10 +64,9 @@ impl<T: SendData + Sync> LedgerOps for Ledger<T> {
     fn rollback(
         &self,
         peer: &Peer,
-        rollback_header: &Header,
+        point: &Point,
     ) -> BoxFuture<'_, anyhow::Result<(), ProcessingFailed>> {
-        self.0
-            .external(RollbackBlockEffect::new(peer, &rollback_header.point()))
+        self.0.external(RollbackBlockEffect::new(peer, point))
     }
 }
 

--- a/crates/amaru-consensus/src/consensus/events.rs
+++ b/crates/amaru-consensus/src/consensus/events.rs
@@ -90,11 +90,6 @@ pub enum DecodedChainSyncEvent {
         #[serde(skip, default = "Span::none")]
         span: Span,
     },
-    CaughtUp {
-        peer: Peer,
-        #[serde(skip, default = "Span::none")]
-        span: Span,
-    },
 }
 
 impl DecodedChainSyncEvent {
@@ -102,7 +97,6 @@ impl DecodedChainSyncEvent {
         match self {
             DecodedChainSyncEvent::RollForward { peer, .. } => peer.clone(),
             DecodedChainSyncEvent::Rollback { peer, .. } => peer.clone(),
-            DecodedChainSyncEvent::CaughtUp { peer, .. } => peer.clone(),
         }
     }
 }
@@ -128,11 +122,7 @@ impl fmt::Debug for DecodedChainSyncEvent {
             } => f
                 .debug_struct("Rollback")
                 .field("peer", &peer.name)
-                .field("rollback_point", &rollback_point.to_string())
-                .finish(),
-            DecodedChainSyncEvent::CaughtUp { peer, .. } => f
-                .debug_struct("CaughtUp")
-                .field("peer", &peer.name)
+                .field("rollback_point", &rollback_point)
                 .finish(),
         }
     }
@@ -148,7 +138,7 @@ pub enum ValidateHeaderEvent {
     },
     Rollback {
         peer: Peer,
-        rollback_header: Header,
+        rollback_point: Point,
         #[serde(skip, default = "Span::none")]
         span: Span,
     },
@@ -166,7 +156,7 @@ pub enum ValidateBlockEvent {
     },
     Rollback {
         peer: Peer,
-        rollback_header: Header,
+        rollback_point: Point,
         #[serde(skip, default = "Span::none")]
         span: Span,
     },
@@ -192,7 +182,7 @@ impl Debug for ValidateBlockEvent {
                 .finish(),
             ValidateBlockEvent::Rollback {
                 peer,
-                rollback_header: rollback_point,
+                rollback_point,
                 ..
             } => f
                 .debug_struct("Rollback")
@@ -221,12 +211,12 @@ impl PartialEq for ValidateBlockEvent {
             (
                 ValidateBlockEvent::Rollback {
                     peer: p1,
-                    rollback_header: rp1,
+                    rollback_point: rp1,
                     ..
                 },
                 ValidateBlockEvent::Rollback {
                     peer: p2,
-                    rollback_header: rp2,
+                    rollback_point: rp2,
                     ..
                 },
             ) => p1 == p2 && rp1 == rp2,

--- a/crates/amaru-consensus/src/consensus/span.rs
+++ b/crates/amaru-consensus/src/consensus/span.rs
@@ -41,7 +41,6 @@ mod impls {
             match self {
                 DecodedChainSyncEvent::RollForward { span, .. } => span,
                 DecodedChainSyncEvent::Rollback { span, .. } => span,
-                DecodedChainSyncEvent::CaughtUp { span, .. } => span,
             }
         }
     }

--- a/crates/amaru-consensus/src/consensus/stages/fetch_block.rs
+++ b/crates/amaru-consensus/src/consensus/stages/fetch_block.rs
@@ -64,7 +64,7 @@ pub async fn stage(
         }
         ValidateHeaderEvent::Rollback {
             peer,
-            rollback_header: rollback_point,
+            rollback_point,
             span,
             ..
         } => {
@@ -73,7 +73,7 @@ pub async fn stage(
                     &downstream,
                     ValidateBlockEvent::Rollback {
                         peer,
-                        rollback_header: rollback_point,
+                        rollback_point,
                         span,
                     },
                 )

--- a/crates/amaru-consensus/src/consensus/stages/mod.rs
+++ b/crates/amaru-consensus/src/consensus/stages/mod.rs
@@ -18,5 +18,6 @@ pub mod receive_header;
 pub mod select_chain;
 pub mod store_block;
 pub mod store_header;
+pub mod track_peers;
 pub mod validate_block;
 pub mod validate_header;

--- a/crates/amaru-consensus/src/consensus/stages/select_chain.rs
+++ b/crates/amaru-consensus/src/consensus/stages/select_chain.rs
@@ -15,7 +15,7 @@
 use crate::consensus::EVENT_TARGET;
 use crate::consensus::effects::{BaseOps, ConsensusOps};
 use crate::consensus::errors::{ConsensusError, ValidationFailed};
-use crate::consensus::events::{DecodedChainSyncEvent, ValidateHeaderEvent};
+use crate::consensus::events::{BlockValidationResult, DecodedChainSyncEvent, ValidateHeaderEvent};
 use crate::consensus::headers_tree::{HeadersTree, HeadersTreeState};
 use crate::consensus::span::HasSpan;
 use amaru_kernel::{HEADER_HASH_SIZE, Header, Point, peer::Peer, string_utils::ListToString};
@@ -26,53 +26,21 @@ use pure_stage::{BoxFuture, StageRef};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::{
-    collections::BTreeSet,
     fmt::{Debug, Display, Formatter},
     mem,
 };
-use tracing::{Level, Span, debug, info, span, trace};
+use tracing::{Level, Span, info, span, trace};
 
 pub const DEFAULT_MAXIMUM_FRAGMENT_LENGTH: usize = 2160;
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Default)]
 pub struct SelectChain {
     tree_state: HeadersTreeState,
-    sync_tracker: SyncTracker,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
-pub struct SyncTracker {
-    syncing_peers: BTreeSet<Peer>,
-}
-
-impl SyncTracker {
-    pub fn new(peers: &[Peer]) -> Self {
-        let syncing_peers = peers.iter().cloned().collect();
-        Self { syncing_peers }
-    }
-
-    pub fn caught_up(&mut self, peer: &Peer) {
-        self.syncing_peers.remove(peer);
-    }
-
-    pub fn is_caught_up(&self) -> bool {
-        self.syncing_peers.is_empty()
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub enum SyncState {
-    Syncing,
-    CaughtUp,
 }
 
 impl SelectChain {
-    pub fn new(tree_state: HeadersTreeState, peers: &[Peer]) -> Self {
-        let sync_tracker = SyncTracker::new(peers);
-        SelectChain {
-            tree_state,
-            sync_tracker,
-        }
+    pub fn new(tree_state: HeadersTreeState) -> Self {
+        SelectChain { tree_state }
     }
 
     fn forward_block(peer: Peer, header: Header, span: Span) -> ValidateHeaderEvent {
@@ -81,12 +49,12 @@ impl SelectChain {
 
     fn switch_to_fork(
         peer: Peer,
-        rollback_header: Header,
+        rollback_point: Point,
         fork: Vec<Header>,
         span: Span,
     ) -> Vec<ValidateHeaderEvent> {
         let mut result = vec![ValidateHeaderEvent::Rollback {
-            rollback_header,
+            rollback_point,
             peer: peer.clone(),
             span: span.clone(),
         }];
@@ -117,11 +85,6 @@ impl SelectChain {
 
         let events = match result {
             ForwardChainSelection::NewTip { peer, tip } => {
-                if self.sync_tracker.is_caught_up() {
-                    debug!(target: EVENT_TARGET, %peer, hash = %tip.hash(), slot = %tip.slot(), "new tip");
-                } else {
-                    trace!(target: EVENT_TARGET, %peer, hash = %tip.hash(), slot = %tip.slot(), "new tip");
-                }
                 vec![SelectChain::forward_block(peer, tip, span)]
             }
             ForwardChainSelection::SwitchToFork(Fork {
@@ -130,7 +93,7 @@ impl SelectChain {
                 fork,
             }) => {
                 info!(target: EVENT_TARGET, rollback = %rollback_header.point(), length = fork.len(), "switching to fork");
-                SelectChain::switch_to_fork(peer, rollback_header, fork, span)
+                SelectChain::switch_to_fork(peer, rollback_header.point(), fork, span)
             }
             ForwardChainSelection::NoChange => {
                 trace!(target: EVENT_TARGET, "no change");
@@ -163,7 +126,7 @@ impl SelectChain {
                 info!(target: EVENT_TARGET, rollback = %rollback_header.point(), length = fork.len(), "switching to fork");
                 Ok(SelectChain::switch_to_fork(
                     peer,
-                    rollback_header,
+                    rollback_header.point(),
                     fork,
                     span,
                 ))
@@ -199,14 +162,8 @@ impl SelectChain {
                     self.select_rollback(store, peer, rollback_point, span)
                         .await
                 }
-                DecodedChainSyncEvent::CaughtUp { peer, .. } => self.caught_up(&peer),
             }
         })
-    }
-
-    fn caught_up(&mut self, peer: &Peer) -> Result<Vec<ValidateHeaderEvent>, ConsensusError> {
-        self.sync_tracker.caught_up(peer);
-        Ok(vec![])
     }
 }
 
@@ -305,7 +262,7 @@ impl<H: IsHeader + Display> Display for RollbackChainSelection<H> {
 
 type State = (
     SelectChain,
-    StageRef<ValidateHeaderEvent>,
+    StageRef<BlockValidationResult>,
     StageRef<ValidationFailed>,
 );
 
@@ -330,7 +287,37 @@ pub async fn stage(
     };
 
     for event in events {
-        eff.base().send(&downstream, event).await;
+        match event {
+            ValidateHeaderEvent::Validated { peer, header, span } => {
+                let event = BlockValidationResult::BlockValidated { peer, header, span };
+                eff.base().send(&downstream, event).await;
+            }
+            ValidateHeaderEvent::Rollback {
+                peer,
+                rollback_point,
+                span,
+            } => match eff.store().load_header(&rollback_point.hash()) {
+                Some(rollback_header) => {
+                    let event = BlockValidationResult::RolledBackTo {
+                        peer,
+                        rollback_header,
+                        span,
+                    };
+                    eff.base().send(&downstream, event).await;
+                }
+                None => {
+                    eff.base()
+                        .send(
+                            &errors,
+                            ValidationFailed::new(
+                                &peer,
+                                ConsensusError::UnknownPoint(rollback_point.hash()),
+                            ),
+                        )
+                        .await
+                }
+            },
+        }
     }
 
     (select_chain, downstream, errors)
@@ -341,42 +328,16 @@ mod tests {
     use super::*;
     use crate::consensus::effects::mock_consensus_ops;
     use crate::consensus::errors::ValidationFailed;
+    use crate::consensus::events::BlockValidationResult::BlockValidated;
     use crate::consensus::events::DecodedChainSyncEvent;
     use crate::consensus::headers_tree::Tracker;
     use crate::consensus::headers_tree::Tracker::{Me, SomePeer};
-    use crate::consensus::stages::select_chain::SyncTracker;
     use crate::consensus::tests::{any_header, any_headers_chain};
     use amaru_kernel::peer::Peer;
     use amaru_ouroboros_traits::fake::tests::run;
     use pure_stage::StageRef;
     use std::collections::BTreeMap;
-    use std::slice;
     use tracing::Span;
-
-    #[tokio::test]
-    async fn is_caught_up_when_all_peers_are_caught_up() {
-        let alice = Peer::new("alice");
-        let bob = Peer::new("bob");
-        let peers = vec![alice.clone(), bob.clone()];
-        let mut tracker = SyncTracker::new(&peers);
-
-        tracker.caught_up(&alice);
-        tracker.caught_up(&bob);
-
-        assert!(tracker.is_caught_up());
-    }
-
-    #[tokio::test]
-    async fn is_not_caught_up_given_some_peer_is_not() {
-        let alice = Peer::new("alice");
-        let bob = Peer::new("bob");
-        let peers = vec![alice.clone(), bob.clone()];
-        let mut tracker = SyncTracker::new(&peers);
-
-        tracker.caught_up(&alice);
-
-        assert!(!tracker.is_caught_up());
-    }
 
     #[tokio::test]
     async fn a_roll_forward_updates_the_tree_state() -> anyhow::Result<()> {
@@ -393,7 +354,7 @@ mod tests {
             consensus_ops.clone(),
         )
         .await;
-        let output = make_validated_event(&peer, &header);
+        let output = make_block_validated_event(&peer, &header);
 
         assert_eq!(
             consensus_ops.mock_base.received(),
@@ -435,8 +396,8 @@ mod tests {
         let state = stage(state, message2, consensus_ops.clone()).await;
         let (select_chain, _, _) = stage(state, message3.clone(), consensus_ops.clone()).await;
 
-        let output1 = make_validated_event(&peer, &header1);
-        let output2 = make_validated_event(&peer, &header2);
+        let output1 = make_block_validated_event(&peer, &header1);
+        let output2 = make_block_validated_event(&peer, &header2);
 
         assert_eq!(
             consensus_ops.mock_base.received(),
@@ -463,17 +424,13 @@ mod tests {
         peer: &Peer,
         anchor: &Hash<HEADER_HASH_SIZE>,
     ) -> State {
-        let downstream: StageRef<ValidateHeaderEvent> = StageRef::named("downstream");
+        let downstream: StageRef<BlockValidationResult> = StageRef::named("downstream");
         let errors: StageRef<ValidationFailed> = StageRef::named("errors");
         let mut tree_state = HeadersTreeState::new(10);
         tree_state
             .initialize_peer(store.clone(), peer, anchor)
             .unwrap();
-        (
-            SelectChain::new(tree_state, slice::from_ref(peer)),
-            downstream,
-            errors,
-        )
+        (SelectChain::new(tree_state), downstream, errors)
     }
 
     fn make_roll_forward_message(peer: &Peer, header: &Header) -> DecodedChainSyncEvent {
@@ -493,8 +450,8 @@ mod tests {
         }
     }
 
-    fn make_validated_event(peer: &Peer, header: &Header) -> ValidateHeaderEvent {
-        ValidateHeaderEvent::Validated {
+    fn make_block_validated_event(peer: &Peer, header: &Header) -> BlockValidationResult {
+        BlockValidated {
             peer: peer.clone(),
             header: header.clone(),
             span: Span::current(),

--- a/crates/amaru-consensus/src/consensus/stages/store_header.rs
+++ b/crates/amaru-consensus/src/consensus/stages/store_header.rs
@@ -38,7 +38,6 @@ pub async fn stage(
             eff.base().send(&downstream, msg).await
         }
         DecodedChainSyncEvent::Rollback { .. } => eff.base().send(&downstream, msg).await,
-        DecodedChainSyncEvent::CaughtUp { .. } => eff.base().send(&downstream, msg).await,
     }
     downstream
 }

--- a/crates/amaru-consensus/src/consensus/stages/track_peers.rs
+++ b/crates/amaru-consensus/src/consensus/stages/track_peers.rs
@@ -1,0 +1,99 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::consensus::EVENT_TARGET;
+use crate::consensus::effects::ConsensusOps;
+use crate::consensus::events::ChainSyncEvent;
+use crate::consensus::span::HasSpan;
+use amaru_kernel::peer::Peer;
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeSet, fmt::Debug};
+use tracing::{Level, debug, span, trace};
+
+type State = SyncTracker;
+
+pub async fn stage(mut state: State, msg: ChainSyncEvent, _eff: impl ConsensusOps) -> State {
+    let span = span!(parent: msg.span(), Level::TRACE, "stage.track_peers");
+    let _entered = span.enter();
+
+    match msg {
+        ChainSyncEvent::RollForward { peer, point, .. } => {
+            if state.is_caught_up() {
+                debug!(target: EVENT_TARGET, %peer, point = %point, "new tip");
+            } else {
+                trace!(target: EVENT_TARGET, %peer, point = %point, "new tip");
+            }
+        }
+        ChainSyncEvent::CaughtUp { peer, .. } => state.caught_up(&peer),
+        ChainSyncEvent::Rollback { .. } => {}
+    }
+    state
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct SyncTracker {
+    syncing_peers: BTreeSet<Peer>,
+}
+
+impl SyncTracker {
+    pub fn new(peers: &[Peer]) -> Self {
+        let syncing_peers = peers.iter().cloned().collect();
+        Self { syncing_peers }
+    }
+
+    pub fn caught_up(&mut self, peer: &Peer) {
+        self.syncing_peers.remove(peer);
+    }
+
+    pub fn is_caught_up(&self) -> bool {
+        self.syncing_peers.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub enum SyncState {
+    Syncing,
+    CaughtUp,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use amaru_kernel::peer::Peer;
+
+    #[tokio::test]
+    async fn is_caught_up_when_all_peers_are_caught_up() {
+        let alice = Peer::new("alice");
+        let bob = Peer::new("bob");
+        let peers = vec![alice.clone(), bob.clone()];
+        let mut tracker = SyncTracker::new(&peers);
+
+        tracker.caught_up(&alice);
+        tracker.caught_up(&bob);
+
+        assert!(tracker.is_caught_up());
+    }
+
+    #[tokio::test]
+    async fn is_not_caught_up_given_some_peer_is_not() {
+        let alice = Peer::new("alice");
+        let bob = Peer::new("bob");
+        let peers = vec![alice.clone(), bob.clone()];
+        let mut tracker = SyncTracker::new(&peers);
+
+        tracker.caught_up(&alice);
+
+        assert!(!tracker.is_caught_up());
+    }
+}

--- a/crates/amaru/src/stages/mod.rs
+++ b/crates/amaru/src/stages/mod.rs
@@ -33,6 +33,7 @@ use amaru_kernel::{
 };
 use amaru_ledger::block_validator::BlockValidator;
 
+use amaru_consensus::consensus::stages::track_peers::SyncTracker;
 use amaru_metrics::METRICS_METER_NAME;
 use amaru_network::block_fetch_client::PallasBlockFetchClient;
 use amaru_ouroboros_traits::{
@@ -232,6 +233,7 @@ pub async fn bootstrap(
         &peers,
         global_parameters.consensus_security_param,
     )?;
+    let sync_tracker = SyncTracker::new(&peers);
 
     let forward_event_listener = Arc::new(
         TcpForwardChainServer::new(
@@ -251,6 +253,7 @@ pub async fn bootstrap(
         global_parameters,
         era_history,
         chain_selector,
+        sync_tracker,
         our_tip,
         &mut network,
     );
@@ -409,7 +412,7 @@ fn make_chain_selector(
         tree_state.initialize_peer(chain_store.clone(), peer, &anchor)?;
     }
 
-    Ok(SelectChain::new(tree_state, peers))
+    Ok(SelectChain::new(tree_state))
 }
 
 pub trait PallasPoint {


### PR DESCRIPTION
This PR moves the `select_chain` stage to the end of the stage graph.

In order to do so:

 - A new `track_peers` stage is introduced in order to log a message when an upstream peer has caught up (this processing used to be done in the `select_chain` stage with a `CaughtUp` message).
 
 - During a rollback, the rolled-back header is retrieved from the `ChainStore` in the `select_chain` stage in order to forward it to downstream peers.

The new stage graph is:
```mermaid
graph TD
    receive_header[receive header]
    track_peers[track peers]
    store_header[store header]
    validate_header[validate header]
    fetch_block[fetch block]
    store_block[store block]
    validate_block[validate block]
    select_chain[select chain]
    forward_header[forward header]

    downstream([downstream])
    store@{ shape: cyl, label: "Chain store" }
    net@{ shape: delay, label: "Peers" }

    upstream([upstream]) -.-> net
    upstream -- chain sync --> pull
    pull -- ChainSyncEvent --> receive_header

    receive_header -- DecodedChainSyncEvent --> store_header
    receive_header -- ChainSyncEvent::CaughtUp --> track_peers

    store_header -.-> store
    store_header -- ValidateHeaderEvent --> validate_header

    validate_header -- ValidateHeaderEvent --> fetch_block

    fetch_block -- ValidateBlockEvent --> store_block
    fetch_block -.-> net

    store_block -.-> store
    store_block -- ValidateBlockEvent --> validate_block

    validate_block -.-> store
    validate_block -- DecodedChainSyncEvent --> select_chain

    select_chain -.-> store
    select_chain -- ForwardHeader --> forward_header

    forward_header --> downstream
    downstream -.-> net
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added peer sync tracking to detect when all peers are caught up.
  - Introduced a clearer, staged syncing pipeline with explicit steps and improved logging.
  - Rollback operations now target specific points for more precise recovery.

- Documentation
  - Updated consensus flow narrative with new stages, diagrams, and detailed error-handling guidance.

- Refactor
  - Rewired stage graph and streamlined event flow; removed legacy caught-up path from core pipeline.
  - Simplified chain selection interface and downstream event types.

- Tests
  - Updated simulator configuration usage and trace expectations to reflect the new staged pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->