### PR TITLE
fix: stop unnecessary rebuilds caused by missing test folder

### DIFF
--- a/crates/amaru-ledger/build.rs
+++ b/crates/amaru-ledger/build.rs
@@ -21,7 +21,9 @@ fn main() {
 #[allow(clippy::unwrap_used)]
 fn get_conformance_test_vectors() {
     let test_dir = Path::new("tests/data/rules-conformance");
-    println!("cargo:rerun-if-changed={}", test_dir.to_str().unwrap());
+    if test_dir.exists() {
+        println!("cargo:rerun-if-changed={}", test_dir.to_str().unwrap());
+    }
 
     let mut files = Vec::new();
     visit_dirs(test_dir, &mut files);


### PR DESCRIPTION
The `amaru-ledger` build script was telling Cargo to watch the `tests/data/rules-conformance` folder for changes, even if that folder didn't exist.

Because the folder was missing, Cargo always thought the code was out of date. This forced the project to rebuild, starting from `amaru-ledger` and up, every run. This update fixes the script so it only watches that folder if it exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential build failure when a tests directory is missing by adding a conditional check before emitting a build directive.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->