### PR TITLE
fix: set the proper max buffer size for the blockfetch and txsubmission protocols

### DIFF
--- a/crates/amaru-protocols/src/blockfetch/mod.rs
+++ b/crates/amaru-protocols/src/blockfetch/mod.rs
@@ -94,7 +94,7 @@ pub async fn register_blockfetch_initiator<M>(
             handler: eff
                 .contramap(&blockfetch, "blockfetch_bytes", Inputs::Network)
                 .await,
-            max_buffer: 25000000,
+            max_buffer: 2_500_000,
         },
     )
     .await;
@@ -121,7 +121,7 @@ pub async fn register_blockfetch_responder<M>(
             handler: eff
                 .contramap(&blockfetch, "blockfetch_bytes", Inputs::Network)
                 .await,
-            max_buffer: 25000000,
+            max_buffer: 2_500_000,
         },
     )
     .await;

--- a/crates/amaru-protocols/src/tx_submission/mod.rs
+++ b/crates/amaru-protocols/src/tx_submission/mod.rs
@@ -119,7 +119,7 @@ pub async fn register_tx_submission(
             protocol: PROTO_N2N_TX_SUB.for_role(role).erase(),
             frame: mux::Frame::OneCborItem,
             handler: tx_submission.clone(),
-            max_buffer: 5760,
+            max_buffer: 2_500_000,
         },
     )
     .await;


### PR DESCRIPTION
According to [the network specification](https://ouroboros-network.cardano.intersectmbo.org/pdfs/network-spec/network-spec.pdf).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted network buffer limits for block fetching and transaction submission to optimize memory usage and improve data transmission stability and throughput during syncing and submission.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->