### PR TITLE
feat: allow to customize AMARU_TRACE when running e2e tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,6 +14,9 @@ on:
       timeout:
         description: "Override timeout for snapshot tests"
         required: false
+      demo_trace_level:
+        description: "Override AMARU_TRACE (leave empty for default)"
+        required: false
   push:
     branches: ["main"]
   pull_request:
@@ -29,7 +32,7 @@ env:
     ~/.cargo/git/db/
     target/
   INPUT_TIMEOUT: ${{ github.event.inputs.timeout }}
-  INPUT_DEMO_TARGET_EPOCH: ${{ github.event.inputs.demo_target_epoch }}
+  AMARU_TRACE: ${{ github.event.inputs.demo_trace_level }}
 
 jobs:
   build:

--- a/scripts/demo
+++ b/scripts/demo
@@ -26,11 +26,11 @@ fi
 echo -e "      \033[1;32mTarget\033[00m epoch $TARGET_EPOCH"
 cargo build --profile $BUILD_PROFILE --bin amaru
 
+export AMARU_TRACE="${AMARU_TRACE:-amaru=info}"
+
 function run() {
   /bin/sh -c "echo exitPID=\$\$; exec cargo run --profile $BUILD_PROFILE -- --with-json-traces run"
 }
-
-export AMARU_TRACE="amaru=info"
 
 ENDED=false
 while read -r line; do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow: added a new optional input to configure the demo trace level for runs.
  * Demo script: applies an optional trace-level setting at invocation and removed the prior global export.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->