### PR TITLE
chore: simplify Read-only interface for ChainStore

### DIFF
--- a/crates/amaru-consensus/src/consensus/stages/validate_header.rs
+++ b/crates/amaru-consensus/src/consensus/stages/validate_header.rs
@@ -279,24 +279,6 @@ mod tests {
             self.store.load_block(hash)
         }
 
-        fn load_headers(&self) -> Box<dyn Iterator<Item = BlockHeader> + '_> {
-            self.store.load_headers()
-        }
-
-        fn load_nonces(&self) -> Box<dyn Iterator<Item = (HeaderHash, Nonces)> + '_> {
-            self.store.load_nonces()
-        }
-
-        fn load_blocks(&self) -> Box<dyn Iterator<Item = (HeaderHash, RawBlock)> + '_> {
-            self.store.load_blocks()
-        }
-
-        fn load_parents_children(
-            &self,
-        ) -> Box<dyn Iterator<Item = (HeaderHash, Vec<HeaderHash>)> + '_> {
-            self.store.load_parents_children()
-        }
-
         fn get_nonces(&self, hash: &HeaderHash) -> Option<Nonces> {
             self.store.get_nonces(hash)
         }

--- a/crates/amaru-ouroboros-traits/src/stores/consensus/in_memory_consensus_store.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/consensus/in_memory_consensus_store.rs
@@ -74,60 +74,6 @@ impl<H: IsHeader + Clone + Send + Sync + 'static> ReadOnlyChainStore<H> for InMe
     }
 
     #[expect(clippy::unwrap_used)]
-    fn load_headers(&self) -> Box<dyn Iterator<Item = H>> {
-        let inner = self.inner.lock().unwrap();
-        Box::new(
-            inner
-                .headers
-                .values()
-                .cloned()
-                .collect::<Vec<H>>()
-                .into_iter(),
-        )
-    }
-
-    #[expect(clippy::unwrap_used)]
-    fn load_nonces(&self) -> Box<dyn Iterator<Item = (HeaderHash, Nonces)> + '_> {
-        let inner = self.inner.lock().unwrap();
-        Box::new(
-            inner
-                .nonces
-                .iter()
-                .map(|(h, n)| (*h, n.clone()))
-                .collect::<Vec<_>>()
-                .into_iter(),
-        )
-    }
-
-    #[expect(clippy::unwrap_used)]
-    fn load_blocks(&self) -> Box<dyn Iterator<Item = (HeaderHash, RawBlock)> + '_> {
-        let inner = self.inner.lock().unwrap();
-        Box::new(
-            inner
-                .blocks
-                .iter()
-                .map(|(h, b)| (*h, b.clone()))
-                .collect::<Vec<_>>()
-                .into_iter(),
-        )
-    }
-
-    #[expect(clippy::unwrap_used)]
-    fn load_parents_children(
-        &self,
-    ) -> Box<dyn Iterator<Item = (HeaderHash, Vec<HeaderHash>)> + '_> {
-        let inner = self.inner.lock().unwrap();
-        Box::new(
-            inner
-                .parent_child_relationship
-                .iter()
-                .map(|(k, v)| (*k, v.to_vec()))
-                .collect::<Vec<(HeaderHash, Vec<HeaderHash>)>>()
-                .into_iter(),
-        )
-    }
-
-    #[expect(clippy::unwrap_used)]
     fn get_nonces(&self, header: &HeaderHash) -> Option<Nonces> {
         let inner = self.inner.lock().unwrap();
         inner.nonces.get(header).cloned()

--- a/crates/amaru-stores/src/rocksdb/consensus/util.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/util.rs
@@ -25,12 +25,12 @@ pub(crate) const CONSENSUS_PREFIX_LEN: usize = 5;
 /// function from the previous version.
 pub const CHAIN_DB_VERSION: u16 = 1;
 
-pub(crate) const HEADER_PREFIX: [u8; CONSENSUS_PREFIX_LEN] = *b"heade";
-pub(crate) const NONCES_PREFIX: [u8; CONSENSUS_PREFIX_LEN] = *b"nonce";
-pub(crate) const BLOCK_PREFIX: [u8; CONSENSUS_PREFIX_LEN] = *b"block";
 pub(crate) const ANCHOR_PREFIX: [u8; CONSENSUS_PREFIX_LEN] = *b"ancho";
 pub(crate) const BEST_CHAIN_PREFIX: [u8; CONSENSUS_PREFIX_LEN] = *b"best_";
+pub(crate) const BLOCK_PREFIX: [u8; CONSENSUS_PREFIX_LEN] = *b"block";
 pub(crate) const CHILD_PREFIX: [u8; CONSENSUS_PREFIX_LEN] = *b"child";
+pub(crate) const HEADER_PREFIX: [u8; CONSENSUS_PREFIX_LEN] = *b"heade";
+pub(crate) const NONCES_PREFIX: [u8; CONSENSUS_PREFIX_LEN] = *b"nonce";
 
 /// Open a Chain DB for reading and writing.
 /// The DB _must_ exist otherwise the function will return an error.

--- a/crates/amaru/src/bin/amaru/cmd/dump_chain_db.rs
+++ b/crates/amaru/src/bin/amaru/cmd/dump_chain_db.rs
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use amaru_consensus::{DiagnosticChainStore, ReadOnlyChainStore};
 use amaru_kernel::network::NetworkName;
 use amaru_kernel::string_utils::ListToString;
 use amaru_kernel::to_cbor;
-use amaru_ouroboros_traits::{BlockHeader, ChainStore, IsHeader};
+use amaru_ouroboros_traits::{BlockHeader, IsHeader};
 use amaru_stores::rocksdb::RocksDbConfig;
-use amaru_stores::rocksdb::consensus::RocksDBStore;
+use amaru_stores::rocksdb::consensus::{ReadOnlyChainDB, RocksDBStore};
 use clap::{Parser, arg};
 use std::fmt::Display;
-use std::sync::Arc;
 use std::{error::Error, path::PathBuf};
 
 #[derive(Debug, Parser)]
@@ -44,8 +44,7 @@ pub struct Args {
 
 pub async fn run(args: Args) -> Result<(), Box<dyn Error>> {
     let chain_dir = args.chain_dir;
-    let db: Arc<dyn ChainStore<BlockHeader>> =
-        Arc::new(RocksDBStore::open(RocksDbConfig::new(chain_dir))?);
+    let db: ReadOnlyChainDB = RocksDBStore::open_for_readonly(RocksDbConfig::new(chain_dir))?;
 
     print_iterator(
         "headers",
@@ -76,9 +75,9 @@ pub async fn run(args: Args) -> Result<(), Box<dyn Error>> {
 }
 
 #[expect(clippy::print_stdout)]
-pub fn print_best_chain(db: Arc<dyn ChainStore<BlockHeader>>) {
+pub fn print_best_chain(db: ReadOnlyChainDB) {
     println!();
-    let best_chain = db.retrieve_best_chain();
+    let best_chain = <ReadOnlyChainDB as ReadOnlyChainStore<BlockHeader>>::retrieve_best_chain(&db);
     println!(
         "The best chain is:\n  {}",
         best_chain.list_to_string("\n  ")
@@ -86,8 +85,14 @@ pub fn print_best_chain(db: Arc<dyn ChainStore<BlockHeader>>) {
 
     println!();
     println!("The best chain length is: {}", best_chain.len());
-    println!("The best chain anchor is: {}", db.get_anchor_hash());
-    println!("The best chain tip is: {}", db.get_best_chain_hash());
+    println!(
+        "The best chain anchor is: {}",
+        <ReadOnlyChainDB as ReadOnlyChainStore<BlockHeader>>::get_anchor_hash(&db)
+    );
+    println!(
+        "The best chain tip is: {}",
+        <ReadOnlyChainDB as ReadOnlyChainStore<BlockHeader>>::get_best_chain_hash(&db)
+    );
 }
 
 #[expect(clippy::print_stdout)]


### PR DESCRIPTION
The previous interface contained 'diagnostic' functions which are only used for the `dump-chain-store` command, and contain `panic` or `expect` calls. 

This PR moves those functions to a (monomorphic) `DiagnosticChainStore` interface which has the consequence of simplifying the various stores implementation (RocksDB, InMemory, Effects).