### PR TITLE
fix: too many `adopted tip` messages at the `INFO` level during catch-up

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -78,10 +78,10 @@ jobs:
             target: riscv32gc-unknown-linux-gnu
             title: riscv32
             packages: -p amaru-ledger
-            extra-args: +nightly -Zbuild-std=std,panic_abort
+            extra-args: +nightly-2025-11-21 -Zbuild-std=std,panic_abort
             command: build
             setup: |
-              rustup component add rust-src --toolchain nightly
+              rustup component add rust-src --toolchain nightly-2025-11-21
               curl -L -o riscv32-glibc-llvm.tar.xz \
                 "https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/2025.11.04/riscv32-glibc-ubuntu-22.04-llvm.tar.xz"
               tar -xvf riscv32-glibc-llvm.tar.xz

--- a/crates/amaru-consensus/benches/stage_msgs.rs
+++ b/crates/amaru-consensus/benches/stage_msgs.rs
@@ -60,7 +60,7 @@ fn stage_msgs(c: &mut Criterion) {
     let msg: Box<dyn SendData> = Box::new(msg);
     group.bench_function("SelectChainMsg::FetchNextFrom", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
 
-    let msg = FetchBlocksMsg::NewTip(tip, point);
+    let msg = FetchBlocksMsg::NewTip(tip, point, bh);
     let msg: Box<dyn SendData> = Box::new(msg);
     group.bench_function("FetchBlocksMsg::NewTip", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
 

--- a/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
@@ -72,9 +72,14 @@ impl FetchBlocks {
     }
 
     #[expect(clippy::expect_used)]
-    pub async fn new_tip(&mut self, tip: Tip, parent: Point, eff: Effects<FetchBlocksMsg>) {
-        self.block_height = tip.block_height().max(self.block_height);
-
+    pub async fn new_tip(
+        &mut self,
+        tip: Tip,
+        parent: Point,
+        max_block_height: BlockHeight,
+        eff: Effects<FetchBlocksMsg>,
+    ) {
+        self.block_height = self.block_height.max(max_block_height);
         tracing::debug!(tip = %tip.point(), parent = %parent, "fetching blocks");
         let store = Store::new(eff);
         // find blocks to retrieve
@@ -193,7 +198,7 @@ impl FetchBlocks {
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum FetchBlocksMsg {
-    NewTip(Tip, Point),
+    NewTip(Tip, Point, BlockHeight),
     Block(NetworkBlock),
     Timeout(u64),
 }
@@ -204,7 +209,9 @@ pub async fn stage(mut state: FetchBlocks, msg: FetchBlocksMsg, eff: Effects<Fet
         state.cleanup_replies = eff.wire_up(stage, (0, eff.me())).await;
     }
     match msg {
-        FetchBlocksMsg::NewTip(tip, parent) => state.new_tip(tip, parent, eff).await,
+        FetchBlocksMsg::NewTip(tip, parent, max_block_height) => {
+            state.new_tip(tip, parent, max_block_height, eff).await
+        }
         FetchBlocksMsg::Block(block) => state.block(block, eff).await,
         FetchBlocksMsg::Timeout(req_id) => state.timeout(req_id, eff).await,
     }

--- a/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
@@ -32,7 +32,7 @@ fn test_new_tip_load_header_fails() {
     // Tip h2 but store has no headers - load will fail
     let tip = prep.headers.h2.tip();
     let parent = prep.headers.h1.point();
-    let msg = FetchBlocksMsg::NewTip(tip, parent);
+    let msg = FetchBlocksMsg::NewTip(tip, parent, tip.block_height());
 
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
     assert_trace(
@@ -61,7 +61,7 @@ fn test_new_tip_no_blocks_to_fetch() {
 
     let tip = prep.headers.h2.tip();
     let parent = prep.headers.h1.point();
-    let msg = FetchBlocksMsg::NewTip(tip, parent);
+    let msg = FetchBlocksMsg::NewTip(tip, parent, tip.block_height());
 
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
     assert_trace(
@@ -95,7 +95,7 @@ fn test_new_tip_blocks_to_fetch() {
 
     let tip = prep.headers.h2.tip();
     let parent = prep.headers.h1.point();
-    let msg = FetchBlocksMsg::NewTip(tip, parent);
+    let msg = FetchBlocksMsg::NewTip(tip, parent, tip.block_height());
 
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
     let timeout_at = Instant::at_offset(Duration::from_secs(5));

--- a/crates/amaru-consensus/src/stages/select_chain/mod.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/mod.rs
@@ -14,14 +14,14 @@
 
 use std::{cmp::Ordering, collections::BTreeMap};
 
-use amaru_kernel::{BlockHeader, HeaderHash, IsHeader, Point, Tip};
+use amaru_kernel::{BlockHeader, BlockHeight, HeaderHash, IsHeader, Point, Tip};
 use amaru_ouroboros::{ChainStore, ReadOnlyChainStore};
 use amaru_protocols::store_effects::Store;
 use pure_stage::{Effects, StageRef, TryInStage};
 
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SelectChain {
-    downstream: StageRef<(Tip, Point)>,
+    downstream: StageRef<(Tip, Point, BlockHeight)>,
     /// Maps all block tree tips to the list of headers whose blocks are yet to be validated
     /// (oldest first)
     tips: BTreeMap<HeaderHash, Vec<HeaderHash>>,
@@ -32,7 +32,10 @@ pub struct SelectChain {
 }
 
 impl SelectChain {
-    pub fn new(downstream: StageRef<(Tip, Point)>, best_tip: Option<(BlockHeader, Vec<HeaderHash>)>) -> Self {
+    pub fn new(
+        downstream: StageRef<(Tip, Point, BlockHeight)>,
+        best_tip: Option<(BlockHeader, Vec<HeaderHash>)>,
+    ) -> Self {
         let mut tips = BTreeMap::new();
         let best_tip = best_tip.map(|(best_tip, to_validate)| {
             tips.insert(best_tip.hash(), to_validate);
@@ -123,7 +126,7 @@ impl SelectChain {
             tracing::debug!(tip = %tip.point(), height = %tip.block_height(), %best_tip, "new best tip candidate");
             if self.may_fetch_blocks {
                 self.may_fetch_blocks = false;
-                eff.send(&self.downstream, (tip, parent)).await;
+                eff.send(&self.downstream, (tip, parent, header.block_height())).await;
             }
             self.best_tip = Some(header);
         }
@@ -199,7 +202,7 @@ impl SelectChain {
                     };
                     if self.may_fetch_blocks {
                         self.may_fetch_blocks = false;
-                        eff.send(&self.downstream, (new_best_tip.tip(), parent)).await;
+                        eff.send(&self.downstream, (new_best_tip.tip(), parent, new_best_tip.block_height())).await;
                     }
                     // if falling back to best_chain_hash, add as fully validated to the tips map
                     self.tips.entry(new_best_tip.hash()).or_insert(vec![]);
@@ -240,7 +243,7 @@ impl SelectChain {
                 Point::Origin
             };
             tracing::debug!(tip = %best_tip.point(), %parent, "resuming block fetching");
-            store.eff().send(&self.downstream, (best_tip.tip(), parent)).await;
+            store.eff().send(&self.downstream, (best_tip.tip(), parent, best_tip.block_height())).await;
         } else {
             self.may_fetch_blocks = true;
         }

--- a/crates/amaru-consensus/src/stages/select_chain/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/test_setup.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use amaru_kernel::{BlockHeader, HeaderHash, Tip, make_header, make_header_with_op_cert_seq};
+use amaru_kernel::{BlockHeader, BlockHeight, HeaderHash, Tip, make_header, make_header_with_op_cert_seq};
 use amaru_ouroboros_traits::{ChainStore, in_memory_consensus_store::InMemConsensusStore};
 use amaru_protocols::store_effects::{
     GetAnchorHashEffect, GetBestChainHashEffect, HasHeaderEffect, LoadHeaderEffect, LoadHeaderWithValidityEffect,
@@ -86,7 +86,7 @@ impl HeaderTree {
 pub struct TestPrep {
     pub state: SelectChain,
     pub rt: Runtime,
-    pub downstream: StageRef<(Tip, Point)>,
+    pub downstream: StageRef<(Tip, Point, BlockHeight)>,
     pub headers: HeaderTree,
     pub store: Arc<dyn ChainStore<BlockHeader>>,
 }
@@ -120,7 +120,7 @@ pub fn register_guards() -> DeserializerGuards {
         pure_stage::register_data_deserializer::<SelectChain>().boxed(),
         pure_stage::register_data_deserializer::<SelectChainMsg>().boxed(),
         pure_stage::register_data_deserializer::<Tip>().boxed(),
-        pure_stage::register_data_deserializer::<(Tip, Point)>().boxed(),
+        pure_stage::register_data_deserializer::<(Tip, Point, BlockHeight)>().boxed(),
         pure_stage::register_effect_deserializer::<LoadHeaderEffect>().boxed(),
         pure_stage::register_effect_deserializer::<GetAnchorHashEffect>().boxed(),
         pure_stage::register_effect_deserializer::<GetBestChainHashEffect>().boxed(),

--- a/crates/amaru-consensus/src/stages/select_chain/tests.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/tests.rs
@@ -102,7 +102,7 @@ fn test_tip_extends_from_origin() {
             te_state("sc-1", &prep.state),
             te_input("sc-1", &msg),
             te_load_header("sc-1", tip.hash(), true),
-            te_send("sc-1", "downstream", (tip, parent)),
+            te_send("sc-1", "downstream", (tip, parent, tip.block_height())),
             te_state("sc-1", &expected),
         ],
     );
@@ -142,7 +142,7 @@ fn test_tip_extends_from_h1() {
             te_load_header("sc-1", ORIGIN_HASH, false),
             te_load_header("sc-1", prep.headers.h1.hash(), true),
             te_load_header("sc-1", prep.headers.h0.hash(), true),
-            te_send("sc-1", "downstream", (tip, parent)),
+            te_send("sc-1", "downstream", (tip, parent, tip.block_height())),
             te_state("sc-1", &expected),
         ],
     );
@@ -178,7 +178,7 @@ fn test_tip_h3_extends_with_anchor_at_h2() {
             te_get_anchor_hash("sc-1"),
             te_load_header("sc-1", prep.headers.h2.hash(), false),
             te_load_header("sc-1", prep.headers.h2.hash(), true),
-            te_send("sc-1", "downstream", (tip, parent)),
+            te_send("sc-1", "downstream", (tip, parent, tip.block_height())),
             te_state("sc-1", &expected),
         ],
     );
@@ -225,7 +225,7 @@ fn test_tip_h3_extends_with_best_chain_h3a() {
             te_load_header("sc-1", prep.headers.h2.hash(), true),
             te_load_header("sc-1", prep.headers.h1.hash(), true),
             te_load_header("sc-1", prep.headers.h0.hash(), true),
-            te_send("sc-1", "downstream", (tip, parent)),
+            te_send("sc-1", "downstream", (tip, parent, tip.block_height())),
             te_state("sc-1", &expected),
         ],
     );
@@ -309,7 +309,7 @@ fn test_tip_h3a_extends_with_best_chain_h2() {
             te_load_header("sc-1", prep.headers.h1.hash(), false),
             te_load_header("sc-1", prep.headers.h2a.hash(), true),
             te_load_header("sc-1", prep.headers.h1.hash(), true),
-            te_send("sc-1", "downstream", (tip, parent)),
+            te_send("sc-1", "downstream", (tip, parent, tip.block_height())),
             te_state("sc-1", &expected),
         ],
     );
@@ -406,7 +406,11 @@ fn test_block_validation_result_invalid_best_tip_invalidated() {
             te_get_best_chain_hash("sc-1"),
             te_load_header("sc-1", prep.headers.h1.hash(), false),
             te_load_header("sc-1", prep.headers.h0.hash(), false),
-            te_send("sc-1", "downstream", (prep.headers.h1.tip(), prep.headers.h0.point())),
+            te_send(
+                "sc-1",
+                "downstream",
+                (prep.headers.h1.tip(), prep.headers.h0.point(), prep.headers.h1.block_height()),
+            ),
             te_state("sc-1", &expected),
         ],
     );
@@ -447,7 +451,11 @@ fn test_block_validation_result_invalid_best_tip_invalidated_switch_fork() {
             te_set_block_valid("sc-1", tip.hash(), false),
             te_load_header("sc-1", prep.headers.h3a.hash(), false),
             te_load_header("sc-1", prep.headers.h2a.hash(), false),
-            te_send("sc-1", "downstream", (prep.headers.h3a.tip(), prep.headers.h2a.point())),
+            te_send(
+                "sc-1",
+                "downstream",
+                (prep.headers.h3a.tip(), prep.headers.h2a.point(), prep.headers.h3a.block_height()),
+            ),
             te_state("sc-1", &expected),
         ],
     );
@@ -567,7 +575,11 @@ fn test_startup_with_non_empty_store() {
             te_input("sc-1", &msg),
             te_load_header("sc-1", prep.headers.h3.hash(), false),
             te_load_header("sc-1", prep.headers.h2.hash(), false),
-            te_send("sc-1", "downstream", (prep.headers.h3.tip(), prep.headers.h2.point())),
+            te_send(
+                "sc-1",
+                "downstream",
+                (prep.headers.h3.tip(), prep.headers.h2.point(), prep.headers.h3.block_height()),
+            ),
             te_state("sc-1", &prep.state),
         ],
     );

--- a/crates/amaru/src/stages/build_stage_graph.rs
+++ b/crates/amaru/src/stages/build_stage_graph.rs
@@ -77,7 +77,9 @@ pub fn build_stage_graph(
     let fetch_blocks = stage_graph
         .wire_up(fetch_blocks, FetchBlocks::new(validate_block_input, select_chain.sender(), manager.sender()));
     let fetch_blocks_input =
-        stage_graph.contramap(fetch_blocks, "fetch_blocks_input", |(tip, parent)| FetchBlocksMsg::NewTip(tip, parent));
+        stage_graph.contramap(fetch_blocks, "fetch_blocks_input", |(tip, parent, max_block_height)| {
+            FetchBlocksMsg::NewTip(tip, parent, max_block_height)
+        });
 
     let select_chain = stage_graph.wire_up(select_chain, SelectChain::new(fetch_blocks_input, our_candidate));
     #[expect(clippy::expect_used)]


### PR DESCRIPTION
This PR sends down the best known block height from the `select_chain` stage to the `adopt_chain` stage.

Otherwise the `max_block_height` information that the `adopt_chain` receives comes only from the max block height that the `fetch_blocks` stage has been required to fetch. Then that height will drag along closely to the adopted tip and we will then print too many `adopted_tip` messages at the `INFO` level.

@rkuhn do you agree with that diagnosis and fix?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consensus pipeline now consistently propagates block-height information through tip selection and block-fetching stages, improving correctness of tip handling and fetch behavior.
* **Tests**
  * Updated test expectations and benchmarks to reflect the new block-height-aware message shape, keeping test coverage aligned with runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->