### PR TITLE
Amaru performances

### DIFF
--- a/.cargo/deny.toml
+++ b/.cargo/deny.toml
@@ -97,7 +97,8 @@ allow = [
     "Unicode-3.0",
     "BlueOak-1.0.0",
     "MPL-2.0",
-    "CDLA-Permissive-2.0"
+    "CDLA-Permissive-2.0",
+    "Zlib"
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,7 +43,7 @@ jobs:
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
             title: x86_64/windows
-            command: test-amaru --profile dev-debug
+            command: test --workspace
 
           - runner: ubuntu-latest
             target: wasm32-unknown-unknown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "hex",
  "indoc",
  "insta",
+ "mimalloc",
  "minicbor",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -110,6 +111,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror 2.0.17",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1089,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "dtor"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58a0764cddb55ab28955347b45be00ade43d4d6f3ba4bf3dc354e4ec9432934"
+checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
 dependencies = [
  "dtor-proc-macro",
 ]
@@ -1906,6 +1908,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "librocksdb-sys"
 version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,6 +1997,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -3410,6 +3431,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3484,9 +3525,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3933,9 +3974,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "amaru"
 version = "0.1.0"
 dependencies = [
@@ -188,6 +194,7 @@ dependencies = [
  "amaru-tracing-json",
  "anyhow",
  "async-trait",
+ "hashbrown",
  "hex",
  "minicbor",
  "num",
@@ -1225,6 +1232,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +1454,11 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ pallas-crypto = "0.33.0"
 pallas-math = "0.33.0"
 pallas-network = "0.33.0"
 pallas-primitives = "0.33.0"
+mimalloc = "0.1.48"
 pallas-traverse = "0.33.0"
 parking_lot = "0.12.3"
 rand = "0.9.2"
@@ -75,6 +76,7 @@ tracing-subscriber = { version = "0.3.20", features = [
   "std",
   "json",
 ] }
+tikv-jemallocator = "0.6.1"
 typetag = "0.2.21"
 
 # Internal dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ either = "1.15"
 futures-util = "0.3.31"
 gasket = { version = "0.8.0", features = ["derive"] } # More recent versions have regression (e.g. https://github.com/construkts/gasket-rs/pull/34)
 hex = "0.4.3"
+hashbrown = "0.16.0"
 indicatif = "0.18.0"
 indoc = "2.0"
 itertools = "0.14.0"

--- a/crates/amaru-kernel/src/protocol_parameters.rs
+++ b/crates/amaru-kernel/src/protocol_parameters.rs
@@ -67,11 +67,11 @@ pub struct ProtocolParameters {
     pub optimal_stake_pools_count: u16,
     pub pledge_influence: RationalNumber,
     pub collateral_percentage: u16,
-    pub cost_models: CostModels,
+    pub cost_models: Box<CostModels>,
 
     // Governance group
-    pub pool_voting_thresholds: PoolVotingThresholds,
-    pub drep_voting_thresholds: DRepVotingThresholds,
+    pub pool_voting_thresholds: Box<PoolVotingThresholds>,
+    pub drep_voting_thresholds: Box<DRepVotingThresholds>,
     pub min_committee_size: u16,
     pub max_committee_term_length: EpochInterval,
     pub gov_action_lifetime: EpochInterval,
@@ -146,8 +146,14 @@ impl ProtocolParameters {
             // FIXME: update in Pallas; should be a u16
             u.max_collateral_inputs.map(|x| x as u16),
         );
-        set(&mut self.pool_voting_thresholds, u.pool_voting_thresholds);
-        set(&mut self.drep_voting_thresholds, u.drep_voting_thresholds);
+        set(
+            &mut self.pool_voting_thresholds,
+            u.pool_voting_thresholds.map(Box::new),
+        );
+        set(
+            &mut self.drep_voting_thresholds,
+            u.drep_voting_thresholds.map(Box::new),
+        );
         set(
             &mut self.min_committee_size,
             // FIXME: update in Pallas; should be a u16
@@ -279,11 +285,11 @@ impl<'b, C> cbor::decode::Decode<'b, C> for ProtocolParameters {
             treasury_expansion_rate,
             min_pool_cost,
             lovelace_per_utxo_byte,
-            cost_models: CostModels {
+            cost_models: Box::new(CostModels {
                 plutus_v1,
                 plutus_v2,
                 plutus_v3,
-            },
+            }),
             prices,
             max_tx_ex_units,
             max_block_ex_units,
@@ -930,9 +936,9 @@ pub mod tests {
             optimal_stake_pools_count,
             pledge_influence,
             collateral_percentage,
-            cost_models,
-            pool_voting_thresholds,
-            drep_voting_thresholds,
+            cost_models: Box::new(cost_models),
+            pool_voting_thresholds: Box::new(pool_voting_thresholds),
+            drep_voting_thresholds: Box::new(drep_voting_thresholds),
             min_committee_size,
             max_committee_term_length,
             gov_action_lifetime,

--- a/crates/amaru-kernel/src/protocol_parameters/default.rs
+++ b/crates/amaru-kernel/src/protocol_parameters/default.rs
@@ -140,7 +140,7 @@ pub static PREPROD_INITIAL_PROTOCOL_PARAMETERS: LazyLock<ProtocolParameters> =
             },
             min_pool_cost: 340000000,
             collateral_percentage: 150,
-            cost_models: CostModels {
+            cost_models: Box::new(CostModels {
                 plutus_v1: Some(vec![
                     100788, 420, 1, 1, 1000, 173, 0, 1, 1000, 59957, 4, 1, 11183, 32, 201305, 8356,
                     4, 16000, 100, 16000, 100, 16000, 100, 16000, 100, 16000, 100, 16000, 100, 100,
@@ -192,8 +192,8 @@ pub static PREPROD_INITIAL_PROTOCOL_PARAMETERS: LazyLock<ProtocolParameters> =
                     281145, 18848, 0, 1, 180194, 159, 1, 1, 158519, 8942, 0, 1, 159378, 8813, 0, 1,
                     107490, 3298, 1, 106057, 655, 1, 1964219, 24520, 3,
                 ]),
-            },
-            pool_voting_thresholds: PoolVotingThresholds {
+            }),
+            pool_voting_thresholds: Box::new(PoolVotingThresholds {
                 motion_no_confidence: RationalNumber {
                     numerator: 51,
                     denominator: 100,
@@ -214,8 +214,8 @@ pub static PREPROD_INITIAL_PROTOCOL_PARAMETERS: LazyLock<ProtocolParameters> =
                     numerator: 51,
                     denominator: 100,
                 },
-            },
-            drep_voting_thresholds: DRepVotingThresholds {
+            }),
+            drep_voting_thresholds: Box::new(DRepVotingThresholds {
                 motion_no_confidence: RationalNumber {
                     numerator: 51,
                     denominator: 100,
@@ -256,7 +256,7 @@ pub static PREPROD_INITIAL_PROTOCOL_PARAMETERS: LazyLock<ProtocolParameters> =
                     numerator: 67,
                     denominator: 100,
                 },
-            },
+            }),
             min_committee_size: 7,
             max_committee_term_length: 146,
             gov_action_lifetime: 6,
@@ -363,7 +363,7 @@ pub static PREVIEW_INITIAL_PROTOCOL_PARAMETERS: LazyLock<ProtocolParameters> =
             },
             min_pool_cost: 340000000,
             collateral_percentage: 150,
-            cost_models: CostModels {
+            cost_models: Box::new(CostModels {
                 plutus_v1: Some(vec![
                     100788, 420, 1, 1, 1000, 173, 0, 1, 1000, 59957, 4, 1, 11183, 32, 201305, 8356,
                     4, 16000, 100, 16000, 100, 16000, 100, 16000, 100, 16000, 100, 16000, 100, 100,
@@ -412,8 +412,8 @@ pub static PREVIEW_INITIAL_PROTOCOL_PARAMETERS: LazyLock<ProtocolParameters> =
                     36, 333849714, 1, 254006273, 72, 2174038, 72, 2261318, 64571, 4, 207616, 8310,
                     4, 1293828, 28716, 63, 0, 1, 1006041, 43623, 251, 0, 1,
                 ]),
-            },
-            pool_voting_thresholds: PoolVotingThresholds {
+            }),
+            pool_voting_thresholds: Box::new(PoolVotingThresholds {
                 motion_no_confidence: RationalNumber {
                     numerator: 51,
                     denominator: 100,
@@ -434,8 +434,8 @@ pub static PREVIEW_INITIAL_PROTOCOL_PARAMETERS: LazyLock<ProtocolParameters> =
                     numerator: 51,
                     denominator: 100,
                 },
-            },
-            drep_voting_thresholds: DRepVotingThresholds {
+            }),
+            drep_voting_thresholds: Box::new(DRepVotingThresholds {
                 motion_no_confidence: RationalNumber {
                     numerator: 67,
                     denominator: 100,
@@ -476,7 +476,7 @@ pub static PREVIEW_INITIAL_PROTOCOL_PARAMETERS: LazyLock<ProtocolParameters> =
                     numerator: 67,
                     denominator: 100,
                 },
-            },
+            }),
             min_committee_size: 0,
             max_committee_term_length: 365,
             gov_action_lifetime: 30,

--- a/crates/amaru-ledger/Cargo.toml
+++ b/crates/amaru-ledger/Cargo.toml
@@ -19,13 +19,14 @@ test-utils = ["proptest", "amaru-slot-arithmetic/test-utils", "amaru-kernel/test
 [dependencies]
 # External dependencies ───────────────────────────────────────────────────────┐
 anyhow.workspace = true
+async-trait.workspace = true
+hashbrown.workspace = true
 hex.workspace = true
 num.workspace = true
 proptest = { workspace = true, optional = true }
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-async-trait.workspace = true
 
 # Internal dependencies ───────────────────────────────────────────────────────┐
 amaru-kernel.workspace = true

--- a/crates/amaru-ledger/src/governance/ratification/dreps.rs
+++ b/crates/amaru-ledger/src/governance/ratification/dreps.rs
@@ -186,7 +186,7 @@ pub fn tally(
             .iter()
             .fold((0, 0), |(yes, denominator), (drep, st)| {
                 if st.is_active(epoch) {
-                    match drep {
+                    match drep.as_ref() {
                         DRep::Abstain => (yes, denominator),
                         DRep::NoConfidence if proposal.is_no_confidence() => {
                             (yes + st.stake, denominator + st.stake)
@@ -344,7 +344,12 @@ mod tests {
     pub fn any_votes(
         stake_distribution: &StakeDistribution,
     ) -> impl Strategy<Value = BTreeMap<DRep, &'static Vote>> + use<> {
-        let dreps: Vec<DRep> = stake_distribution.dreps.keys().cloned().collect();
+        let dreps: Vec<DRep> = stake_distribution
+            .dreps
+            .keys()
+            .map(|k| k.as_ref())
+            .cloned()
+            .collect();
 
         let upper_bound = dreps.len() - 1;
 

--- a/crates/amaru-ledger/src/governance/ratification/stake_pools.rs
+++ b/crates/amaru-ledger/src/governance/ratification/stake_pools.rs
@@ -109,7 +109,7 @@ pub fn tally(
             .pools
             .iter()
             .fold((0, 0), |(yes, abstain), (pool_id, pool)| {
-                match votes.get(pool_id) {
+                match votes.get(pool_id.as_ref()) {
                     Some(Vote::Yes) => (yes + pool.voting_stake, abstain),
                     Some(Vote::No) => (yes, abstain),
                     Some(Vote::Abstain) => (yes, abstain + pool.voting_stake),
@@ -133,7 +133,7 @@ pub fn tally(
                         let drep = stake_distribution
                             .accounts
                             .get(&reward_account)
-                            .and_then(|st| st.drep.as_ref());
+                            .and_then(|st| st.drep.as_deref());
 
                         match drep {
                             Some(DRep::NoConfidence) if proposal.is_no_confidence() => {
@@ -250,7 +250,7 @@ mod tests {
                             stake_distribution
                                     .accounts
                                     .get(&reward_account)
-                                    .map(|st| st.drep.as_ref() == Some(&DRep::Abstain))
+                                    .map(|st| st.drep.as_deref() == Some(&DRep::Abstain))
                                     .unwrap_or(false)
                         });
 
@@ -456,7 +456,12 @@ mod tests {
     pub fn any_votes(
         stake_distribution: &StakeDistribution,
     ) -> impl Strategy<Value = BTreeMap<PoolId, &'static Vote>> + use<> {
-        let pools: Vec<PoolId> = stake_distribution.pools.keys().cloned().collect();
+        let pools: Vec<PoolId> = stake_distribution
+            .pools
+            .keys()
+            .map(|p| p.as_ref())
+            .cloned()
+            .collect();
 
         let upper_bound = pools.len() - 1;
 

--- a/crates/amaru-ledger/src/store/columns/pools.rs
+++ b/crates/amaru-ledger/src/store/columns/pools.rs
@@ -31,7 +31,7 @@ pub type Key = PoolId;
 #[derive(Debug, Clone, PartialEq)]
 pub struct Row {
     pub registered_at: CertificatePointer,
-    pub current_params: PoolParams,
+    pub current_params: Box<PoolParams>,
     pub future_params: Vec<(Option<PoolParams>, Epoch)>,
 }
 
@@ -39,7 +39,7 @@ impl Row {
     pub fn new(registered_at: CertificatePointer, current_params: PoolParams) -> Self {
         Self {
             registered_at,
-            current_params,
+            current_params: Box::new(current_params),
             future_params: Vec::new(),
         }
     }
@@ -137,7 +137,7 @@ impl Row {
                     ?new_params,
                     "tick.updating"
                 );
-                pool.current_params = new_params;
+                pool.current_params = Box::new(new_params);
             }
 
             // Regardless, always prune future params from those that are now-obsolete.
@@ -262,7 +262,7 @@ pub mod tests {
             any_certificate_pointer(u64::MAX),
         )
             .prop_map(|(future_params, current_params, registered_at)| Row {
-                current_params,
+                current_params: Box::new(current_params),
                 future_params,
                 registered_at,
             })
@@ -370,7 +370,7 @@ pub mod tests {
                     Some(row) => {
                         prop_assert_eq!(
                             model.current.as_ref(),
-                            Some(&row.current_params),
+                            Some(row.current_params.as_ref()),
                             "current_epoch = {:?}, model = {:?}",
                             current_epoch,
                             model

--- a/crates/amaru-ledger/src/summary/arc_interner.rs
+++ b/crates/amaru-ledger/src/summary/arc_interner.rs
@@ -1,0 +1,83 @@
+// Copyright 2024 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use amaru_kernel::{DRep, PoolId, StakeCredential};
+use std::{collections::BTreeSet, sync::Arc};
+
+/// A structure for [interning](https://en.wikipedia.org/wiki/String_interning) recurring keys held
+/// in memory. This allows to drastically reduce the number of allocated elements for keys that are
+/// often found over many places.
+///
+/// This is particularly true for:
+///
+/// - Stake distributions (we hold 2 to 3 in memory usually).
+/// - Rewards summary (only transient, but shared many stake credentials and pool ids with stake distr)
+#[derive(Default)]
+pub struct ArcInterner {
+    pub accounts: hashbrown::HashSet<Arc<StakeCredential>>,
+    pub pools: hashbrown::HashSet<Arc<PoolId>>,
+    pub dreps: BTreeSet<Arc<DRep>>,
+}
+
+impl ArcInterner {
+    /// This must be called periodically (e.g. once every epoch) to free-up previously allocated
+    /// keys that are no longer used (because pool have fully unregistered, for example);
+    /// otherwise, we're just leaking memory forever...
+    ///
+    /// Fortunately, the Arc makes this easy because they keep a count of references to them. So it
+    /// suffices to look for items that have don't have references anymore and drop them.
+    pub fn free_orphans(&mut self) {
+        self.accounts.retain(|arc| Arc::strong_count(arc) > 0);
+        self.pools.retain(|arc| Arc::strong_count(arc) > 0);
+        self.dreps.retain(|arc| Arc::strong_count(arc) > 0);
+    }
+}
+
+/// A common interface for any intern-able object.
+pub trait ArcIntern<T> {
+    fn intern(&mut self, value: T) -> Arc<T>;
+}
+
+impl ArcIntern<StakeCredential> for ArcInterner {
+    fn intern(&mut self, account: StakeCredential) -> Arc<StakeCredential> {
+        self.accounts.get(&account).cloned().unwrap_or_else(|| {
+            let rc = Arc::new(account);
+            let clone = rc.clone();
+            self.accounts.insert(rc);
+            clone
+        })
+    }
+}
+
+impl ArcIntern<PoolId> for ArcInterner {
+    fn intern(&mut self, pool: PoolId) -> Arc<PoolId> {
+        self.pools.get(&pool).cloned().unwrap_or_else(|| {
+            let rc = Arc::new(pool);
+            let clone = rc.clone();
+            self.pools.insert(rc);
+            clone
+        })
+    }
+}
+
+impl ArcIntern<DRep> for ArcInterner {
+    fn intern(&mut self, drep: DRep) -> Arc<DRep> {
+        self.dreps.get(&drep).cloned().unwrap_or_else(|| {
+            let rc = Arc::new(drep);
+            let clone = rc.clone();
+            self.dreps.insert(rc);
+            clone
+        })
+    }
+}

--- a/crates/amaru-ledger/src/summary/mod.rs
+++ b/crates/amaru-ledger/src/summary/mod.rs
@@ -72,7 +72,7 @@ pub struct PoolState {
     pub margin: SafeRatio,
 
     /// The pool's parameters, as define per its last registration certificate.
-    pub parameters: PoolParams,
+    pub parameters: Box<PoolParams>,
 }
 
 impl ::serde::Serialize for PoolState {

--- a/crates/amaru-ledger/src/summary/mod.rs
+++ b/crates/amaru-ledger/src/summary/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod arc_interner;
 pub mod governance;
 pub mod rewards;
 pub mod serde;
@@ -24,6 +25,7 @@ use crate::{
 use ::serde::ser::SerializeStruct;
 use amaru_kernel::{CertificatePointer, DRep, Lovelace, PoolId, PoolParams, RationalNumber};
 use num::{BigUint, rational::Ratio};
+use std::sync::Arc;
 
 // ---------------------------------------------------------------- AccountState
 
@@ -31,16 +33,16 @@ use num::{BigUint, rational::Ratio};
 #[cfg_attr(test, derive(Clone))]
 pub struct AccountState {
     pub lovelace: Lovelace,
-    pub pool: Option<PoolId>,
-    pub drep: Option<DRep>,
+    pub pool: Option<Arc<PoolId>>,
+    pub drep: Option<Arc<DRep>>,
 }
 
 impl ::serde::Serialize for AccountState {
     fn serialize<S: ::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut s = serializer.serialize_struct("AccountState", 3)?;
         s.serialize_field("lovelace", &self.lovelace)?;
-        s.serialize_field("pool", &self.pool.as_ref().map(encode_pool_id))?;
-        s.serialize_field("drep", &self.drep.as_ref().map(encode_drep))?;
+        s.serialize_field("pool", &self.pool.as_deref().map(encode_pool_id))?;
+        s.serialize_field("drep", &self.drep.as_deref().map(encode_drep))?;
         s.end()
     }
 }

--- a/crates/amaru-ledger/src/summary/stake_distribution.rs
+++ b/crates/amaru-ledger/src/summary/stake_distribution.rs
@@ -456,7 +456,7 @@ pub mod tests {
                 stake,
                 voting_stake: stake.max(voting_stake),
                 margin,
-                parameters,
+                parameters: Box::new(parameters),
             }
         }
     }

--- a/crates/amaru-stores/src/lib.rs
+++ b/crates/amaru-stores/src/lib.rs
@@ -328,7 +328,8 @@ pub mod tests {
         let stored_pool = stored_pool.unwrap();
 
         assert_eq!(
-            stored_pool.current_params, fixture.pool_params,
+            stored_pool.current_params.as_ref(),
+            &fixture.pool_params,
             "current pool params mismatch"
         );
         assert_eq!(

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -13,6 +13,11 @@ documentation.workspace = true
 rust-version.workspace = true
 build = "build.rs"
 
+[features]
+default = []
+mimalloc = ["dep:mimalloc"]
+jemalloc = ["dep:tikv-jemallocator"]
+
 [dependencies]
 # External dependencies ───────────────────────────────────────────────────────┐
 acto.workspace = true
@@ -44,6 +49,10 @@ tokio-util.workspace = true
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
+
+# Optional dependencies ───────────────────────────────────────────────────────┐
+mimalloc = { workspace = true, optional = true }
+tikv-jemallocator = { workspace = true, optional = true }
 
 # Internal dependencies ───────────────────────────────────────────────────────┐
 amaru-consensus = { workspace = true, features = [] }

--- a/crates/amaru/build.rs
+++ b/crates/amaru/build.rs
@@ -23,4 +23,13 @@ fn main() {
     let network = env::var("NETWORK").unwrap_or_else(|_| "preprod".into());
     println!("cargo:rerun-if-env-changed=AMARU_NETWORK");
     println!("cargo:rustc-env=AMARU_NETWORK={}", network);
+
+    let jemalloc = std::env::var("CARGO_FEATURE_JEMALLOC").is_ok();
+    let mimalloc = std::env::var("CARGO_FEATURE_MIMALLOC").is_ok();
+
+    if jemalloc && mimalloc {
+        println!(
+            "cargo:warning=Features `jemalloc` and `mimalloc` are mutually exclusive yet both enabled; the default allocator will be used instead."
+        );
+    }
 }

--- a/crates/amaru/src/bin/amaru/main.rs
+++ b/crates/amaru/src/bin/amaru/main.rs
@@ -12,11 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru::observability;
-use amaru::observability::{DEFAULT_OTLP_METRIC_URL, DEFAULT_OTLP_SPAN_URL, DEFAULT_SERVICE_NAME};
+use amaru::{
+    observability,
+    observability::{DEFAULT_OTLP_METRIC_URL, DEFAULT_OTLP_SPAN_URL, DEFAULT_SERVICE_NAME},
+};
 use clap::{Parser, Subcommand};
 use observability::OpenTelemetryConfig;
 use panic::panic_handler;
+
+#[cfg(all(feature = "jemalloc", not(feature = "mimalloc")))]
+mod jemalloc {
+    use tikv_jemallocator::Jemalloc;
+    #[global_allocator]
+    static GLOBAL: Jemalloc = Jemalloc;
+}
+
+#[cfg(all(feature = "mimalloc", not(feature = "jemalloc")))]
+mod mimalloc {
+    use mimalloc::MiMalloc;
+    #[global_allocator]
+    static GLOBAL: MiMalloc = MiMalloc;
+}
 
 mod cmd;
 mod metrics;


### PR DESCRIPTION
- :round_pushpin: **perf: box a few inner large types in struct.**
    Rust allocate struct fields based on the size of their largest field. So struct with many small fields and a large one pay a significant cost. This is cheap to do, and an easy win.

- :round_pushpin: **perf: intern stake distribution map keys**
    There's an enormous repetition of keys between the stake distribution maps; by interning the keys, we avoid copying and re-allocating most of those elements.

  This interning is currently done via an adhoc structure held by the ledger (and is thus, local to the ledger). However, I've considered using something more holistic such as: https://docs.rs/internment/latest/internment/struct.ArcIntern.html

  The issue with the latter is that it uses HashMap under the hood, and thus requires keys to be Hashshable. StakeCredential aren't at the moment. But easily done should we want to push the change in Pallas.

  One gotcha though: because the interning is local, we need to explicit manage the "lifetime" of the interned object. When entities are no longer referenced, they must be cleaned up from the interned struct. This is done once per epoch, and is relatively quick.

- :round_pushpin: **perf: conditionally enable different allocators: jemalloc / mimalloc**
    Jemalloc seems to perform generally better for us... but it is not longer maintained as of recently. No one stood up to pick it up *yet*; so mimalloc (from Microsoft) might be a better choice in the long-run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional memory allocator features (mimalloc, jemalloc) to tune runtime allocation.
  * In-memory interner to deduplicate recurring keys and reduce memory use.

* **Chores**
  * Memory- and data-structure optimizations across summaries, rewards, and stores.
  * CI/build updates and added Zlib to the license allowlist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->