### PR TITLE
preserve more immutable chunks cardano-node cache.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -289,8 +289,10 @@ jobs:
           make BUILD_PROFILE=test AMARU_NETWORK=${{ matrix.network.name }} test-e2e
 
       - name: Teardown haskell node
+        if: ${{ always() }}
         shell: bash
         run: |
+          docker logs --tail 200 cardano-node || true
           docker stop cardano-node
           docker rm cardano-node
 

--- a/.github/workflows/nightly-synchronization.yml
+++ b/.github/workflows/nightly-synchronization.yml
@@ -37,7 +37,7 @@ jobs:
         restore-keys: |
           cardano-node-ogmios-${{ matrix.network }}
 
-    - uses: CardanoSolutions/gh-action-cardano-node-ogmios-docker-sync@671d58cc73fe1edf9eab19c21dc3ae92e4176c37
+    - uses: CardanoSolutions/gh-action-cardano-node-ogmios-docker-sync@6b83f3dbb55f22fd586c9003f7d5fe9e21edc906
       with:
         db-dir: ${{ runner.temp }}/db-${{ matrix.network }}
         network: ${{ matrix.network }}
@@ -50,4 +50,4 @@ jobs:
       shell: bash
       working-directory: ${{ runner.temp }}/db-${{ matrix.network }}
       run: |
-        ls immutable/*.chunk | sort | head -n -500 | xargs -r rm -f --
+        ls immutable/*.chunk | sort | head -n -2500 | xargs -r rm -f --


### PR DESCRIPTION
This only pushes the issue back in time for a bit; but it'll force us to maintain more recent snapshots. Keeping data that is too old like this is indeed requiring more disk-space than we have available on runners. While annoying, this is in a way a 'good' problem to have.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline reliability with enhanced logging and guaranteed cleanup procedures.
  * Updated container synchronization action and optimized data retention policies for maintenance efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->