### PR TITLE
refactor: remove an unused chain store effect

### DIFF
--- a/crates/amaru-consensus/src/consensus/effects/store_effects.rs
+++ b/crates/amaru-consensus/src/consensus/effects/store_effects.rs
@@ -112,10 +112,6 @@ impl<T: SendData + Sync> ChainStore<BlockHeader> for Store<T> {
         self.external_sync(StoreBlockEffect::new(hash, block.clone()))
     }
 
-    fn remove_header(&self, hash: &HeaderHash) -> Result<(), StoreError> {
-        self.external_sync(RemoveHeaderEffect::new(*hash))
-    }
-
     fn put_nonces(&self, header: &HeaderHash, nonces: &Nonces) -> Result<(), StoreError> {
         self.external_sync(PutNoncesEffect::new(*header, nonces.clone()))
     }
@@ -265,34 +261,6 @@ impl ExternalEffect for UpdateBestChainEffect {
 }
 
 impl ExternalEffectAPI for UpdateBestChainEffect {
-    type Response = Result<(), StoreError>;
-}
-
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-struct RemoveHeaderEffect {
-    hash: HeaderHash,
-}
-
-impl RemoveHeaderEffect {
-    pub fn new(hash: HeaderHash) -> Self {
-        Self { hash }
-    }
-}
-
-impl ExternalEffect for RemoveHeaderEffect {
-    #[expect(clippy::expect_used)]
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap(async move {
-            let store = resources
-                .get::<ResourceHeaderStore>()
-                .expect("RemoveHeaderEffect requires a chain store")
-                .clone();
-            store.remove_header(&self.hash)
-        })
-    }
-}
-
-impl ExternalEffectAPI for RemoveHeaderEffect {
     type Response = Result<(), StoreError>;
 }
 

--- a/crates/amaru-consensus/src/consensus/stages/validate_header.rs
+++ b/crates/amaru-consensus/src/consensus/stages/validate_header.rs
@@ -342,10 +342,6 @@ mod tests {
             self.store.store_block(hash, block)
         }
 
-        fn remove_header(&self, hash: &Hash<32>) -> Result<(), StoreError> {
-            self.store.remove_header(hash)
-        }
-
         fn put_nonces(&self, hash: &Hash<32>, nonces: &Nonces) -> Result<(), StoreError> {
             self.store.put_nonces(hash, nonces)
         }

--- a/crates/amaru-ouroboros-traits/src/stores/consensus/in_memory_consensus_store.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/consensus/in_memory_consensus_store.rs
@@ -202,28 +202,6 @@ impl<H: IsHeader + Send + Sync + Clone + 'static> ChainStore<H> for InMemConsens
     }
 
     #[expect(clippy::unwrap_used)]
-    fn remove_header(&self, hash: &Hash<32>) -> Result<(), StoreError> {
-        let mut inner = self.inner.lock().unwrap();
-        // unlink from parent's children list if present
-        if let Some(parent) = inner.headers.get(hash).and_then(|h| h.parent())
-            && let Some(children) = inner.parent_child_relationship.get_mut(&parent)
-        {
-            if let Some(pos) = children.iter().position(|h| h == hash) {
-                children.swap_remove(pos);
-            }
-            if children.is_empty() {
-                inner.parent_child_relationship.remove(&parent);
-            }
-        }
-
-        // remove this node's children list
-        inner.parent_child_relationship.remove(hash);
-        // finally remove the header
-        inner.headers.remove(hash);
-        Ok(())
-    }
-
-    #[expect(clippy::unwrap_used)]
     fn set_anchor_hash(&self, hash: &Hash<32>) -> Result<(), StoreError> {
         let mut inner = self.inner.lock().unwrap();
         inner.anchor = *hash;

--- a/crates/amaru-ouroboros-traits/src/stores/consensus/mod.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/consensus/mod.rs
@@ -146,7 +146,6 @@ where
     fn set_anchor_hash(&self, hash: &Hash<32>) -> Result<(), StoreError>;
     fn set_best_chain_hash(&self, hash: &Hash<32>) -> Result<(), StoreError>;
     fn update_best_chain(&self, anchor: &Hash<32>, tip: &Hash<32>) -> Result<(), StoreError>;
-    fn remove_header(&self, hash: &Hash<32>) -> Result<(), StoreError>;
     fn store_block(&self, hash: &Hash<32>, block: &RawBlock) -> Result<(), StoreError>;
     fn put_nonces(&self, header: &Hash<32>, nonces: &Nonces) -> Result<(), StoreError>;
 }

--- a/crates/amaru-stores/src/rocksdb/consensus.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus.rs
@@ -303,12 +303,6 @@ impl<H: IsHeader + Clone + for<'d> cbor::Decode<'d, ()>> ChainStore<H> for Rocks
             })
     }
 
-    fn remove_header(&self, hash: &Hash<32>) -> Result<(), StoreError> {
-        self.db.delete(hash).map_err(|e| StoreError::WriteError {
-            error: e.to_string(),
-        })
-    }
-
     fn set_anchor_hash(&self, hash: &Hash<32>) -> Result<(), StoreError> {
         self.db
             .put(ANCHOR_PREFIX, hash.as_ref())


### PR DESCRIPTION
This effect is not currently being used. We can always reintroduce it later if necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed header removal capability across consensus store implementations, including elimination of the `RemoveHeaderEffect` type. Headers can no longer be deleted through the ChainStore interface. This change affects all storage backends and represents a shift in header lifecycle management within the consensus system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->