### PR TITLE
feat: also run CI on preview

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -187,15 +187,12 @@ jobs:
       AMARU_NETWORK: ${{ matrix.network.name }}
       BUILD_PROFILE: test
       DEMO_TARGET_EPOCH: ${{ matrix.network.target_epoch }}
-    if: ${{ !github.event.pull_request.draft }}
-
-    env:
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: auto
       ENDPOINT: ${{ secrets.S3_ENDPOINT }}
       OBJECT: "s3://${{ secrets.CARDANO_NODE_BUCKET_NAME }}/${{ matrix.network.name }}.tar.zstd"
-
+    if: ${{ !github.event.pull_request.draft }}
     continue-on-error: true
 
     steps:


### PR DESCRIPTION
Run e2e CI tests on preview too. A new matrix field `target_epoch` allows to specify per network target epoch for demo (only applies to tests triggered for PRs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI matrix now pins target epochs for preprod and preview to control snapshot timing.
  * New top-level CI environment variables surface selected network, build profile and demo target epoch to workflow steps.
  * CI steps simplified to call make targets directly, removing repeated explicit environment injection and streamlining build/demo/test flows.
  * Test runs can be marked allowed-to-fail; CI now continues where configured and preserves PR-draft guards and error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->