### PR TITLE
fix: print a log message when receiving a header even if > tip

### DIFF
--- a/crates/amaru-consensus/src/stages/receive_header.rs
+++ b/crates/amaru-consensus/src/stages/receive_header.rs
@@ -70,7 +70,7 @@ pub fn stage(mut state: State, msg: ChainSyncEvent, eff: impl ConsensusOps) -> i
                 };
 
                 state.recv_count += 1;
-                if header.point() == tip.point() {
+                if header.point() >= tip.point() {
                     tracing::info!(%peer, point = %header.point(), "received header");
                 } else if state.recv_count & 0xff == 0 {
                     tracing::debug!(%peer, point = %header.point(), tip_point = %tip.point(), recv_count = %state.recv_count, "received header (catching up)");
@@ -110,7 +110,7 @@ pub fn stage(mut state: State, msg: ChainSyncEvent, eff: impl ConsensusOps) -> i
         }
         state
     }
-    .instrument(span)
+        .instrument(span)
 }
 
 #[trace(amaru::consensus::chain_sync::DECODE_HEADER)]


### PR DESCRIPTION
It seems that the cardano node can send us chainsync messages where the tip is strictly older than the sent header.
In this case we should still log a message saying that we received that header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ignore test data and temporary build artifacts for relay automation scripts.

* **Bug Fixes**
  * Enhanced header validation and synchronization logic to correctly process headers that match or exceed the current network tip point, with improved diagnostic tracing to better monitor catch-up scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->