### PR TITLE
fix: don't display spans list in json log messages

### DIFF
--- a/crates/amaru/src/observability.rs
+++ b/crates/amaru/src/observability.rs
@@ -155,7 +155,11 @@ impl TracingSubscriber<Registry> {
 // -----------------------------------------------------------------------------
 
 pub fn setup_json_traces(subscriber: &mut TracingSubscriber<Registry>) -> DelayedWarning {
-    let format = || tracing_subscriber::fmt::format().json();
+    let format = || {
+        tracing_subscriber::fmt::format()
+            .json()
+            .with_span_list(false)
+    };
     let events = || FmtSpan::ENTER | FmtSpan::EXIT;
     let filter = || new_default_filter(AMARU_TRACE_VAR, DEFAULT_AMARU_TRACE_FILTER);
 


### PR DESCRIPTION
This PR adjusts the JSON formatting of log lines to remove the list of entered spans.

We are currently observing log lines mentioning a long list of spans such as:
```
{"timestamp":"2025-10-28T23:30:28.197105Z","level":"TRACE","fields":{"message":"drop","count":0,"self":"ActoRef(chain_forward(consensus.forward/0))"},"target":"acto::acto_ref","span":{"name":"stage.receive_header"},"spans":[{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.fetch_block"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.fetch_block"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"},{"name":"stage.receive_header"}]}
```

Those spans are all the spans that have been entered up to the point where the `chain_forward` actor was called.
It remains to be seen if the current list make sense (why is `stage.receive_header` duplicated so many times?) but in any case we don't need to display the full list of spans when exporting log lines as JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JSON trace output configuration to exclude span lists from trace events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->