### PR TITLE
perf: vec over btree

### DIFF
--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -49,7 +49,7 @@ use anyhow::{Context, anyhow};
 use std::{
     borrow::Cow,
     cmp::max,
-    collections::{BTreeMap, BTreeSet, VecDeque, btree_map},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     ops::Deref,
     sync::{Arc, Mutex, MutexGuard},
 };
@@ -1021,14 +1021,10 @@ fn new_ratification_context<'distr>(
     let votes = snapshot
         .iter_votes()?
         .fold(BTreeMap::new(), |mut votes, (k, v)| {
-            match votes.entry(k.proposal) {
-                btree_map::Entry::Vacant(entry) => {
-                    entry.insert(BTreeMap::from([(k.voter, v)]));
-                }
-                btree_map::Entry::Occupied(mut entry) => {
-                    entry.get_mut().insert(k.voter, v);
-                }
-            }
+            votes
+                .entry(k.proposal)
+                .or_insert_with(Vec::new)
+                .push((k.voter, v));
 
             votes
         });


### PR DESCRIPTION
`votes` is the single largest allocation at peak memory usage. There are structural changes that should fix this problem, but for now it hasn't been prioritized. Some [back of the envelope math](https://discord.com/channels/1202416088776712253/1437818120830976112/1438675919521972225) suggests this "ALL votes" known issue should take about ~1GB. This is also confirmed by switching to an alternative allocator and seeing the maximum memory usage be <2GB.  So why is it taking comfortably over 3GB on preprod when talking to a fast peer? In poking around the code to try and understand what refactors were possible, I made a small experimental change that seems to have "fixed" it on my machine. With this change the default allocator has the same top memory as `jemalloc` at peek. However, I'm not really sure why it works. Or rather, I have many theories about why it could work, but none of them seem to be justified by the code.

- `BTrees` have a reasonably constant 50% memory overhead. `Vec` over allocates to amortize the cost of allocations. When it's full, it has 0% overhead. Just after it reallocates, it has 100% overhead.       On average they should be about the same. It could be we're just getting lucky. However, this PR reduces maximum memory usage by >1.5GB, but the data itself is 500MB.  So the math does not work there. The savings are just too big.
- `Vec` can use `Iterator::size_hint` do one allocation up front. This would guarantee us the lucky case. But, being lucky is insufficient to explain the problem. AND We are repeatedly using `push` so there is no place for the code to sneak in a `with_capacity`. (Although we could manually do it easily enough, if we want to do follow up micro optimizations.)
- `BTrees` consist of lots of tiny allocations. This provides ample opportunity for memory fragmentation. Which tends to happen when there are a lot of allocations going on with widely different life times. Amos explains this better than I can in https://www.youtube.com/watch?v=YB6LTaGRQJg and https://www.youtube.com/watch?v=DpnXaNkM9_M. Alternating between inserting into a BTree and constructing data that will long outlive the BTree, is a setup for the data being left scattered all across the memory space, preventing the allocator from freeing the memory. Unfortunately, all the allocations I can track that occurred during the lifespan of this BTree are either extremely short lived (`Box::new` in `rocksdb`) or end up owned by the BTree. Also, empirically fixing those other allocations has no effect on the memory usage. So while this is still my leading theory, I do not have a smoking gun to point to to explain the connection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changed how governance ratification votes are stored: per-proposal votes are now stored as ordered lists instead of nested maps.
  * Updated internal vote-processing logic to operate on these per-proposal lists (call sites adapted accordingly).
  * No user-facing behavior changes; improves internal maintainability and processing consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->