### PR TITLE
Store (Haskell) cardano-node's db in R2 buckets for e2e tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
-        shell: bash 
+        shell: bash
         run: make coverage-lconv
       - name: Upload test artifacts on failure
         if: failure()
@@ -177,9 +177,16 @@ jobs:
         network:
           - name: preprod
             magic: 1
-        cardano_node_version: [10.1.4]
+        cardano_node_version: [10.5.3]
 
     if: ${{ !github.event.pull_request.draft }}
+
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: auto
+      ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+      OBJECT: "s3://${{ secrets.CARDANO_NODE_BUCKET_NAME }}/${{ matrix.network.name }}.tar.zstd"
 
     continue-on-error: true
 
@@ -198,23 +205,13 @@ jobs:
         run: |
           echo "value=$(/bin/date -u '+%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
 
-      - name: Restore cardano-node DB
-        id: cache-cardano-node-db
-        uses: buildjet/cache/restore@v4
-        with:
-          # The path should match the one used for the 'Nightly Sync' workflow.
-          path: ${{ runner.temp }}/db-${{ matrix.network.name }}
-          # The key should also match
-          key: cardano-node-ogmios-${{ matrix.network.name }}
-          restore-keys: |
-            cardano-node-ogmios-${{ matrix.network.name }}
-
-      - name: Check if cardano-node-db is available
-        if: steps.cache-cardano-node-db.outputs.cache-hit == ''
+      - name: Download (Haskell) cardano-node's db
         shell: bash
         run: |
-          echo "Haskell node db not available, aborting job."
-          exit 1
+          set -euo pipefail
+          mkdir -p "${{ runner.temp }}/db"
+          aws s3 cp "$OBJECT" - --endpoint-url "$ENDPOINT" | tar --zstd -xf - -C "${{ runner.temp }}/db"
+          touch ${{ runner.temp }}/db/clean
 
       - name: Spawn Haskell Node
         id: spawn-cardano-node
@@ -222,8 +219,10 @@ jobs:
         run: |
           docker pull ghcr.io/intersectmbo/cardano-node:${{ matrix.cardano_node_version }}
           make HASKELL_NODE_CONFIG_DIR=cardano-node-config AMARU_NETWORK=${{ matrix.network.name }} download-haskell-config
+          jq 'del(.bootstrapPeers)' ./cardano-node-config/topology.json > cardano-node-config/topology.patched.json
+          mv cardano-node-config/topology.patched.json cardano-node-config/topology.json
           docker run -d --name cardano-node \
-            -v ${{ runner.temp }}/db-${{ matrix.network.name }}:/db \
+            -v ${{ runner.temp }}/db:/db \
             -v ${{ runner.temp }}/ipc:/ipc \
             -v ./cardano-node-config:/config \
             -v ./cardano-node-config:/genesis \

--- a/.github/workflows/nightly-synchronization.yml
+++ b/.github/workflows/nightly-synchronization.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   sync_and_cache:
+    name: Synchronize (Haskell) cardano-node
     strategy:
       matrix:
         network: [ preprod, preview ]

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ download-haskell-config: ## &start Download Haskell node configuration files for
 	mkdir -p $(HASKELL_NODE_CONFIG_DIR)
 	curl -fsSL -O --output-dir "$(HASKELL_NODE_CONFIG_DIR)" "$(HASKELL_NODE_CONFIG_SOURCE)/$(AMARU_NETWORK)/config.json"
 	curl -fsSL -O --output-dir "$(HASKELL_NODE_CONFIG_DIR)" "$(HASKELL_NODE_CONFIG_SOURCE)/$(AMARU_NETWORK)/topology.json"
+	curl -fsSL -O --output-dir "$(HASKELL_NODE_CONFIG_DIR)" "$(HASKELL_NODE_CONFIG_SOURCE)/$(AMARU_NETWORK)/peer-snapshot.json"
 	curl -fsSL -O --output-dir "$(HASKELL_NODE_CONFIG_DIR)" "$(HASKELL_NODE_CONFIG_SOURCE)/$(AMARU_NETWORK)/byron-genesis.json"
 	curl -fsSL -O --output-dir "$(HASKELL_NODE_CONFIG_DIR)" "$(HASKELL_NODE_CONFIG_SOURCE)/$(AMARU_NETWORK)/shelley-genesis.json"
 	curl -fsSL -O --output-dir "$(HASKELL_NODE_CONFIG_DIR)" "$(HASKELL_NODE_CONFIG_SOURCE)/$(AMARU_NETWORK)/alonzo-genesis.json"


### PR DESCRIPTION
The cache system from Buildjet is quite unreliable in the end. We cannot predict _which cache_ will be made available; whereas Github's cache returned them in descending cache key order. This makes it incredibly annoying to build the database cache incrementally, as well as recover the latest version of it reliably. 

So instead, I've been creating another bucket on our PRAGMA's R2 storage hosting both Preview and PreProd databases. This has several advantages:

- We can easily re-use the bucket across github instances if needs be (handy for testing things on a fork...)
- We can even pre-construct the data locally, upload it, and use it right away; instead of having to awkwardly create it through several workflow dispatches.

Quick note as well: 

- Cached databases are stored using zstd compression; as it was the one offering the better trade-offs between speed of compression / uncompression and sizes while being "natively" available. 
- I pre-constructed the databases locally, using a 10.5.3 cardano-node; which has incompatible database changes compared to 10.1.4. So I had to bump it in CI too. 
- I've left the R2 endpoint and bucketname behind github secrets also; to avoid leaking anything. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Cardano node to 10.5.3.
  * Switched CI/nightly flows to object-based S3/R2 sync and direct snapshot download for faster, more reliable pipeline runs.
* **New Features**
  * Automatically fetches peer snapshot and node DB from object storage during runs.
  * Topology patched before node start to remove bootstrap peers and use the fetched peer list.
* **Refactor**
  * Simplified DB mount and restore flow for runner environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->