### PR TITLE
ci: fix the riscv32 job that was not compiling with rust nightly

### DIFF
--- a/.github/workflows/coding-practices.yml
+++ b/.github/workflows/coding-practices.yml
@@ -20,6 +20,12 @@ env:
     target/
 
 jobs:
+  rust-toolchain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/check-rust-toolchain-version
+
   changes:
     runs-on: ubuntu-latest
     # Required to expose outputs to dependent jobs (unused-dependencies, licenses-compatibility)

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -279,42 +279,8 @@ jobs:
           key: cargo-x86_64-unknown-linux-gnu
           restore-keys: |
             cargo-x86_64-unknown-linux-gnu
-      - name: Generate current schemas
-        run: |
-          cargo run --bin amaru --quiet -- dump-traces-schema 2> /tmp/schemas-current.json
-      - name: Check for unused trace schemas
-        run: ./scripts/unused-schemas
-      - name: Compare schemas
-        run: |
-          set -euo pipefail
-
-          # Canonicalize JSON to avoid formatting noise
-          # Remove 'private' field from comparison as it doesn't affect functionality
-          jq -S 'walk(if type == "object" then del(.private) else . end)' docs/traces-schema.json > /tmp/expected.json
-          jq -S 'walk(if type == "object" then del(.private) else . end)' /tmp/schemas-current.json > /tmp/current.json
-
-          if diff -u /tmp/expected.json /tmp/current.json > /tmp/schemas.diff; then
-            echo "✓ Schemas are up-to-date"
-          else
-            echo "::group::❌ Schema diff (expected → generated)"
-            diff --color=always -u /tmp/expected.json /tmp/current.json || true
-            echo "::endgroup::"
-
-            echo "::error title=Schema out of date::Generated schema does not match docs/traces-schema.json"
-
-            {
-              echo "## ❌ Schema mismatch"
-              echo ""
-              echo "The generated schema differs from \`docs/traces-schema.json\`."
-              echo ""
-              echo "**How to fix:**"
-              echo '```bash'
-              echo './scripts/generate-traces-doc'
-              echo '```'
-            } >> "$GITHUB_STEP_SUMMARY"
-
-            exit 1
-          fi
+      - name: Validate trace schemas
+        run: make validate-trace-schemas
       - name: Upload schema diff
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,6 +31,7 @@ env:
     ~/.cargo/registry/cache/
     ~/.cargo/git/db/
     target/
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2026-04-17
   RUSTUP_LOG: error
 
 permissions:
@@ -78,10 +79,10 @@ jobs:
             target: riscv32gc-unknown-linux-gnu
             title: riscv32
             packages: -p amaru-ledger
-            extra-args: +nightly -Zbuild-std=std,panic_abort
+            extra-args: +$RUST_NIGHTLY_TOOLCHAIN -Zbuild-std=std,panic_abort
             command: build
             setup: |
-              rustup component add rust-src --toolchain nightly
+              rustup component add rust-src --toolchain "$RUST_NIGHTLY_TOOLCHAIN"
               curl -L -o riscv32-glibc-llvm.tar.xz \
                 "https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/2025.11.04/riscv32-glibc-ubuntu-22.04-llvm.tar.xz"
               tar -xvf riscv32-glibc-llvm.tar.xz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file provides instructions for agentic coding tools (e.g. opencode, Cursor 
 - `cargo check-amaru`: `check --workspace --all-targets`
 - `cargo clippy-amaru`: `clippy --workspace --all-targets -- -D warnings`
 - `cargo fmt-amaru`: `fmt --all -- --check`
-- Use nightly toolchain: `nightly-2025-11-21` (see rust-toolchain.toml)
+- Use nightly toolchain: `nightly-2026-04-17` (see rust-toolchain.toml)
 
 ### Makefile Targets (preferred for consistency)
 - `make build`: Build in release profile

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/pragma-org/amaru"
 documentation = "https://docs.rs/amaru"
 keywords = ["cardano", "blockchain", "node", "ouroboros", "crypto"]
 categories = ["cryptography::cryptocurrencies"]
-rust-version = "1.93"                                    # ⚠️ Also change in rust-toolchain.toml
+rust-version = "1.93" # Find versions here: https://rust-lang.github.io/rustup-components-history
 
 [workspace]
 members = ["crates/*", "crates/amaru-observability/macros/", "crates/vendor/*", "simulation/*"]

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ else
 TRACE_SUMMARY_OUTPUT_ENABLED := 0
 endif
 
-.PHONY: help bootstrap start import-headers import-nonces download-haskell-config coverage-html coverage-lconv check-llvm-cov check-rust-toolchain-version dev generate-traces-doc run-until compare-trace-contract update-trace-contract generate-traces-doc serve-traces-doc
+.PHONY: help bootstrap start import-headers import-nonces download-haskell-config coverage-html coverage-lconv check-llvm-cov check-rust-toolchain-version dev generate-traces-doc run-until compare-trace-contract update-trace-contract generate-traces-doc serve-traces-doc validate-trace-schemas
 
 help:
 	@echo "\033[1;4mGetting Started:\033[00m"
@@ -77,6 +77,33 @@ generate-traces-doc: ## &build Generate documentation for Amaru's tracing spans
 serve-traces-doc: generate-traces-doc ## &build Regenerate traces docs and serve docs/traces.html on http://127.0.0.1:$(TRACES_PORT)/traces.html
 	@echo "Serving docs/traces.html at http://127.0.0.1:$(TRACES_PORT)/traces.html"
 	@python3 -m http.server $(TRACES_PORT) --directory docs
+
+validate-trace-schemas: ## &test Validate generated trace schemas against docs/traces-schema.json
+	@cargo build --bin amaru --quiet
+	@./target/debug/amaru dump-traces-schema 2> /tmp/schemas-current.json
+	@./scripts/unused-schemas
+	@set -eu; \
+	jq -S 'walk(if type == "object" then del(.private) else . end)' docs/traces-schema.json > /tmp/expected.json; \
+	jq -S 'walk(if type == "object" then del(.private) else . end)' /tmp/schemas-current.json > /tmp/current.json; \
+	if diff -u /tmp/expected.json /tmp/current.json > /tmp/schemas.diff; then \
+		echo "✓ Schemas are up-to-date"; \
+	else \
+		echo "::group::❌ Schema diff (expected → generated)"; \
+		diff --color=always -u /tmp/expected.json /tmp/current.json || true; \
+		echo "::endgroup::"; \
+		echo "::error title=Schema out of date::Generated schema does not match docs/traces-schema.json"; \
+		{ \
+			echo "## ❌ Schema mismatch"; \
+			echo ""; \
+			echo "The generated schema differs from \`docs/traces-schema.json\`."; \
+			echo ""; \
+			echo "**How to fix:**"; \
+			echo '```bash'; \
+			echo './scripts/generate-traces-doc'; \
+			echo '```'; \
+		} >> "$${GITHUB_STEP_SUMMARY:-/dev/null}"; \
+		exit 1; \
+	fi
 
 dev: start # 'backward-compatibility'; might remove after a while.
 start: ## &build Compile and run for $BUILD_PROFILE with default options

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ else
 TRACE_SUMMARY_OUTPUT_ENABLED := 0
 endif
 
-.PHONY: help bootstrap start import-headers import-nonces download-haskell-config coverage-html coverage-lconv check-llvm-cov dev generate-traces-doc run-until compare-trace-contract update-trace-contract generate-traces-doc serve-traces-doc
+.PHONY: help bootstrap start import-headers import-nonces download-haskell-config coverage-html coverage-lconv check-llvm-cov check-rust-toolchain-version dev generate-traces-doc run-until compare-trace-contract update-trace-contract generate-traces-doc serve-traces-doc
 
 help:
 	@echo "\033[1;4mGetting Started:\033[00m"
@@ -113,7 +113,11 @@ update-trace-contract: ## &test Refresh $(TRACE_CONTRACT) from a traced run-unti
 	rm -f "$$tmp_log"
 	@echo "Updated $(TRACE_CONTRACT)"
 
+check-rust-toolchain-version: ## &test Verify rust-toolchain.toml and Cargo.toml rust-version stay aligned
+	@./scripts/check-rust-toolchain-version
+
 all-ci-checks: ## &test Run all CI checks
+	@$(MAKE) check-rust-toolchain-version
 	@cargo fmt-amaru
 	@cargo clippy-amaru
 	@cargo test --workspace --all-targets

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -574,7 +574,7 @@ fn import_dreps(
 
     info!(size = delegations.len(), "dreps delegations");
 
-    transaction.add_drep_delegations(delegations.into_iter())?;
+    transaction.add_drep_delegations(delegations)?;
 
     Ok(transaction.commit()?)
 }
@@ -678,7 +678,7 @@ fn import_stake_pools(
         None,
         store::Columns {
             utxo: iter::empty(),
-            pools: state.registered.into_iter().flat_map(move |(_, registrations)| {
+            pools: state.registered.into_values().flat_map(move |registrations| {
                 registrations.into_iter().map(|r| (r, *DEFAULT_CERTIFICATE_POINTER, epoch)).collect::<Vec<_>>()
             }),
             accounts: iter::empty(),

--- a/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
+++ b/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
@@ -1212,15 +1212,13 @@ mod tests {
 
         (Just(ids), any_root, any_parents, any_pointers, any_action_args).prop_map(
             move |(ids, root, parents, mut pointers, mut args)| {
-                let mut next = 1;
-
                 let root = root.map(|ix| ids[ix].clone());
 
                 let mut known_parents = vec![root.clone()];
 
                 let mut sequence = Vec::new();
 
-                for parent in parents {
+                for (next, parent) in (1..).zip(parents) {
                     let sibling = ids[next].clone();
 
                     let action = into_action(select(&known_parents, parent), args.remove(0));
@@ -1230,8 +1228,6 @@ mod tests {
                     sequence.push((sibling.as_ref().clone(), pointer, action));
 
                     known_parents.push(Some(sibling));
-
-                    next += 1;
                 }
 
                 (root.clone(), sequence)

--- a/crates/amaru-ledger/src/lib.rs
+++ b/crates/amaru-ledger/src/lib.rs
@@ -14,7 +14,7 @@
 
 // EDR-010 - Ledger Validation Context
 // <https://github.com/pragma-org/amaru/blob/main/engineering-decision-records/010-ledger-validation-context.md>
-#![feature(try_trait_v2)]
+#![feature(try_trait_v2, try_trait_v2_residual)]
 
 pub mod block_validator;
 pub mod bootstrap;

--- a/crates/amaru-ledger/src/rules/block.rs
+++ b/crates/amaru-ledger/src/rules/block.rs
@@ -14,7 +14,7 @@
 
 use std::{
     fmt::{self, Display},
-    ops::{ControlFlow, FromResidual, Try},
+    ops::{ControlFlow, FromResidual, Residual, Try},
     process::{ExitCode, Termination},
 };
 
@@ -54,6 +54,11 @@ pub enum InvalidBlockDetails {
 #[derive(Debug)]
 pub enum BlockValidation<A, E> {
     Valid(A),
+    Invalid(Slot, HeaderHash, InvalidBlockDetails),
+    Err(E),
+}
+
+pub enum BlockValidationResidual<E> {
     Invalid(Slot, HeaderHash, InvalidBlockDetails),
     Err(E),
 }
@@ -115,7 +120,7 @@ impl<A, E> Termination for BlockValidation<A, E> {
 
 impl<A, E> Try for BlockValidation<A, E> {
     type Output = A;
-    type Residual = Result<(Slot, HeaderHash, InvalidBlockDetails), E>;
+    type Residual = BlockValidationResidual<E>;
 
     fn from_output(result: Self::Output) -> Self {
         Self::Valid(result)
@@ -124,19 +129,25 @@ impl<A, E> Try for BlockValidation<A, E> {
     fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
         match self {
             Self::Valid(result) => ControlFlow::Continue(result),
-            Self::Invalid(slot, id, violation) => ControlFlow::Break(Ok((slot, id, violation))),
-            Self::Err(err) => ControlFlow::Break(Err(err)),
+            Self::Invalid(slot, id, violation) => {
+                ControlFlow::Break(BlockValidationResidual::Invalid(slot, id, violation))
+            }
+            Self::Err(err) => ControlFlow::Break(BlockValidationResidual::Err(err)),
         }
     }
 }
 
 impl<A, E> FromResidual for BlockValidation<A, E> {
-    fn from_residual(residual: Result<(Slot, HeaderHash, InvalidBlockDetails), E>) -> Self {
+    fn from_residual(residual: BlockValidationResidual<E>) -> Self {
         match residual {
-            Ok((slot, id, violation)) => BlockValidation::Invalid(slot, id, violation),
-            Err(err) => BlockValidation::Err(err),
+            BlockValidationResidual::Invalid(slot, id, violation) => BlockValidation::Invalid(slot, id, violation),
+            BlockValidationResidual::Err(err) => BlockValidation::Err(err),
         }
     }
+}
+
+impl<A, E> Residual<A> for BlockValidationResidual<E> {
+    type TryType = BlockValidation<A, E>;
 }
 
 pub fn execute<C, S: From<C>>(

--- a/crates/vendor/amaru-curve25519-dalek/src/traits.rs
+++ b/crates/vendor/amaru-curve25519-dalek/src/traits.rs
@@ -378,7 +378,6 @@ pub trait VartimePrecomputedMultiscalarMul: Sized {
 /// This trait is only for debugging/testing, since it should be
 /// impossible for a `curve25519-dalek` user to construct an invalid
 /// point.
-#[expect(dead_code)]
 pub(crate) trait ValidityCheck {
     /// Checks whether the point is on the curve. Not CT.
     fn is_valid(&self) -> bool;

--- a/crates/vendor/amaru-curve25519-dalek/src/traits.rs
+++ b/crates/vendor/amaru-curve25519-dalek/src/traits.rs
@@ -378,6 +378,7 @@ pub trait VartimePrecomputedMultiscalarMul: Sized {
 /// This trait is only for debugging/testing, since it should be
 /// impossible for a `curve25519-dalek` user to construct an invalid
 /// point.
+#[allow(dead_code)]
 pub(crate) trait ValidityCheck {
     /// Checks whether the point is on the curve. Not CT.
     fn is_valid(&self) -> bool;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2026-04-17"              # ⚠️ Also change in top-level Cargo.toml. Find versions here: https://rust-lang.github.io/rustup-components-history/
+channel = "nightly-2026-04-17" # Find versions here: https://rust-lang.github.io/rustup-components-history/
 components = ["rustc", "rust-src", "rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-11-21"              # ⚠️ Also change in top-level Cargo.toml. Find versions here: https://rust-lang.github.io/rustup-components-history/
+channel = "nightly-2026-04-17"              # ⚠️ Also change in top-level Cargo.toml. Find versions here: https://rust-lang.github.io/rustup-components-history/
 components = ["rustc", "rust-src", "rustfmt", "clippy"]

--- a/scripts/check-rust-toolchain-version
+++ b/scripts/check-rust-toolchain-version
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CARGO_TOML="$ROOT_DIR/Cargo.toml"
+TOOLCHAIN_TOML="$ROOT_DIR/rust-toolchain.toml"
+
+channel="$(
+  sed -nE 's/^channel = "([^"]+)".*/\1/p' "$TOOLCHAIN_TOML" | head -n 1
+)"
+
+rust_version="$(
+  sed -nE 's/^rust-version = "([^"]+)".*/\1/p' "$CARGO_TOML" | head -n 1
+)"
+
+if [[ -z "$channel" ]]; then
+  echo "Could not read toolchain channel from $TOOLCHAIN_TOML" >&2
+  exit 1
+fi
+
+if [[ -z "$rust_version" ]]; then
+  echo "Could not read rust-version from $CARGO_TOML" >&2
+  exit 1
+fi
+
+actual_version="$(
+  rustc "+$channel" --version | sed -nE 's/^rustc ([0-9]+\.[0-9]+)\..*/\1/p'
+)"
+
+if [[ -z "$actual_version" ]]; then
+  echo "Could not determine Rust version for toolchain $channel" >&2
+  exit 1
+fi
+
+if [[ "$(printf '%s\n%s\n' "$rust_version" "$actual_version" | sort -V | tail -n 1)" != "$actual_version" ]]; then
+  echo "Rust toolchain is too old for the declared rust-version:" >&2
+  echo "  rust-toolchain.toml channel: $channel" >&2
+  echo "  channel resolves to Rust:    $actual_version" >&2
+  echo "  Cargo.toml rust-version:    $rust_version" >&2
+  exit 1
+fi
+
+echo "Rust toolchain is compatible: $channel -> $actual_version (rust-version: $rust_version)"


### PR DESCRIPTION
And pinned  down the nightly version. This fixes CI on main and currently opened PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Rust nightly to nightly-2026-04-17 and bumped workspace rust-version to 1.97; CI now uses a configurable toolchain env var.
  * Added a CI check for toolchain consistency and a script/Makefile target to validate it.
  * Added a Makefile target to validate trace JSON schemas during CI.

* **Refactor**
  * Simplified internal control-flow handling and optimized iterator usage.

* **Tests**
  * Cleaned up test generator structure.

* **Documentation**
  * Updated agent toolchain guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->