### PR TITLE
chore: use latest uplc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "amaru-uplc-turbo"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80bbaa184a54245cee2477d8da4833b505838e63160cd2d6fbf0c46c6dcdfdf"
+checksum = "5be84c377654d70899b2f3d55d4ed56f3fd09ffc8e7164ca12f2b9ba53d9b501"
 dependencies = [
  "append-only-vec",
  "blst",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ amaru-sim = { path = "crates/amaru-sim", version = "0.1.2" }
 amaru-stores = { path = "crates/amaru-stores", version = "0.1.2" }
 amaru-tracing-json = { path = "crates/amaru-tracing-json", version = "0.1.2" }
 pure-stage = { path = "crates/pure-stage", version = "0.1.2" }
-amaru-uplc-turbo = "0.1.0"
+amaru-uplc-turbo = "0.1.1"
 
 # The vrf crate has not been fully tested in production environments and still has several upstream issues that are open PRs but not merged yet.
 vrf_dalek = { package = "amaru-vrf-dalek", path = "crates/vendor/amaru-vrf-dalek", version = "0.1.0" }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the workspace-wide dependency amaru-uplc-turbo from 0.1.0 to 0.1.1, ensuring all workspace members now use the newer crate version. This change is internal and should be transparent to end users, improving consistency across the workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->