### PR TITLE
Increase snapshot test timeout

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -193,7 +193,7 @@ jobs:
     uses: ./.github/workflows/snapshot-tests.yml
     with:
       use_fixed_epoch: true
-      default_timeout: 15
+      default_timeout: 30
       network: ${{ github.event.inputs.network || '' }}
       run_until_target_epoch: ${{ github.event.inputs.run_until_target_epoch || '' }}
       timeout: ${{ github.event.inputs.timeout || '' }}


### PR DESCRIPTION
Recent PRs have seen the e2e snapshot jobs fail due to timeout. Those PRs are introducing additional validations, so it's likely they've added *just* enough execution time to push it over the threshold.

Future work (#792, #793, and #794) will give us better insights so we can improve this, but we should let those tests run to completion in the meantime.