### PR TITLE
chore: remove the build warning about the conformance vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,12 +188,14 @@ dependencies = [
  "amaru-tracing-json",
  "anyhow",
  "async-trait",
+ "flate2",
  "hex",
  "minicbor",
  "num",
  "once_cell",
  "proptest",
  "serde",
+ "tar",
  "test-case",
  "thiserror 2.0.17",
  "tracing",
@@ -1191,6 +1193,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1886,6 +1900,17 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libredox"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "librocksdb-sys"
@@ -3297,6 +3322,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4237,6 +4273,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ bytes = "1.10.1"
 cbor4ii = { version = "1.1.1", features = ["serde1", "use_std"] }
 clap = { version = "4.5.48", features = ["derive", "env"] }
 either = "1.15"
+flate2 = "1.1"
 futures-util = "0.3.31"
 gasket = { version = "0.8.0", features = ["derive"] } # More recent versions have regression (e.g. https://github.com/construkts/gasket-rs/pull/34)
 hex = "0.4.3"
@@ -63,6 +64,7 @@ serde = { version = "1.0.228", default-features = false }
 serde_json = { version = "1.0.145", default-features = false }
 sha3 = "0.10.8"
 sysinfo = "0.37.1"
+tar = "0.4"
 thiserror = "2.0.17"
 tokio = { version = "1.45.0", features = ["sync"] }
 tokio-util = "0.7.12"
@@ -88,7 +90,7 @@ amaru-minicbor-extra = { path = "crates/amaru-minicbor-extra" }
 amaru-network = { path = "crates/amaru-network" }
 amaru-ouroboros = { path = "crates/amaru-ouroboros" }
 amaru-ouroboros-traits = { path = "crates/amaru-ouroboros-traits" }
-amaru-plutus = {path = "crates/amaru-plutus"}
+amaru-plutus = { path = "crates/amaru-plutus" }
 amaru-progress-bar = { path = "crates/amaru-progress-bar" }
 amaru-sim = { path = "crates/amaru-sim" }
 amaru-slot-arithmetic = { path = "crates/amaru-slot-arithmetic" }

--- a/crates/amaru-ledger/Cargo.toml
+++ b/crates/amaru-ledger/Cargo.toml
@@ -53,3 +53,7 @@ num = { workspace = true, default-features = false, features = [
   "alloc",
   "libm",
 ] }
+
+[build-dependencies]
+flate2.workspace = true
+tar.workspace = true


### PR DESCRIPTION
This PR removes a build warning:

 - When a tar file containing the ledger conformance vectors is present in the test directory (which is the case right now), it unpacks that file to the correct directory
 - If eventually no file is found, a warning is still emitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added dependencies to support automated extraction of test data archives during the build process.
  * Updated build configuration to automatically extract test data when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->