### PR TITLE
fix: chainsync responder

### DIFF
--- a/crates/amaru-consensus/src/headers_tree/data_generation/actions.rs
+++ b/crates/amaru-consensus/src/headers_tree/data_generation/actions.rs
@@ -342,6 +342,11 @@ impl GeneratedActions {
         self.tree.tree().value.clone()
     }
 
+    /// Return all the generated headers
+    pub fn get_headers(&self) -> Vec<BlockHeader> {
+        self.tree.tree().nodes()
+    }
+
     pub fn generated_tree(&self) -> &GeneratedTree {
         &self.tree
     }
@@ -352,6 +357,11 @@ impl GeneratedActions {
 
     pub fn actions_per_peer(&self) -> BTreeMap<Peer, Vec<Action>> {
         self.actions_per_peer.clone()
+    }
+
+    /// Return all the actions to be executed by a given peer
+    pub fn get_peer_actions(&self, peer: &Peer) -> Vec<Action> {
+        self.actions_per_peer.get(peer).into_iter().flatten().cloned().collect::<Vec<_>>()
     }
 
     /// Transpose the actions per peer to interleave them

--- a/crates/amaru-protocols/src/chainsync/responder.rs
+++ b/crates/amaru-protocols/src/chainsync/responder.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp::Reverse;
+use std::collections::{BTreeSet, VecDeque};
 
-use amaru_kernel::{BlockHeader, EraName, IsHeader, Peer, Point, Tip};
+use amaru_kernel::{BlockHeader, EraName, HeaderHash, IsHeader, Peer, Point, Tip};
 use amaru_ouroboros::{ConnectionId, ReadOnlyChainStore};
 use anyhow::{Context, ensure};
 use pure_stage::{DeserializerGuards, Effects, StageRef, Void};
@@ -48,10 +48,48 @@ pub enum ResponderMessage {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct ChainFragment {
+    rollback_to: Option<Point>,
+    forwards: VecDeque<Point>,
+}
+
+impl ChainFragment {
+    fn empty() -> Self {
+        Self { rollback_to: None, forwards: VecDeque::new() }
+    }
+
+    fn set_rollback_to(&mut self, rollback_to: Point) {
+        self.rollback_to = Some(rollback_to);
+    }
+
+    fn set_forward_points(&mut self, forwards: impl IntoIterator<Item = Point>) {
+        self.forwards = forwards.into_iter().collect();
+    }
+
+    fn extend_forwards(&mut self, points: Vec<Point>) {
+        let mut points: VecDeque<Point> = points.into();
+        self.forwards.append(&mut points)
+    }
+
+    fn take_rollback(&mut self) -> Option<Point> {
+        self.rollback_to.take()
+    }
+
+    fn pop_forward(&mut self) -> Option<Point> {
+        self.forwards.pop_front()
+    }
+
+    fn is_at(&self, pointer: Point) -> bool {
+        self.forwards.back() == Some(&pointer) || self.rollback_to == Some(pointer)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ChainSyncResponder {
     upstream: Tip,
     peer: Peer,
     pointer: Point,
+    fragment: ChainFragment,
     conn_id: ConnectionId,
     muxer: StageRef<MuxMessage>,
 }
@@ -63,7 +101,22 @@ impl ChainSyncResponder {
         conn_id: ConnectionId,
         muxer: StageRef<MuxMessage>,
     ) -> (ResponderState, Self) {
-        (ResponderState::Idle { send_rollback: false }, Self { upstream, peer, pointer: Point::Origin, conn_id, muxer })
+        (
+            ResponderState::Idle { send_rollback: false },
+            Self { upstream, peer, pointer: Point::Origin, fragment: ChainFragment::empty(), conn_id, muxer },
+        )
+    }
+
+    pub fn peer(&self) -> &Peer {
+        &self.peer
+    }
+
+    pub fn pointer(&self) -> &Point {
+        &self.pointer
+    }
+
+    pub fn upstream(&self) -> &Tip {
+        &self.upstream
     }
 }
 
@@ -80,8 +133,8 @@ impl StageState<ResponderState, Responder> for ChainSyncResponder {
             ResponderMessage::NewTip(tip) => {
                 tracing::trace!(%tip, "New tip");
                 self.upstream = tip;
-                let action = next_header(*proto, &mut self.pointer, &Store::new(eff.clone()), self.upstream)
-                    .context("failed to get next header")?;
+                let store = Store::new(eff.clone());
+                let action = next_action(&mut self, &store, *proto)?;
                 Ok((action, self))
             }
         }
@@ -100,12 +153,13 @@ impl StageState<ResponderState, Responder> for ChainSyncResponder {
                     .context("failed to find intersection")?;
                 if let ResponderAction::IntersectFound(point, _tip) = &action {
                     self.pointer = *point;
+                    self.fragment = ChainFragment::empty();
                 }
                 Ok((Some(action), self))
             }
             ResponderResult::RequestNext => {
-                let action = next_header(*proto, &mut self.pointer, &Store::new(eff.clone()), self.upstream)
-                    .context("failed to get next header")?;
+                let action =
+                    next_action(&mut self, &Store::new(eff.clone()), *proto).context("failed to get next action")?;
                 Ok((action, self))
             }
             ResponderResult::Done => {
@@ -120,63 +174,286 @@ impl StageState<ResponderState, Responder> for ChainSyncResponder {
     }
 }
 
-fn next_header(
-    state: ResponderState,
-    pointer: &mut Point,
+fn next_action(
+    responder: &mut ChainSyncResponder,
     store: &dyn ReadOnlyChainStore<BlockHeader>,
-    tip: Tip,
+    state: ResponderState,
 ) -> anyhow::Result<Option<ResponderAction>> {
+    tracing::trace!(peer = %responder.peer(), pointer = %responder.pointer(), tip = %responder.upstream.point(), "computing the next header to return");
     match state {
         ResponderState::CanAwait { send_rollback: true } => {
-            return Ok(Some(ResponderAction::RollBackward(*pointer, tip)));
+            tracing::trace!(point = %responder.pointer, tip = %responder.upstream.point(), "emit rollback header after intersect");
+            return Ok(Some(ResponderAction::RollBackward(responder.pointer, responder.upstream)));
         }
         ResponderState::MustReply | ResponderState::CanAwait { .. } => {}
         ResponderState::Idle { .. } | ResponderState::Intersect | ResponderState::Done => {
             return Ok(None);
         }
     };
-    if *pointer == tip.point() {
+
+    // The peer has now caught up
+    if responder.pointer == responder.upstream.point() {
+        tracing::trace!(peer = %responder.peer(), pointer = %responder.pointer(), tip = %responder.upstream.point(), "peer caught-up");
         return Ok((matches!(state, ResponderState::CanAwait { .. })).then_some(ResponderAction::AwaitReply));
     }
 
-    if store.load_from_best_chain(pointer).is_none() {
-        // client is on a different fork, we need to roll backward
-        let header = store.load_header(&pointer.hash()).ok_or_else(|| anyhow::anyhow!("remote pointer not found"))?;
-        for header in store.ancestors(header) {
-            if store.load_from_best_chain(&header.point()).is_some() {
-                *pointer = header.point();
-                return Ok(Some(ResponderAction::RollBackward(header.point(), tip)));
-            }
-        }
-        anyhow::bail!("no overlap found between client pointer chain and stored best chain");
+    // The peer has not yet caught up.
+    // If its pointer is before the current anchor then we can serve headers directly from the immutable best chain
+    if let Some(action) = next_action_from_immutable_best_chain(responder, store)? {
+        return Ok(Some(action));
     }
-    // pointer is on the best chain, we need to roll forward
-    let Some(point) = store.next_best_chain(pointer) else {
+
+    // The peer has not yet caught up, and its pointer is after the anchor.
+    // We compute a chain fragment that is a snapshot of the best chain from 'pointer' to 'upstream'
+    // if not already computed and return headers from it.
+    // We need to keep track of that chain fragment because in between 2 initiator requests we could
+    // have switched to another best chain and we need to remember which chain we were following to
+    // provide a rollback point.
+    next_action_from_chain_fragment(responder, store)
+}
+
+/// Return the next action from the immutable best chain
+/// if the peer pointer is before the best chain anchor. Following points with `next_best_chain`
+/// is safe there since those points can not change.
+fn next_action_from_immutable_best_chain(
+    responder: &mut ChainSyncResponder,
+    store: &dyn ReadOnlyChainStore<BlockHeader>,
+) -> anyhow::Result<Option<ResponderAction>> {
+    let anchor_hash = store.get_anchor_hash();
+    let anchor_point = get_header(store, &anchor_hash).point();
+    if responder.pointer.slot_or_default() < anchor_point.slot_or_default() {
+        #[expect(clippy::expect_used)]
+        let point = store
+            .next_best_chain(&responder.pointer)
+            .expect("the pointer is on the best chain, before the anchor, there must be a next point on that chain");
+
+        let header = get_header(store, &point.hash());
+        tracing::trace!(
+            peer = %responder.peer(),
+            pointer = %point,
+            anchor = %anchor_point,
+            tip = %responder.upstream.point(),
+            "emit forward header while streaming towards anchor"
+        );
+        responder.pointer = point;
+        Ok(Some(ResponderAction::RollForward(HeaderContent::new(&header, EraName::Conway), responder.upstream)))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Return the next action from a computed ChainFragment.
+/// Recompute or extend the current chain fragment if necessary (the tip might have moved).
+fn next_action_from_chain_fragment(
+    responder: &mut ChainSyncResponder,
+    store: &dyn ReadOnlyChainStore<BlockHeader>,
+) -> anyhow::Result<Option<ResponderAction>> {
+    if responder.pointer == responder.upstream.point() {
         return Ok(None);
+    }
+
+    update_chain_fragment(responder, store)?;
+
+    // Return a rollback point if the peer must first rollback
+    if let Some(point) = responder.fragment.take_rollback() {
+        responder.pointer = point;
+        tracing::trace!(
+            peer = %responder.peer(),
+            pointer = %point,
+            tip = %responder.upstream.point(),
+            "emit rollback header"
+        );
+        return Ok(Some(ResponderAction::RollBackward(point, responder.upstream)));
+    }
+
+    // Otherwise return a forward header
+    if let Some(point) = responder.fragment.pop_forward() {
+        let header = get_header(store, &point.hash());
+        responder.pointer = point;
+        tracing::trace!(
+            peer = %responder.peer(),
+            pointer = %point,
+            tip = %responder.upstream.point(),
+            "emit forward header"
+        );
+        Ok(Some(ResponderAction::RollForward(HeaderContent::new(&header, EraName::Conway), responder.upstream)))
+    } else {
+        Err(anyhow::anyhow!("there should be at least one action to return"))
+    }
+}
+
+/// Update the chain fragment that describes the list of headers to return for going from 'pointer'
+/// to 'upstream'. This might just extend the existing fragment with new 'forwards' points if there are
+/// new tips on the same best chain.
+fn update_chain_fragment(
+    responder: &mut ChainSyncResponder,
+    store: &dyn ReadOnlyChainStore<BlockHeader>,
+) -> Result<(), amaru_ouroboros::StoreError> {
+    // Early exit if there's nothing to do
+    if responder.pointer == responder.upstream.point() {
+        responder.fragment = ChainFragment::empty();
+        return Ok(());
+    }
+
+    let mut from_visited: BTreeSet<Point> = BTreeSet::new();
+    let mut to_visited: BTreeSet<Point> = BTreeSet::new();
+
+    from_visited.insert(responder.pointer);
+    to_visited.insert(responder.upstream.point());
+
+    let mut from_current = responder.pointer;
+    let mut to_current = responder.upstream.point();
+    let mut to_ancestors = vec![to_current];
+
+    // We visit ancestors of from and to, until there's an intersection point
+    let intersection_point = loop {
+        let parent = get_parent_point(store, to_current)?;
+        to_current = parent;
+
+        // If the new responder.upstream tip extends the current fragment target, extend it with the new
+        // points that can reach it.
+        if responder.fragment.is_at(to_current) {
+            // ancestors have been accumulated from tip to target,
+            // we need to reverse them to extend the fragment forwards from the target
+            to_ancestors.reverse();
+            responder.fragment.extend_forwards(to_ancestors);
+            return Ok(());
+        }
+
+        // Otherwise we continue iterating on ancestors for 'to' and 'from'
+        to_ancestors.push(to_current);
+        to_visited.insert(to_current);
+
+        if from_visited.contains(&to_current) {
+            break to_current;
+        }
+
+        let parent = get_parent_point(store, from_current)?;
+        from_current = parent;
+        from_visited.insert(from_current);
+
+        if to_visited.contains(&from_current) {
+            break from_current;
+        }
     };
-    let header =
-        store.load_header(&point.hash()).ok_or_else(|| anyhow::anyhow!("best-chain header not found: {}", point))?;
-    *pointer = point;
-    Ok(Some(ResponderAction::RollForward(HeaderContent::new(&header, EraName::Conway), tip)))
+
+    if let Some(rollback_to) = (intersection_point != responder.pointer).then_some(intersection_point) {
+        responder.fragment.set_rollback_to(rollback_to);
+    }
+    let intersection_index = to_ancestors.iter().position(|p| *p == intersection_point).unwrap_or(to_ancestors.len());
+    let forwards: VecDeque<Point> = to_ancestors[..intersection_index].iter().rev().copied().collect();
+
+    responder.fragment.set_forward_points(forwards);
+    Ok(())
 }
 
 fn intersect(
-    mut points: Vec<Point>,
+    points: Vec<Point>,
     store: &dyn ReadOnlyChainStore<BlockHeader>,
     tip: Tip,
 ) -> anyhow::Result<ResponderAction> {
+    Ok(match best_chain_intersection(store, &points)? {
+        Some(point) => ResponderAction::IntersectFound(point, tip),
+        None => ResponderAction::IntersectNotFound(tip),
+    })
+}
+
+/// Find the most recent point that intersects the node best chain.
+/// Since the best chain might be changing while we perform this search, we split the search by splitting
+/// the input points into two categories:
+///
+///  - Points that are above the current anchor.
+///  - And points that are at or before the current anchor.
+///
+/// 1. For the points above the anchor, we take a snapshot of the best chain tip and try to
+///    find if one of the points is part of the tip ancestors => this is an intersection point.
+///    Since iterating over the tip ancestors could be costly, we first try to see if one of the
+///    points could be part of the current best chain by using the `load_from_best_chain` function.
+///    If the best chain didn't change too much, this is a faster way to find an intersection point.
+///
+/// 2. For the points below the anchor, we can directly use `load_from_best_chain` to check if one
+///    of the points is part of the best chain since those points are immutable.
+///
+fn best_chain_intersection(
+    store: &dyn ReadOnlyChainStore<BlockHeader>,
+    points: &[Point],
+) -> Result<Option<Point>, amaru_ouroboros::StoreError> {
     if points.is_empty() {
-        return Ok(ResponderAction::IntersectNotFound(tip));
+        return Ok(None);
     }
 
-    points.sort_by_key(|p| Reverse(*p));
+    let anchor_hash = store.get_anchor_hash();
+    let anchor_point = get_header(store, &anchor_hash).point();
+    let best_tip = store.get_best_chain_hash();
+    let mut requested_origin = false;
 
-    for point in &points {
-        if store.load_from_best_chain(point).is_some() {
-            return Ok(ResponderAction::IntersectFound(*point, tip));
+    let mut candidates: Vec<Point> = points.to_vec();
+    candidates.sort_by_key(|point| std::cmp::Reverse(*point));
+    candidates.dedup();
+
+    let mut above_anchor = Vec::new();
+    let mut at_or_before_anchor = Vec::new();
+    for point in candidates {
+        if point == Point::Origin {
+            requested_origin = true;
+        } else if point.slot_or_default() > anchor_point.slot_or_default() {
+            above_anchor.push(point);
+        } else {
+            at_or_before_anchor.push(point);
         }
     }
-    Ok(ResponderAction::IntersectNotFound(tip))
+
+    for point in &above_anchor {
+        if store.load_from_best_chain(point).is_some() {
+            return Ok(Some(*point));
+        }
+    }
+
+    let above_anchor: BTreeSet<Point> = above_anchor.into_iter().collect();
+
+    for hash in store.ancestors_hashes(&best_tip) {
+        let point = get_header(store, &hash).point();
+        if point.slot_or_default() <= anchor_point.slot_or_default() {
+            break;
+        }
+        if above_anchor.contains(&point) {
+            return Ok(Some(point));
+        }
+    }
+
+    for point in at_or_before_anchor {
+        if store.load_from_best_chain(&point).is_some() {
+            return Ok(Some(point));
+        }
+    }
+
+    if requested_origin {
+        return Ok(Some(Point::Origin));
+    }
+
+    Ok(None)
+}
+
+/// Return the header for a given header hash when the header is expected to exist in the store.
+#[expect(clippy::expect_used)]
+fn get_header(store: &dyn ReadOnlyChainStore<BlockHeader>, hash: &HeaderHash) -> BlockHeader {
+    store.load_header(hash).expect("cannot load header")
+}
+
+/// Return the point correponding to a parent header
+fn get_parent_point(
+    store: &dyn ReadOnlyChainStore<BlockHeader>,
+    point: Point,
+) -> Result<Point, amaru_ouroboros::StoreError> {
+    if point == Point::Origin {
+        return Ok(Point::Origin);
+    }
+
+    let header = get_header(store, &point.hash());
+    match header.parent() {
+        Some(parent_hash) => Ok(store.load_header(&parent_hash).map(|parent| parent.point()).unwrap_or(Point::Origin)),
+        None => Ok(Point::Origin),
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -273,8 +550,10 @@ impl ProtocolState<Responder> for ResponderState {
 mod tests {
     use std::sync::Arc;
 
-    use amaru_kernel::{BlockHeader, Hash, Slot, make_header, size::HEADER};
-    use amaru_ouroboros_traits::{ChainStore, in_memory_consensus_store::InMemConsensusStore};
+    use amaru_kernel::{BlockHeader, Hash, IsHeader, Slot, from_cbor, make_header, size::HEADER};
+    use amaru_ouroboros_traits::{
+        ChainStore, in_memory_consensus_store::InMemConsensusStore, overriding_consensus_store::OverridingChainStore,
+    };
 
     use super::*;
     use crate::{chainsync::initiator::InitiatorState, protocol::ProtoSpec};
@@ -283,7 +562,6 @@ mod tests {
     fn intersect_finds_point_on_best_chain() {
         let (store, points) = build_chain_store(10, 0);
         let tip = make_tip(&points);
-
         let result = intersect(vec![points[5]], store.as_ref(), tip).unwrap();
         assert_eq!(result, ResponderAction::IntersectFound(points[5], tip));
     }
@@ -325,6 +603,175 @@ mod tests {
         let unknown = Point::Specific(Slot::from(999), Hash::new([0xff; HEADER]));
         let result = intersect(vec![unknown], store.as_ref(), tip).unwrap();
         assert_eq!(result, ResponderAction::IntersectNotFound(tip));
+    }
+
+    #[test]
+    fn best_chain_intersection_returns_origin_when_requested() {
+        let (store, _points) = build_chain_store(10, 0);
+
+        let result = best_chain_intersection(store.as_ref(), &[Point::Origin]).unwrap();
+
+        assert_eq!(result, Some(Point::Origin));
+    }
+
+    #[test]
+    fn best_chain_intersection_prefers_newer_match_over_origin() {
+        let (store, points) = build_chain_store(10, 0);
+
+        let result = best_chain_intersection(store.as_ref(), &[Point::Origin, points[7]]).unwrap();
+
+        assert_eq!(result, Some(points[7]));
+    }
+
+    #[test]
+    fn best_chain_intersection_falls_back_to_snapshotted_tip_scan_above_anchor() {
+        let (store, points) = build_chain_store(10, 5);
+        let anchor_slot = points[5].slot_or_default();
+        let store: Arc<dyn ChainStore<BlockHeader>> = store;
+        let overridden = OverridingChainStore::builder(store)
+            .with_load_from_best_chain(move |inner, point| {
+                if point.slot_or_default() > anchor_slot { None } else { inner.load_from_best_chain(point) }
+            })
+            .build();
+
+        let result = best_chain_intersection(&overridden, &[points[7]]).unwrap();
+
+        assert_eq!(result, Some(points[7]));
+    }
+
+    #[test]
+    fn best_chain_intersection_falls_back_to_pre_anchor_lookup_when_tip_scan_misses() {
+        let (store, points) = build_chain_store(10, 5);
+        let anchor_slot = points[5].slot_or_default();
+        let store: Arc<dyn ChainStore<BlockHeader>> = store;
+        let overridden = OverridingChainStore::builder(store)
+            .with_load_from_best_chain(move |inner, point| {
+                if point.slot_or_default() > anchor_slot { None } else { inner.load_from_best_chain(point) }
+            })
+            .build();
+
+        let unknown = Point::Specific(Slot::from(999), Hash::new([0xff; HEADER]));
+        let result = best_chain_intersection(&overridden, &[unknown, points[2]]).unwrap();
+
+        assert_eq!(result, Some(points[2]));
+    }
+
+    #[test]
+    fn update_chain_fragment_when_peer_is_at_tip_clears_the_fragment() {
+        let (store, points) = build_chain_store(4, 0);
+        let mut responder = make_responder(Tip::new(points[1], 0.into()));
+        responder.pointer = points[1];
+
+        update_chain_fragment(&mut responder, store.as_ref()).unwrap();
+
+        assert_eq!(responder.fragment, ChainFragment::empty());
+    }
+
+    #[test]
+    fn update_chain_fragment_from_anchor() {
+        let (store, points) = build_chain_store(3, 0);
+        let mut responder = make_responder(make_tip(&points));
+
+        update_chain_fragment(&mut responder, store.as_ref()).unwrap();
+        let mut expected = ChainFragment::empty();
+        expected.set_forward_points(vec![points[0], points[1], points[2]]);
+        assert_eq!(responder.fragment, expected);
+    }
+
+    #[test]
+    fn update_chain_fragment_when_forward_points_are_extended() {
+        let (store, points) = build_chain_store(4, 0);
+        let mut responder = make_responder(make_tip(&points));
+        // The peer starts at 1, it needs 2 and 3 to get to the tip
+        responder.pointer = points[1];
+
+        update_chain_fragment(&mut responder, store.as_ref()).unwrap();
+
+        let mut expected = ChainFragment::empty();
+        expected.set_forward_points(vec![points[2], points[3]]);
+        assert_eq!(responder.fragment, expected);
+    }
+
+    #[test]
+    fn update_chain_fragment_rollback_on_same_chain() {
+        let (store, points) = build_chain_store(4, 0);
+        let mut responder = make_responder(Tip::new(points[1], 0.into()));
+        responder.pointer = points[3];
+
+        update_chain_fragment(&mut responder, store.as_ref()).unwrap();
+
+        let mut expected = ChainFragment::empty();
+        expected.set_rollback_to(points[1]);
+        assert_eq!(responder.fragment, expected);
+    }
+
+    #[test]
+    fn next_action_streams_incrementally_from_origin_to_anchor() {
+        // We stream the first point of the chain if the intersection is at origin
+        // 0 ---- 5 ----- 10
+        // ^      ^        ^
+        // peer  anchor   tip
+
+        let (store, points) = build_chain_store(10, 5);
+        let tip = make_tip(&points);
+        let mut responder = make_responder(tip);
+
+        let action = next_action(&mut responder, store.as_ref(), ResponderState::MustReply).unwrap().unwrap();
+
+        assert_eq!(responder.pointer, points[0]);
+        assert_eq!(responder.fragment, ChainFragment::empty());
+        assert_is_rollforward(&action, points[0], tip);
+    }
+
+    #[test]
+    fn next_action_streams_incrementally_before_anchor() {
+        // Before
+        // 0 ---- 2 --- 5 ----- 10
+        //        ^     ^        ^
+        //      peer  anchor   tip
+        let (store, points) = build_chain_store(10, 5);
+        let tip = make_tip(&points);
+        let mut responder = make_responder(tip);
+        responder.pointer = points[2];
+
+        let action = next_action(&mut responder, store.as_ref(), ResponderState::MustReply).unwrap().unwrap();
+
+        // After
+        // 0 ---- 2 - 3 --- 5 ----- 10
+        //            ^     ^        ^
+        //           peer  anchor   tip
+        assert_eq!(responder.pointer, points[3]);
+        // no need to store a chain fragment because we are streaming the immutable part of the best chain
+        assert_eq!(responder.fragment, ChainFragment::empty());
+        assert_is_rollforward(&action, points[3], tip);
+    }
+
+    #[test]
+    fn next_action_switches_to_fragment_at_anchor() {
+        // Before
+        // 0 ---- 2 --- 5 ----- 10
+        //              ^       ^
+        //            anchor    tip
+        //            peer
+        let (store, points) = build_chain_store(10, 5);
+        let tip = make_tip(&points);
+        let mut responder = make_responder(tip);
+        responder.pointer = points[5];
+
+        let action = next_action(&mut responder, store.as_ref(), ResponderState::MustReply).unwrap().unwrap();
+
+        // After
+        // 0 ---- 2 --- 5 -- 6 ---- 10
+        //              ^    ^       ^
+        //            anchor |      tip
+        //                  peer
+        assert_eq!(responder.pointer, points[6]);
+
+        let mut expected = ChainFragment::empty();
+        // We will send all the headers to the tip even if it has moved in the meantime in the database
+        expected.set_forward_points(vec![points[7], points[8], points[9]]);
+        assert_eq!(responder.fragment, expected);
+        assert_is_rollforward(&action, points[6], tip);
     }
 
     #[expect(clippy::wildcard_enum_match_arm)]
@@ -387,15 +834,15 @@ mod tests {
         let mut points = Vec::new();
         let mut prev_hash = None;
 
-        for slot in 0..n {
+        for slot in 1..=n {
             let header_raw = make_header(slot, slot, prev_hash);
             let hash = Hash::new([slot as u8; HEADER]);
             let header = BlockHeader::new(header_raw, hash);
             store.store_header(&header).unwrap();
-            let point = Point::Specific(Slot::from(slot), hash);
+            let point = header.point();
             store.roll_forward_chain(&point).unwrap();
             points.push(point);
-            prev_hash = Some(hash);
+            prev_hash = Some(header.hash());
         }
 
         store.set_anchor_hash(&points[anchor_index as usize].hash()).unwrap();
@@ -406,5 +853,26 @@ mod tests {
     fn make_tip(points: &[Point]) -> Tip {
         let last = points.last().unwrap();
         Tip::new(*last, 0.into())
+    }
+
+    fn make_responder(upstream: Tip) -> ChainSyncResponder {
+        ChainSyncResponder {
+            upstream,
+            peer: Peer::new("peer"),
+            pointer: Point::Origin,
+            fragment: ChainFragment::empty(),
+            conn_id: ConnectionId::initial(),
+            muxer: StageRef::named_for_tests("muxer"),
+        }
+    }
+
+    fn assert_is_rollforward(action: &ResponderAction, expected: Point, expected_tip: Tip) {
+        if let ResponderAction::RollForward(content, tip) = action {
+            assert_eq!(*tip, expected_tip);
+            let header: BlockHeader = from_cbor(&content.cbor).expect("should decode roll-forward header");
+            assert_eq!(header.point().slot_or_default(), expected.slot_or_default());
+        } else {
+            panic!("expected RollForward, got {action:?}");
+        }
     }
 }

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -28,7 +28,10 @@ use crate::{
     keepalive::register_keepalive,
     manager::ManagerConfig,
     mux::{self, HandlerMessage, MuxMessage},
-    protocol::{Inputs, PROTO_HANDSHAKE, Role},
+    protocol::{
+        Inputs, PROTO_HANDSHAKE, PROTO_N2N_BLOCK_FETCH, PROTO_N2N_CHAIN_SYNC, PROTO_N2N_KEEP_ALIVE, PROTO_N2N_TX_SUB,
+        Role,
+    },
     protocol_messages::{
         handshake::HandshakeResult, version_data::VersionData, version_number::VersionNumber,
         version_table::VersionTable,
@@ -163,8 +166,16 @@ pub async fn stage(
 }
 
 async fn do_initialize(Params { conn_id, role, magic, .. }: &Params, eff: Effects<ConnectionMessage>) -> State {
+    let buffered_protocols = [
+        (PROTO_HANDSHAKE.for_role(*role), 5760),
+        (PROTO_N2N_KEEP_ALIVE.for_role(*role), 65535),
+        (PROTO_N2N_TX_SUB.for_role(*role), 2_500_000),
+        (PROTO_N2N_CHAIN_SYNC.for_role(*role), 5760),
+        (PROTO_N2N_BLOCK_FETCH.for_role(*role), 2_500_000),
+    ];
+
     let muxer = eff.stage("mux", mux::stage).await;
-    let muxer = eff.wire_up(muxer, mux::State::new(*conn_id, &[(PROTO_HANDSHAKE.erase(), 5760)], *role)).await;
+    let muxer = eff.wire_up(muxer, mux::State::new(*conn_id, &buffered_protocols, *role)).await;
 
     let handshake_result = eff.contramap(eff.me(), "handshake_result", ConnectionMessage::Handshake).await;
 

--- a/crates/amaru/src/tests/node.rs
+++ b/crates/amaru/src/tests/node.rs
@@ -23,7 +23,7 @@ use amaru_protocols::{manager::ManagerMessage, mux::HandlerMessage, protocol::PR
 use futures_util::FutureExt;
 use parking_lot::Mutex;
 use pure_stage::{
-    Effect, Resources, StageGraphRunning, StageRef,
+    Effect, Instant, Resources, StageGraphRunning, StageRef,
     simulation::{Blocked, SimulationRunning},
     trace_buffer::TraceBuffer,
 };
@@ -185,13 +185,24 @@ impl Node {
     }
 
     /// Return true if the node still has pending actions to enqueue.
-    pub fn has_pending_actions(&self) -> bool {
-        !self.pending_actions.is_empty()
+    /// or enqueued actions in the actions_stage mailbox.
+    pub fn has_waiting_actions(&self) -> bool {
+        !self.pending_actions.is_empty() || self.running.mailbox_len(&self.actions_stage) > 0
     }
 
     /// Return true if the node still has runnable effects.
     pub fn has_runnable_effects(&self) -> bool {
         self.running.has_runnable()
+    }
+
+    /// Return the next wakeup time for this node, if any.
+    pub fn next_wakeup(&self) -> Option<Instant> {
+        self.running.next_wakeup()
+    }
+
+    /// Advance this node to the given wakeup time and wake any tasks scheduled for it.
+    pub fn advance_to_wakeup(&mut self, at: Instant) -> bool {
+        self.running.skip_to_next_wakeup(Some(at))
     }
 
     /// Return true for the node under test

--- a/crates/amaru/src/tests/nodes.rs
+++ b/crates/amaru/src/tests/nodes.rs
@@ -15,7 +15,7 @@
 use std::collections::BTreeSet;
 
 use anyhow::anyhow;
-use pure_stage::{Effect, Name, Resources, simulation::RandStdRng, trace_buffer::TraceEntry};
+use pure_stage::{Resources, simulation::RandStdRng, trace_buffer::TraceEntry};
 
 use crate::tests::node::Node;
 

--- a/crates/amaru/src/tests/nodes.rs
+++ b/crates/amaru/src/tests/nodes.rs
@@ -15,7 +15,7 @@
 use std::collections::BTreeSet;
 
 use anyhow::anyhow;
-use pure_stage::{Resources, simulation::RandStdRng};
+use pure_stage::{Effect, Name, Resources, simulation::RandStdRng, trace_buffer::TraceEntry};
 
 use crate::tests::node::Node;
 
@@ -114,7 +114,7 @@ impl Nodes {
                 node.advance_inputs();
             }
 
-            if self.nodes.iter().all(|n| !n.has_pending_actions()) {
+            if self.nodes.iter().all(|n| !n.has_waiting_actions()) {
                 tracing::info!("All actions consumed at step {step}, entering drain phase");
                 break;
             }
@@ -132,27 +132,76 @@ impl Nodes {
 
     /// Drain remaining effects after all actions have been consumed.
     ///
-    /// Runs effects identically to Phase 1 but without
-    ///  - Time advancement for sleeping nodes (since we want to avoid keep-alive make the system run forever).
-    ///  - Enqueueing new actions (since everything has been enqueued before).
+    /// Runs effects identically to Phase 1 but without enqueueing new actions.
     ///
-    /// Stops when no node has any effects to run.
+    /// Stops when the system reaches a fixed point: all nodes are quiescent, we advance
+    /// to the earliest global wakeup, and the system becomes quiescent again without any
+    /// runnable work in between. This lets delayed retries run while still terminating
+    /// once only background wait/sleep activity remains.
     ///
     fn drain(&mut self, rng: &mut RandStdRng) {
         // Bound the drain loop in case it does not terminate
         let max_drain_steps = 1_000_000;
+        // This keeps track of the nodes trace buffers lengths in order
+        // to examine only new trace entries since the last wake-up and check if only
+        // transport activity was performed.
+        let mut trace_marks: Option<Vec<usize>> = None;
         for step in 0..max_drain_steps {
             for node in self.nodes.iter_mut() {
                 node.advance_inputs();
             }
 
-            let Some(node) = self.pick_random_runnable_node(rng) else {
-                tracing::info!("drain[{step}]: all nodes terminated or have no effects to run");
+            if let Some(node) = self.pick_random_runnable_node(rng) {
+                node.run_effect();
+                continue;
+            }
+
+            if let Some(marks) = trace_marks.take() {
+                if self.only_transport_activity_since(&marks) {
+                    tracing::info!("drain[{step}]: only transport activity after wakeup cycle");
+                    return;
+                } else {
+                    tracing::info!("drain[{step}]: non-transport activity detected, continuing");
+                    continue;
+                }
+            }
+
+            let Some(next_wakeup) = self.next_global_wakeup() else {
+                tracing::info!("drain[{step}]: quiescent");
                 return;
             };
-            node.run_effect();
+
+            trace_marks = Some(self.trace_lengths());
+
+            let mut woke_any = false;
+            for node in self.nodes.iter_mut().filter(|node| !node.is_terminated()) {
+                woke_any |= node.advance_to_wakeup(next_wakeup);
+            }
+
+            if !woke_any {
+                tracing::info!("drain[{step}]: no work after advancing to next wakeup");
+                return;
+            }
         }
         tracing::info!("Drain phase completed after {max_drain_steps} steps");
+    }
+
+    fn trace_lengths(&self) -> Vec<usize> {
+        self.nodes.iter().map(|node| node.trace_buffer().lock().len()).collect()
+    }
+
+    fn next_global_wakeup(&self) -> Option<pure_stage::Instant> {
+        self.nodes.iter().filter(|node| !node.is_terminated()).filter_map(Node::next_wakeup).min()
+    }
+
+    fn only_transport_activity_since(&self, marks: &[usize]) -> bool {
+        self.nodes.iter().zip(marks).all(|(node, mark)| {
+            node.trace_buffer()
+                .lock()
+                .iter_entries()
+                .skip(*mark)
+                .all(|(_, entry)| trace_entry_is_transport_activity(&entry))
+        })
     }
 
     pub fn get_node_under_test(&mut self) -> anyhow::Result<&mut Node> {
@@ -190,4 +239,14 @@ impl Nodes {
         let idx = indices[rng.random_range(0..indices.len())];
         Some(&mut self.nodes[idx])
     }
+}
+
+/// Return true if a trace entry represents some transport activity
+/// (e.g. sending/receiving messages, scheduling keeepalive timer) rather than internal computation.
+fn trace_entry_is_transport_activity(entry: &TraceEntry) -> bool {
+    let Some(name) = entry.name() else {
+        return true;
+    };
+    let prefix = name.as_str().split('-').next().unwrap_or(name.as_str());
+    matches!(prefix, "keepalive" | "mux" | "reader" | "writer")
 }

--- a/crates/amaru/src/tests/setup.rs
+++ b/crates/amaru/src/tests/setup.rs
@@ -18,7 +18,9 @@ use amaru_consensus::{
     effects::{ResourceBlockValidation, ResourceHeaderValidation},
     headers_tree::data_generation::Action,
 };
-use amaru_kernel::{BlockHeight, GlobalParameters, IsHeader, Tip, Transaction};
+use amaru_kernel::{
+    BlockHeight, EraHistory, GlobalParameters, IsHeader, Tip, Transaction, cardano::network_block::make_encoded_block,
+};
 use amaru_ouroboros::{
     ChainStore, ConnectionsResource, ResourceMempool,
     can_validate_blocks::mock::{MockCanValidateBlocks, MockCanValidateHeaders},
@@ -86,7 +88,8 @@ pub fn create_node(
     // The actions stage allows us to send NewTip messages to the manager so that chainsync
     // events can be sent to the node under test.
     let actions_stage = stage_graph.stage("actions", actions_stage);
-    let actions_stage = stage_graph.wire_up(actions_stage, (manager_stage.clone(), node_config.seed));
+    let actions_stage = stage_graph
+        .wire_up(actions_stage, (manager_stage.clone(), node_config.seed, node_config.era_history().clone()));
 
     set_resources(node_config, stage_graph)?;
     Ok((manager_stage, actions_stage.without_state()))
@@ -112,7 +115,7 @@ pub fn start_initiator(
     Ok(())
 }
 
-type ActionsState = (StageRef<ManagerMessage>, u64);
+type ActionsState = (StageRef<ManagerMessage>, u64, EraHistory);
 
 /// Create an "actions" stage to send NewTip messages to the Manager, and eventually to the node
 /// under test.
@@ -122,7 +125,7 @@ type ActionsState = (StageRef<ManagerMessage>, u64);
 /// from the ChainStore.
 ///
 async fn actions_stage(state: ActionsState, msg: Action, eff: Effects<Action>) -> ActionsState {
-    let (manager_stage, seed) = &state;
+    let (manager_stage, seed, era_history) = &state;
     tracing::info!("Received action: {msg:?}");
     let store = Store::new(eff.clone());
     let tip = match &msg {
@@ -132,6 +135,12 @@ async fn actions_stage(state: ActionsState, msg: Action, eff: Effects<Action>) -
                 .store_header(header)
                 .or_terminate(&eff, |e| async move {
                     tracing::error!("Cannot store the header {}: {e:?}. The seed is {seed}", &header);
+                })
+                .await;
+            store
+                .store_block(&header.hash(), &make_encoded_block(header, era_history))
+                .or_terminate(&eff, |e| async move {
+                    tracing::error!("Cannot store the block for header {}: {e:?}. The seed is {seed}", &header);
                 })
                 .await;
             store

--- a/crates/pure-stage/src/effect.rs
+++ b/crates/pure-stage/src/effect.rs
@@ -883,6 +883,22 @@ impl Effect {
             }),
         }
     }
+
+    pub fn name(&self) -> Name {
+        match self {
+            Effect::Receive { at_stage }
+            | Effect::Clock { at_stage }
+            | Effect::Wait { at_stage, .. }
+            | Effect::Schedule { at_stage, .. }
+            | Effect::CancelSchedule { at_stage, .. }
+            | Effect::External { at_stage, .. }
+            | Effect::Terminate { at_stage }
+            | Effect::AddStage { at_stage, .. }
+            | Effect::WireStage { at_stage, .. }
+            | Effect::Contramap { at_stage, .. } => at_stage.clone(),
+            Effect::Send { from, .. } | Effect::Call { from, .. } => from.clone(),
+        }
+    }
 }
 
 impl Display for Effect {

--- a/crates/pure-stage/src/trace_buffer.rs
+++ b/crates/pure-stage/src/trace_buffer.rs
@@ -78,6 +78,19 @@ pub enum TraceEntry {
     },
 }
 
+impl TraceEntry {
+    pub fn name(&self) -> Option<Name> {
+        match self {
+            TraceEntry::Resume { stage, .. }
+            | TraceEntry::Input { stage, .. }
+            | TraceEntry::State { stage, .. }
+            | TraceEntry::Terminated { stage, .. } => Some(stage.clone()),
+            TraceEntry::Suspend(effect) => Some(effect.name()),
+            TraceEntry::Clock(_) => None,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum TerminationReason {
     Voluntary,

--- a/simulation/amaru-sim/src/simulator/report.rs
+++ b/simulation/amaru-sim/src/simulator/report.rs
@@ -83,8 +83,10 @@ pub fn persist_args(dir: &Path, args: &Args, persist: bool) -> Result<(), anyhow
 
 /// Create a symlink to a directory
 pub fn create_symlink_dir(target: &Path, link: &Path) {
-    // Clean up existing link or directory first
-    if link.exists() {
+    // Clean up existing link or directory first.
+    // Use symlink_metadata instead of exists() because exists() follows symlinks
+    // and returns false for dangling symlinks, leaving them uncleaned.
+    if link.symlink_metadata().is_ok() {
         std::fs::remove_file(link).or_else(|_| std::fs::remove_dir_all(link)).ok();
     }
 
@@ -92,12 +94,21 @@ pub fn create_symlink_dir(target: &Path, link: &Path) {
     #[cfg(unix)]
     {
         use std::os::unix::fs::symlink;
-        symlink(&abs_target, link).unwrap();
+        // Ignore AlreadyExists errors from concurrent test runs
+        match symlink(&abs_target, link) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(e) => panic!("failed to create symlink {link:?} -> {abs_target:?}: {e}"),
+        }
     }
     #[cfg(windows)]
     {
         use std::os::windows::fs::symlink_dir;
-        symlink_dir(&abs_target, link).unwrap();
+        match symlink_dir(&abs_target, link) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(e) => panic!("failed to create symlink {link:?} -> {abs_target:?}: {e}"),
+        }
     }
 }
 

--- a/simulation/amaru-sim/src/simulator/run_tests.rs
+++ b/simulation/amaru-sim/src/simulator/run_tests.rs
@@ -21,8 +21,8 @@ use amaru::tests::{
     },
     setup::create_nodes,
 };
-use amaru_consensus::headers_tree::data_generation::{Action, GeneratedActions, shrink};
-use amaru_kernel::{BlockHeader, Peer};
+use amaru_consensus::headers_tree::data_generation::{GeneratedActions, shrink};
+use amaru_kernel::Peer;
 use anyhow::anyhow;
 use pure_stage::trace_buffer::TraceBuffer;
 use rayon::prelude::*;
@@ -131,7 +131,7 @@ pub fn node_configs(run_config: &RunConfig, actions: &GeneratedActions) -> Vec<N
     // Only create nodes for peers that have actions. During shrinking, some peers may lose
     // all their actions, so we skip creating nodes for them.
     let active_peers: Vec<_> =
-        upstream_peers.iter().filter(|peer| !get_peer_actions(actions, peer).is_empty()).cloned().collect();
+        upstream_peers.iter().filter(|peer| !actions.get_peer_actions(peer).is_empty()).cloned().collect();
 
     let upstream_nodes = active_peers
         .iter()
@@ -140,8 +140,9 @@ pub fn node_configs(run_config: &RunConfig, actions: &GeneratedActions) -> Vec<N
                 .with_no_upstream_peers()
                 .with_listen_address(&peer.name)
                 .with_chain_length(run_config.generated_chain_depth)
-                .with_actions(get_peer_actions(actions, peer))
-                .with_validated_blocks(get_headers(actions, peer))
+                // Upstream nodes already have all the blocks
+                .with_validated_blocks(actions.get_headers())
+                .with_actions(actions.get_peer_actions(peer))
                 .with_node_type(UpstreamNode)
         })
         .collect::<Vec<_>>();
@@ -170,20 +171,4 @@ pub fn node_configs(run_config: &RunConfig, actions: &GeneratedActions) -> Vec<N
         .collect::<Vec<_>>();
 
     upstream_nodes.into_iter().chain(once(node_under_test)).chain(downstream_nodes).collect()
-}
-
-/// Extract all the actions to be executed by a given peer
-fn get_peer_actions(actions: &GeneratedActions, peer: &Peer) -> Vec<Action> {
-    actions.actions_per_peer().get(peer).into_iter().flatten().cloned().collect::<Vec<_>>()
-}
-
-/// Extract all the block headers forwarded by a given peer
-fn get_headers(actions: &GeneratedActions, peer: &Peer) -> Vec<BlockHeader> {
-    get_peer_actions(actions, peer)
-        .into_iter()
-        .filter_map(|action| match action {
-            Action::RollForward { header, .. } => Some(header),
-            Action::Rollback { .. } => None,
-        })
-        .collect::<Vec<_>>()
 }


### PR DESCRIPTION
This PR fixes an issue with the responder side of the chainsync protocol (shown by the simulation tests [here](https://github.com/pragma-org/amaru/actions/runs/23520515770/job/68462657284)).

Basically the problem is that we determine the headers to be sent in reaction to a new tip based of the retrieval of a "best chain" that could be mutated at the same time.

The fix consists in:

 - Serving headers from the immutable part of the chain, as long as we haven't reached the anchor.
 - Serving headers from a snapshot of the best chain at the moment when a `NewTip` message was received. This is called a `ChainFragment` in this PR and it is re-adjusted if the best chain has moved again when a new `NewTip` message is received.

The same kind of logic is applied to finding the best intersection point when initiating the protocol.