### PR TITLE
fix: don't fail rollback inside the volatile ledger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,7 @@ dependencies = [
  "amaru-ouroboros-traits",
  "amaru-plutus",
  "amaru-progress-bar",
+ "amaru-stores",
  "amaru-tracing-json",
  "amaru-uplc",
  "anyhow",

--- a/crates/amaru-ledger/Cargo.toml
+++ b/crates/amaru-ledger/Cargo.toml
@@ -50,6 +50,7 @@ toml.workspace = true
 
 # Internal dependencies ───────────────────────────────────────────────────────┐
 amaru-kernel = { workspace = true, features = ["test-utils"] }
+amaru-stores.workspace = true
 amaru-tracing-json.workspace = true
 
 [build-dependencies]

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -663,18 +663,20 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             trace_span!(amaru_observability::amaru::ledger::state::ROLL_BACKWARD, rollback_point = to.to_string());
         let _guard = _span.enter();
 
-        // NOTE: This happens typically on start-up; The consensus layer will typically ask us to
-        // rollback to the last known point, which ought to be the tip of the database.
-        if self.volatile.is_empty() && self.tip().as_ref() == to {
-            return Ok(());
-        }
-
-        if self.tip().as_ref() > to {
-            return Err(BackwardError::RollbackPointBeforeTip { rollback_point: *to, tip: self.tip().into_owned() });
-        }
-
-        if self.volatile.is_empty() && self.tip().as_ref() < to {
-            return Err(BackwardError::RollbackPointInFuture(*to));
+        if self.volatile.is_empty() {
+            // NOTE: This happens typically on start-up; The consensus layer will typically ask us to
+            // rollback to the last known point, which ought to be the tip of the database.
+            // Otherwise we return an error.
+            if self.tip().as_ref() == to {
+                return Ok(());
+            } else if self.tip().as_ref() > to {
+                return Err(BackwardError::RollbackPointBeforeTip {
+                    rollback_point: *to,
+                    tip: self.tip().into_owned(),
+                });
+            } else {
+                return Err(BackwardError::RollbackPointInFuture(*to));
+            }
         }
 
         if let Some(last) = self.volatile.view_back()

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -232,14 +232,19 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
 
     /// Inspect the tip of this ledger state. This corresponds to the point of the latest block
     /// applied to the ledger.
-    #[expect(clippy::panic)]
-    #[expect(clippy::unwrap_used)]
     pub fn tip(&'_ self) -> Cow<'_, Point> {
         if let Some(st) = self.volatile.view_back() {
             return Cow::Owned(st.anchor.0.point());
         }
 
-        Cow::Owned(self.stable.lock().unwrap().tip().unwrap_or_else(|e| panic!("no tip found in stable db: {e:?}")))
+        Cow::Owned(self.immutable_tip())
+    }
+
+    #[expect(clippy::panic)]
+    #[expect(clippy::unwrap_used)]
+    /// Tip of the immutable db (i.e. farthest point we can ever rollback to).
+    pub fn immutable_tip(&self) -> Point {
+        self.stable.lock().unwrap().tip().unwrap_or_else(|e| panic!("no tip found in stable db: {e:?}"))
     }
 
     /// Tip of the volatile (`VolatileDB`) sequence only, if non-empty.
@@ -659,33 +664,43 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
     }
 
     pub fn rollback_to(&mut self, to: &Point) -> Result<(), BackwardError> {
-        let _span =
-            trace_span!(amaru_observability::amaru::ledger::state::ROLL_BACKWARD, rollback_point = to.to_string());
-        let _guard = _span.enter();
+        trace_span!(amaru_observability::amaru::ledger::state::ROLL_BACKWARD, rollback_point = to.to_string()).in_scope(
+            || {
+                // NOTE: Rolling back to the tip of the immutable
+                //
+                // On start-up where the consensus layer will typically ask the ledger to rollback
+                // to the last known point, which ought to be the tip of the (immutable) database.
+                //
+                // Said differently, if the volatile db is empty, the rollback point MUST be the
+                // tip of the immutable.
+                let tip = match self.volatile_tip() {
+                    Some(volatile_tip) => volatile_tip.point(),
+                    None => {
+                        let immutable_tip = self.immutable_tip();
 
-        if self.volatile.is_empty() {
-            // NOTE: This happens typically on start-up; The consensus layer will typically ask us to
-            // rollback to the last known point, which ought to be the tip of the database.
-            // Otherwise we return an error.
-            if self.tip().as_ref() == to {
-                return Ok(());
-            } else if self.tip().as_ref() > to {
-                return Err(BackwardError::RollbackPointBeforeTip {
-                    rollback_point: *to,
-                    tip: self.tip().into_owned(),
-                });
-            } else {
-                return Err(BackwardError::RollbackPointInFuture(*to));
-            }
-        }
+                        if &immutable_tip != to {
+                            return Err(BackwardError::UnknownRollbackPoint {
+                                rollback_point: *to,
+                                tip: immutable_tip,
+                            });
+                        }
 
-        if let Some(last) = self.volatile.view_back()
-            && last.anchor.0.point() < *to
-        {
-            return Err(BackwardError::RollbackPointInFuture(*to));
-        }
+                        immutable_tip
+                    }
+                };
 
-        self.volatile.rollback_to(to, |point| BackwardError::UnknownRollbackPoint(*point))
+                // Would still be caught by the next check, but this is a special case for which we
+                // can provide a better error.
+                if to > &tip {
+                    return Err(BackwardError::RollbackPointInFuture { rollback_point: *to, tip });
+                }
+
+                self.volatile.rollback_to(to).map_err(|rollback_point| BackwardError::UnknownRollbackPoint {
+                    rollback_point: *rollback_point,
+                    tip,
+                })
+            },
+        )
     }
 
     pub fn contains_volatile_point(&self, point: &Point) -> bool {
@@ -1100,14 +1115,11 @@ impl HasStakeDistribution for StakeDistributionObserver {
 pub enum BackwardError {
     /// The ledger has been instructed to rollback to an unknown point. This should be impossible
     /// if chain-sync messages (roll-forward and roll-backward) are all passed to the ledger.
-    #[error("error rolling back to unknown {0:?}")]
-    UnknownRollbackPoint(Point),
+    #[error("error rolling back to unknown point at {rollback_point}; current ledger tip is at {tip}")]
+    UnknownRollbackPoint { rollback_point: Point, tip: Point },
 
-    #[error("error rolling back to point {rollback_point:?}: before tip {tip:?}")]
-    RollbackPointBeforeTip { rollback_point: Point, tip: Point },
-
-    #[error("cannot roll back to a point in the future: {0:?}")]
-    RollbackPointInFuture(Point),
+    #[error("cannot roll back to a point {rollback_point} in the future of the current ledger tip {tip}")]
+    RollbackPointInFuture { rollback_point: Point, tip: Point },
 }
 
 #[derive(Debug, Error)]

--- a/crates/amaru-ledger/src/state/volatile_db.rs
+++ b/crates/amaru-ledger/src/state/volatile_db.rs
@@ -95,7 +95,7 @@ impl VolatileDB {
         self.sequence.push_back(state);
     }
 
-    pub fn rollback_to<E>(&mut self, point: &Point, on_unknown_point: impl Fn(&Point) -> E) -> Result<(), E> {
+    pub fn rollback_to<'a>(&mut self, point: &'a Point) -> Result<(), &'a Point> {
         let target_slot = point.slot_or_default();
 
         // Check if the target point is beyond the sequence
@@ -121,7 +121,7 @@ impl VolatileDB {
                 first_slot = ?first.anchor.0.slot(),
                 "Attempting to rollback to a point before the first point of the volatile state"
             );
-            return Err(on_unknown_point(point));
+            return Err(point);
         }
 
         // Now we know the target point is within the sequence
@@ -141,12 +141,12 @@ impl VolatileDB {
                     break;
                 }
             } else {
-                return Err(on_unknown_point(point));
+                return Err(point);
             }
         }
 
         if !found {
-            return Err(on_unknown_point(point));
+            return Err(point);
         }
 
         self.sequence.truncate(ix);
@@ -387,7 +387,7 @@ mod tests {
         // This represents rolling back to a point in the stable DB
         let rollback_point = Point::Specific(Slot::from(5), Hash::new([0u8; 32]));
 
-        let result = db.rollback_to(&rollback_point, |_| "Point not found");
+        let result = db.rollback_to(&rollback_point);
 
         // This should fail
         // (rolling back to a point inside the stable DB is not allowed)
@@ -404,7 +404,7 @@ mod tests {
         let rollback_point = Point::Specific(Slot::from(30), Hash::new([0u8; 32]));
 
         // This should succeed, keeping all 3 elements
-        let result = db.rollback_to(&rollback_point, |_| "Point not found");
+        let result = db.rollback_to(&rollback_point);
 
         assert!(result.is_ok(), "Rolling back to the exact slot of the last element should succeed");
         assert_eq!(db.len(), 3, "All elements should be retained");
@@ -418,7 +418,7 @@ mod tests {
         // Rollback to slot 20 (middle element)
         let rollback_point = Point::Specific(Slot::from(20), Hash::new([0u8; 32]));
 
-        let result = db.rollback_to(&rollback_point, |_| "Point not found");
+        let result = db.rollback_to(&rollback_point);
 
         // This should succeed
         assert!(result.is_ok());
@@ -433,7 +433,7 @@ mod tests {
         // Try to rollback to slot 40 (after the sequence)
         let rollback_point = Point::Specific(Slot::from(40), Hash::new([0u8; 32]));
 
-        let result = db.rollback_to(&rollback_point, |_| "Point not found");
+        let result = db.rollback_to(&rollback_point);
 
         // This should succeed
         assert!(result.is_ok(), "Rolling back to a point after the sequence should succeed");
@@ -448,9 +448,9 @@ mod tests {
         // Rollback to slot 25 (between 20 and 30)
         let rollback_point = Point::Specific(Slot::from(25), Hash::new([0u8; 32]));
 
-        let result = db.rollback_to(&rollback_point, |_| "Point not found");
+        let result = db.rollback_to(&rollback_point);
 
-        assert_eq!(result.unwrap_err(), "Point not found");
+        assert_eq!(result.unwrap_err(), &rollback_point);
         assert_eq!(db.len(), 3, "All elements should be retained");
     }
 

--- a/crates/amaru-ledger/tests/state_rollback.rs
+++ b/crates/amaru-ledger/tests/state_rollback.rs
@@ -1,0 +1,93 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::VecDeque;
+
+use amaru_kernel::{
+    BlockHeight, EraHistory, GlobalParameters, Hash, NetworkName, Point, ProtocolParameters, Slot, Tip,
+};
+use amaru_ledger::{
+    state::{BackwardError, State, VolatileState},
+    store::GovernanceActivity,
+};
+use amaru_stores::in_memory::MemoryStore;
+
+#[test]
+fn rollback_to_a_volatile_common_ancestor_succeeds() {
+    let mut state = make_state();
+    let earlier = point(100, 1);
+    let later = point(200, 2);
+
+    forward_to(&mut state, earlier, 1);
+    forward_to(&mut state, later, 2);
+    assert_eq!(*state.tip(), later);
+
+    state.rollback_to(&earlier).unwrap();
+    assert_eq!(*state.tip(), earlier);
+}
+
+#[test]
+fn rollback_before_volatile_front_is_rejected() {
+    let mut state = make_state();
+    forward_to(&mut state, point(100, 1), 1);
+    forward_to(&mut state, point(200, 2), 2);
+
+    let before_volatile = point(50, 9);
+    let err = state.rollback_to(&before_volatile).err().unwrap();
+
+    assert!(
+        matches!(err, BackwardError::UnknownRollbackPoint(p) if p == before_volatile),
+        "expected UnknownRollbackPoint, got {err:?}",
+    );
+    assert_eq!(*state.tip(), point(200, 2), "tip is unchanged after a rejected rollback");
+}
+
+// HELPERS
+
+/// Create an initial ledger state
+#[expect(clippy::expect_used)]
+fn make_state() -> State<MemoryStore, MemoryStore> {
+    let network = NetworkName::Preprod;
+    let era_history: EraHistory = <&EraHistory>::from(network).clone();
+    let global_parameters: GlobalParameters = <&GlobalParameters>::from(network).clone();
+    let protocol_parameters: ProtocolParameters =
+        <&ProtocolParameters>::try_from(network).expect("preprod parameters available").clone();
+
+    let store = MemoryStore::new(era_history.clone(), protocol_parameters.clone());
+    let snapshots = MemoryStore::new(era_history.clone(), protocol_parameters.clone());
+
+    State::new_with(
+        store,
+        snapshots,
+        network,
+        era_history,
+        global_parameters,
+        protocol_parameters,
+        GovernanceActivity { consecutive_dormant_epochs: 0 },
+        VecDeque::new(),
+    )
+}
+
+/// Forward the ldeger to a given point
+#[expect(clippy::expect_used)]
+fn forward_to(state: &mut State<MemoryStore, MemoryStore>, point: Point, height: u64) {
+    let issuer = Hash::new([0u8; 28]);
+    state
+        .forward(VolatileState::default().anchor(Tip::new(point, BlockHeight::from(height)), issuer))
+        .expect("forward");
+}
+
+fn point(slot: u64, tag: u8) -> Point {
+    Point::Specific(Slot::from(slot), Hash::new([tag; 32]))
+}

--- a/crates/amaru-ledger/tests/state_rollback.rs
+++ b/crates/amaru-ledger/tests/state_rollback.rs
@@ -43,14 +43,57 @@ fn rollback_before_volatile_front_is_rejected() {
     forward_to(&mut state, point(100, 1), 1);
     forward_to(&mut state, point(200, 2), 2);
 
-    let before_volatile = point(50, 9);
-    let err = state.rollback_to(&before_volatile).err().unwrap();
+    let to = point(50, 9);
 
-    assert!(
-        matches!(err, BackwardError::UnknownRollbackPoint(p) if p == before_volatile),
-        "expected UnknownRollbackPoint, got {err:?}",
-    );
+    assert!(matches!(
+        dbg!(state.rollback_to(&to)),
+        Err(BackwardError::UnknownRollbackPoint { rollback_point, .. }) if rollback_point == to,
+    ));
     assert_eq!(*state.tip(), point(200, 2), "tip is unchanged after a rejected rollback");
+}
+
+#[test]
+fn rollback_within_volatile_but_unknown_hash_is_rejected() {
+    let mut state = make_state();
+    forward_to(&mut state, point(100, 1), 1);
+    forward_to(&mut state, point(200, 2), 2);
+
+    let to = point(100, 2);
+
+    assert!(matches!(
+        dbg!(state.rollback_to(&to)),
+        Err(BackwardError::UnknownRollbackPoint { rollback_point, .. }) if rollback_point == to,
+    ));
+    assert_eq!(*state.tip(), point(200, 2), "tip is unchanged after a rejected rollback");
+}
+
+#[test]
+fn rollback_within_volatile_but_unknown_slot_is_rejected() {
+    let mut state = make_state();
+    forward_to(&mut state, point(100, 1), 1);
+    forward_to(&mut state, point(200, 2), 2);
+
+    let to = point(150, 1);
+
+    assert!(matches!(
+        dbg!(state.rollback_to(&to)),
+        Err(BackwardError::UnknownRollbackPoint { rollback_point, .. }) if rollback_point == to,
+    ));
+    assert_eq!(*state.tip(), point(200, 2), "tip is unchanged after a rejected rollback");
+}
+
+#[test]
+fn rollback_after_volatile_front_is_rejected() {
+    let mut state = make_state();
+    forward_to(&mut state, point(100, 1), 1);
+
+    let to = point(101, 2);
+
+    assert!(matches!(
+        dbg!(state.rollback_to(&to)),
+        Err(BackwardError::RollbackPointInFuture { rollback_point, .. }) if rollback_point == to,
+    ));
+    assert_eq!(*state.tip(), point(100, 1), "tip is unchanged after a rejected rollback");
 }
 
 // HELPERS


### PR DESCRIPTION
We can't currently rollback the ledger to a previous volatile state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined ledger state rollback behavior with enhanced error handling that distinguishes between different rollback failure scenarios, including unknown rollback points and future-dated rollback targets.

* **Tests**
  * Added new test suite for ledger rollback functionality covering success cases and various error conditions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/801)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->