### PR TITLE
feat: make a full effect for validating headers

### DIFF
--- a/crates/amaru-consensus/src/consensus/effects/consensus_effects.rs
+++ b/crates/amaru-consensus/src/consensus/effects/consensus_effects.rs
@@ -100,6 +100,7 @@ pub mod tests {
     use amaru_kernel::{Point, PoolId, RawBlock};
     use amaru_metrics::MetricsEvent;
     use amaru_metrics::ledger::LedgerMetrics;
+    use amaru_ouroboros_traits::can_validate_blocks::HeaderValidationError;
     use amaru_ouroboros_traits::in_memory_consensus_store::InMemConsensusStore;
     use amaru_ouroboros_traits::{
         BlockHeader, BlockValidationError, HasStakeDistribution, PoolSummary,
@@ -200,7 +201,15 @@ pub mod tests {
     pub struct MockLedgerOps;
 
     impl LedgerOps for MockLedgerOps {
-        fn validate(
+        fn validate_header(
+            &self,
+            _point: &Point,
+            _header: &BlockHeader,
+        ) -> BoxFuture<'_, Result<(), HeaderValidationError>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn validate_block(
             &self,
             _peer: &Peer,
             _point: &Point,

--- a/crates/amaru-consensus/src/consensus/errors.rs
+++ b/crates/amaru-consensus/src/consensus/errors.rs
@@ -15,8 +15,8 @@
 use crate::consensus;
 use amaru_kernel::peer::Peer;
 use amaru_kernel::{HEADER_HASH_SIZE, Point};
-use amaru_ouroboros::praos::header::AssertHeaderError;
 use amaru_ouroboros_traits::StoreError;
+use amaru_ouroboros_traits::can_validate_blocks::HeaderValidationError;
 use pallas_crypto::hash::Hash;
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
@@ -31,7 +31,7 @@ pub enum ConsensusError {
     #[error("Failed to fetch block at {0}")]
     FetchBlockFailed(Point),
     #[error("Failed to validate header at {0}: {1}")]
-    InvalidHeader(Point, AssertHeaderError),
+    InvalidHeader(Point, HeaderValidationError),
     #[error("Failed to store header at {0}: {1}")]
     StoreHeaderFailed(Hash<HEADER_HASH_SIZE>, StoreError),
     #[error("Failed to remove header at {0}: {1}")]

--- a/crates/amaru-consensus/src/consensus/stages/validate_block.rs
+++ b/crates/amaru-consensus/src/consensus/stages/validate_block.rs
@@ -45,7 +45,7 @@ pub async fn stage(
         } => {
             let point = header.point();
 
-            match eff.ledger().validate(&peer, &point, block).await {
+            match eff.ledger().validate_block(&peer, &point, block).await {
                 Ok(Ok(metrics)) => {
                     eff.metrics().record(metrics.into()).await;
                     eff.base()

--- a/crates/amaru-ouroboros-traits/src/can_validate_blocks/mock.rs
+++ b/crates/amaru-ouroboros-traits/src/can_validate_blocks/mock.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::CanValidateBlocks;
-use crate::can_validate_blocks::BlockValidationError;
+use crate::can_validate_blocks::{BlockValidationError, CanValidateHeaders, HeaderValidationError};
+use crate::{BlockHeader, CanValidateBlocks};
 use amaru_kernel::{Point, RawBlock};
 use amaru_metrics::ledger::LedgerMetrics;
 
@@ -32,6 +32,20 @@ impl CanValidateBlocks for MockCanValidateBlocks {
     }
 
     fn rollback_block(&self, _to: &Point) -> Result<(), BlockValidationError> {
+        Ok(())
+    }
+}
+
+/// A fake header validator that always returns ok
+#[derive(Clone, Debug, Default)]
+pub struct MockCanValidateHeaders;
+
+impl CanValidateHeaders for MockCanValidateHeaders {
+    fn validate_header(
+        &self,
+        _point: &Point,
+        _header: &BlockHeader,
+    ) -> Result<(), HeaderValidationError> {
         Ok(())
     }
 }

--- a/crates/amaru-ouroboros-traits/src/can_validate_blocks/mod.rs
+++ b/crates/amaru-ouroboros-traits/src/can_validate_blocks/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::BlockHeader;
 use amaru_kernel::{Point, RawBlock};
 use amaru_metrics::ledger::LedgerMetrics;
 use serde::{Deserialize, Serialize};
@@ -87,6 +88,76 @@ impl<'de> Deserialize<'de> for BlockValidationError {
 }
 
 impl PartialEq for BlockValidationError {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.to_string() == other.0.to_string()
+    }
+}
+
+pub trait CanValidateHeaders: Send + Sync {
+    fn validate_header(
+        &self,
+        point: &Point,
+        header: &BlockHeader,
+    ) -> Result<(), HeaderValidationError>;
+}
+#[derive(Debug)]
+pub struct HeaderValidationError(anyhow::Error);
+
+impl HeaderValidationError {
+    pub fn new(err: anyhow::Error) -> Self {
+        HeaderValidationError(err)
+    }
+
+    pub fn to_anyhow(self) -> anyhow::Error {
+        self.0
+    }
+
+    pub fn downcast<T: std::error::Error + Debug + Send + Sync + 'static>(
+        self,
+    ) -> Result<T, anyhow::Error> {
+        self.0.downcast::<T>()
+    }
+
+    pub fn downcast_ref<T: std::error::Error + Debug + Send + Sync + 'static>(&self) -> Option<&T> {
+        self.0.downcast_ref::<T>()
+    }
+}
+
+impl From<anyhow::Error> for HeaderValidationError {
+    fn from(err: anyhow::Error) -> Self {
+        HeaderValidationError::new(err)
+    }
+}
+
+impl Display for HeaderValidationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "HeaderValidationError: {}", self.0)
+    }
+}
+
+impl Serialize for HeaderValidationError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
+/// This deserialization implementation is a best-effort attempt to
+/// recover the error message. The original error type is lost during
+/// serialization, so we can only reconstruct the error message as a string.
+impl<'de> Deserialize<'de> for HeaderValidationError {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(HeaderValidationError::new(anyhow::anyhow!(s)))
+    }
+}
+
+impl PartialEq for HeaderValidationError {
     fn eq(&self, other: &Self) -> bool {
         self.0.to_string() == other.0.to_string()
     }

--- a/crates/amaru/src/stages/build_stage_graph.rs
+++ b/crates/amaru/src/stages/build_stage_graph.rs
@@ -22,17 +22,12 @@ use amaru_consensus::consensus::stages::{
     validate_header,
 };
 use amaru_consensus::consensus::tip::HeaderTip;
-use amaru_kernel::protocol_parameters::{ConsensusParameters, GlobalParameters};
-use amaru_slot_arithmetic::EraHistory;
 use pure_stage::{Effects, SendData, StageGraph, StageRef};
-use std::sync::Arc;
 
 /// Create the graph of stages supporting the consensus protocol.
 /// The output of the graph is passed as a parameter, allowing the caller to
 /// decide what to do with the results the graph processing.
 pub fn build_stage_graph(
-    global_parameters: &GlobalParameters,
-    era_history: &'static EraHistory,
     chain_selector: SelectChain,
     sync_tracker: SyncTracker,
     our_tip: HeaderTip,
@@ -119,11 +114,6 @@ pub fn build_stage_graph(
     let validate_header_stage = network.wire_up(
         validate_header_stage,
         (
-            Arc::new(ConsensusParameters::new(
-                global_parameters.clone(),
-                era_history,
-                Default::default(),
-            )),
             fetch_block_stage.without_state(),
             validation_errors_stage.clone().without_state(),
         ),

--- a/simulation/amaru-sim/src/simulator/ledger.rs
+++ b/simulation/amaru-sim/src/simulator/ledger.rs
@@ -25,11 +25,14 @@ use std::{fs::File, io::BufReader, path::Path};
 
 /// A fake stake distribution used for simulation purposes.
 /// It can be loaded from a JSON file or instantiated directly from a list of pools (FakeStakePoolInfo).
+/// TODO: This is dead code for now remove when changing the data generation for the simulation module.
+#[allow(dead_code)]
 pub struct FakeStakeDistribution {
     total_active_stake: u64,
     pools: Vec<FakeStakePoolInfo>,
 }
 
+#[allow(dead_code)]
 impl FakeStakeDistribution {
     /// Deserialize a stake distribution from a JSON file.
     pub fn from_file(stake_distribution_file: &Path) -> Result<FakeStakeDistribution, Error> {

--- a/simulation/amaru-sim/tests/traces.rs
+++ b/simulation/amaru-sim/tests/traces.rs
@@ -91,16 +91,6 @@ fn run_simulator_with_traces() {
                 },
                 {
                   "name": "stage.validate_header",
-                  "children": [
-                    {
-                      "name": "consensus.roll_forward",
-                      "children": [
-                        {
-                          "name": "header_is_valid"
-                        }
-                      ]
-                    }
-                  ]
                 },
                 {
                   "name": "stage.fetch_block"


### PR DESCRIPTION
This PR adds a full external effect for validating a header. This allows the simulation to easily override the `validate_header` stage and allow headers to be validated even though the generated data does not produce fully consistent headers.

Note: @abailly this pushes us in a direction where 2 stages, `validate_block` and `validate_header` are mere wrappers on top of external effects. Which begs the question: should they be fused with `receive_header` and `fetch_block` like we did for `store_header` and `store_block`?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added header-centric validation flow with a dedicated ValidateHeader effect and HeaderValidationError.
  - Simplified node bootstrap: stage graph no longer requires global parameters or era history.

- Refactor
  - Reworked ledger validation APIs and resources to a header-first interface; updated error mapping and stage wiring.
  - Adjusted stage and effect names and public signatures to reflect header validation.

- Tests
  - Added mock header validator and updated traces/tests to match new validation path.

- Chores
  - Removed legacy stake-distribution wiring; annotated unused simulator code as dead code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->