### PR TITLE
chore: increase timeout

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -200,13 +200,13 @@ jobs:
           - name: preprod
             magic: 1
             target_epoch: 182
-            default-timeout-light-run: 15
+            default-timeout-light-run: 30
             default-timeout-full-run: 60
           - name: preview
             magic: 2
             target_epoch: 680
             tests-may-fail: true
-            default-timeout-light-run: 15
+            default-timeout-light-run: 30
             default-timeout-full-run: 120
         cardano_node_version: [10.5.3]
     env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -207,7 +207,7 @@ jobs:
             target_epoch: 680
             tests-may-fail: true
             default-timeout-light-run: 15
-            default-timeout-full-run: 60
+            default-timeout-full-run: 120
         cardano_node_version: [10.5.3]
     env:
       AMARU_NETWORK: ${{ matrix.network.name }}


### PR DESCRIPTION
Check to see how much time is needed to have preview test running. Also allows to see if preview is still [failing](https://github.com/pragma-org/amaru/issues/619)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased snapshot run timeouts to reduce premature timeouts during preprod and preview checks:
    * Preprod: light-run timeout increased from 15s to 30s.
    * Preview: light-run timeout increased from 15s to 30s; full-run timeout increased from 60s to 120s.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->