### PR TITLE
feat: get peer candidates from ledger

### DIFF
--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -88,7 +88,7 @@ jobs:
         network:
           - name: preprod
             magic: 1
-            target_epoch: 181
+            target_epoch: 179
           - name: preview
             magic: 2
             target_epoch: 673

--- a/crates/amaru-consensus/src/effects/consensus_effects.rs
+++ b/crates/amaru-consensus/src/effects/consensus_effects.rs
@@ -102,7 +102,12 @@ impl<T: SendData + Sync> ConsensusOps for ConsensusEffects<T> {
 /// This module provides mock implementations of ConsensusOps and its sub-traits for unit testing.
 #[cfg(test)]
 pub mod tests {
-    use std::{collections::BTreeMap, sync::Arc, time::Duration};
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        net::SocketAddr,
+        sync::Arc,
+        time::Duration,
+    };
 
     use amaru_kernel::{Peer, Point, PoolId, Slot, Tip};
     use amaru_mempool::strategies::InMemoryMempool;
@@ -199,6 +204,12 @@ pub mod tests {
 
         fn volatile_tip(&self) -> Option<Tip> {
             None
+        }
+
+        fn registered_relay_socket_addrs(
+            &self,
+        ) -> BoxFuture<'_, Result<BTreeSet<SocketAddr>, BlockValidationError>> {
+            Box::pin(async { Ok(BTreeSet::new()) })
         }
     }
 

--- a/crates/amaru-consensus/src/effects/consensus_effects.rs
+++ b/crates/amaru-consensus/src/effects/consensus_effects.rs
@@ -206,9 +206,7 @@ pub mod tests {
             None
         }
 
-        fn registered_relay_socket_addrs(
-            &self,
-        ) -> BoxFuture<'_, Result<BTreeSet<SocketAddr>, BlockValidationError>> {
+        fn registered_relay_socket_addrs(&self) -> BoxFuture<'_, Result<BTreeSet<SocketAddr>, BlockValidationError>> {
             Box::pin(async { Ok(BTreeSet::new()) })
         }
     }

--- a/crates/amaru-consensus/src/effects/ledger_effects.rs
+++ b/crates/amaru-consensus/src/effects/ledger_effects.rs
@@ -12,12 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::{
+    collections::BTreeSet,
+    net::SocketAddr,
+    sync::Arc,
+};
 
 use amaru_kernel::{BlockHeader, IgnoreEq, Peer, Point, Tip, Transaction};
 use amaru_metrics::ledger::LedgerMetrics;
 use amaru_ouroboros_traits::{
-    BlockValidationError, CanValidateBlocks, CanValidateHeaders, CanValidateTxs, HeaderValidationError,
+    BlockValidationError, CanValidateBlocks, CanValidateHeaders, CanValidateTxs, HasStakePools, HeaderValidationError,
     TransactionValidationError,
 };
 use amaru_protocols::store_effects::ResourceHeaderStore;
@@ -56,6 +60,10 @@ pub trait LedgerOps: Send + Sync {
     fn tip(&self) -> Tip;
 
     fn volatile_tip(&self) -> Option<Tip>;
+
+    fn registered_relay_socket_addrs(
+        &self,
+    ) -> BoxFuture<'_, Result<BTreeSet<SocketAddr>, BlockValidationError>>;
 }
 
 /// Implementation of LedgerOps using pure_stage::Effects.
@@ -113,6 +121,12 @@ impl<T: SendData + Sync> LedgerOps for Ledger<T> {
     fn volatile_tip(&self) -> Option<Tip> {
         self.0.external_sync(VolatileTipEffect)
     }
+
+    fn registered_relay_socket_addrs(
+        &self,
+    ) -> BoxFuture<'_, Result<BTreeSet<SocketAddr>, BlockValidationError>> {
+        self.0.external(RegisteredRelaySocketAddrsEffect)
+    }
 }
 
 // EXTERNAL EFFECTS DEFINITIONS
@@ -121,6 +135,7 @@ impl<T: SendData + Sync> LedgerOps for Ledger<T> {
 pub type ResourceBlockValidation = Arc<dyn CanValidateBlocks + Send + Sync>;
 pub type ResourceHeaderValidation = Arc<dyn CanValidateHeaders + Send + Sync>;
 pub type ResourceTxValidation = Arc<dyn CanValidateTxs + Send + Sync>;
+pub type ResourceHasStakePools = Arc<dyn HasStakePools + Send + Sync>;
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ValidateTxEffect {
@@ -344,3 +359,23 @@ impl ExternalEffectAPI for VolatileTipEffect {
 }
 
 impl ExternalEffectSync for VolatileTipEffect {}
+
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RegisteredRelaySocketAddrsEffect;
+
+impl ExternalEffect for RegisteredRelaySocketAddrsEffect {
+    #[expect(clippy::expect_used)]
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        Self::wrap(async move {
+            let stake_pools = resources
+                .get::<ResourceHasStakePools>()
+                .expect("RegisteredRelaySocketAddrsEffect requires a ResourceHasStakePools resource")
+                .clone();
+            stake_pools.registered_relay_socket_addrs().await
+        })
+    }
+}
+
+impl ExternalEffectAPI for RegisteredRelaySocketAddrsEffect {
+    type Response = Result<BTreeSet<SocketAddr>, BlockValidationError>;
+}

--- a/crates/amaru-consensus/src/effects/ledger_effects.rs
+++ b/crates/amaru-consensus/src/effects/ledger_effects.rs
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    collections::BTreeSet,
-    net::SocketAddr,
-    sync::Arc,
-};
+use std::{collections::BTreeSet, net::SocketAddr, sync::Arc};
 
 use amaru_kernel::{BlockHeader, IgnoreEq, Peer, Point, Tip, Transaction};
 use amaru_metrics::ledger::LedgerMetrics;
@@ -61,9 +57,12 @@ pub trait LedgerOps: Send + Sync {
 
     fn volatile_tip(&self) -> Option<Tip>;
 
-    fn registered_relay_socket_addrs(
-        &self,
-    ) -> BoxFuture<'_, Result<BTreeSet<SocketAddr>, BlockValidationError>>;
+    /// Get the registered relay socket addresses from the stable store.
+    ///
+    /// **NOTE:** This operation blocks the ledger for about 4ms (mainnet late
+    /// 2025), so it should be called with care. Please cache the result, it
+    /// only changes meaningfully once per epoch.
+    fn registered_relay_socket_addrs(&self) -> BoxFuture<'_, Result<BTreeSet<SocketAddr>, BlockValidationError>>;
 }
 
 /// Implementation of LedgerOps using pure_stage::Effects.
@@ -122,9 +121,7 @@ impl<T: SendData + Sync> LedgerOps for Ledger<T> {
         self.0.external_sync(VolatileTipEffect)
     }
 
-    fn registered_relay_socket_addrs(
-        &self,
-    ) -> BoxFuture<'_, Result<BTreeSet<SocketAddr>, BlockValidationError>> {
+    fn registered_relay_socket_addrs(&self) -> BoxFuture<'_, Result<BTreeSet<SocketAddr>, BlockValidationError>> {
         self.0.external(RegisteredRelaySocketAddrsEffect)
     }
 }

--- a/crates/amaru-consensus/src/effects/mod.rs
+++ b/crates/amaru-consensus/src/effects/mod.rs
@@ -22,7 +22,8 @@ pub use base_effects::{Base, BaseOps};
 pub use consensus_effects::tests::*;
 pub use consensus_effects::{ConsensusEffects, ConsensusOps};
 pub use ledger_effects::{
-    ContainsPointEffect, Ledger, LedgerOps, ResourceBlockValidation, ResourceHeaderValidation, ResourceTxValidation,
-    RollbackBlockEffect, TipEffect, ValidateBlockEffect, ValidateHeaderEffect, ValidateTxEffect, VolatileTipEffect,
+    ContainsPointEffect, Ledger, LedgerOps, RegisteredRelaySocketAddrsEffect, ResourceBlockValidation,
+    ResourceHasStakePools, ResourceHeaderValidation, ResourceTxValidation, RollbackBlockEffect, TipEffect,
+    ValidateBlockEffect, ValidateHeaderEffect, ValidateTxEffect, VolatileTipEffect,
 };
 pub use metrics_effects::{Metrics, MetricsOps, RecordMetricsEffect, ResourceMeter};

--- a/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
@@ -39,7 +39,10 @@ use tracing_subscriber::util::SubscriberInitExt;
 
 use super::*;
 use crate::{
-    effects::{ResourceBlockValidation, ResourceHeaderValidation, TipEffect, ValidateHeaderEffect, VolatileTipEffect},
+    effects::{
+        ResourceBlockValidation, ResourceHasStakePools, ResourceHeaderValidation, TipEffect, ValidateHeaderEffect,
+        VolatileTipEffect,
+    },
     stages::test_utils::{BufferWriter, Logs},
 };
 
@@ -159,7 +162,9 @@ pub fn setup_with_validation(
     let mut network = SimulationBuilder::default().with_trace_buffer(TraceBuffer::new_shared(100, 1000000));
     network.resources().put::<ResourceHeaderStore>(store.clone());
     network.resources().put::<ResourceHeaderValidation>(validation);
-    network.resources().put::<ResourceBlockValidation>(Arc::new(MockCanValidateBlocks));
+    let block_validation = Arc::new(MockCanValidateBlocks);
+    network.resources().put::<ResourceBlockValidation>(block_validation.clone());
+    network.resources().put::<ResourceHasStakePools>(block_validation);
 
     let tp = network.stage("tp", stage);
     let tp = network.wire_up(tp, state);

--- a/crates/amaru-consensus/src/stages/validate_block/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/validate_block/test_setup.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeSet, fmt, sync::Arc};
+use std::{collections::BTreeSet, fmt, net::SocketAddr, sync::Arc};
 
 use amaru_kernel::{
     BlockHeader, HeaderHash, Point, TESTNET_ERA_HISTORY, Tip, make_header, make_header_with_op_cert_seq,
 };
 use amaru_metrics::ledger::LedgerMetrics;
 use amaru_ouroboros_traits::{
-    BlockValidationError, CanValidateBlocks, ChainStore, in_memory_consensus_store::InMemConsensusStore,
+    BlockValidationError, CanValidateBlocks, ChainStore, HasStakePools, in_memory_consensus_store::InMemConsensusStore,
 };
 use amaru_protocols::store_effects::{
     GetAnchorHashEffect, LoadBlockEffect, LoadHeaderEffect, LoadHeaderWithValidityEffect, ResourceHeaderStore,
@@ -38,8 +38,8 @@ use tracing_subscriber::util::SubscriberInitExt;
 use super::*;
 use crate::{
     effects::{
-        ContainsPointEffect, RecordMetricsEffect, ResourceBlockValidation, RollbackBlockEffect, TipEffect,
-        ValidateBlockEffect,
+        ContainsPointEffect, RecordMetricsEffect, ResourceBlockValidation, ResourceHasStakePools, RollbackBlockEffect,
+        TipEffect, ValidateBlockEffect,
     },
     stages::test_utils::{BufferWriter, Logs},
 };
@@ -206,6 +206,13 @@ impl CanValidateBlocks for MockBlockValidator {
     }
 }
 
+#[async_trait]
+impl HasStakePools for MockBlockValidator {
+    async fn registered_relay_socket_addrs(&self) -> Result<BTreeSet<SocketAddr>, BlockValidationError> {
+        Ok(BTreeSet::new())
+    }
+}
+
 /// Bundles state, runtime, store, ledger, and refs for validate_block2 tests.
 pub struct TestPrep {
     pub state: ValidateBlock,
@@ -308,6 +315,7 @@ pub fn setup(prep: &TestPrep, msg: ValidateBlockMsg) -> (SimulationRunning, Dese
     let mut network = SimulationBuilder::default().with_trace_buffer(TraceBuffer::new_shared(100, 1000000));
     network.resources().put::<ResourceHeaderStore>(prep.store.clone());
     network.resources().put::<ResourceBlockValidation>(prep.block_validator.clone());
+    network.resources().put::<ResourceHasStakePools>(prep.block_validator.clone());
 
     let vb = network.stage("vb", stage);
     let vb = network.wire_up(vb, prep.state.clone());

--- a/crates/amaru-ledger/src/block_validator.rs
+++ b/crates/amaru-ledger/src/block_validator.rs
@@ -21,7 +21,8 @@ use std::{
 use amaru_kernel::{Block, EraHistory, GlobalParameters, NetworkName, Point, Tip, Transaction};
 use amaru_metrics::ledger::LedgerMetrics;
 use amaru_ouroboros_traits::{
-    CanValidateBlocks, CanValidateTxs, HasStakePools, TransactionValidationError, can_validate_blocks::BlockValidationError,
+    CanValidateBlocks, CanValidateTxs, HasStakePools, TransactionValidationError,
+    can_validate_blocks::BlockValidationError,
 };
 use amaru_plutus::arena_pool::ArenaPool;
 use anyhow::anyhow;

--- a/crates/amaru-ledger/src/block_validator.rs
+++ b/crates/amaru-ledger/src/block_validator.rs
@@ -12,12 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::BTreeSet,
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
 
 use amaru_kernel::{Block, EraHistory, GlobalParameters, NetworkName, Point, Tip, Transaction};
 use amaru_metrics::ledger::LedgerMetrics;
 use amaru_ouroboros_traits::{
-    CanValidateBlocks, CanValidateTxs, TransactionValidationError, can_validate_blocks::BlockValidationError,
+    CanValidateBlocks, CanValidateTxs, HasStakePools, TransactionValidationError, can_validate_blocks::BlockValidationError,
 };
 use amaru_plutus::arena_pool::ArenaPool;
 use anyhow::anyhow;
@@ -124,5 +128,20 @@ where
     fn volatile_tip(&self) -> Option<Tip> {
         let state = self.state.lock().unwrap();
         state.volatile_tip()
+    }
+}
+
+#[async_trait::async_trait]
+impl<S, HS> HasStakePools for BlockValidator<S, HS>
+where
+    S: Store + Send,
+    HS: HistoricalStores + Send,
+{
+    async fn registered_relay_socket_addrs(&self) -> Result<BTreeSet<SocketAddr>, BlockValidationError> {
+        #[expect(clippy::unwrap_used)]
+        {
+            let state = self.state.lock().unwrap();
+            state.registered_relay_socket_addrs().map_err(|e| BlockValidationError::new(anyhow!(e)))
+        }
     }
 }

--- a/crates/amaru-ledger/src/lib.rs
+++ b/crates/amaru-ledger/src/lib.rs
@@ -18,9 +18,9 @@
 
 pub mod block_validator;
 pub mod bootstrap;
-pub mod registered_relay_addrs;
 pub mod context;
 pub mod governance;
+pub mod registered_relay_addrs;
 pub mod rules;
 pub mod state;
 pub mod store;

--- a/crates/amaru-ledger/src/lib.rs
+++ b/crates/amaru-ledger/src/lib.rs
@@ -18,6 +18,7 @@
 
 pub mod block_validator;
 pub mod bootstrap;
+pub mod registered_relay_addrs;
 pub mod context;
 pub mod governance;
 pub mod rules;

--- a/crates/amaru-ledger/src/registered_relay_addrs.rs
+++ b/crates/amaru-ledger/src/registered_relay_addrs.rs
@@ -37,15 +37,15 @@ pub fn collect_from_read_store(db: &impl ReadStore) -> Result<BTreeSet<SocketAdd
 fn relay_to_socket_addrs(relay: &Relay, set: &mut BTreeSet<SocketAddr>) {
     match relay {
         Relay::SingleHostAddr(port, ipv4, ipv6) => {
-            let Some(port) = null_to_port(port) else {
+            let Some(port) = nullable_to_port(port) else {
                 return;
             };
-            if let Some(ip) = null_ipv4_to_ip(ipv4)
+            if let Some(ip) = nullable_ipv4_to_ip(ipv4)
                 && !is_excluded_relay_ip(ip)
             {
                 set.insert(SocketAddr::new(ip, port));
             }
-            if let Some(ip) = null_ipv6_to_ip(ipv6)
+            if let Some(ip) = nullable_ipv6_to_ip(ipv6)
                 && !is_excluded_relay_ip(ip)
             {
                 set.insert(SocketAddr::new(ip, port));
@@ -57,14 +57,14 @@ fn relay_to_socket_addrs(relay: &Relay, set: &mut BTreeSet<SocketAddr>) {
     }
 }
 
-fn null_to_port(port: &Nullable<u32>) -> Option<u16> {
+fn nullable_to_port(port: &Nullable<u32>) -> Option<u16> {
     match port {
         Nullable::Some(p) => u16::try_from(*p).ok(),
         Nullable::Null | Nullable::Undefined => None,
     }
 }
 
-fn null_ipv4_to_ip(null: &Nullable<Bytes>) -> Option<IpAddr> {
+fn nullable_ipv4_to_ip(null: &Nullable<Bytes>) -> Option<IpAddr> {
     let bytes = match null {
         Nullable::Some(b) => <[u8; 4]>::try_from(b).ok()?,
         Nullable::Null | Nullable::Undefined => return None,
@@ -72,7 +72,7 @@ fn null_ipv4_to_ip(null: &Nullable<Bytes>) -> Option<IpAddr> {
     Some(IpAddr::V4(Ipv4Addr::from_octets(bytes)))
 }
 
-fn null_ipv6_to_ip(null: &Nullable<Bytes>) -> Option<IpAddr> {
+fn nullable_ipv6_to_ip(null: &Nullable<Bytes>) -> Option<IpAddr> {
     let mut bytes = match null {
         Nullable::Some(b) => <[u8; 16]>::try_from(b).ok()?,
         Nullable::Null | Nullable::Undefined => return None,

--- a/crates/amaru-ledger/src/registered_relay_addrs.rs
+++ b/crates/amaru-ledger/src/registered_relay_addrs.rs
@@ -1,0 +1,107 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    collections::BTreeSet,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+};
+
+use amaru_kernel::{Bytes, Nullable, Relay};
+use tracing::field;
+
+use crate::store::{ReadStore, StoreError};
+
+pub fn collect_from_read_store(db: &impl ReadStore) -> Result<BTreeSet<SocketAddr>, StoreError> {
+    let span = tracing::info_span!("collect relay addresses from ledger", addresses = field::Empty).entered();
+    let mut set = BTreeSet::new();
+    for (_, row) in db.iter_pools()? {
+        for relay in &row.current_params.relays {
+            relay_to_socket_addrs(relay, &mut set);
+        }
+    }
+    span.record("addresses", set.len());
+    Ok(set)
+}
+
+fn relay_to_socket_addrs(relay: &Relay, set: &mut BTreeSet<SocketAddr>) {
+    match relay {
+        Relay::SingleHostAddr(port, ipv4, ipv6) => {
+            let Some(port) = null_to_port(port) else {
+                return;
+            };
+            if let Some(ip) = null_ipv4_to_ip(ipv4)
+                && !is_excluded_relay_ip(ip)
+            {
+                set.insert(SocketAddr::new(ip, port));
+            }
+            if let Some(ip) = null_ipv6_to_ip(ipv6)
+                && !is_excluded_relay_ip(ip)
+            {
+                set.insert(SocketAddr::new(ip, port));
+            }
+        }
+        Relay::SingleHostName(..) | Relay::MultiHostName(..) => {
+            // DNS usage is very inconsistent, don't bother for now
+        }
+    }
+}
+
+fn null_to_port(port: &Nullable<u32>) -> Option<u16> {
+    match port {
+        Nullable::Some(p) => u16::try_from(*p).ok(),
+        Nullable::Null | Nullable::Undefined => None,
+    }
+}
+
+fn null_ipv4_to_ip(null: &Nullable<Bytes>) -> Option<IpAddr> {
+    let bytes = match null {
+        Nullable::Some(b) => <[u8; 4]>::try_from(b).ok()?,
+        Nullable::Null | Nullable::Undefined => return None,
+    };
+    Some(IpAddr::V4(Ipv4Addr::from_octets(bytes)))
+}
+
+fn null_ipv6_to_ip(null: &Nullable<Bytes>) -> Option<IpAddr> {
+    let mut bytes = match null {
+        Nullable::Some(b) => <[u8; 16]>::try_from(b).ok()?,
+        Nullable::Null | Nullable::Undefined => return None,
+    };
+    // manual inspection of the ledger contents has confirmed that Haskell node
+    // serialization of IPv6 addresses is in “screwed-endian” byte order
+    bytes[0..4].reverse();
+    bytes[4..8].reverse();
+    bytes[8..12].reverse();
+    bytes[12..16].reverse();
+    Some(IpAddr::V6(Ipv6Addr::from_octets(bytes)))
+}
+
+fn is_excluded_relay_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_broadcast()
+                || v4.is_unspecified()
+                || v4.is_documentation()
+        }
+        IpAddr::V6(v6) => {
+            v6.is_loopback() || v6.is_unicast_link_local() || is_unique_local_v6(&v6) || v6.is_unspecified()
+        }
+    }
+}
+
+fn is_unique_local_v6(v6: &Ipv6Addr) -> bool {
+    (v6.segments()[0] & 0xfe00) == 0xfc00
+}

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -247,6 +247,11 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
         self.volatile.view_back().map(|st| st.anchor.0)
     }
 
+    /// Get the registered relay socket addresses from the stable store.
+    ///
+    /// **NOTE:** This operation blocks the ledger for about 4ms (mainnet late
+    /// 2025), so it should be called with care. Please cache the result, it
+    /// only changes meaningfully once per epoch.
     #[expect(clippy::unwrap_used)]
     pub fn registered_relay_socket_addrs(&self) -> Result<BTreeSet<SocketAddr>, StateError> {
         let db = self.stable.lock().unwrap();

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -15,7 +15,8 @@
 use std::{
     borrow::Cow,
     cmp::max,
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    net::SocketAddr,
     ops::Deref,
     sync::{Arc, Mutex, MutexGuard},
 };
@@ -244,6 +245,12 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
     /// Tip of the volatile (`VolatileDB`) sequence only, if non-empty.
     pub fn volatile_tip(&self) -> Option<Tip> {
         self.volatile.view_back().map(|st| st.anchor.0)
+    }
+
+    #[expect(clippy::unwrap_used)]
+    pub fn registered_relay_socket_addrs(&self) -> Result<BTreeSet<SocketAddr>, StateError> {
+        let db = self.stable.lock().unwrap();
+        Ok(crate::registered_relay_addrs::collect_from_read_store(&*db)?)
     }
 
     #[expect(clippy::unwrap_used)]

--- a/crates/amaru-ouroboros-traits/src/has_stake_pools.rs
+++ b/crates/amaru-ouroboros-traits/src/has_stake_pools.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 PRAGMA
+// Copyright 2026 PRAGMA
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,23 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod has_stake_distribution;
-pub use has_stake_distribution::{HasStakeDistribution, PoolSummary};
+use std::{collections::BTreeSet, net::SocketAddr};
 
-pub mod has_stake_pools;
-pub use has_stake_pools::HasStakePools;
+use crate::BlockValidationError;
 
-pub mod validators;
-pub use validators::*;
-
-pub mod connections;
-pub use connections::*;
-
-pub mod mempool;
-pub use mempool::*;
-
-pub mod stores;
-pub use stores::*;
-
-pub mod praos;
-pub use praos::*;
+#[async_trait::async_trait]
+pub trait HasStakePools: Send + Sync {
+    async fn registered_relay_socket_addrs(&self) -> Result<BTreeSet<SocketAddr>, BlockValidationError>;
+}

--- a/crates/amaru-ouroboros-traits/src/validators/blocks/can_validate_blocks_mock.rs
+++ b/crates/amaru-ouroboros-traits/src/validators/blocks/can_validate_blocks_mock.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{collections::BTreeSet, net::SocketAddr};
+
 use amaru_kernel::{Block, Point, Tip};
 use amaru_metrics::ledger::LedgerMetrics;
 
-use crate::{CanValidateBlocks, can_validate_blocks::BlockValidationError};
+use crate::{CanValidateBlocks, HasStakePools, can_validate_blocks::BlockValidationError};
 
 /// A fake block validator that always returns the same height.
 #[derive(Clone, Debug, Default)]
@@ -45,5 +47,12 @@ impl CanValidateBlocks for MockCanValidateBlocks {
 
     fn volatile_tip(&self) -> Option<Tip> {
         None
+    }
+}
+
+#[async_trait::async_trait]
+impl HasStakePools for MockCanValidateBlocks {
+    async fn registered_relay_socket_addrs(&self) -> Result<BTreeSet<SocketAddr>, BlockValidationError> {
+        Ok(BTreeSet::new())
     }
 }

--- a/crates/amaru-protocols/src/tests/setup.rs
+++ b/crates/amaru-protocols/src/tests/setup.rs
@@ -26,8 +26,8 @@ use amaru_kernel::{BlockHeader, NonEmptyBytes, Peer, Transaction};
 use amaru_network::connection::TokioConnections;
 use amaru_ouroboros_traits::{
     CanValidateBlocks, CanValidateHeaders, CanValidateTxs, ChainStore, ConnectionId, ConnectionProvider,
-    ConnectionsResource, Mempool, MockCanValidateBlocks, MockCanValidateHeaders, MockCanValidateTxs, ResourceMempool,
-    ToSocketAddrs,
+    ConnectionsResource, HasStakePools, Mempool, MockCanValidateBlocks, MockCanValidateHeaders, MockCanValidateTxs,
+    ResourceMempool, ToSocketAddrs,
 };
 use pure_stage::{BoxFuture, StageGraph, tokio::TokioBuilder};
 use socket2::{Domain, Protocol, Socket, Type};
@@ -52,6 +52,7 @@ pub(super) fn ephemeral_localhost_addr() -> anyhow::Result<SocketAddr> {
 
 /// Resource type definitions
 pub(super) type ResourceBlockValidation = Arc<dyn CanValidateBlocks + Send + Sync>;
+pub(super) type ResourceHasStakePools = Arc<dyn HasStakePools + Send + Sync>;
 pub(super) type ResourceHeaderValidation = Arc<dyn CanValidateHeaders + Send + Sync>;
 pub(super) type ResourceTxValidation = Arc<dyn CanValidateTxs + Send + Sync>;
 
@@ -74,7 +75,9 @@ pub(super) fn set_resources_with_connections(
     connections: ConnectionsResource,
 ) -> anyhow::Result<()> {
     network.resources().put::<ResourceHeaderStore>(chain_store);
-    network.resources().put::<ResourceBlockValidation>(Arc::new(MockCanValidateBlocks));
+    let block_validation = Arc::new(MockCanValidateBlocks);
+    network.resources().put::<ResourceBlockValidation>(block_validation.clone());
+    network.resources().put::<ResourceHasStakePools>(block_validation);
     network.resources().put::<ResourceHeaderValidation>(Arc::new(MockCanValidateHeaders));
     network.resources().put::<ResourceTxValidation>(Arc::new(MockCanValidateTxs));
     network.resources().put::<ConnectionsResource>(connections);

--- a/crates/amaru/src/stages/build_node.rs
+++ b/crates/amaru/src/stages/build_node.rs
@@ -15,7 +15,9 @@
 use std::sync::Arc;
 
 use amaru_consensus::{
-    effects::{ResourceBlockValidation, ResourceHeaderValidation, ResourceMeter, ResourceTxValidation},
+    effects::{
+        ResourceBlockValidation, ResourceHasStakePools, ResourceHeaderValidation, ResourceMeter, ResourceTxValidation,
+    },
     stages::select_chain::cmp_tip,
     validate_header::ValidateHeader,
 };
@@ -110,6 +112,9 @@ pub fn build_node(
     // Make the ledger and get its tip
     let ledger = Ledger::new(config, era_history.clone(), global_parameters.clone())
         .context("Failed to create ledger. Have you bootstrapped your node?")?;
+
+    let stake_pools = ledger.get_stake_pools();
+    Handle::current().spawn(async move { stake_pools.registered_relay_socket_addrs().await });
 
     let ledger_tip = ledger.get_tip();
     tracing::info!(
@@ -207,6 +212,7 @@ fn register_resources(
     stage_graph.resources().put::<ResourceHeaderStore>(chain_store);
     stage_graph.resources().put::<ResourceParameters>(global_parameters.clone());
     stage_graph.resources().put::<ResourceBlockValidation>(ledger.get_block_validation());
+    stage_graph.resources().put::<ResourceHasStakePools>(ledger.get_stake_pools());
     stage_graph.resources().put::<ResourceHeaderValidation>(Arc::new(validate_header));
     stage_graph.resources().put::<ResourceTxValidation>(ledger.get_tx_validation());
     stage_graph.resources().put::<ConnectionsResource>(Arc::new(TokioConnections::new(65535)));

--- a/crates/amaru/src/stages/build_node.rs
+++ b/crates/amaru/src/stages/build_node.rs
@@ -113,9 +113,6 @@ pub fn build_node(
     let ledger = Ledger::new(config, era_history.clone(), global_parameters.clone())
         .context("Failed to create ledger. Have you bootstrapped your node?")?;
 
-    let stake_pools = ledger.get_stake_pools();
-    Handle::current().spawn(async move { stake_pools.registered_relay_socket_addrs().await });
-
     let ledger_tip = ledger.get_tip();
     tracing::info!(
         tip.hash = %ledger_tip.hash(),

--- a/crates/amaru/src/stages/ledger.rs
+++ b/crates/amaru/src/stages/ledger.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use amaru_kernel::{EraHistory, GlobalParameters, Point};
 use amaru_ledger::block_validator::BlockValidator;
-use amaru_ouroboros::{CanValidateBlocks, CanValidateTxs, HasStakeDistribution};
+use amaru_ouroboros::{CanValidateBlocks, CanValidateTxs, HasStakeDistribution, HasStakePools};
 use amaru_plutus::arena_pool::ArenaPool;
 use amaru_stores::{
     in_memory::MemoryStore,
@@ -91,6 +91,13 @@ impl Ledger {
 
     /// Return the ledger as a capability for validating blocks.
     pub fn get_block_validation(&self) -> Arc<dyn CanValidateBlocks + Send + Sync> {
+        match self {
+            Ledger::InMemLedger(stage) => Arc::new((*stage).clone()),
+            Ledger::OnDiskLedger(stage) => Arc::new((*stage).clone()),
+        }
+    }
+
+    pub fn get_stake_pools(&self) -> Arc<dyn HasStakePools + Send + Sync> {
         match self {
             Ledger::InMemLedger(stage) => Arc::new((*stage).clone()),
             Ledger::OnDiskLedger(stage) => Arc::new((*stage).clone()),

--- a/crates/amaru/src/tests/setup.rs
+++ b/crates/amaru/src/tests/setup.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use amaru_consensus::{
-    effects::{ResourceBlockValidation, ResourceHeaderValidation, ResourceTxValidation},
+    effects::{ResourceBlockValidation, ResourceHasStakePools, ResourceHeaderValidation, ResourceTxValidation},
     headers_tree::data_generation::Action,
 };
 use amaru_kernel::{BlockHeight, GlobalParameters, IsHeader, Tip, Transaction};
@@ -183,7 +183,9 @@ async fn actions_stage(state: ActionsState, msg: Action, eff: Effects<Action>) -
 /// Add resources depending on the simulation configuration.
 /// For example this function can be used to set a different chain store for the initiator and the responder.
 fn set_resources(node_config: &NodeTestConfig, stage_graph: &mut impl StageGraph) -> anyhow::Result<()> {
-    stage_graph.resources().put::<ResourceBlockValidation>(Arc::new(MockCanValidateBlocks));
+    let block_validation = Arc::new(MockCanValidateBlocks);
+    stage_graph.resources().put::<ResourceBlockValidation>(block_validation.clone());
+    stage_graph.resources().put::<ResourceHasStakePools>(block_validation);
     stage_graph.resources().put::<ResourceHeaderValidation>(Arc::new(MockCanValidateHeaders));
     stage_graph.resources().put::<ResourceTxValidation>(Arc::new(MockCanValidateTxs));
     stage_graph.resources().put::<ResourceMempool<Transaction>>(node_config.mempool.clone());


### PR DESCRIPTION
This is only the effect implementation, the addresses aren’t used yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nodes and ledger now expose and surface registered relay socket addresses from stake pools for network use
  * Runtime provides a stake-pools resource at startup for downstream stages

* **Tests**
  * Test harnesses updated to register and exercise the stake-pools capability

* **Chores**
  * CI snapshot workflow matrix target epoch adjusted
<!-- end of auto-generated comment: release notes by coderabbit.ai -->