### PR TITLE
fix: start a trace from the pull stage

### DIFF
--- a/crates/amaru-kernel/src/consensus_events.rs
+++ b/crates/amaru-kernel/src/consensus_events.rs
@@ -88,6 +88,19 @@ impl fmt::Debug for ChainSyncEvent {
     }
 }
 
+impl ChainSyncEvent {
+    pub fn set_span(&mut self, span: Span) {
+        match self {
+            ChainSyncEvent::RollForward { span: s, .. } => {
+                *s = span;
+            }
+            ChainSyncEvent::Rollback { span: s, .. } => {
+                *s = span;
+            }
+        }
+    }
+}
+
 #[derive(Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum DecodedChainSyncEvent {
     RollForward {


### PR DESCRIPTION
This PR fixes the parenting of spans from the `pull` stage:
<img width="375" height="283" alt="image" src="https://github.com/user-attachments/assets/a9be1788-6866-47eb-96d8-de3332aa4f55" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved tracing infrastructure for consensus operations to provide better visibility and debugging capabilities during the pull stage of chain synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->