### PR TITLE
feat: get rid on anchor

### DIFF
--- a/crates/amaru-kernel/src/ballot.rs
+++ b/crates/amaru-kernel/src/ballot.rs
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Anchor, Vote, cbor, heterogeneous_array};
+use crate::{Vote, cbor, heterogeneous_array};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Ballot {
     pub vote: Vote,
-    pub anchor: Option<Anchor>,
 }
 
 impl<C> cbor::encode::Encode<C> for Ballot {
@@ -28,7 +27,6 @@ impl<C> cbor::encode::Encode<C> for Ballot {
     ) -> Result<(), cbor::encode::Error<W::Error>> {
         e.array(2)?;
         e.encode_with(&self.vote, ctx)?;
-        e.encode_with(&self.anchor, ctx)?;
         Ok(())
     }
 }
@@ -39,7 +37,6 @@ impl<'d, C> cbor::decode::Decode<'d, C> for Ballot {
             assert_len(2)?;
             Ok(Self {
                 vote: d.decode_with(ctx)?,
-                anchor: d.decode_with(ctx)?,
             })
         })
     }
@@ -48,20 +45,15 @@ impl<'d, C> cbor::decode::Decode<'d, C> for Ballot {
 #[cfg(any(test, feature = "test-utils"))]
 pub mod tests {
     use super::Ballot;
-    use crate::{
-        prop_cbor_roundtrip,
-        tests::{any_anchor, any_vote},
-    };
-    use proptest::{option, prelude::*};
+    use crate::{prop_cbor_roundtrip, tests::any_vote};
+    use proptest::prelude::*;
 
     prop_compose! {
         pub fn any_ballot()(
             vote in any_vote(),
-            anchor in option::of(any_anchor()),
         ) -> Ballot  {
             Ballot {
                 vote,
-                anchor,
             }
         }
     }

--- a/crates/amaru-kernel/src/drep_state.rs
+++ b/crates/amaru-kernel/src/drep_state.rs
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Anchor, Epoch, Lovelace, Set, StakeCredential, StrictMaybe, cbor};
+use crate::{Epoch, Lovelace, Set, StakeCredential, cbor};
 
 #[derive(Debug)]
 pub struct DRepState {
     pub expiry: Epoch,
-    pub anchor: StrictMaybe<Anchor>,
     pub deposit: Lovelace,
     pub delegators: Set<StakeCredential>,
 }
@@ -27,7 +26,6 @@ impl<'b, C> cbor::decode::Decode<'b, C> for DRepState {
         d.array()?;
         Ok(DRepState {
             expiry: d.decode_with(ctx)?,
-            anchor: d.decode_with(ctx)?,
             deposit: d.decode_with(ctx)?,
             delegators: d.decode_with(ctx)?,
         })

--- a/crates/amaru-ledger/README.md
+++ b/crates/amaru-ledger/README.md
@@ -11,7 +11,7 @@ Ledger State
  ├─ UTxO (TxIn |-> TxOut)
  ├─ Stake distribution (StakeCredential |-> Lovelace)
  ├─ Certificates
- │   ├─ DReps (DRepID |-> Epoch, Anchor, Lovelace, Set StakeCredential)
+ │   ├─ DReps (DRepID |-> Epoch, Lovelace, Set StakeCredential)
  │   ├─ Committee (CCID |-> Committee State)
  │   ├─ SPOs
  │   │   ├─ Current Parameters (PoolID |-> PoolParams)

--- a/crates/amaru-ledger/src/context.rs
+++ b/crates/amaru-ledger/src/context.rs
@@ -17,7 +17,7 @@ mod default;
 
 use crate::state::diff_bind;
 use amaru_kernel::{
-    AddrKeyhash, Anchor, CertificatePointer, DRep, DRepRegistration, DatumHash, Hash, Lovelace,
+    AddrKeyhash, CertificatePointer, DRep, DRepRegistration, DatumHash, Hash, Lovelace,
     MemoizedDatum, MemoizedPlutusData, MemoizedScript, MemoizedTransactionOutput, PoolId,
     PoolParams, Proposal, ProposalId, ProposalPointer, RequiredScript, ScriptHash, StakeCredential,
     TransactionInput, Vote, Voter,
@@ -204,14 +204,7 @@ pub trait DRepsSlice {
         &mut self,
         drep: StakeCredential,
         registration: DRepRegistration,
-        anchor: Option<Anchor>,
     ) -> Result<(), RegisterError<DRepRegistration, StakeCredential>>;
-
-    fn update(
-        &mut self,
-        drep: StakeCredential,
-        anchor: Option<Anchor>,
-    ) -> Result<(), UpdateError<StakeCredential>>;
 
     fn unregister(&mut self, drep: StakeCredential, refund: Lovelace, pointer: CertificatePointer);
 }
@@ -238,7 +231,6 @@ pub trait CommitteeSlice {
     fn resign(
         &mut self,
         cc_member: StakeCredential,
-        anchor: Option<Anchor>,
     ) -> Result<(), UnregisterError<CCMember, StakeCredential>>;
 }
 
@@ -248,7 +240,7 @@ pub trait CommitteeSlice {
 pub trait ProposalsSlice {
     fn acknowledge(&mut self, id: ProposalId, pointer: ProposalPointer, proposal: Proposal);
 
-    fn vote(&mut self, proposal: ProposalId, voter: Voter, vote: Vote, anchor: Option<Anchor>);
+    fn vote(&mut self, proposal: ProposalId, voter: Voter, vote: Vote);
 }
 
 // Witnesses

--- a/crates/amaru-ledger/src/context/assert.rs
+++ b/crates/amaru-ledger/src/context/assert.rs
@@ -15,12 +15,11 @@
 use crate::context::{
     AccountState, AccountsSlice, CCMember, CommitteeSlice, DRepsSlice, DelegateError, Hash,
     PoolsSlice, PotsSlice, PreparationContext, PrepareAccountsSlice, PrepareDRepsSlice,
-    PreparePoolsSlice, PrepareUtxoSlice, ProposalsSlice, RegisterError, UnregisterError,
-    UpdateError, UtxoSlice, ValidationContext, WitnessSlice, blanket_known_datums,
-    blanket_known_scripts,
+    PreparePoolsSlice, PrepareUtxoSlice, ProposalsSlice, RegisterError, UnregisterError, UtxoSlice,
+    ValidationContext, WitnessSlice, blanket_known_datums, blanket_known_scripts,
 };
 use amaru_kernel::{
-    AddrKeyhash, Anchor, CertificatePointer, DRep, DRepRegistration, DatumHash, Lovelace,
+    AddrKeyhash, CertificatePointer, DRep, DRepRegistration, DatumHash, Lovelace,
     MemoizedPlutusData, MemoizedScript, MemoizedTransactionOutput, PoolId, PoolParams, Proposal,
     ProposalId, ProposalPointer, RequiredScript, ScriptHash, StakeCredential, StakeCredentialType,
     TransactionInput, Vote, Voter, VoterType, serde_utils, stake_credential_hash,
@@ -209,16 +208,7 @@ impl DRepsSlice for AssertValidationContext {
         &mut self,
         _drep: StakeCredential,
         _registration: DRepRegistration,
-        _anchor: Option<Anchor>,
     ) -> Result<(), RegisterError<DRepRegistration, StakeCredential>> {
-        unimplemented!()
-    }
-
-    fn update(
-        &mut self,
-        _drep: StakeCredential,
-        _anchor: Option<Anchor>,
-    ) -> Result<(), UpdateError<StakeCredential>> {
         unimplemented!()
     }
 
@@ -244,7 +234,6 @@ impl CommitteeSlice for AssertValidationContext {
     fn resign(
         &mut self,
         _cc_member: StakeCredential,
-        _anchor: Option<Anchor>,
     ) -> Result<(), UnregisterError<CCMember, StakeCredential>> {
         unimplemented!()
     }
@@ -263,8 +252,7 @@ impl ProposalsSlice for AssertValidationContext {
         skip_all,
         name = "vote"
     )]
-    fn vote(&mut self, _proposal: ProposalId, _voter: Voter, _vote: Vote, _anchor: Option<Anchor>) {
-    }
+    fn vote(&mut self, _proposal: ProposalId, _voter: Voter, _vote: Vote) {}
 }
 
 impl WitnessSlice for AssertValidationContext {

--- a/crates/amaru-ledger/src/context/default/validation.rs
+++ b/crates/amaru-ledger/src/context/default/validation.rs
@@ -15,16 +15,16 @@
 use crate::{
     context::{
         AccountState, AccountsSlice, CCMember, CommitteeSlice, DRepsSlice, DelegateError,
-        PoolsSlice, PotsSlice, ProposalsSlice, RegisterError, UnregisterError, UpdateError,
-        UtxoSlice, ValidationContext, WitnessSlice, blanket_known_datums, blanket_known_scripts,
+        PoolsSlice, PotsSlice, ProposalsSlice, RegisterError, UnregisterError, UtxoSlice,
+        ValidationContext, WitnessSlice, blanket_known_datums, blanket_known_scripts,
     },
     state::volatile_db::VolatileState,
 };
 use amaru_kernel::{
-    Anchor, Ballot, BallotId, CertificatePointer, ComparableProposalId, DRep, DRepRegistration,
-    DatumHash, Hash, Lovelace, MemoizedPlutusData, MemoizedScript, MemoizedTransactionOutput,
-    PoolId, PoolParams, Proposal, ProposalId, ProposalPointer, RequiredScript, ScriptHash,
-    StakeCredential, TransactionInput, Vote, Voter,
+    Ballot, BallotId, CertificatePointer, ComparableProposalId, DRep, DRepRegistration, DatumHash,
+    Hash, Lovelace, MemoizedPlutusData, MemoizedScript, MemoizedTransactionOutput, PoolId,
+    PoolParams, Proposal, ProposalId, ProposalPointer, RequiredScript, ScriptHash, StakeCredential,
+    TransactionInput, Vote, Voter,
 };
 use amaru_slot_arithmetic::Epoch;
 use core::mem;
@@ -167,22 +167,9 @@ impl DRepsSlice for DefaultValidationContext {
         &mut self,
         drep: StakeCredential,
         registration: DRepRegistration,
-        anchor: Option<Anchor>,
     ) -> Result<(), RegisterError<DRepRegistration, StakeCredential>> {
         trace!(?drep, deposit = %registration.deposit, "certificate.drep.registration");
-        self.state
-            .dreps
-            .register(drep, registration, anchor, None)?;
-        Ok(())
-    }
-
-    fn update(
-        &mut self,
-        drep: StakeCredential,
-        anchor: Option<Anchor>,
-    ) -> Result<(), UpdateError<StakeCredential>> {
-        trace!(?drep, ?anchor, "certificate.drep.update");
-        self.state.dreps.bind_left(drep, anchor)?;
+        self.state.dreps.register(drep, registration, None, None)?;
         Ok(())
     }
 
@@ -209,9 +196,8 @@ impl CommitteeSlice for DefaultValidationContext {
     fn resign(
         &mut self,
         cc_member: StakeCredential,
-        anchor: Option<Anchor>,
     ) -> Result<(), UnregisterError<CCMember, StakeCredential>> {
-        trace!(name: "certificate.committee.resign", ?cc_member, ?anchor);
+        trace!(name: "certificate.committee.resign", ?cc_member);
         self.state.committee.unregister(cc_member);
         Ok(())
     }
@@ -225,13 +211,13 @@ impl ProposalsSlice for DefaultValidationContext {
             .unwrap_or_default(); // Can't happen as by construction key is unique
     }
 
-    fn vote(&mut self, proposal: ProposalId, voter: Voter, vote: Vote, anchor: Option<Anchor>) {
+    fn vote(&mut self, proposal: ProposalId, voter: Voter, vote: Vote) {
         self.state.votes.produce(
             BallotId {
                 proposal: ComparableProposalId::from(proposal),
                 voter,
             },
-            Ballot { vote, anchor },
+            Ballot { vote },
         )
     }
 }

--- a/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
+++ b/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
@@ -674,8 +674,7 @@ impl fmt::Display for ProposalsForest {
             }),
             Rc::new(|constitution, _| {
                 Ok(format!(
-                    "{} with {}",
-                    constitution.anchor.url,
+                    "with {}",
                     match constitution.guardrail_script {
                         Nullable::Some(hash) => format!(
                             "guardrails={}",

--- a/crates/amaru-ledger/src/rules/transaction/certificates.rs
+++ b/crates/amaru-ledger/src/rules/transaction/certificates.rs
@@ -204,7 +204,7 @@ where
             Ok(())
         }
 
-        Certificate::RegDRepCert(drep, deposit, anchor) => {
+        Certificate::RegDRepCert(drep, deposit, _anchor) => {
             match drep {
                 StakeCredential::ScriptHash(hash) => {
                     context.require_script_witness(into_required_script(hash))
@@ -229,7 +229,6 @@ where
                     registered_at: pointer,
                     valid_until,
                 },
-                Option::from(anchor),
             )?;
             Ok(())
         }
@@ -245,14 +244,13 @@ where
             Ok(())
         }
 
-        Certificate::UpdateDRepCert(drep, anchor) => {
+        Certificate::UpdateDRepCert(drep, _anchor) => {
             match drep {
                 StakeCredential::ScriptHash(hash) => {
                     context.require_script_witness(into_required_script(hash))
                 }
                 StakeCredential::AddrKeyhash(hash) => context.require_vkey_witness(hash),
             };
-            DRepsSlice::update(context, drep, Option::from(anchor))?;
             Ok(())
         }
 
@@ -278,14 +276,14 @@ where
             Ok(())
         }
 
-        Certificate::ResignCommitteeCold(cold_credential, anchor) => {
+        Certificate::ResignCommitteeCold(cold_credential, _anchor) => {
             match cold_credential {
                 StakeCredential::ScriptHash(hash) => {
                     context.require_script_witness(into_required_script(hash))
                 }
                 StakeCredential::AddrKeyhash(hash) => context.require_vkey_witness(hash),
             };
-            CommitteeSlice::resign(context, cold_credential, Option::from(anchor))?;
+            CommitteeSlice::resign(context, cold_credential)?;
             Ok(())
         }
 

--- a/crates/amaru-ledger/src/rules/transaction/voting_procedures.rs
+++ b/crates/amaru-ledger/src/rules/transaction/voting_procedures.rs
@@ -45,12 +45,7 @@ pub(crate) fn execute<C>(
                 }
 
                 votes.into_iter().for_each(|(proposal_id, ballot)| {
-                    context.vote(
-                        proposal_id,
-                        voter.clone(),
-                        ballot.vote,
-                        Option::from(ballot.anchor),
-                    );
+                    context.vote(proposal_id, voter.clone(), ballot.vote);
                 })
             });
     }

--- a/crates/amaru-ledger/src/state/volatile_db.rs
+++ b/crates/amaru-ledger/src/state/volatile_db.rs
@@ -22,8 +22,8 @@ use crate::{
     store::{self, columns::*},
 };
 use amaru_kernel::{
-    Anchor, Ballot, BallotId, CertificatePointer, ComparableProposalId, DRep, DRepRegistration,
-    Lovelace, MemoizedTransactionOutput, Point, PoolId, PoolParams, Proposal, ProposalPointer,
+    Ballot, BallotId, CertificatePointer, ComparableProposalId, DRep, DRepRegistration, Lovelace,
+    MemoizedTransactionOutput, Point, PoolId, PoolParams, Proposal, ProposalPointer,
     StakeCredential, TransactionInput, protocol_parameters::ProtocolParameters,
 };
 use amaru_slot_arithmetic::Epoch;
@@ -148,7 +148,7 @@ pub struct VolatileState {
         (DRep, CertificatePointer),
         Lovelace,
     >,
-    pub dreps: DiffBind<StakeCredential, Anchor, Empty, DRepRegistration>,
+    pub dreps: DiffBind<StakeCredential, Empty, Empty, DRepRegistration>,
     pub dreps_deregistrations: BTreeMap<StakeCredential, CertificatePointer>,
     pub committee: DiffBind<StakeCredential, StakeCredential, Empty, Empty>,
     pub withdrawals: BTreeSet<StakeCredential>,
@@ -305,17 +305,17 @@ fn add_accounts(
 // --------------------------------------------------------------------------
 
 fn add_dreps(
-    iterator: impl Iterator<Item = (StakeCredential, Bind<Anchor, Empty, DRepRegistration>)>,
+    iterator: impl Iterator<Item = (StakeCredential, Bind<Empty, Empty, DRepRegistration>)>,
 ) -> impl Iterator<Item = (dreps::Key, dreps::Value)> {
     iterator.map(
         move |(
             credential,
             Bind {
-                left: anchor,
+                left: _,
                 right: _,
                 value: registration,
             },
-        ): (_, Bind<_, Empty, _>)| { (credential, (anchor, registration)) },
+        ): (_, Bind<_, Empty, _>)| { (credential, registration) },
     )
 }
 

--- a/crates/amaru-ledger/src/summary/governance.rs
+++ b/crates/amaru-ledger/src/summary/governance.rs
@@ -14,7 +14,7 @@
 
 use crate::store::{GovernanceActivity, Snapshot, StoreError, columns::dreps};
 use amaru_kernel::{
-    Anchor, CertificatePointer, DRep, Lovelace, Slot, StakeCredential, TransactionPointer,
+    CertificatePointer, DRep, Lovelace, Slot, StakeCredential, TransactionPointer,
     expect_stake_credential, network::EraHistory,
 };
 use amaru_slot_arithmetic::{Epoch, EraHistoryError};
@@ -31,7 +31,6 @@ pub struct GovernanceSummary {
 pub struct DRepState {
     #[serde(rename(serialize = "mandate"))]
     pub valid_until: Option<Epoch>,
-    pub metadata: Option<Anchor>,
     pub stake: Lovelace,
     #[serde(skip)]
     pub registered_at: CertificatePointer,
@@ -115,7 +114,6 @@ impl GovernanceSummary {
                         registered_at,
                         previous_deregistration,
                         valid_until,
-                        anchor,
                         ..
                     },
                 )| {
@@ -129,7 +127,6 @@ impl GovernanceSummary {
                         DRepState {
                             registered_at,
                             previous_deregistration,
-                            metadata: anchor,
                             valid_until: Some(valid_until + consecutive_dormant_epochs as u64),
                             // The actual stake is filled later when computing the stake distribution.
                             stake: 0,
@@ -141,7 +138,6 @@ impl GovernanceSummary {
 
         let default_protocol_drep = || DRepState {
             valid_until: None,
-            metadata: None,
             stake: 0,
             registered_at: CertificatePointer {
                 transaction: TransactionPointer {

--- a/crates/amaru-ledger/src/summary/stake_distribution.rs
+++ b/crates/amaru-ledger/src/summary/stake_distribution.rs
@@ -341,8 +341,7 @@ pub mod tests {
     use amaru_kernel::{
         Epoch, Lovelace, expect_stake_credential,
         tests::{
-            any_anchor, any_certificate_pointer, any_drep, any_pool_id, any_pool_params,
-            any_stake_credential,
+            any_certificate_pointer, any_drep, any_pool_id, any_pool_params, any_stake_credential,
         },
     };
     use proptest::{collection, option, prelude::*, prop_compose};
@@ -467,7 +466,6 @@ pub mod tests {
             max_epoch: u64,
         )(
             valid_until in min_epoch..=max_epoch,
-            metadata in option::of(any_anchor()),
             stake in 0_u64..1_000_000_000_000,
             registered_at in any_certificate_pointer(u64::MAX),
             previous_deregistration in option::of(any_certificate_pointer(u64::MAX)),
@@ -486,7 +484,6 @@ pub mod tests {
 
             DRepState {
                 valid_until: Some(Epoch::from(valid_until)),
-                metadata,
                 stake,
                 registered_at,
                 previous_deregistration

--- a/crates/amaru-stores/src/in_memory/ledger/columns/dreps.rs
+++ b/crates/amaru-stores/src/in_memory/ledger/columns/dreps.rs
@@ -26,7 +26,7 @@ pub fn add(
 ) -> Result<(), StoreError> {
     let mut dreps = store.dreps.borrow_mut();
 
-    for (credential, (anchor, registration)) in rows {
+    for (credential, registration) in rows {
         if let Some(row) = dreps.get_mut(&credential) {
             // Re-registration or update
             if let Some(DRepRegistration {
@@ -40,8 +40,6 @@ pub fn add(
                 row.registered_at = registered_at;
                 row.valid_until = valid_until;
             }
-
-            anchor.set_or_reset(&mut row.anchor);
         } else if let Some(DRepRegistration {
             deposit,
             registered_at,
@@ -50,14 +48,12 @@ pub fn add(
         }) = registration
         {
             // New registration
-            let mut row = Row {
+            let row = Row {
                 deposit,
                 registered_at,
                 valid_until,
-                anchor: None,
                 previous_deregistration: None,
             };
-            anchor.set_or_reset(&mut row.anchor);
             dreps.insert(credential, row);
         } else {
             error!(

--- a/crates/amaru-stores/src/lib.rs
+++ b/crates/amaru-stores/src/lib.rs
@@ -20,9 +20,8 @@ pub mod rocksdb;
 #[cfg(test)]
 pub mod tests {
     use amaru_kernel::{
-        Anchor, ComparableProposalId, DRepRegistration, EraHistory, Hash,
-        MemoizedTransactionOutput, Point, PoolId, PoolParams, Slot, StakeCredential,
-        TransactionInput,
+        ComparableProposalId, DRepRegistration, EraHistory, Hash, MemoizedTransactionOutput, Point,
+        PoolId, PoolParams, Slot, StakeCredential, TransactionInput,
         network::NetworkName,
         protocol_parameters::PREPROD_INITIAL_PROTOCOL_PARAMETERS,
         tests::{
@@ -139,28 +138,18 @@ pub mod tests {
             .unwrap()
             .current();
 
-        if drep_row.anchor.is_none() {
-            drep_row.anchor = Some(Anchor {
-                url: "https://example.com".to_string(),
-                content_hash: Hash::from([0u8; 32]),
-            });
-        }
         drep_row.previous_deregistration = None;
 
-        let anchor = drep_row.anchor.clone().expect("Expected anchor to be Some");
         let deposit = drep_row.deposit;
         let registered_at = drep_row.registered_at;
 
         let drep_iter = std::iter::once((
             drep_key.clone(),
-            (
-                Resettable::Set(anchor),
-                Some(DRepRegistration {
-                    deposit,
-                    registered_at,
-                    valid_until: drep_row.valid_until,
-                }),
-            ),
+            Some(DRepRegistration {
+                deposit,
+                registered_at,
+                valid_until: drep_row.valid_until,
+            }),
         ));
 
         // proposals (Does not generate proposal row on Windows due to stack overflow)
@@ -345,11 +334,6 @@ pub mod tests {
             .find(|(key, _)| key == &fixture.drep_key)
             .map(|(_, row)| row)
             .expect("drep not found in store");
-
-        assert_eq!(
-            stored_drep.anchor, fixture.drep_row.anchor,
-            "drep anchor mismatch"
-        );
 
         assert_eq!(
             stored_drep.deposit, fixture.drep_row.deposit,

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/dreps.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/dreps.rs
@@ -53,7 +53,7 @@ pub fn add<DB>(
     valid_until_on_update: Epoch,
     rows: impl Iterator<Item = (Key, Value)>,
 ) -> Result<(), StoreError> {
-    for (credential, (anchor, registration)) in rows {
+    for (credential, registration) in rows {
         let key = as_key(&PREFIX, &credential);
 
         // Registration already exists. Which can represents one of two cases:
@@ -97,7 +97,6 @@ pub fn add<DB>(
                 deposit,
                 registered_at,
                 valid_until,
-                anchor: None,
                 previous_deregistration: None,
             })
         } else {
@@ -106,9 +105,7 @@ pub fn add<DB>(
         };
 
         match row {
-            Some(mut row) => {
-                anchor.set_or_reset(&mut row.anchor);
-
+            Some(row) => {
                 db.put(key, as_value(row))
                     .map_err(|err| StoreError::Internal(err.into()))?;
             }

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -103,7 +103,6 @@ const DIR_LIVE_DB: &str = "live";
 // * 'acct:'StakeCredential      * (Option<PoolId>, Lovelace, Lovelace)           *
 // * 'drep:'StakeCredential      * (                                              *
 // *                             *   Lovelace,                                    *
-// *                             *   Option<Anchor>,                              *
 // *                             *   CertificatePointer,                          *
 // *                             *   Option<Epoch>,                               *
 // *                             *   Option<CertificatePointer>,                  *


### PR DESCRIPTION
Get rid of useless `anchor` as it introduces extra memory usage and processing time.

⚠️ This will break the ledger db. It is proposed not to implement any migration for this as the cost would be significant while we are till in development phase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed anchor metadata across governance flows (voting, registrations, resignations); simplified ballots, DRep state/rows, and related APIs.
* **Documentation**
  * Ledger docs updated to reflect the reduced DRep schema (anchor removed).
* **Tests**
  * Updated test data, generators, and assertions to omit anchor.
* **UI/Display**
  * Constitution display no longer shows the prior anchor URL.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->