### PR TITLE
fix: wait for the connection initialization on fetch blocks

### DIFF
--- a/crates/amaru-protocols/src/keepalive/tests.rs
+++ b/crates/amaru-protocols/src/keepalive/tests.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::manager::ManagerConfig;
 use crate::{
     connection::{self, ConnectionMessage},
     network_effects::create_connection,
@@ -54,6 +55,7 @@ fn test_keepalive_with_node() {
             Peer::new("upstream"),
             conn_id,
             Role::Initiator,
+            ManagerConfig::default(),
             NetworkMagic::for_testing(),
             StageRef::blackhole(),
             Arc::new(era_history.clone()),

--- a/crates/amaru-protocols/src/manager.rs
+++ b/crates/amaru-protocols/src/manager.rs
@@ -300,6 +300,7 @@ async fn start_connection_stage(
                 peer.clone(),
                 conn_id,
                 role,
+                manager.config,
                 manager.magic,
                 manager.chain_sync.clone(),
                 manager.era_history.clone(),

--- a/crates/amaru-protocols/src/tx_submission/tests/system_test.rs
+++ b/crates/amaru-protocols/src/tx_submission/tests/system_test.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::manager::ManagerConfig;
 use crate::{
     connection::{self, ConnectionMessage},
     network_effects::create_connection,
@@ -65,6 +66,7 @@ async fn test_tx_submission_with_node() -> anyhow::Result<()> {
             Peer::new("upstream"),
             conn_id,
             Role::Initiator,
+            ManagerConfig::default(),
             NetworkMagic::for_testing(),
             StageRef::blackhole(),
             Arc::new(era_history.clone()),

--- a/crates/amaru/src/stages/build_stage_graph.rs
+++ b/crates/amaru/src/stages/build_stage_graph.rs
@@ -84,7 +84,7 @@ pub fn build_stage_graph(
                 | StoreBlockFailed(_, _)
                 | RollbackBlockFailed(_, _) // this can failed if the block was not downloaded in the first place
                 | UnknownPeer(_) => {
-                    tracing::error!(%peer, %error, "validation error, this needs to be investigated");
+                    tracing::error!(%peer, %error, "validation error");
                 }
             }
             manager


### PR DESCRIPTION
This is a fix for https://github.com/pragma-org/amaru/issues/673.

If a `FetchBlock` message is received by the connection while a connection is not yet fully initialized, it will be re-scheduled after the connection timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection stability by scheduling delayed retries for block fetch requests received during initial connection and handshake, reducing premature failures during sync.

* **Chores**
  * Added a manager configuration parameter to connection initialization to support configurable retry behavior.

* **Tests**
  * Added tests and scaffolding validating rescheduled fetch behavior and the new configuration handling.

* **Style**
  * Minor log message wording clarified for validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->