### PR TITLE
fix: ensure sufficient permissions for pruning cardano-node immutable.

### DIFF
--- a/.github/workflows/nightly-synchronization.yml
+++ b/.github/workflows/nightly-synchronization.yml
@@ -49,4 +49,5 @@ jobs:
       shell: bash
       working-directory: ${{ runner.temp }}/db-${{ matrix.network }}
       run: |
+        sudo chown -R $(whoami):$(whoami) immutable
         ls immutable/*.chunk | sort | head -n -2500 | xargs -r rm -f --


### PR DESCRIPTION
  The problem didn't occur before because we were not pruning the cache
  on the first run, but only after a cache-hit. In that latter case, the
  ownership of the cache folder was already reset to our user and it
  just happened that we never deleted files that were created in the
  ongoing run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of the nightly database maintenance process by ensuring proper access permissions before removing deprecated data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->