### PR TITLE
perf: anchor is mostly None

### DIFF
--- a/crates/amaru-kernel/src/ballot.rs
+++ b/crates/amaru-kernel/src/ballot.rs
@@ -16,8 +16,38 @@ use crate::{Anchor, Vote, cbor, heterogeneous_array};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Ballot {
-    pub vote: Vote,
-    pub anchor: Option<Box<Anchor>>,
+    vote: Vote,
+
+    /// NOTE: Anchors are kept in a Box since
+    ///
+    /// - Anchors are often absent from votes (~60% of the time on Mainnet); thus reducing the
+    ///   memory footprint of this from 64B to 16B
+    ///
+    /// - Rarely (i.e. never) accessed anyway by the ledger which completely neglects the cost of
+    ///   the indirection.
+    ///
+    /// One may ask: if never accessed, why keep it around?
+    ///
+    /// -> Because it is still on-chain data which may be relevant to users even though it has no
+    ///    influence on the ledger validations.
+    anchor: Option<Box<Anchor>>,
+}
+
+impl Ballot {
+    pub fn new(vote: Vote, anchor: Option<Anchor>) -> Self {
+        Self {
+            vote,
+            anchor: anchor.map(Box::new),
+        }
+    }
+
+    pub fn vote(&self) -> &Vote {
+        &self.vote
+    }
+
+    pub fn anchor(&self) -> Option<&Anchor> {
+        self.anchor.as_deref()
+    }
 }
 
 impl<C> cbor::encode::Encode<C> for Ballot {
@@ -27,8 +57,8 @@ impl<C> cbor::encode::Encode<C> for Ballot {
         ctx: &mut C,
     ) -> Result<(), cbor::encode::Error<W::Error>> {
         e.array(2)?;
-        e.encode_with(&self.vote, ctx)?;
-        e.encode_with(&self.anchor, ctx)?;
+        e.encode_with(self.vote(), ctx)?;
+        e.encode_with(self.anchor(), ctx)?;
         Ok(())
     }
 }
@@ -59,10 +89,7 @@ pub mod tests {
             vote in any_vote(),
             anchor in option::of(any_anchor()),
         ) -> Ballot  {
-            Ballot {
-                vote,
-                anchor: anchor.map(Box::new),
-            }
+            Ballot::new(vote, anchor)
         }
     }
 

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -1053,7 +1053,7 @@ fn import_votes(
                     StakeCredential::ScriptHash(hash) => Voter::ConstitutionalCommitteeScript(hash),
                 };
 
-                let ballot = Ballot { vote, anchor: None };
+                let ballot = Ballot::new(vote, None);
 
                 votes.push((new_ballot_id(voter), ballot));
             }
@@ -1064,7 +1064,7 @@ fn import_votes(
                     StakeCredential::ScriptHash(hash) => Voter::DRepScript(hash),
                 };
 
-                let ballot = Ballot { vote, anchor: None };
+                let ballot = Ballot::new(vote, None);
 
                 votes.push((new_ballot_id(voter), ballot));
             }
@@ -1072,7 +1072,7 @@ fn import_votes(
             for (pool_id, vote) in st.pools_votes.into_iter() {
                 let voter = Voter::StakePoolKey(pool_id);
 
-                let ballot = Ballot { vote, anchor: None };
+                let ballot = Ballot::new(vote, None);
 
                 votes.push((new_ballot_id(voter), ballot));
             }

--- a/crates/amaru-ledger/src/context/default/validation.rs
+++ b/crates/amaru-ledger/src/context/default/validation.rs
@@ -231,10 +231,7 @@ impl ProposalsSlice for DefaultValidationContext {
                 proposal: ComparableProposalId::from(proposal),
                 voter,
             },
-            Ballot {
-                vote,
-                anchor: anchor.map(Box::new),
-            },
+            Ballot::new(vote, anchor),
         )
     }
 }

--- a/crates/amaru-ledger/src/governance/ratification.rs
+++ b/crates/amaru-ledger/src/governance/ratification.rs
@@ -530,19 +530,19 @@ fn partition_votes(
         |(mut dreps, mut committee, mut pools), (voter, ballot)| {
             match voter {
                 Voter::ConstitutionalCommitteeKey(hash) => {
-                    committee.insert(StakeCredential::AddrKeyhash(*hash), &ballot.vote);
+                    committee.insert(StakeCredential::AddrKeyhash(*hash), ballot.vote());
                 }
                 Voter::ConstitutionalCommitteeScript(hash) => {
-                    committee.insert(StakeCredential::ScriptHash(*hash), &ballot.vote);
+                    committee.insert(StakeCredential::ScriptHash(*hash), ballot.vote());
                 }
                 Voter::DRepKey(hash) => {
-                    dreps.insert(DRep::Key(*hash), &ballot.vote);
+                    dreps.insert(DRep::Key(*hash), ballot.vote());
                 }
                 Voter::DRepScript(hash) => {
-                    dreps.insert(DRep::Script(*hash), &ballot.vote);
+                    dreps.insert(DRep::Script(*hash), ballot.vote());
                 }
                 Voter::StakePoolKey(pool_id) => {
-                    pools.insert(pool_id, &ballot.vote);
+                    pools.insert(pool_id, ballot.vote());
                 }
             };
 


### PR DESCRIPTION
On preprod the [anchor of a Ballot](https://github.com/pragma-org/amaru/blob/main/crates/amaru-kernel/src/ballot.rs#L20) is <1% of the time `Some` on mainnet it is more like 42%. In this PR we change from `pub anchor: Option<Anchor>` to `pub anchor: Option<Box<Anchor>>`. Witch makes Ballot go from 64 bytes to 16, but at the cost of adding an additional allocation for the `Box` when the anchor is Some. For <1% `Some` that is a clear win. For the mainnet numbers we have approximately `(1497*64)=95808` vs `(1497*16 + 636 * 56)=59568`.

This is a less drastic alternative to #601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal ballot representation changed to reduce memory footprint and use an explicit constructor and accessors.
  * Encoding/validation/bootstrapping updated to use the new constructor and accessors.
  * Tests updated to construct ballots via the new API.
  * No user-visible behavior or workflow changes; functionality and encoding remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->