### PR TITLE
chore: add encoding benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "amaru-stores",
  "anyhow",
  "async-trait",
+ "criterion",
  "hex",
  "itertools 0.14.0",
  "opentelemetry",
@@ -173,6 +174,7 @@ dependencies = [
  "bech32 0.11.1",
  "bytes",
  "cbor4ii",
+ "criterion",
  "getrandom 0.3.4",
  "hex",
  "itertools 0.14.0",
@@ -492,6 +494,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -921,6 +929,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbor-data"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1219,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -2996,6 +3043,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3293,6 +3346,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -4615,6 +4696,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/amaru-consensus/Cargo.toml
+++ b/crates/amaru-consensus/Cargo.toml
@@ -52,6 +52,7 @@ pretty_assertions.workspace = true
 proptest.workspace = true
 rand.workspace = true
 serde_json.workspace = true
+criterion.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["rt", "macros"] }
 tracing-subscriber.workspace = true
@@ -66,5 +67,10 @@ amaru-stores.workspace = true
 
 [[bench]]
 name = "headers_tree"
+harness = false
+required-features = ["test-utils"]
+
+[[bench]]
+name = "stage_msgs"
 harness = false
 required-features = ["test-utils"]

--- a/crates/amaru-consensus/benches/stage_msgs.rs
+++ b/crates/amaru-consensus/benches/stage_msgs.rs
@@ -1,0 +1,112 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{hint::black_box, time::Duration};
+
+use amaru_consensus::stages::{
+    adopt_chain::AdoptChainMsg,
+    fetch_blocks::FetchBlocksMsg,
+    select_chain::SelectChainMsg,
+    track_peers::{DeferReqNextMsg, TrackPeersMsg},
+    validate_block::ValidateBlockMsg,
+};
+use amaru_kernel::{
+    BlockHeader, BlockHeight, EraName, Point, TESTNET_ERA_HISTORY, Tip, any_header_hash,
+    cardano::network_block::{NetworkBlock, make_block},
+    make_header,
+    utils::tests::run_strategy,
+};
+use amaru_ouroboros::ConnectionId;
+use amaru_protocols::chainsync::{ChainSyncInitiatorMsg, HeaderContent, InitiatorMessage, InitiatorResult};
+use criterion::{Criterion, criterion_group, criterion_main};
+use pure_stage::{SendData, serde::to_cbor};
+
+fn stage_msgs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Stage Messages");
+    group.measurement_time(Duration::from_secs(5));
+
+    let point = Point::Specific(1_234_567_890.into(), run_strategy(any_header_hash()));
+    let bh = BlockHeight::from(123_456_789);
+    let tip = Tip::new(point, bh);
+
+    let msg = ValidateBlockMsg::new(tip, point, bh);
+    let msg: Box<dyn SendData> = Box::new(msg);
+    group.bench_function("ValidateBlockMsg", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
+
+    let msg = AdoptChainMsg::new(tip, bh);
+    let msg: Box<dyn SendData> = Box::new(msg);
+    group.bench_function("AdoptChainMsg", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
+
+    let msg = SelectChainMsg::TipFromUpstream(tip, point);
+    let msg: Box<dyn SendData> = Box::new(msg);
+    group.bench_function("SelectChainMsg::TipFromUpstream", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
+
+    let msg = SelectChainMsg::BlockValidationResult(tip, true);
+    let msg: Box<dyn SendData> = Box::new(msg);
+    group.bench_function("SelectChainMsg::BlockValidationResult", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
+
+    let msg = SelectChainMsg::FetchNextFrom(point);
+    let msg: Box<dyn SendData> = Box::new(msg);
+    group.bench_function("SelectChainMsg::FetchNextFrom", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
+
+    let msg = FetchBlocksMsg::NewTip(tip, point);
+    let msg: Box<dyn SendData> = Box::new(msg);
+    group.bench_function("FetchBlocksMsg::NewTip", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
+
+    let msg = FetchBlocksMsg::Timeout(1000);
+    let msg: Box<dyn SendData> = Box::new(msg);
+    group.bench_function("FetchBlocksMsg::Timeout", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
+
+    let block = make_block();
+    #[allow(clippy::expect_used)]
+    let nb = NetworkBlock::new(&TESTNET_ERA_HISTORY, &block).expect("minimal network block");
+    let header = BlockHeader::from(make_header(1234, 12345, None));
+    let header_content = HeaderContent::new(&header, EraName::Conway);
+
+    let msg = DeferReqNextMsg::Poll;
+    let msg: Box<dyn SendData> = Box::new(msg);
+    group.bench_function("DeferReqNextMsg::Poll", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
+
+    let msg = FetchBlocksMsg::Block(nb.clone());
+    let msg: Box<dyn SendData> = Box::new(msg);
+    group.bench_function("FetchBlocksMsg::Block", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
+
+    let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
+        peer: amaru_kernel::Peer { name: "peer1".to_string() },
+        conn_id: ConnectionId::initial(),
+        handler: pure_stage::StageRef::<InitiatorMessage>::named_for_tests("test"),
+        msg: InitiatorResult::Initialize,
+    });
+    let msg: Box<dyn SendData> = Box::new(msg);
+    group.bench_function("TrackPeersMsg::FromUpstream", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
+
+    let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
+        peer: amaru_kernel::Peer { name: "peer1".to_string() },
+        conn_id: ConnectionId::initial(),
+        handler: pure_stage::StageRef::<InitiatorMessage>::named_for_tests("test"),
+        msg: InitiatorResult::RollForward(header_content.clone(), tip),
+    });
+    let msg: Box<dyn SendData> = Box::new(msg);
+    group
+        .bench_function("TrackPeersMsg::FromUpstream(RollForward)", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().measurement_time(Duration::from_secs(10));
+    targets = stage_msgs
+);
+criterion_main!(benches);

--- a/crates/amaru-kernel/Cargo.toml
+++ b/crates/amaru-kernel/Cargo.toml
@@ -49,8 +49,14 @@ amaru-minicbor-extra.workspace = true
 proptest.workspace = true
 rand.workspace = true
 test-case.workspace = true
+criterion.workspace = true
 # Internal dependencies ───────────────────────────────────────────────────────┐
 cbor4ii.workspace = true
 
 [target.'cfg(target_family="wasm")'.dependencies]
 getrandom = { workspace = true, features = ["wasm_js"] }
+
+[[bench]]
+name = "cbor_encoding"
+harness = false
+required-features = ["test-utils"]

--- a/crates/amaru-kernel/benches/cbor_encoding.rs
+++ b/crates/amaru-kernel/benches/cbor_encoding.rs
@@ -1,0 +1,41 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{hint::black_box, time::Duration};
+
+use amaru_kernel::{BlockHeader, BlockHeight, Point, Tip, make_header, to_cbor};
+use criterion::{Criterion, criterion_group, criterion_main};
+
+fn kernel_types(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Kernel Types CBOR");
+    group.measurement_time(Duration::from_secs(5));
+
+    let header = make_header(1_234_567, 1_234_567_890, None);
+    let bh = BlockHeader::from(header);
+    let tip = Tip::new(Point::Origin, BlockHeight::from(0));
+    let point = Point::Origin;
+
+    group.bench_function("BlockHeader", |b| b.iter(|| black_box(to_cbor(black_box(&bh)))));
+    group.bench_function("Tip", |b| b.iter(|| black_box(to_cbor(black_box(&tip)))));
+    group.bench_function("Point", |b| b.iter(|| black_box(to_cbor(black_box(&point)))));
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().measurement_time(Duration::from_secs(10));
+    targets = kernel_types
+);
+criterion_main!(benches);


### PR DESCRIPTION
in anticipation of wanting the TraceBuffer activated in production, which will need some thinking

Signed-off-by: Roland Kuhn <rk@rkuhn.info>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Criterion performance benchmarks measuring CBOR serialization/encoding for consensus stage messages and kernel types, covering validation, chain selection, adoption, block fetching, and peer-tracking scenarios.
* **Chores**
  * Enabled benchmarking in the dev environment and added configuration for new benchmark targets, gated to run only when the test-utils feature is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->