### PR TITLE
ci: add a nightly job to run the simulation

### DIFF
--- a/.github/workflows/nightly-simulation.yml
+++ b/.github/workflows/nightly-simulation.yml
@@ -1,0 +1,94 @@
+name: "Simulation Tests"
+
+permissions:
+  contents: read
+
+env:
+  AMARU_NUMBER_OF_TESTS: ${{ inputs.tests-number || 100 }}
+  AMARU_GENERATED_CHAIN_DEPTH: ${{ inputs.chain-depth || 100 }}
+  AMARU_NUMBER_OF_UPSTREAM_PEERS: ${{ inputs.upstream-peers-number || 4 }}
+  AMARU_TEST_DATA_DIR: simulation/amaru-sim/test-data
+  RUST_BACKTRACE: full
+  RUST_MIN_STACK: 16777216
+
+  RUST_CACHE_PATH: |
+    ~/.cargo/bin/
+    ~/.cargo/registry/index/
+    ~/.cargo/registry/cache/
+    ~/.cargo/git/db/
+    target/
+
+on:
+
+  # This workflow runs on the main branch when there's a push
+  push:
+    branches: ["main"]
+
+  # This workflow can also be dispatched manually
+  workflow_dispatch:
+    inputs:
+      tests-number:
+        description: 'Number of tests'
+        required: true
+        default: 100
+        type: number
+      chain-depth:
+        description: 'Length of the longest generated chain'
+        required: true
+        default: 100
+        type: number
+      upstream-peers-number:
+        description: 'Number of upstream peers'
+        required: true
+        default: 4
+        type: number
+      test-seed:
+        description: 'Run with a specific seed (leave empty for a random seed)'
+        required: false
+        default: ''
+        type: string
+  schedule:
+    # run every 6 hours
+    - cron: '5 1,7,13,19 * * *'
+
+jobs:
+  run-simulation-tests:
+    name: Build ${{ matrix.environments.title }}
+    timeout-minutes: 600
+    strategy:
+      fail-fast: false
+      matrix:
+        # run only on linux for now.
+        environments:
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            title: x86_64/linux
+
+    runs-on: ${{ matrix.environments.runner }}
+    steps:
+      - name: Set AMARU_TEST_SEED if provided
+        if: ${{ inputs.test-seed != '' }}
+        run: echo "AMARU_TEST_SEED=${{ inputs.test-seed }}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      # restore the cache
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.RUST_CACHE_PATH }}
+          key: cargo-${{ matrix.environments.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ matrix.environments.target }}-
+      - name: Run tests
+        shell: bash
+        run: |
+          set -e
+          cargo run -p amaru-sim --locked --target ${{ matrix.environments.target }}
+
+      - name: Upload test artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed-simulation-data
+          path: simulation/amaru-sim/test-data

--- a/simulation/amaru-sim/src/simulator/args.rs
+++ b/simulation/amaru-sim/src/simulator/args.rs
@@ -24,38 +24,38 @@ pub const TEST_DATA_DIR: &str = "test-data";
 #[clap(author, version, about, long_about = None)]
 pub struct Args {
     /// Number of tests to run in simulation
-    #[arg(long, default_value = "50")]
+    #[arg(long, default_value = "50", env = "AMARU_NUMBER_OF_TESTS")]
     pub number_of_tests: u32,
 
     /// Number of nodes in simulation.
-    #[arg(long, default_value = "1")]
+    #[arg(long, default_value = "1", env = "AMARU_NUMBER_OF_NODES")]
     pub number_of_nodes: u8,
 
     /// Number of upstream peers to simulate
-    #[arg(long, default_value = "2")]
+    #[arg(long, default_value = "2", env = "AMARU_NUMBER_OF_UPSTREAM_PEERS")]
     pub number_of_upstream_peers: u8,
 
     /// Number of downstream peers to simulate
-    #[arg(long, default_value = "1")]
+    #[arg(long, default_value = "1", env = "AMARU_NUMBER_OF_DOWNSTREAM_PEERS")]
     pub number_of_downstream_peers: u8,
 
     /// Maximum depth of the generated chain for a given peer
-    #[arg(long, default_value = "10")]
+    #[arg(long, default_value = "10", env = "AMARU_GENERATED_CHAIN_DEPTH")]
     pub generated_chain_depth: u64,
 
-    #[arg(long)]
+    #[arg(long, default_value = "false", env = "AMARU_DISABLE_SHRINKING")]
     pub disable_shrinking: bool,
 
     /// Seed for simulation testing.
-    #[arg(long)]
+    #[arg(long, env = "AMARU_TEST_SEED")]
     pub seed: Option<u64>,
 
     /// Persist generated data and pure-stage traces even if the test passes.
-    #[arg(long)]
+    #[arg(long, default_value = "false", env = "AMARU_PERSIST_ON_SUCCESS")]
     pub persist_on_success: bool,
 
     /// Directory where test data must be persisted
-    #[arg(long, default_value = TEST_DATA_DIR)]
+    #[arg(long, default_value = TEST_DATA_DIR, env = "AMARU_TEST_DATA_DIR")]
     pub persist_directory: String,
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a scheduled (nightly) and on-demand simulation test workflow with configurable inputs, extended timeout, cross-target caching for faster runs, and artifact collection on failures.

* **Chores**
  * Made simulation parameters configurable via environment variables (test counts, node/peer counts, chain depth, optional seed, shrink control, persistence and output directory) for more flexible CI and local runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->