### PR TITLE
feat: add traces and metrics for the mempool

### DIFF
--- a/crates/amaru-consensus/src/stages/mempool/mod.rs
+++ b/crates/amaru-consensus/src/stages/mempool/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod stage;
+pub mod traces;
 
 pub use stage::*;
 

--- a/crates/amaru-consensus/src/stages/mempool/stage.rs
+++ b/crates/amaru-consensus/src/stages/mempool/stage.rs
@@ -12,14 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{Tip, Transaction};
-use amaru_ouroboros::{
-    MempoolError, MempoolInsertError, MempoolMsg, MempoolSeqNo, TxInsertResult, TxOrigin, TxRejectReason,
-};
-use amaru_protocols::mempool_effects::MemoryPool;
-use pure_stage::{Effects, StageRef};
+use std::time::Instant;
 
-use crate::effects::{Ledger, LedgerOps};
+use amaru_kernel::{Tip, Transaction};
+use amaru_ouroboros::{MempoolError, MempoolMsg, MempoolSeqNo, TxInsertResult, TxOrigin, TxRejectReason};
+use amaru_protocols::mempool_effects::MemoryPool;
+use pure_stage::{Effects, StageRef, Void};
+
+use crate::{
+    effects::{Ledger, LedgerOps, Metrics},
+    stages::mempool::traces::{RevalidationOutcome, emit_tx_received, record_insert, record_revalidation},
+};
 
 /// The Mempool stage is a pure_stage actor that coordinates validation and insertion of
 /// transactions into the shared mempool via effects, while managing asynchronous waiter
@@ -66,6 +69,7 @@ use crate::effects::{Ledger, LedgerOps};
 pub async fn stage(state: MempoolStageState, msg: MempoolMsg, eff: Effects<MempoolMsg>) -> MempoolStageState {
     let memory_pool = MemoryPool::new(eff.clone());
     let ledger = Ledger::new(eff.clone());
+    let metrics_ops = Metrics::new(&eff);
     let mut state = state;
     match msg {
         MempoolMsg::WaitForAtLeast { seq_no, caller } => {
@@ -78,16 +82,24 @@ pub async fn stage(state: MempoolStageState, msg: MempoolMsg, eff: Effects<Mempo
         MempoolMsg::Insert { tx, origin, caller } => {
             let tx = *tx;
             let tx_id = tx.tx_id();
+            emit_tx_received(&tx_id, &origin);
+
             match validate_and_insert(&ledger, &memory_pool, tx, &origin).await {
                 Ok(result) => {
-                    if let TxInsertResult::Accepted { seq_no, .. } = result {
-                        notify_ready_waiters(&mut state, &eff, seq_no).await;
+                    record_insert(memory_pool.state().await, &metrics_ops, &origin, &result).await;
+                    match result {
+                        TxInsertResult::Accepted { seq_no, .. } => {
+                            notify_ready_waiters(&mut state, &eff, seq_no).await;
+                        }
+                        TxInsertResult::Rejected { tx_id, ref reason } => {
+                            tracing::info!(%tx_id, %reason, "transaction rejected by mempool");
+                        }
                     }
                     eff.send(&caller, Ok(result)).await;
                 }
-                Err(error) => {
-                    tracing::error!(%error, %tx_id, "failed to insert transaction into mempool");
-                    eff.send(&caller, Err(MempoolInsertError { tx_id, error })).await;
+                Err(e) => {
+                    tracing::error!(%e, %tx_id, "cannot insert transaction into the mempool");
+                    eff.send(&caller, Err(e)).await;
                 }
             };
         }
@@ -95,28 +107,41 @@ pub async fn stage(state: MempoolStageState, msg: MempoolMsg, eff: Effects<Mempo
             let mut results = Vec::with_capacity(txs.len());
             for tx in txs {
                 let tx_id = tx.tx_id();
+                emit_tx_received(&tx_id, &origin);
                 match validate_and_insert(&ledger, &memory_pool, tx, &origin).await {
                     Ok(result) => {
-                        if let TxInsertResult::Accepted { seq_no, .. } = result {
-                            notify_ready_waiters(&mut state, &eff, seq_no).await;
+                        record_insert(memory_pool.state().await, &metrics_ops, &origin, &result).await;
+                        match result {
+                            TxInsertResult::Accepted { seq_no, .. } => {
+                                notify_ready_waiters(&mut state, &eff, seq_no).await;
+                            }
+                            TxInsertResult::Rejected { tx_id, ref reason } => {
+                                tracing::info!(%tx_id, %reason, "transaction rejected by mempool");
+                            }
                         }
                         results.push(result);
                     }
-                    Err(error) => {
-                        tracing::error!(%error, %tx_id, "failed to insert transaction into mempool");
-                        eff.send(&caller, Err(MempoolInsertError { tx_id, error })).await;
+                    Err(e) => {
+                        tracing::error!(%e, %tx_id, "cannot insert transaction into the mempool");
+                        eff.send(&caller, Err(e)).await;
                         return state;
                     }
                 }
             }
             eff.send(&caller, Ok(results)).await;
         }
-        MempoolMsg::NewTip(tip) => {
-            let removed = apply_new_tip(&ledger, &memory_pool, tip).await;
-            if removed > 0 {
-                notify_capacity_waiters(&mut state, &eff).await;
+        MempoolMsg::NewTip(tip) => match apply_new_tip(&ledger, &memory_pool, tip).await {
+            Ok(outcome) => {
+                record_revalidation(memory_pool.state().await, &metrics_ops, &outcome).await;
+                if !outcome.evicted_tx_ids.is_empty() {
+                    notify_capacity_waiters(&mut state, &eff).await;
+                }
             }
-        }
+            Err(e) => {
+                tracing::error!(%e, "failed to apply new tip to the mempool");
+                eff.terminate::<Void>().await;
+            }
+        },
         MempoolMsg::SubscribeCapacity { caller } => {
             state.capacity_waiters.push(caller);
         }
@@ -140,24 +165,33 @@ async fn validate_and_insert(
 }
 
 /// Revalidate all the mempool transactions when a new tip has been adopted.
-/// Returns the number of invalid txs that were successfully removed.
-async fn apply_new_tip(ledger: &Ledger, memory_pool: &MemoryPool, tip: Tip) -> usize {
+async fn apply_new_tip(
+    ledger: &Ledger,
+    memory_pool: &MemoryPool,
+    tip: Tip,
+) -> Result<RevalidationOutcome, MempoolError> {
+    let started = Instant::now();
+    let txs = memory_pool.mempool_txs().await;
+    let total_before = txs.len() as u64;
+
     let mut invalid_tx_ids = vec![];
-    for tx in memory_pool.mempool_txs().await {
+    for tx in txs {
         if ledger.validate_tx(&tx).await.is_err() {
             invalid_tx_ids.push(tx.tx_id());
         }
     }
 
-    if !invalid_tx_ids.is_empty()
-        && let Err(error) = memory_pool.remove_txs(&invalid_tx_ids).await
-    {
-        tracing::error!(%error, %tip, "failed to remove invalid transactions after new tip");
-        return 0;
+    if !invalid_tx_ids.is_empty() {
+        memory_pool.remove_txs(&invalid_tx_ids).await?;
     }
 
     tracing::debug!(%tip, invalidated_txs = invalid_tx_ids.len(), "revalidated mempool after new tip");
-    invalid_tx_ids.len()
+    Ok(RevalidationOutcome {
+        tip_slot: u64::from(tip.slot()),
+        total_before,
+        evicted_tx_ids: invalid_tx_ids,
+        duration_micros: started.elapsed().as_micros() as u64,
+    })
 }
 
 /// Notify the waiters whose target sequence number has just been reached.

--- a/crates/amaru-consensus/src/stages/mempool/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/mempool/test_setup.rs
@@ -15,9 +15,9 @@
 use amaru_kernel::{
     Hash, NetworkName, Transaction, TransactionBody, TransactionInput, WitnessSet, size::TRANSACTION_BODY,
 };
-use amaru_ouroboros::{
-    MempoolInsertError, MempoolMsg, MockCanValidateBlocks, ResourceMempool, TxInsertResult, TxOrigin,
-};
+use amaru_metrics::{MetricsEvent, mempool::MempoolMetrics};
+use amaru_ouroboros::{MempoolMsg, MockCanValidateBlocks, ResourceMempool, TxInsertResult, TxOrigin};
+use amaru_ouroboros_traits::MempoolError;
 use amaru_protocols::store_effects::ResourceParameters;
 use pure_stage::{
     DeserializerGuards, Effect, ExternalEffect, StageGraph, UnknownExternalEffect,
@@ -31,7 +31,9 @@ use tracing_subscriber::util::SubscriberInitExt;
 
 use super::*;
 use crate::{
-    effects::{ResourceBlockValidation, ResourceEraHistory, ResourceTxValidation, ValidateTxEffect},
+    effects::{
+        RecordMetricsEffect, ResourceBlockValidation, ResourceEraHistory, ResourceTxValidation, ValidateTxEffect,
+    },
     stages::test_utils::{BufferWriter, Logs},
 };
 
@@ -52,8 +54,9 @@ pub fn register_guards() -> DeserializerGuards {
     vec![
         pure_stage::register_data_deserializer::<MempoolStageState>().boxed(),
         pure_stage::register_data_deserializer::<MempoolMsg>().boxed(),
-        pure_stage::register_data_deserializer::<Result<Vec<TxInsertResult>, MempoolInsertError>>().boxed(),
+        pure_stage::register_data_deserializer::<Result<Vec<TxInsertResult>, MempoolError>>().boxed(),
         pure_stage::register_effect_deserializer::<ValidateTxEffect>().boxed(),
+        pure_stage::register_effect_deserializer::<RecordMetricsEffect>().boxed(),
     ]
 }
 
@@ -106,9 +109,25 @@ pub fn te_insert(at_stage: &str, tx: &Transaction, tx_origin: TxOrigin) -> Trace
 pub fn te_send(
     from: impl AsRef<str>,
     to: impl AsRef<str>,
-    msg: Result<Vec<TxInsertResult>, MempoolInsertError>,
+    msg: Result<Vec<TxInsertResult>, MempoolError>,
 ) -> TraceEntry {
     TraceEntry::suspend(Effect::send(from, to, Box::new(msg)))
+}
+
+pub fn te_mempool_state(at_stage: &str) -> TraceEntry {
+    let value = SendDataValue::from_json("payload", ()).cast::<SendDataValue>().unwrap().value;
+    let effect: Box<dyn ExternalEffect> = Box::new(UnknownExternalEffect::new(SendDataValue {
+        typetag: "amaru_protocols::mempool_effects::State".to_string(),
+        value,
+    }));
+    TraceEntry::suspend(Effect::external(at_stage, effect))
+}
+
+pub fn te_record_metrics(at_stage: &str, metrics: MempoolMetrics) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(
+        at_stage,
+        Box::new(RecordMetricsEffect::new(MetricsEvent::MempoolMetrics(metrics))),
+    ))
 }
 
 pub fn create_transaction(input_index: usize) -> Transaction {

--- a/crates/amaru-consensus/src/stages/mempool/tests.rs
+++ b/crates/amaru-consensus/src/stages/mempool/tests.rs
@@ -14,10 +14,13 @@
 
 use std::sync::Arc;
 
-use amaru_kernel::Transaction;
+use amaru_kernel::{Transaction, to_cbor};
 use amaru_mempool::InMemoryMempool;
-use amaru_ouroboros::{MempoolMsg, MempoolSeqNo, TransactionValidationError, TxInsertResult, TxOrigin, TxRejectReason};
-use amaru_ouroboros_traits::TxSubmissionMempool;
+use amaru_metrics::mempool::{MempoolMetricEvent, MempoolMetrics, TxInsertionOrigin, TxInsertionResult};
+use amaru_ouroboros::{
+    MempoolMsg, MempoolSeqNo, MempoolState, TransactionValidationError, TxInsertResult, TxOrigin, TxRejectReason,
+};
+use amaru_ouroboros_traits::{MempoolError, TxSubmissionMempool};
 use pure_stage::StageRef;
 use tokio::runtime::Builder;
 use tracing::Level;
@@ -25,7 +28,10 @@ use tracing::Level;
 use crate::stages::{
     mempool::{
         MempoolStageState,
-        test_setup::{TestPrep, create_transaction, setup, te_insert, te_send, te_validate_tx},
+        test_setup::{
+            TestPrep, create_transaction, setup, te_insert, te_mempool_state, te_record_metrics, te_send,
+            te_validate_tx,
+        },
     },
     test_utils::{assert_trace, te_input, te_state},
 };
@@ -37,6 +43,9 @@ fn insert_batch_returns_one_result_per_transaction() {
     let (running, _guards, mut logs) = setup(&batch_example);
 
     let MempoolMsg::InsertBatch { txs, .. } = batch_example.msg else { unreachable!() };
+    // After tx[0] is accepted the mempool holds exactly one transaction; tx[1] is rejected by the
+    // validator and tx[2] is a duplicate of tx[0], so neither changes the state.
+    let state = MempoolState { size_bytes: to_cbor(&txs[0]).len() as u64, tx_count: 1 };
     assert_trace(
         &running,
         &[
@@ -44,17 +53,25 @@ fn insert_batch_returns_one_result_per_transaction() {
             te_input("mempool-1", &expected_msg),
             te_validate_tx("mempool-1", &txs[0]),
             te_insert("mempool-1", &txs[0], TxOrigin::Local),
+            te_mempool_state("mempool-1"),
+            te_record_metrics("mempool-1", insertion_metric(state, TxInsertionResult::Accepted)),
             te_validate_tx("mempool-1", &txs[1]),
+            te_mempool_state("mempool-1"),
+            te_record_metrics("mempool-1", insertion_metric(state, TxInsertionResult::RejectedInvalid)),
             te_validate_tx("mempool-1", &txs[2]),
             // Note that the de-duplication check is performed by the mempool when the insertion
             // is attempted
             te_insert("mempool-1", &txs[2], TxOrigin::Local),
-            te_send("mempool-1", "caller", Ok(expected_results(&txs))),
+            te_mempool_state("mempool-1"),
+            te_record_metrics("mempool-1", insertion_metric(state, TxInsertionResult::RejectedDuplicate)),
+            te_send("mempool-1", "caller", expected_results(&txs)),
             te_state("mempool-1", &MempoolStageState::default()),
         ],
     );
 
-    logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+    logs.assert_and_remove(Level::INFO, &["transaction rejected by mempool", "transaction rejected for testing"])
+        .assert_and_remove(Level::INFO, &["transaction rejected by mempool", "Transaction is a duplicate"])
+        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 
 #[test]
@@ -102,13 +119,21 @@ fn reject_tx_1(tx: &Transaction) -> Result<(), TransactionValidationError> {
     }
 }
 
-fn expected_results(txs: &[Transaction]) -> Vec<TxInsertResult> {
-    vec![
+fn insertion_metric(state: MempoolState, result: TxInsertionResult) -> MempoolMetrics {
+    MempoolMetrics {
+        size_bytes: state.size_bytes,
+        tx_count: state.tx_count,
+        event: MempoolMetricEvent::TxInsertion { origin: TxInsertionOrigin::Local, result },
+    }
+}
+
+fn expected_results(txs: &[Transaction]) -> Result<Vec<TxInsertResult>, MempoolError> {
+    Ok(vec![
         TxInsertResult::accepted(txs[0].tx_id(), MempoolSeqNo(1)),
         TxInsertResult::rejected(
             txs[1].tx_id(),
             TxRejectReason::Invalid(anyhow::anyhow!("transaction rejected for testing").into()),
         ),
         TxInsertResult::rejected(txs[2].tx_id(), TxRejectReason::Duplicate),
-    ]
+    ])
 }

--- a/crates/amaru-consensus/src/stages/mempool/traces.rs
+++ b/crates/amaru-consensus/src/stages/mempool/traces.rs
@@ -1,0 +1,170 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use amaru_kernel::TransactionId;
+use amaru_metrics::mempool::{
+    MempoolMetricEvent, MempoolMetrics, TxEvictedReason, TxInsertionOrigin, TxInsertionResult,
+};
+use amaru_observability::trace_record;
+use amaru_ouroboros::MempoolMsg;
+use amaru_ouroboros_traits::{MempoolState, TxInsertResult, TxOrigin, TxRejectReason};
+
+use crate::effects::{Metrics, MetricsOps};
+
+/// Add traces for a transaction that is candidate for mempool insertion.
+pub(super) fn emit_tx_received(tx_id: &TransactionId, origin: &TxOrigin) {
+    trace_record!(
+        amaru_observability::amaru::mempool::TX_RECEIVED,
+        tx_id = tx_id.to_string(),
+        origin = tx_origin_label(origin)
+    );
+    if let TxOrigin::Remote(peer) = origin {
+        trace_record!(
+            amaru_observability::amaru::mempool::TX_RECEIVED_DETAIL,
+            tx_id = tx_id.to_string(),
+            peer = peer.to_string()
+        );
+    }
+}
+
+/// Add a trace to register the result of a mempool insertion (successful or not).
+/// Emit the corresponding metric.
+pub(super) async fn record_insert(
+    mempool_state: MempoolState,
+    metrics: &Metrics<'_, MempoolMsg>,
+    origin: &TxOrigin,
+    result: &TxInsertResult,
+) {
+    match result {
+        TxInsertResult::Accepted { tx_id, seq_no } => {
+            trace_record!(
+                amaru_observability::amaru::mempool::TX_ACCEPTED,
+                tx_id = tx_id.to_string(),
+                seq_no = seq_no.0,
+                origin = tx_origin_label(origin)
+            );
+        }
+        TxInsertResult::Rejected { tx_id, reason } => {
+            let reason_label = reject_reason_label(reason);
+            match reason {
+                TxRejectReason::Invalid(err) => {
+                    let validation_error = err.to_string();
+                    trace_record!(
+                        amaru_observability::amaru::mempool::TX_REJECTED,
+                        tx_id = tx_id.to_string(),
+                        reason = reason_label,
+                        validation_error = validation_error
+                    );
+                }
+                TxRejectReason::Duplicate | TxRejectReason::MempoolFull => {
+                    trace_record!(
+                        amaru_observability::amaru::mempool::TX_REJECTED,
+                        tx_id = tx_id.to_string(),
+                        reason = reason_label
+                    );
+                }
+            }
+        }
+    }
+    emit_metrics(
+        mempool_state,
+        metrics,
+        MempoolMetricEvent::TxInsertion { origin: tx_origin_metric(origin), result: insertion_result_metric(result) },
+    )
+    .await;
+}
+
+/// When a new tip is adopted, add a trace recording the result of the transactions revalidations,
+/// and emit metrics
+pub(super) async fn record_revalidation(
+    mempool_state: MempoolState,
+    metrics: &Metrics<'_, MempoolMsg>,
+    outcome: &RevalidationOutcome,
+) {
+    let evicted_count = outcome.evicted_tx_ids.len() as u64;
+
+    for tx_id in &outcome.evicted_tx_ids {
+        trace_record!(
+            amaru_observability::amaru::mempool::TX_EVICTED,
+            tx_id = tx_id.to_string(),
+            reason = "invalid_after_tip".to_string()
+        );
+    }
+    if evicted_count > 0 {
+        emit_metrics(
+            mempool_state,
+            metrics,
+            MempoolMetricEvent::TxEvicted { reason: TxEvictedReason::InvalidAfterTip, count: evicted_count },
+        )
+        .await;
+    }
+
+    trace_record!(
+        amaru_observability::amaru::mempool::REVALIDATION_DETAIL,
+        tip_slot = outcome.tip_slot,
+        total_before = outcome.total_before,
+        evicted_count = evicted_count,
+        duration_micros = outcome.duration_micros
+    );
+
+    emit_metrics(mempool_state, metrics, MempoolMetricEvent::Revalidated { duration_micros: outcome.duration_micros })
+        .await;
+}
+
+pub(super) struct RevalidationOutcome {
+    pub(super) tip_slot: u64,
+    pub(super) total_before: u64,
+    pub(super) evicted_tx_ids: Vec<TransactionId>,
+    pub(super) duration_micros: u64,
+}
+
+async fn emit_metrics(mempool_state: MempoolState, metrics: &Metrics<'_, MempoolMsg>, event: MempoolMetricEvent) {
+    let MempoolState { size_bytes, tx_count } = mempool_state;
+    metrics.record(MempoolMetrics { size_bytes, tx_count, event }.into()).await;
+}
+
+fn tx_origin_label(origin: &TxOrigin) -> String {
+    match origin {
+        TxOrigin::Local => "local",
+        TxOrigin::Remote(_) => "remote",
+    }
+    .to_string()
+}
+
+fn tx_origin_metric(origin: &TxOrigin) -> TxInsertionOrigin {
+    match origin {
+        TxOrigin::Local => TxInsertionOrigin::Local,
+        TxOrigin::Remote(_) => TxInsertionOrigin::Remote,
+    }
+}
+
+fn reject_reason_label(reason: &TxRejectReason) -> String {
+    match reason {
+        TxRejectReason::Invalid(_) => "invalid",
+        TxRejectReason::Duplicate => "duplicate",
+        TxRejectReason::MempoolFull => "mempool_full",
+    }
+    .to_string()
+}
+
+fn insertion_result_metric(result: &TxInsertResult) -> TxInsertionResult {
+    match result {
+        TxInsertResult::Accepted { .. } => TxInsertionResult::Accepted,
+        TxInsertResult::Rejected { reason, .. } => match reason {
+            TxRejectReason::Invalid(_) => TxInsertionResult::RejectedInvalid,
+            TxRejectReason::Duplicate => TxInsertionResult::RejectedDuplicate,
+            TxRejectReason::MempoolFull => TxInsertionResult::RejectedFull,
+        },
+    }
+}

--- a/crates/amaru-ledger/src/rules/block.rs
+++ b/crates/amaru-ledger/src/rules/block.rs
@@ -58,10 +58,10 @@ pub enum InvalidBlockDetails {
 
 #[derive(Debug, Error)]
 pub enum TransactionValidationFailed {
-    #[error("transaction {transaction_hash} is invalid: {violation}")]
-    Transaction { transaction_hash: TransactionId, violation: TransactionInvalid },
-    #[error("failed to prepare transaction {transaction_hash} for validation: {error}")]
-    Preparation { transaction_hash: TransactionId, error: ValidationContextError },
+    #[error("transaction {transaction_id} is invalid: {violation}")]
+    Transaction { transaction_id: TransactionId, violation: TransactionInvalid },
+    #[error("failed to prepare transaction {transaction_id} for validation: {error}")]
+    Preparation { transaction_id: TransactionId, error: ValidationContextError },
 }
 
 #[derive(Debug)]
@@ -278,10 +278,7 @@ where
         transaction.auxiliary_data.as_ref(),
         tx_size,
     )
-    .map_err(|err| TransactionValidationFailed::Transaction {
-        transaction_hash: transaction_id,
-        violation: err.into(),
-    })?;
+    .map_err(|err| TransactionValidationFailed::Transaction { transaction_id, violation: err.into() })?;
 
     transaction::phase_two::execute(
         context,
@@ -294,10 +291,7 @@ where
         &transaction.body,
         &transaction.witnesses,
     )
-    .map_err(|err| TransactionValidationFailed::Transaction {
-        transaction_hash: transaction_id,
-        violation: err.into(),
-    })?;
+    .map_err(|err| TransactionValidationFailed::Transaction { transaction_id, violation: err.into() })?;
 
     consumed_inputs.into_iter().for_each(|input| context.consume(input));
     Ok(())

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -23,9 +23,9 @@ use std::{
 
 use amaru_kernel::{
     AsHash, Block, ComparableProposalId, ConstitutionalCommitteeStatus, Epoch, EraHistory, EraHistoryError,
-    GlobalParameters, Hasher, Lovelace, MemoizedTransactionOutput, NetworkName, Point, PoolId, ProtocolParameters,
-    Slot, StakeCredential, StakeCredentialKind, Tip, Transaction, TransactionInput, TransactionPointer,
-    expect_stake_credential, to_cbor,
+    GlobalParameters, HasTransactionId, Hasher, Lovelace, MemoizedTransactionOutput, NetworkName, Point, PoolId,
+    ProtocolParameters, Slot, StakeCredential, StakeCredentialKind, Tip, Transaction, TransactionInput,
+    TransactionPointer, expect_stake_credential, to_cbor,
 };
 use amaru_metrics::ledger::LedgerMetrics;
 use amaru_observability::trace_span;
@@ -658,7 +658,7 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
         arena_pool: &ArenaPool,
     ) -> Result<(), rules::block::TransactionValidationFailed> {
         let mut context = self.create_transaction_validation_context(transaction).map_err(|error| {
-            rules::block::TransactionValidationFailed::Preparation { transaction_hash: transaction.tx_id(), error }
+            rules::block::TransactionValidationFailed::Preparation { transaction_id: transaction.tx_id(), error }
         })?;
         let tx_size = to_cbor(transaction).len() as u64;
         rules::block::validate_transaction(
@@ -695,7 +695,8 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
         let block_height = block.header.header_body.block_number;
         let issuer = Hasher::<224>::hash(&block.header.header_body.issuer_vkey[..]);
         let prev_hash = block.header.header_body.prev_hash;
-        let txs_processed = block.transaction_bodies.len() as u64;
+        let tx_count = block.transaction_bodies.len() as u64;
+        trace_block_transactions(point, block_height, &block);
 
         match rules::validate_block(
             &mut context,
@@ -709,6 +710,8 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             BlockValidation::Err(err) => BlockValidation::Err(err),
             BlockValidation::Invalid(slot, id, err) => BlockValidation::Invalid(slot, id, err),
             BlockValidation::Valid(()) => {
+                trace!(target: EVENT_TARGET, %point, block_height, tx_count, "block transactions validated");
+
                 let state: VolatileState = context.into();
                 let slot = point.slot_or_default();
                 let epoch = match self.era_history().slot_to_epoch(slot, slot) {
@@ -732,7 +735,6 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
 
                 let metrics = LedgerMetrics {
                     block_height,
-                    txs_processed,
                     slot,
                     slot_in_epoch,
                     epoch,
@@ -1203,6 +1205,19 @@ impl HasStakeDistribution for StakeDistributionObserver {
             stake: st.stake,
             active_stake: stake_distribution.active_stake,
         }))
+    }
+}
+
+fn trace_block_transactions(point: &Point, block_height: u64, block: &Block) {
+    if !tracing::enabled!(target: EVENT_TARGET, tracing::Level::TRACE) {
+        return;
+    }
+
+    let tx_count = block.transaction_bodies.len();
+    trace!(target: EVENT_TARGET, %point, block_height, tx_count, "block transactions found");
+    for (tx_index, body) in block.transaction_bodies.iter().enumerate() {
+        let tx_id = body.tx_id();
+        trace!(target: EVENT_TARGET, %point, block_height, tx_index, tx_id = %tx_id, "transaction found in block");
     }
 }
 

--- a/crates/amaru-mempool/src/strategies/in_memory_mempool.rs
+++ b/crates/amaru-mempool/src/strategies/in_memory_mempool.rs
@@ -218,6 +218,14 @@ impl<Tx: Send + Sync + 'static + HasTransactionId + cbor::Encode<()> + Clone> Tx
         let current = self.inner.read().current_bytes;
         current.saturating_add(additional_bytes) > self.config.max_bytes
     }
+
+    fn state(&self) -> amaru_ouroboros_traits::MempoolState {
+        let inner = self.inner.read();
+        amaru_ouroboros_traits::MempoolState {
+            tx_count: inner.entries_by_id.len() as u64,
+            size_bytes: inner.current_bytes,
+        }
+    }
 }
 
 impl<Tx: Send + Sync + 'static + HasTransactionId + cbor::Encode<()> + Clone> Mempool<Tx> for InMemoryMempool<Tx> {

--- a/crates/amaru-metrics/src/ledger.rs
+++ b/crates/amaru-metrics/src/ledger.rs
@@ -16,13 +16,12 @@
 use std::sync::OnceLock;
 
 #[cfg(not(target_arch = "wasm32"))]
-use crate::{Counter, Gauge};
+use crate::Gauge;
 use crate::{Meter, MetricRecorder, MetricsEvent};
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct LedgerMetrics {
     pub block_height: u64,
-    pub txs_processed: u64,
     pub slot: u64,
     pub slot_in_epoch: u64,
     pub epoch: u64,
@@ -38,7 +37,6 @@ impl Default for LedgerMetrics {
     fn default() -> Self {
         Self {
             block_height: 1,
-            txs_processed: Default::default(),
             slot: Default::default(),
             slot_in_epoch: Default::default(),
             epoch: Default::default(),
@@ -64,7 +62,6 @@ impl MetricRecorder for LedgerMetrics {
 impl MetricRecorder for LedgerMetrics {
     fn record_to_meter(&self, meter: &Meter) {
         static BLOCK_HEIGHT: OnceLock<Gauge<u64>> = OnceLock::new();
-        static TXS_PROCESSED: OnceLock<Counter<u64>> = OnceLock::new();
         static SLOT_NUM: OnceLock<Gauge<u64>> = OnceLock::new();
         static SLOT_IN_EPOCH: OnceLock<Gauge<u64>> = OnceLock::new();
         static EPOCH: OnceLock<Gauge<u64>> = OnceLock::new();
@@ -76,13 +73,6 @@ impl MetricRecorder for LedgerMetrics {
             meter
                 .u64_gauge("cardano_node_metrics_blockNum_int")
                 .with_description("block height of latest processed block")
-                .with_unit("int")
-                .build()
-        });
-        let txs_processed = TXS_PROCESSED.get_or_init(|| {
-            meter
-                .u64_counter("cardano_node_metrics_txsProcessedNum_int")
-                .with_description("total transactions processed")
                 .with_unit("int")
                 .build()
         });
@@ -130,7 +120,6 @@ impl MetricRecorder for LedgerMetrics {
         });
 
         block_height.record(self.block_height, &[]);
-        txs_processed.add(self.txs_processed, &[]);
         slot_num.record(self.slot, &[]);
         epoch.record(self.epoch, &[]);
         slot_in_epoch.record(self.slot_in_epoch, &[]);

--- a/crates/amaru-metrics/src/lib.rs
+++ b/crates/amaru-metrics/src/lib.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 pub use crate::metrics::{Counter, Gauge, Meter};
-use crate::{ledger::LedgerMetrics, protocol::ProtocolMetrics};
+use crate::{ledger::LedgerMetrics, mempool::MempoolMetrics, protocol::ProtocolMetrics};
 pub mod ledger;
+pub mod mempool;
 pub mod metrics;
 pub mod protocol;
 
@@ -23,6 +24,7 @@ pub const METRICS_METER_NAME: &str = "cardano_node_metrics";
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum MetricsEvent {
     LedgerMetrics(LedgerMetrics),
+    MempoolMetrics(MempoolMetrics),
     ProtocolMetrics(ProtocolMetrics),
 }
 
@@ -34,6 +36,7 @@ impl MetricRecorder for MetricsEvent {
     fn record_to_meter(&self, meter: &Meter) {
         match self {
             MetricsEvent::LedgerMetrics(ledger_metrics) => ledger_metrics.record_to_meter(meter),
+            MetricsEvent::MempoolMetrics(mempool_metrics) => mempool_metrics.record_to_meter(meter),
             MetricsEvent::ProtocolMetrics(protocol_metrics) => protocol_metrics.record_to_meter(meter),
         }
     }

--- a/crates/amaru-metrics/src/mempool.rs
+++ b/crates/amaru-metrics/src/mempool.rs
@@ -1,0 +1,194 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::OnceLock;
+
+#[cfg(not(target_arch = "wasm32"))]
+use opentelemetry::KeyValue;
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::{Counter, Gauge};
+use crate::{Meter, MetricRecorder, MetricsEvent};
+
+// EVENTS
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum TxInsertionOrigin {
+    Local,
+    Remote,
+}
+
+impl TxInsertionOrigin {
+    pub fn as_label(self) -> &'static str {
+        match self {
+            TxInsertionOrigin::Local => "local",
+            TxInsertionOrigin::Remote => "remote",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum TxInsertionResult {
+    Accepted,
+    RejectedInvalid,
+    RejectedDuplicate,
+    RejectedFull,
+}
+
+impl TxInsertionResult {
+    pub fn as_label(self) -> &'static str {
+        match self {
+            TxInsertionResult::Accepted => "accepted",
+            TxInsertionResult::RejectedInvalid => "rejected_invalid",
+            TxInsertionResult::RejectedDuplicate => "rejected_duplicate",
+            TxInsertionResult::RejectedFull => "rejected_full",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum TxEvictedReason {
+    InvalidAfterTip,
+}
+
+impl TxEvictedReason {
+    pub fn as_label(self) -> &'static str {
+        match self {
+            TxEvictedReason::InvalidAfterTip => "invalid_after_tip",
+        }
+    }
+}
+
+/// Mempool metric events for the OpenTelemetry:
+///
+///  - TxInsertion is emitted for each insertion attempt.
+///  - TxEvicted is emitted when transactions are removed from the mempool after a revalidation.
+///  - Revalidated marks a revalidation of the mempool when there's a new tip and records its duration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum MempoolMetricEvent {
+    TxInsertion { origin: TxInsertionOrigin, result: TxInsertionResult },
+    TxEvicted { reason: TxEvictedReason, count: u64 },
+    Revalidated { duration_micros: u64 },
+}
+
+// METRICS
+
+/// Mempool metrics aggregate a mempool metric event + the mempool state at the time of the event
+/// emission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MempoolMetrics {
+    pub size_bytes: u64,
+    pub tx_count: u64,
+    pub event: MempoolMetricEvent,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl MetricRecorder for MempoolMetrics {
+    fn record_to_meter(&self, _meter: &Meter) {
+        // no-op in wasm32 environment, because of `opentelemetry` dependency on `js-sys`
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl MetricRecorder for MempoolMetrics {
+    fn record_to_meter(&self, meter: &Meter) {
+        static SIZE_BYTES: OnceLock<Gauge<u64>> = OnceLock::new();
+        static TX_COUNT: OnceLock<Gauge<u64>> = OnceLock::new();
+        static TXS_PROCESSED: OnceLock<Counter<u64>> = OnceLock::new();
+        static TXS_SYNC_DURATION: OnceLock<Gauge<u64>> = OnceLock::new();
+        static TXS_SYNC_DURATION_TOTAL: OnceLock<Counter<u64>> = OnceLock::new();
+        static TX_INSERTIONS: OnceLock<Counter<u64>> = OnceLock::new();
+
+        // Metrics common to amaru and cardano-node
+
+        let size_bytes = SIZE_BYTES.get_or_init(|| {
+            meter
+                .u64_gauge("cardano_node_metrics_mempoolBytes_int")
+                .with_description("current cumulative CBOR size of transactions held in the mempool")
+                .with_unit("int")
+                .build()
+        });
+
+        let tx_count = TX_COUNT.get_or_init(|| {
+            meter
+                .u64_gauge("cardano_node_metrics_txsInMempool_int")
+                .with_description("current number of transactions held in the mempool")
+                .with_unit("int")
+                .build()
+        });
+
+        let txs_processed = TXS_PROCESSED.get_or_init(|| {
+            meter
+                .u64_counter("cardano_node_metrics_txsProcessedNum_int")
+                .with_description("total transactions moved out of the mempool after revalidation")
+                .with_unit("int")
+                .build()
+        });
+
+        let txs_sync_duration = TXS_SYNC_DURATION.get_or_init(|| {
+            meter
+                .u64_gauge("cardano_node_metrics_txsSyncDuration_int")
+                .with_description("latest time to sync the mempool in ms after block adoption")
+                .with_unit("int")
+                .build()
+        });
+
+        // cumulative mempool sync duration.
+        let txs_sync_duration_total = TXS_SYNC_DURATION_TOTAL.get_or_init(|| {
+            meter
+                .u64_counter("cardano_node_metrics_txsSyncDurationTotal_int")
+                .with_description("cumulative time spent syncing the mempool in ms after block adoption")
+                .with_unit("int")
+                .build()
+        });
+
+        // Amaru-specific metrics
+
+        let tx_insertions = TX_INSERTIONS.get_or_init(|| {
+            meter
+                .u64_counter("amaru_metrics_mempoolTxInsertionsNum_int")
+                .with_description("transaction insertion attempts, labelled by origin and result")
+                .with_unit("int")
+                .build()
+        });
+
+        size_bytes.record(self.size_bytes, &[]);
+        tx_count.record(self.tx_count, &[]);
+
+        match self.event {
+            MempoolMetricEvent::TxInsertion { origin, result } => {
+                let attributes =
+                    &[KeyValue::new("origin", origin.as_label()), KeyValue::new("result", result.as_label())];
+                tx_insertions.add(1, attributes);
+            }
+            MempoolMetricEvent::TxEvicted { reason: _, count } => {
+                if count > 0 {
+                    txs_processed.add(count, &[]);
+                }
+            }
+            MempoolMetricEvent::Revalidated { duration_micros } => {
+                let duration_ms = (duration_micros + 500) / 1_000;
+                txs_sync_duration.record(duration_ms, &[]);
+                txs_sync_duration_total.add(duration_ms, &[]);
+            }
+        }
+    }
+}
+
+impl From<MempoolMetrics> for MetricsEvent {
+    fn from(value: MempoolMetrics) -> Self {
+        MetricsEvent::MempoolMetrics(value)
+    }
+}

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -579,6 +579,49 @@ define_schemas! {
         }
     }
 
+    mempool {
+        /// Transaction received by the mempool stage, before validation.
+        public TX_RECEIVED {
+            required tx_id: String
+            required origin: String
+        }
+
+        /// Transaction validated and inserted into the mempool.
+        public TX_ACCEPTED {
+            required tx_id: String
+            required seq_no: u64
+            required origin: String
+        }
+
+        /// Transaction rejected at insertion. Reason ∈ {invalid, duplicate, mempool_full}.
+        public TX_REJECTED {
+            required tx_id: String
+            required reason: String
+            optional validation_error: String
+        }
+
+        /// Transaction removed from the mempool. Reason ∈ {invalid_after_tip}.
+        /// TODO: split the reason into invalid after tip + present in applied block
+        public TX_EVICTED {
+            required tx_id: String
+            required reason: String
+        }
+
+        /// Detail trace carrying upstream peer attribution for a received tx.
+        TX_RECEIVED_DETAIL {
+            required tx_id: String
+            required peer: String
+        }
+
+        /// Detail trace for a tip-driven revalidation pass.
+        REVALIDATION_DETAIL {
+            required tip_slot: u64
+            required total_before: u64
+            required evicted_count: u64
+            required duration_micros: u64
+        }
+    }
+
     protocols {
         connection {
             /// Handle connection stage messages

--- a/crates/amaru-ouroboros-traits/src/mempool/mempool_traits.rs
+++ b/crates/amaru-ouroboros-traits/src/mempool/mempool_traits.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use amaru_kernel::TransactionId;
 
-use crate::mempool::{MempoolError, MempoolSeqNo, TxInsertResult, TxOrigin};
+use crate::mempool::{MempoolError, MempoolSeqNo, MempoolState, TxInsertResult, TxOrigin};
 
 /// An simple mempool interface to:
 ///
@@ -74,4 +74,9 @@ pub trait TxSubmissionMempool<Tx: Send + Sync + 'static>: Send + Sync {
     /// Returns `true` if accepting `additional_bytes` would push the
     /// mempool past its configured maximum byte size.
     fn is_near_capacity(&self, additional_bytes: u64) -> bool;
+
+    /// Snapshot of the mempool's tx count and cumulative CBOR size, used
+    /// to refresh observability gauges. Returned together so observers can
+    /// avoid taking the underlying lock twice.
+    fn state(&self) -> MempoolState;
 }

--- a/crates/amaru-ouroboros-traits/src/mempool/overriding_mempool.rs
+++ b/crates/amaru-ouroboros-traits/src/mempool/overriding_mempool.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use amaru_kernel::TransactionId;
 use parking_lot::Mutex;
 
-use crate::{MempoolError, MempoolSeqNo, TxInsertResult, TxOrigin, TxSubmissionMempool};
+use crate::{MempoolError, MempoolSeqNo, MempoolState, TxInsertResult, TxOrigin, TxSubmissionMempool};
 
 /// Optional method overrides for [`OverridingMempool`].
 /// Each override receives a reference to the underlying mempool and the method arguments.
@@ -41,6 +41,7 @@ struct Overrides<Tx: Send + Sync + 'static> {
         Option<Box<dyn FnMut(&dyn TxSubmissionMempool<Tx>, &[TransactionId]) -> Result<(), MempoolError> + Send>>,
     last_seq_no: Option<Box<dyn FnMut(&dyn TxSubmissionMempool<Tx>) -> MempoolSeqNo + Send>>,
     is_near_capacity: Option<Box<dyn FnMut(&dyn TxSubmissionMempool<Tx>, u64) -> bool + Send>>,
+    state: Option<Box<dyn FnMut(&dyn TxSubmissionMempool<Tx>) -> MempoolState + Send>>,
 }
 
 impl<Tx: Send + Sync + 'static> Default for Overrides<Tx> {
@@ -55,6 +56,7 @@ impl<Tx: Send + Sync + 'static> Default for Overrides<Tx> {
             remove_txs: None,
             last_seq_no: None,
             is_near_capacity: None,
+            state: None,
         }
     }
 }
@@ -158,6 +160,14 @@ impl<Tx: Send + Sync + 'static> OverridingMempoolBuilder<Tx> {
         self
     }
 
+    pub fn with_state<F>(mut self, f: F) -> Self
+    where
+        F: FnMut(&dyn TxSubmissionMempool<Tx>) -> MempoolState + Send + 'static,
+    {
+        self.overrides.state = Some(Box::new(f));
+        self
+    }
+
     pub fn build(self) -> OverridingMempool<Tx> {
         OverridingMempool { inner: self.inner, overrides: Mutex::new(self.overrides) }
     }
@@ -233,6 +243,14 @@ impl<Tx: Send + Sync + 'static> TxSubmissionMempool<Tx> for OverridingMempool<Tx
         match &mut overrides.is_near_capacity {
             Some(f) => f(self.inner.as_ref(), additional_bytes),
             None => self.inner.is_near_capacity(additional_bytes),
+        }
+    }
+
+    fn state(&self) -> MempoolState {
+        let mut overrides = self.overrides.lock();
+        match &mut overrides.state {
+            Some(f) => f(self.inner.as_ref()),
+            None => self.inner.state(),
         }
     }
 }

--- a/crates/amaru-ouroboros-traits/src/mempool/values.rs
+++ b/crates/amaru-ouroboros-traits/src/mempool/values.rs
@@ -49,6 +49,13 @@ impl Display for MempoolSeqNo {
     }
 }
 
+/// Snapshot of the mempool's internal counters, used for observability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MempoolState {
+    pub tx_count: u64,
+    pub size_bytes: u64,
+}
+
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum TxInsertResult {
     Accepted { tx_id: TransactionId, seq_no: MempoolSeqNo },
@@ -72,7 +79,7 @@ impl TxInsertResult {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, thiserror::Error, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error, Serialize, Deserialize)]
 pub enum TxRejectReason {
     #[error("Mempool is full")]
     MempoolFull,
@@ -82,7 +89,7 @@ pub enum TxRejectReason {
     Invalid(#[from] TransactionValidationError),
 }
 
-#[derive(Debug, PartialEq, Eq, thiserror::Error, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error, Serialize, Deserialize)]
 pub struct TransactionValidationError(String);
 
 impl Display for TransactionValidationError {

--- a/crates/amaru-ouroboros/src/mempool.rs
+++ b/crates/amaru-ouroboros/src/mempool.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use amaru_kernel::{Tip, Transaction, TransactionId};
-use amaru_ouroboros_traits::{MempoolError, MempoolSeqNo, TxInsertResult, TxOrigin};
+use amaru_ouroboros_traits::{MempoolError, MempoolSeqNo, TxInsertResult, TxOrigin, TxRejectReason};
 use pure_stage::StageRef;
 
 /// Messages accepted by the mempool stage.
@@ -34,28 +34,15 @@ use pure_stage::StageRef;
 /// still need capacity after being notified.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum MempoolMsg {
-    WaitForAtLeast {
-        seq_no: MempoolSeqNo,
-        caller: StageRef<()>,
-    },
-    Insert {
-        tx: Box<Transaction>,
-        origin: TxOrigin,
-        caller: StageRef<Result<TxInsertResult, MempoolInsertError>>,
-    },
-    InsertBatch {
-        txs: Vec<Transaction>,
-        origin: TxOrigin,
-        caller: StageRef<Result<Vec<TxInsertResult>, MempoolInsertError>>,
-    },
+    WaitForAtLeast { seq_no: MempoolSeqNo, caller: StageRef<()> },
+    Insert { tx: Box<Transaction>, origin: TxOrigin, caller: StageRef<Result<TxInsertResult, MempoolError>> },
+    InsertBatch { txs: Vec<Transaction>, origin: TxOrigin, caller: StageRef<Result<Vec<TxInsertResult>, MempoolError>> },
     NewTip(Tip),
-    SubscribeCapacity {
-        caller: StageRef<()>,
-    },
+    SubscribeCapacity { caller: StageRef<()> },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct MempoolInsertError {
+pub struct MempoolInsertResult {
     pub tx_id: TransactionId,
-    pub error: MempoolError,
+    pub rejected: Option<TxRejectReason>,
 }

--- a/crates/amaru-protocols/src/mempool_effects.rs
+++ b/crates/amaru-protocols/src/mempool_effects.rs
@@ -16,7 +16,7 @@ use std::fmt::Debug;
 
 use amaru_kernel::{Transaction, TransactionId};
 use amaru_ouroboros::ResourceMempool;
-use amaru_ouroboros_traits::{MempoolError, MempoolSeqNo, TxInsertResult, TxOrigin, TxSubmissionMempool};
+use amaru_ouroboros_traits::{MempoolError, MempoolSeqNo, MempoolState, TxInsertResult, TxOrigin, TxSubmissionMempool};
 use pure_stage::{BoxFuture, Effects, ExternalEffect, ExternalEffectAPI, Resources, SendData, Void};
 use serde::{Deserialize, Serialize};
 
@@ -45,6 +45,7 @@ pub trait AsyncMempool: Send + Sync {
     fn remove_txs(&self, ids: &[TransactionId]) -> BoxFuture<'_, Result<(), MempoolError>>;
     fn last_seq_no(&self) -> BoxFuture<'_, MempoolSeqNo>;
     fn is_near_capacity(&self, additional_bytes: u64) -> BoxFuture<'_, bool>;
+    fn state(&self) -> BoxFuture<'_, MempoolState>;
 }
 
 impl MemoryPool {
@@ -102,6 +103,11 @@ impl MemoryPool {
     pub fn is_near_capacity(&self, additional_bytes: u64) -> BoxFuture<'static, bool> {
         self.external(IsNearCapacity { additional_bytes })
     }
+
+    /// This effect retrieves a snapshot of the mempool's tx count and cumulative size.
+    pub fn state(&self) -> BoxFuture<'static, MempoolState> {
+        self.external(State)
+    }
 }
 
 impl AsyncMempool for MemoryPool {
@@ -143,6 +149,10 @@ impl AsyncMempool for MemoryPool {
 
     fn is_near_capacity(&self, additional_bytes: u64) -> BoxFuture<'_, bool> {
         MemoryPool::is_near_capacity(self, additional_bytes)
+    }
+
+    fn state(&self) -> BoxFuture<'_, MempoolState> {
+        MemoryPool::state(self)
     }
 }
 
@@ -188,6 +198,10 @@ impl<T: TxSubmissionMempool<Transaction> + ?Sized> AsyncMempool for T {
 
     fn is_near_capacity(&self, additional_bytes: u64) -> BoxFuture<'_, bool> {
         Box::pin(async move { TxSubmissionMempool::is_near_capacity(self, additional_bytes) })
+    }
+
+    fn state(&self) -> BoxFuture<'_, MempoolState> {
+        Box::pin(async move { TxSubmissionMempool::state(self) })
     }
 }
 
@@ -398,10 +412,29 @@ impl ExternalEffectAPI for IsNearCapacity {
     type Response = bool;
 }
 
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct State;
+
+impl ExternalEffect for State {
+    #[expect(clippy::expect_used)]
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        Self::wrap_sync({
+            let mempool = resources.get::<ResourceMempool<Transaction>>().expect("ResourceMempool requires a mempool");
+            mempool.state()
+        })
+    }
+}
+
+impl ExternalEffectAPI for State {
+    type Response = MempoolState;
+}
+
 #[cfg(test)]
 mod tests {
     use amaru_kernel::{Transaction, TransactionBody, TransactionId, WitnessSet};
-    use amaru_ouroboros_traits::{MempoolError, MempoolSeqNo, TxInsertResult, TxOrigin, TxSubmissionMempool};
+    use amaru_ouroboros_traits::{
+        MempoolError, MempoolSeqNo, MempoolState, TxInsertResult, TxOrigin, TxSubmissionMempool,
+    };
 
     #[allow(dead_code)]
     pub struct ConstantMempool {
@@ -449,6 +482,10 @@ mod tests {
 
         fn is_near_capacity(&self, _additional_bytes: u64) -> bool {
             false
+        }
+
+        fn state(&self) -> MempoolState {
+            MempoolState { tx_count: 1, size_bytes: 0 }
         }
     }
 }

--- a/crates/amaru-protocols/src/tx_submission/outcome.rs
+++ b/crates/amaru-protocols/src/tx_submission/outcome.rs
@@ -15,6 +15,7 @@
 use std::fmt::{Display, Formatter};
 
 use amaru_kernel::TransactionId;
+use amaru_ouroboros_traits::MempoolError;
 use serde::{Deserialize, Serialize};
 
 use crate::tx_submission::{ResponderResult, initiator::InitiatorResult};
@@ -38,8 +39,10 @@ pub enum TerminationCause {
     /// The peer did not deliver `ReplyTxs` within the inflight timeout.
     /// This should be modelled at the protocol level.
     TxFetchTimeout,
-    /// Local mempool stage failed or did not respond.
-    MempoolStageUnavailable,
+    /// Local mempool stage did not respond in time.
+    MempoolBatchInsertFailedTimedout,
+    /// Insertion into the mempool failed.
+    MempoolInsertFailed(MempoolError),
 }
 
 /// Peer-misbehavior protocol errors.
@@ -106,7 +109,8 @@ impl Display for TerminationCause {
         match self {
             TerminationCause::Protocol(err) => write!(f, "{err}"),
             TerminationCause::TxFetchTimeout => write!(f, "peer did not deliver ReplyTxs within timeout"),
-            TerminationCause::MempoolStageUnavailable => write!(f, "mempool stage unavailable"),
+            TerminationCause::MempoolBatchInsertFailedTimedout => write!(f, "mempool stage unavailable"),
+            TerminationCause::MempoolInsertFailed(e) => write!(f, "insertion into mempool failed: {e}"),
         }
     }
 }

--- a/crates/amaru-protocols/src/tx_submission/responder.rs
+++ b/crates/amaru-protocols/src/tx_submission/responder.rs
@@ -23,7 +23,7 @@ use ProtocolError::*;
 use TerminationCause::*;
 use amaru_kernel::{EraHistory, Transaction, TransactionId, to_cbor};
 use amaru_observability::trace_span;
-use amaru_ouroboros::{MempoolInsertError, MempoolMsg, MempoolSeqNo, TxInsertResult, TxOrigin, TxRejectReason};
+use amaru_ouroboros::{MempoolInsertResult, MempoolMsg, MempoolSeqNo, TxInsertResult, TxOrigin, TxRejectReason};
 use pure_stage::{DeserializerGuards, Effects, StageRef, Void};
 use tracing::Instrument;
 
@@ -490,12 +490,9 @@ impl TxSubmissionResponder {
         {
             None => {
                 tracing::error!("mempool stage did not respond to InsertBatch within timeout");
-                return terminate(MempoolStageUnavailable);
+                return terminate(MempoolBatchInsertFailedTimedout);
             }
-            Some(Err(MempoolInsertError { tx_id, error })) => {
-                tracing::error!(%tx_id, %error, "mempool stage failed to process InsertBatch");
-                return terminate(MempoolStageUnavailable);
-            }
+            Some(Err(error)) => return terminate(MempoolInsertFailed(error)),
             Some(Ok(results)) => {
                 // Individual transaction rejection are just logged
                 for result in results {
@@ -744,12 +741,12 @@ pub enum TxSubmissionMsg {
     Insert {
         tx: Box<Transaction>,
         origin: TxOrigin,
-        caller: StageRef<Result<TxInsertResult, MempoolInsertError>>,
+        caller: StageRef<Result<TxInsertResult, MempoolInsertResult>>,
     },
     InsertBatch {
         txs: Vec<Transaction>,
         origin: TxOrigin,
-        caller: StageRef<Result<Vec<TxInsertResult>, MempoolInsertError>>,
+        caller: StageRef<Result<Vec<TxInsertResult>, MempoolInsertResult>>,
     },
 }
 

--- a/crates/amaru/src/submit_api.rs
+++ b/crates/amaru/src/submit_api.rs
@@ -98,7 +98,7 @@ async fn submit_tx(State(mempool_sender): State<SubmitApiState>, headers: Header
             reason.to_string(),
         ),
         Ok(Err(error)) => {
-            warn!(tx_id = %error.tx_id, error = %error.error, "mempool insert failed");
+            warn!(%error, "mempool insert failed");
             text_response(StatusCode::INTERNAL_SERVER_ERROR, "mempool unavailable")
         }
         Err(CallError::TimedOut) => text_response(StatusCode::SERVICE_UNAVAILABLE, "mempool timed out"),
@@ -139,12 +139,12 @@ mod tests {
         effects::{ResourceBlockValidation, ResourceEraHistory, ResourceTxValidation},
         stages::mempool::MempoolStageState,
     };
-    use amaru_kernel::{NetworkName, RawBlock, Transaction, TransactionId, to_cbor};
+    use amaru_kernel::{NetworkName, RawBlock, Transaction, to_cbor};
     use amaru_mempool::{InMemoryMempool, MempoolConfig};
     use amaru_ouroboros::{MempoolMsg, ResourceMempool};
     use amaru_ouroboros_traits::{
         MempoolError, MempoolSeqNo, MockCanValidateBlocks, MockCanValidateTxs, TransactionValidationError,
-        TxInsertResult, TxOrigin, TxSubmissionMempool,
+        TxInsertResult, TxSubmissionMempool, overriding_mempool::OverridingMempool,
     };
     use amaru_protocols::store_effects::ResourceParameters;
     use axum::{
@@ -278,7 +278,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_mempool_stage_survives_insert_failure() -> anyhow::Result<()> {
-        let mempool: Arc<dyn TxSubmissionMempool<Transaction>> = Arc::new(FailOnceMempool::default());
+        let attempts = AtomicUsize::new(0);
+        let mempool: Arc<dyn TxSubmissionMempool<Transaction>> = Arc::new(
+            OverridingMempool::builder(Arc::new(InMemoryMempool::default()))
+                .with_insert(move |_, tx: Transaction, _| {
+                    if attempts.fetch_add(1, Ordering::Relaxed) == 0 {
+                        Err(MempoolError::new("temporary failure"))
+                    } else {
+                        Ok(TxInsertResult::accepted(tx.tx_id(), MempoolSeqNo(1)))
+                    }
+                })
+                .build(),
+        );
         let first = create_transaction(0);
         let second = create_transaction(1);
         let sender = make_mempool_sender(mempool, Arc::new(MockCanValidateTxs));
@@ -422,48 +433,5 @@ mod tests {
             "/sample.cbor"
         ));
         RawBlock::from(RAW_BLOCK)
-    }
-
-    #[derive(Default)]
-    struct FailOnceMempool {
-        attempts: AtomicUsize,
-    }
-
-    impl TxSubmissionMempool<Transaction> for FailOnceMempool {
-        fn insert(&self, tx: Transaction, _tx_origin: TxOrigin) -> Result<TxInsertResult, MempoolError> {
-            if self.attempts.fetch_add(1, Ordering::Relaxed) == 0 {
-                Err(MempoolError::new("temporary failure"))
-            } else {
-                Ok(TxInsertResult::accepted(tx.tx_id(), MempoolSeqNo(1)))
-            }
-        }
-
-        fn get_tx(&self, _tx_id: &TransactionId) -> Option<Transaction> {
-            None
-        }
-
-        fn tx_ids_since(&self, _from_seq: MempoolSeqNo, _limit: u16) -> Vec<(TransactionId, u32, MempoolSeqNo)> {
-            vec![]
-        }
-
-        fn get_txs_for_ids(&self, _ids: &[TransactionId]) -> Vec<Transaction> {
-            vec![]
-        }
-
-        fn mempool_txs(&self) -> Vec<Transaction> {
-            vec![]
-        }
-
-        fn remove_txs(&self, _ids: &[TransactionId]) -> Result<(), MempoolError> {
-            Ok(())
-        }
-
-        fn last_seq_no(&self) -> MempoolSeqNo {
-            MempoolSeqNo(0)
-        }
-
-        fn is_near_capacity(&self, _additional_bytes: u64) -> bool {
-            false
-        }
     }
 }

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -294,6 +294,53 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 </details>
 
+## target: `amaru::mempool`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `tx_accepted` | `TRACE` | public | Transaction validated and inserted into the mempool. | tx_id, seq_no, origin |  |
+| `tx_evicted` | `TRACE` | public | Transaction removed from the mempool. Reason ∈ {invalid_after_tip}. TODO: split the reason into invalid after tip + present in applied block | tx_id, reason |  |
+| `tx_received` | `TRACE` | public | Transaction received by the mempool stage, before validation. | tx_id, origin |  |
+| `tx_rejected` | `TRACE` | public | Transaction rejected at insertion. Reason ∈ {invalid, duplicate, mempool_full}. | tx_id, reason | validation_error |
+
+<details><summary>span: `tx_accepted`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `tx_id` | `string` | ✓ |
+| `seq_no` | `integer` | ✓ |
+| `origin` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `tx_evicted`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `tx_id` | `string` | ✓ |
+| `reason` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `tx_received`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `tx_id` | `string` | ✓ |
+| `origin` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `tx_rejected`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `tx_id` | `string` | ✓ |
+| `reason` | `string` | ✓ |
+| `validation_error` | `string` |  |
+
+</details>
+
 ## target: `amaru::protocols::manager`
 
 | name | level | public | description | required fields | optional fields |

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -714,6 +714,103 @@
       "description": "Persist the oldest volatile block to stable storage once the security parameter is reached",
       "public": true
     },
+    "amaru::mempool::TX_ACCEPTED": {
+      "type": "object",
+      "properties": {
+        "tx_id": {
+          "type": "string"
+        },
+        "seq_no": {
+          "type": "integer"
+        },
+        "origin": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tx_id",
+        "seq_no",
+        "origin"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "tx_accepted",
+      "level": "TRACE",
+      "target": "amaru::mempool",
+      "description": "Transaction validated and inserted into the mempool.",
+      "public": true
+    },
+    "amaru::mempool::TX_EVICTED": {
+      "type": "object",
+      "properties": {
+        "tx_id": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tx_id",
+        "reason"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "tx_evicted",
+      "level": "TRACE",
+      "target": "amaru::mempool",
+      "description": "Transaction removed from the mempool. Reason ∈ {invalid_after_tip}. TODO: split the reason into invalid after tip + present in applied block",
+      "public": true
+    },
+    "amaru::mempool::TX_RECEIVED": {
+      "type": "object",
+      "properties": {
+        "tx_id": {
+          "type": "string"
+        },
+        "origin": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tx_id",
+        "origin"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "tx_received",
+      "level": "TRACE",
+      "target": "amaru::mempool",
+      "description": "Transaction received by the mempool stage, before validation.",
+      "public": true
+    },
+    "amaru::mempool::TX_REJECTED": {
+      "type": "object",
+      "properties": {
+        "tx_id": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "validation_error": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tx_id",
+        "reason"
+      ],
+      "optional": [
+        "validation_error"
+      ],
+      "additionalProperties": false,
+      "name": "tx_rejected",
+      "level": "TRACE",
+      "target": "amaru::mempool",
+      "description": "Transaction rejected at insertion. Reason ∈ {invalid, duplicate, mempool_full}.",
+      "public": true
+    },
     "amaru::protocols::manager::ACCEPTED": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
This PR adds traces and metrics for the most important events on a mempool.

Traces:
 | Trace | Description |
 |---|---|
 | **TX_RECEIVED**  | locally or via the tx submission protocol |
 | **TX_ACCEPTED** | inserted in the mempool | 
 | **TX_REJECTED** | not inserted in the mempool |
 | **TX_EVICTED** | removed from the mempool |


Metrics:
 | Metric | Description |
  |---|---|
 | `cardano_node_metrics_mempoolBytes_int` | current cumulative CBOR byte size of transactions in the mempool |
 | `cardano_node_metrics_txsInMempool_int` | current number of transactions in the mempool|
 | `cardano_node_metrics_txsProcessedNum_int` | transactions removed from the mempool after revalidation |
 | `cardano_node_metrics_txsSyncDuration_int` | latest mempool revalidation duration in milliseconds|
 | `cardano_node_metrics_txsSyncDurationTotal_int` | cumulative mempool revalidation duration in milliseconds |
 | `cardano_node_metrics_mempoolTxInsertionsNum_int` | transaction insertion attempts by origin and result |
  
**NOTES**:

 - All metrics are also produced by the Haskell cardano-node, except for `cardano_node_metrics_mempoolTxInsertionsNum_int`.
 - `cardano_node_metrics_txsSyncDuration_int` is emitted in the cardano-node as a counter while it is actually a gauge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive transaction tracing for mempool operations (received, accepted, rejected, evicted events).
  * Implemented mempool metrics collection for transaction insertion origins, rejection reasons, and revalidation cycles.

* **Documentation**
  * Updated trace schemas and documentation to include new mempool transaction lifecycle events.

* **Refactor**
  * Improved error handling in transaction submission and validation workflows.
  * Standardized transaction identifier naming across validation and rejection reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->