### PR TITLE
fix: always save nightly cardano-node cache, and without variable key

### DIFF
--- a/.github/workflows/nightly-synchronization.yml
+++ b/.github/workflows/nightly-synchronization.yml
@@ -24,16 +24,10 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - id: timestamp
-      shell: bash
-      run: |
-        echo "value=$(/bin/date -u '+%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
-
-    - id: cache
-      uses: buildjet/cache@v4
+    - uses: buildjet/cache/restore@v4
       with:
         path: ${{ runner.temp }}/db-${{ matrix.network }}
-        key: cardano-node-ogmios-${{ matrix.network }}-${{ steps.timestamp.outputs.value }}
+        key: cardano-node-ogmios-${{ matrix.network }}
         restore-keys: |
           cardano-node-ogmios-${{ matrix.network }}
 
@@ -51,3 +45,8 @@ jobs:
       run: |
         sudo chown -R $(whoami):$(whoami) immutable
         ls immutable/*.chunk | sort | head -n -2500 | xargs -r rm -f --
+
+    - uses: buildjet/cache/save@v4
+      with:
+        path: ${{ runner.temp }}/db-${{ matrix.network }}
+        key: cardano-node-ogmios-${{ matrix.network }}


### PR DESCRIPTION
With GitHub caches, we would get cache matched in descending order of timestamps; but this seems different with buildjet. Since there's only one writer of the cache anyway, we can simply drop the timestamp entirely and rely on a single unique cache key (per network).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow caching strategy to improve build efficiency and reduce cache key complexity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->