### PR TITLE
test: deactivate the simulation execution for now

### DIFF
--- a/simulation/amaru-sim/src/bin/amaru-sim/main.rs
+++ b/simulation/amaru-sim/src/bin/amaru-sim/main.rs
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::process::exit;
-
-use amaru_sim::simulator::{Args, run_tests};
+use amaru_sim::simulator::Args;
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 
 fn main() {
-    let args = Args::parse();
+    let _args = Args::parse();
 
     // Initialize tracing subscriber with environment variable filter
     tracing_subscriber::fmt()
@@ -27,10 +25,12 @@ fn main() {
         .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
         .init();
 
+    // FIXME: fix the simulation termination. For now it is not reliable and might stop too soon.
+
     // It might be necessary to run the simulation with a larger stack with RUST_MIN_STACK=16777216 (16MB)
     // because of the deep recursion used when generating data for large chains.
-    if let Err(e) = run_tests(args) {
-        eprintln!("Error running tests: {e}");
-        exit(1);
-    }
+    // if let Err(e) = run_tests(args) {
+    //     eprintln!("Error running tests: {e}");
+    //     exit(1);
+    // }
 }


### PR DESCRIPTION
It's not reliably determining when the nodes should stop to run. We need to come back to this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled simulation test execution due to identified instability concerns in termination behavior, pending further improvements.

* **Chores**
  * Removed unused code imports and declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->