### PR TITLE
feat: allow to run e2e tests when dispatch

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -200,7 +200,6 @@ jobs:
     env:
       AMARU_NETWORK: ${{ matrix.network.name }}
       BUILD_PROFILE: test
-      DEMO_TARGET_EPOCH: ${{ matrix.network.target_epoch }}
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: auto
@@ -235,8 +234,8 @@ jobs:
             DEMO_TARGET_EPOCH="${{ github.event.inputs.demo_target_epoch }}"
             echo "Using DEMO_TARGET_EPOCH from workflow_dispatch: $DEMO_TARGET_EPOCH"
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "Using DEMO_TARGET_EPOCH from matrix.network: $DEMO_TARGET_EPOCH"
             DEMO_TARGET_EPOCH=${{ matrix.network.target_epoch }}
+            echo "Using DEMO_TARGET_EPOCH from matrix.network: $DEMO_TARGET_EPOCH"
           else
             # For pushes, we will retrieve the latest epoch in a later step
             DEMO_TARGET_EPOCH=""


### PR DESCRIPTION
Allows to run full e2e tests via `workflow_dispatch`. Some inputs can be set: `network`, `demo_target_epoch` and `timeout` to override defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI accepts configurable inputs for network, demo target epoch, and timeout.
  * Per-network timeout is applied to node-run steps and propagated to snapshot jobs.
  * CI prepares environment by resolving and exporting the demo target epoch automatically when not provided.
  * Conditional gating allows skipping network tests when a specific network is requested.
  * Dynamic tool version selection downloads the appropriate CLI at runtime.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->