### PR TITLE
fix: log again tip changes

### DIFF
--- a/crates/amaru-consensus/README.md
+++ b/crates/amaru-consensus/README.md
@@ -22,9 +22,10 @@ graph TD
     upstream -- chain sync --> pull
     pull -- ChainSyncEvent --> receive_header
 
-    receive_header -- DecodedChainSyncEvent --> validate_header
-    receive_header -- ChainSyncEvent::CaughtUp --> track_peers
+    receive_header -- Tracked<DecodedChainSyncEvent> --> track_peers
     receive_header -.-> store
+
+    track_peers -- DecodeChainSyncEvent --> validate_header
 
     validate_header -- ValidateHeaderEvent --> fetch_block
 

--- a/crates/amaru-consensus/src/consensus/effects/network_effects.rs
+++ b/crates/amaru-consensus/src/consensus/effects/network_effects.rs
@@ -16,7 +16,11 @@ use crate::consensus::{
     errors::{ConsensusError, ProcessingFailed},
     tip::HeaderTip,
 };
-use amaru_kernel::{BlockHeader, IsHeader, Point, consensus_events::ChainSyncEvent, peer::Peer};
+use amaru_kernel::{
+    BlockHeader, IsHeader, Point,
+    consensus_events::{ChainSyncEvent, Tracked},
+    peer::Peer,
+};
 use amaru_ouroboros::network_operations::ResourceNetworkOperations;
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -173,7 +177,7 @@ impl ExternalEffectAPI for ForwardEventEffect {
 pub struct ChainSyncEffect;
 
 impl ExternalEffectAPI for ChainSyncEffect {
-    type Response = ChainSyncEvent;
+    type Response = Tracked<ChainSyncEvent>;
 }
 
 impl ExternalEffect for ChainSyncEffect {

--- a/crates/amaru-consensus/src/consensus/span.rs
+++ b/crates/amaru-consensus/src/consensus/span.rs
@@ -16,7 +16,7 @@ pub use impls::*;
 
 mod impls {
     use amaru_kernel::consensus_events::{
-        BlockValidationResult, ChainSyncEvent, DecodedChainSyncEvent, ValidateBlockEvent,
+        BlockValidationResult, ChainSyncEvent, DecodedChainSyncEvent, Tracked, ValidateBlockEvent,
         ValidateHeaderEvent,
     };
     use tracing::Span;
@@ -31,7 +31,6 @@ mod impls {
             match self {
                 ChainSyncEvent::RollForward { span, .. } => span,
                 ChainSyncEvent::Rollback { span, .. } => span,
-                ChainSyncEvent::CaughtUp { span, .. } => span,
             }
         }
     }
@@ -69,6 +68,15 @@ mod impls {
                 BlockValidationResult::BlockValidated { span, .. } => span,
                 BlockValidationResult::BlockValidationFailed { span, .. } => span,
                 BlockValidationResult::RolledBackTo { span, .. } => span,
+            }
+        }
+    }
+
+    impl<T: HasSpan> HasSpan for Tracked<T> {
+        fn span(&self) -> &Span {
+            match self {
+                Tracked::Wrapped(e) => e.span(),
+                Tracked::CaughtUp { span, .. } => span,
             }
         }
     }

--- a/crates/amaru-consensus/src/consensus/stages/pull.rs
+++ b/crates/amaru-consensus/src/consensus/stages/pull.rs
@@ -13,17 +13,17 @@
 // limitations under the License.
 
 use crate::consensus::effects::ChainSyncEffect;
-use amaru_kernel::consensus_events::ChainSyncEvent;
+use amaru_kernel::consensus_events::{ChainSyncEvent, Tracked};
 use pure_stage::{Effects, StageRef};
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct NextSync;
 
 pub async fn stage(
-    downstream: StageRef<ChainSyncEvent>,
+    downstream: StageRef<Tracked<ChainSyncEvent>>,
     _msg: NextSync,
     eff: Effects<NextSync>,
-) -> StageRef<ChainSyncEvent> {
+) -> StageRef<Tracked<ChainSyncEvent>> {
     let msg = eff.external(ChainSyncEffect).await;
     eff.send(&downstream, msg).await;
     eff.send(eff.me_ref(), NextSync).await;

--- a/crates/amaru-network/src/network_resource.rs
+++ b/crates/amaru-network/src/network_resource.rs
@@ -17,7 +17,7 @@ use acto::{AcTokioRuntime, ActoRef, ActoRuntime};
 use amaru_kernel::{
     BlockHeader, Point,
     connection::{BlockFetchClientError, ConnMsg},
-    consensus_events::ChainSyncEvent,
+    consensus_events::{ChainSyncEvent, Tracked},
     peer::Peer,
 };
 use amaru_ouroboros::ChainStore;
@@ -71,12 +71,12 @@ impl NetworkResource {
 
 pub struct NetworkInner {
     connections: BTreeMap<Peer, ActoRef<ConnMsg>>,
-    hd_rx: tokio::sync::Mutex<mpsc::Receiver<ChainSyncEvent>>,
+    hd_rx: tokio::sync::Mutex<mpsc::Receiver<Tracked<ChainSyncEvent>>>,
 }
 
 #[async_trait]
 impl NetworkOperations for NetworkResource {
-    async fn next_sync(&self) -> ChainSyncEvent {
+    async fn next_sync(&self) -> Tracked<ChainSyncEvent> {
         #[expect(clippy::expect_used)]
         self.inner
             .hd_rx

--- a/crates/amaru-ouroboros-traits/src/network_operations.rs
+++ b/crates/amaru-ouroboros-traits/src/network_operations.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 use amaru_kernel::{
-    Point, connection::BlockFetchClientError, consensus_events::ChainSyncEvent, peer::Peer,
+    Point,
+    connection::BlockFetchClientError,
+    consensus_events::{ChainSyncEvent, Tracked},
+    peer::Peer,
 };
 use std::sync::Arc;
 
@@ -24,7 +27,9 @@ pub type ResourceNetworkOperations = Arc<dyn NetworkOperations>;
 #[async_trait::async_trait]
 pub trait NetworkOperations: Send + Sync {
     /// Wait for the next chain sync event from upstream peers.
-    async fn next_sync(&self) -> ChainSyncEvent;
+    /// This can either be one of the `ChainSyncEvent` variants or a notification that
+    /// we caught up with this peer's chain.
+    async fn next_sync(&self) -> Tracked<ChainSyncEvent>;
 
     /// Fetch a block from a specific peer at a given point.
     async fn fetch_block(

--- a/simulation/amaru-sim/src/simulator/run.rs
+++ b/simulation/amaru-sim/src/simulator/run.rs
@@ -34,7 +34,7 @@ use amaru_consensus::consensus::{
     stages::select_chain::{DEFAULT_MAXIMUM_FRAGMENT_LENGTH, SelectChain},
     tip::HeaderTip,
 };
-use amaru_kernel::consensus_events::ChainSyncEvent;
+use amaru_kernel::consensus_events::{ChainSyncEvent, Tracked};
 use amaru_kernel::string_utils::{ListDebug, ListToString, ListsToString};
 use amaru_kernel::{BlockHeader, IsHeader};
 use amaru_kernel::{
@@ -148,23 +148,23 @@ pub fn spawn_node(
                 } => {
                     eff.send(
                         &downstream,
-                        ChainSyncEvent::RollForward {
+                        Tracked::Wrapped(ChainSyncEvent::RollForward {
                             peer: Peer::new(&msg.src),
                             point: Point::Specific(slot.into(), hash.into()),
                             raw_header: header.into(),
                             span: Span::current(),
-                        },
+                        }),
                     )
                     .await
                 }
                 ChainSyncMessage::Bck { slot, hash, .. } => {
                     eff.send(
                         &downstream,
-                        ChainSyncEvent::Rollback {
+                        Tracked::Wrapped(ChainSyncEvent::Rollback {
                             peer: Peer::new(&msg.src),
                             rollback_point: Point::Specific(slot.into(), hash.into()),
                             span: Span::current(),
-                        },
+                        }),
                     )
                     .await
                 }


### PR DESCRIPTION
The peer_tracker stage wasn't receiving messages that would allow it to log tip updates. Instead of duplicating sending of messages, this PR put back peer_tracker as one stage of the (linear) pipeline for headers handling using a `Tracker` type to consume `CaughtUp` messages and avoid passing them down to other stages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal event handling infrastructure restructured for enhanced type safety and consistency across the consensus and networking layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->