### PR TITLE
fix: set the initiator_and_responder_diffusion mode as a responder

### DIFF
--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -181,7 +181,9 @@ async fn do_initialize(Params { conn_id, role, magic, .. }: &Params, eff: Effect
                 handshake::HandshakeResponder::new(
                     muxer.clone(),
                     handshake_result,
-                    VersionTable::v11_and_above(*magic, true),
+                    // Use initiator_only_diffusion_mode = false so downstream peers
+                    // know we can serve as chainsync/blockfetch server
+                    VersionTable::v11_and_above(*magic, false),
                 ),
             )
             .await


### PR DESCRIPTION
Without this fix a `cardano-node` can not connect to an `amaru` node upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tuned responder initialization to disable a specific version flag, improving compatibility so the node can serve downstream peers as chain-sync/block-fetch providers. This change is focused on connection protocol behavior and should not alter other runtime behavior or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->