### PR TITLE
fix: incorrect default timeout for full run

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -373,7 +373,7 @@ jobs:
           echo "DEMO_TARGET_EPOCH=$DEMO_TARGET_EPOCH" >> "$GITHUB_ENV"
 
       - name: Run node
-        timeout-minutes: ${{ env.TIMEOUT_RUN }}
+        timeout-minutes: ${{ fromJSON(env.TIMEOUT_RUN) }}
         shell: bash
         run: make AMARU_MAX_EXTRA_LEDGER_SNAPSHOTS=all demo
 


### PR DESCRIPTION
Introduce a custom matrix variable for full run tests: `default-timeout-full-run`. It is now used for full test runs unless overridden via `workflow_dispatch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to support configurable timeouts with event-aware defaults (distinct defaults for pull requests vs pushes), added per-network run variants, and ensured the chosen timeout is consistently propagated across steps.
  * Exported a demo target epoch for downstream steps and added inputs to allow overriding timeouts and target epoch when triggering the workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->