### PR TITLE
fix: switch to buildjet cache for e2e snapshot tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -149,17 +149,32 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
 
+
+  snapshots-instance-choice:
+    name: End-to-end snapshot preparation
+    runs-on: ubuntu-latest
+    outputs:
+      runner: ${{ steps.alt-runner.outputs.runner || 'ubuntu-latest' }}
+    steps:
+      - id: alt-runner
+        if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        run: echo "runner=buildjet-4vcpu-ubuntu-2204" >> $GITHUB_OUTPUT
+
   snapshots:
     name: End-to-end snapshot tests
-    runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
+    needs: snapshots-instance-choice
+    runs-on: ${{ needs.snapshots-instance-choice.outputs.runner }}
     strategy:
       matrix:
         network:
           - name: preprod
             magic: 1
         cardano_node_version: [10.1.4]
+
+    if: ${{ !github.event.pull_request.draft }}
+
     continue-on-error: true
+
     steps:
       - uses: actions/checkout@v4
 
@@ -177,7 +192,7 @@ jobs:
 
       - name: Restore cardano-node DB
         id: cache-cardano-node-db
-        uses: actions/cache/restore@v4
+        uses: buildjet/cache/restore@v4
         with:
           # The path should match the one used for the 'Nightly Sync' workflow.
           path: ${{ runner.temp }}/db-${{ matrix.network.name }}

--- a/.github/workflows/nightly-synchronization.yml
+++ b/.github/workflows/nightly-synchronization.yml
@@ -30,7 +30,7 @@ jobs:
         echo "value=$(/bin/date -u '+%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
 
     - id: cache
-      uses: actions/cache@v4
+      uses: buildjet/cache@v4
       with:
         path: ${{ runner.temp }}/db-${{ matrix.network }}
         key: cardano-node-ogmios-${{ matrix.network }}-${{ steps.timestamp.outputs.value }}
@@ -46,7 +46,6 @@ jobs:
 
     # Remove old immutable chunks from the database, we don't need them and they make cache & on-disk system larger.
     - name: prune node db
-      if: steps.cache.outputs.cache-hit == 'false'
       shell: bash
       working-directory: ${{ runner.temp }}/db-${{ matrix.network }}
       run: |


### PR DESCRIPTION
Maintaining the Haskell's node database as cache has really demonstrated to be unpractical. In an ideal world, we could just run Amaru against a remote cardano-node; but we aren't there quite yet in terms of networking.

So we still have to run a local cardano-node to connect to, which requires a database; thus causing two issues:

- We need to store and restore that database on-demand; which is what we've been using caches for until now. Yet, we are limited to 10GB of caches on Github's free-tier; and it is cumbersome to ensure that our precious node database doesn't get evicted in favor of other caches.

- We're also hitting disk-space quota limit (14GB on free-tier runners) when running the full preprod e2e.

So, this commit:

- externalizes the cardano-node's db cache to buildjet which should avoid clashes between the node's database and the build caches.

- we conditionally use a buildjet runner for long-running e2e tests when merging to main; which comes with more disk space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a preparatory CI step to select execution runners so snapshot jobs run on a dynamic runner.
  * Reworked snapshot job orchestration for per-entry execution and added an explicit non-draft PR guard.
  * Switched cache provider to improve artifact restore reliability.
  * Added early disk reclaiming and made nightly sync’s node DB prune run unconditionally.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->