### PR TITLE
fix: fix the chain selection algorithm to avoid sending irrelevant forks

### DIFF
--- a/crates/amaru-consensus/src/consensus/headers_tree/headers_tree_display.rs
+++ b/crates/amaru-consensus/src/consensus/headers_tree/headers_tree_display.rs
@@ -41,7 +41,7 @@ impl<H: IsHeader + Debug + Clone + PartialEq + Eq + 'static> From<HeadersTree<H>
             tree_state,
             anchor: value.anchor(),
             best_chain: value.best_chain(),
-            best_chains: value.best_chains().into_iter().cloned().collect(),
+            best_chains: value.best_peers_chains().into_iter().cloned().collect(),
             best_length: value.best_length(),
         }
     }


### PR DESCRIPTION
This PR fixes a case where 2 peers are rollbacking from the same chain to another chain.
We used to send the fork data downstream twice and we now just send it once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added runtime validation to prevent duplicated forks in chain selection sequences, improving consensus robustness.

* **Improvements**
  * Enhanced display formatting of peer chain information for better readability.

* **Refactor**
  * Optimized internal chain selection logic and updated rollback handling mechanisms.

* **Tests**
  * Added test coverage for peer chain alternation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->