### PR TITLE
feat: add daemon alias

### DIFF
--- a/crates/amaru/src/bin/amaru/main.rs
+++ b/crates/amaru/src/bin/amaru/main.rs
@@ -60,6 +60,7 @@ enum Command {
     FetchChainHeaders(cmd::fetch_chain_headers::Args),
 
     /// Run the node in all its glory.
+    #[command(alias = "daemon")]
     Run(cmd::run::Args),
 
     /// Import the ledger state from a CBOR export produced by a Haskell node.


### PR DESCRIPTION
Make sure the older `amaru daemon` is still supported for some time to avoid regression.
e.g. it is useful to simplify the upgrade path for `amaru-pi` project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "daemon" as an alias for the "run" command, allowing the subcommand to be invoked using either "run" or "daemon" for improved usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->