### PR TITLE
feat: update the visualization of traces now that runnables are not produced anymore

### DIFF
--- a/simulation/amaru-sim/tests/animations/traces.html
+++ b/simulation/amaru-sim/tests/animations/traces.html
@@ -1001,16 +1001,9 @@
         }
     }
 
+
     function addRunnableFromInputEvent(ev) {
-        const stageName = displayStageName(ev.stage ?? '(unknown)');
-        if (!Array.isArray(currentRunnable)) {
-            currentRunnable = [];
-        }
-        // Only add if not already present
-        const exists = currentRunnable.some(it => it && it.name === stageName);
-        if (exists) return;
-        currentRunnable = currentRunnable.concat([{name: stageName}]);
-        updateStack();
+        addRunnableStage(ev.stage);
     }
 
     function addRunnableFromSuspendEvent(ev) {
@@ -1024,7 +1017,11 @@
         } else {
             return;
         }
-        const stageName = displayStageName(name);
+        addRunnableStage(name);
+    }
+
+    function addRunnableStage(stageNameRaw) {
+        const stageName = displayStageName(stageNameRaw ?? '(unknown)');
         if (!Array.isArray(currentRunnable)) {
             currentRunnable = [];
         }


### PR DESCRIPTION
The previous animation of traces was relying on the fact that a list of runnables to execute was included in the trace file.
This PR now keeps track of that list of runnables based on input and external effects.

I also fixed the display of stage circles in Firefox and Safari.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incremental, deduplicated management of the runnable stack for more predictable animation state updates.
  * Node sizing now initialized during rendering to ensure consistent visual setup across environments.

* **Bug Fixes**
  * More reliable handling of resume, input, and suspend events to keep animation stages consistent.
  * Consistent rendering of animation nodes for stable playback and fewer edge-case glitches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->