### PR TITLE
feat(bootstrap): report progress during long-running stages

### DIFF
--- a/crates/amaru/src/bootstrap.rs
+++ b/crates/amaru/src/bootstrap.rs
@@ -14,17 +14,17 @@
 
 use std::{
     error::Error,
-    io,
+    io::{self, IsTerminal},
     path::{Path, PathBuf},
 };
 
-use amaru_kernel::{BlockHeader, EraHistory, Hash, HeaderHash, IsHeader, NetworkName, Nonce, Point, from_cbor};
+use amaru_kernel::{BlockHeader, EraHistory, Hash, HeaderHash, NetworkName, Nonce, Point, from_cbor};
 use amaru_ledger::{
     bootstrap::import_initial_snapshot,
     store::{EpochTransitionProgress, Store, TransactionalContext},
 };
 use amaru_ouroboros::{ChainStore, Nonces};
-use amaru_progress_bar::new_terminal_progress_bar;
+use amaru_progress_bar::{ProgressBar, new_terminal_progress_bar, no_progress_bar};
 use amaru_stores::rocksdb::{RocksDB, RocksDbConfig, consensus::RocksDBStore};
 use async_compression::tokio::bufread::GzipDecoder;
 use futures_util::TryStreamExt;
@@ -77,6 +77,12 @@ pub enum BootstrapError {
     DownloadInvalidStatusCode(String, reqwest::StatusCode),
 }
 
+/// Pick a progress-bar factory that draws to the terminal only when stderr is a TTY,
+/// so non-interactive runs (CI, log capture) stay quiet.
+fn pick_progress_factory() -> fn(usize, &str) -> Box<dyn ProgressBar> {
+    if std::io::stderr().is_terminal() { new_terminal_progress_bar } else { no_progress_bar }
+}
+
 async fn download_snapshots(snapshots_content: Vec<u8>, snapshots_dir: &PathBuf) -> Result<(), BootstrapError> {
     // Create the target directory if it doesn't exist
     fs::create_dir_all(snapshots_dir)
@@ -88,9 +94,10 @@ async fn download_snapshots(snapshots_content: Vec<u8>, snapshots_dir: &PathBuf)
 
     // Create a reqwest client
     let client = reqwest::Client::new();
+    let total = snapshots.len();
 
     // Download each snapshot
-    for snapshot in &snapshots {
+    for (i, snapshot) in snapshots.iter().enumerate() {
         info!(epoch=%snapshot.epoch, point=%snapshot.point,
             "Downloading snapshot",
         );
@@ -101,9 +108,12 @@ async fn download_snapshots(snapshots_content: Vec<u8>, snapshots_dir: &PathBuf)
 
         // Skip if file already exists
         if target_path.exists() {
+            eprintln!("  - snapshot {}/{} (epoch {}): already present, skipping", i + 1, total, snapshot.epoch);
             info!(filename=%filename, "Snapshot already exists, skipping");
             continue;
         }
+
+        eprintln!("  - snapshot {}/{} (epoch {}): downloading", i + 1, total, snapshot.epoch);
 
         // Download the file
         let response = client
@@ -146,11 +156,20 @@ pub async fn bootstrap(network: NetworkName, ledger_dir: PathBuf, chain_dir: Pat
     let snapshots_dir: PathBuf = default_snapshots_dir(network).into();
     let snapshots_file = get_bootstrap_file(network, snapshot_file_name)?
         .ok_or(BootstrapError::MissingConfigFile(snapshot_file_name.into()))?;
+
+    eprintln!("Downloading snapshots...");
     download_snapshots(snapshots_file, &snapshots_dir).await?;
+
+    eprintln!("Importing ledger snapshots...");
     import_snapshots_from_directory(network, &ledger_dir, &snapshots_dir).await?;
+
+    eprintln!("Importing nonces...");
     import_nonces(network.into(), &chain_dir, default_initial_nonces(network)?).await?;
+
+    eprintln!("Importing headers...");
     import_headers_for_network(&chain_dir, get_bootstrap_headers(network)?.collect::<Vec<_>>()).await?;
 
+    eprintln!("Bootstrap complete.");
     Ok(())
 }
 
@@ -211,15 +230,15 @@ pub async fn import_nonces(
 pub async fn import_headers_for_network(chain_dir: &PathBuf, headers: Vec<Vec<u8>>) -> Result<(), Box<dyn Error>> {
     let db = RocksDBStore::open_and_migrate(&RocksDbConfig::new(chain_dir.into()))?;
 
+    let progress = pick_progress_factory()(headers.len(), "  importing headers {bar:40} {pos}/{len}");
+
     for header in headers {
         let block_header: BlockHeader = from_cbor(&header).unwrap();
-        let hash = block_header.hash();
-
-        info!(hash = hash.to_string().chars().take(8).collect::<String>(), "inserting header");
-
         db.store_header(&block_header)?;
+        progress.tick(1);
     }
 
+    progress.clear();
     Ok(())
 }
 
@@ -255,7 +274,14 @@ pub async fn import_snapshots(
     ledger_dir: &PathBuf,
 ) -> Result<(), Box<dyn std::error::Error>> {
     info!(count = snapshots.len(), "Importing snapshots");
-    for snapshot in snapshots {
+    let total = snapshots.len();
+    for (i, snapshot) in snapshots.iter().enumerate() {
+        eprintln!(
+            "  - importing snapshot {}/{}: {}",
+            i + 1,
+            total,
+            snapshot.file_name().and_then(|s| s.to_str()).unwrap_or("?")
+        );
         import_snapshot(network, snapshot, ledger_dir).await?;
     }
     info!("Imported snapshots");

--- a/crates/amaru/src/bootstrap.rs
+++ b/crates/amaru/src/bootstrap.rs
@@ -14,20 +14,21 @@
 
 use std::{
     error::Error,
-    io::{self, IsTerminal},
+    io,
     path::{Path, PathBuf},
 };
 
-use amaru_kernel::{BlockHeader, EraHistory, Hash, HeaderHash, NetworkName, Nonce, Point, from_cbor};
+use amaru_kernel::{BlockHeader, EraHistory, Hash, HeaderHash, IsHeader, NetworkName, Nonce, Point, from_cbor};
 use amaru_ledger::{
     bootstrap::import_initial_snapshot,
     store::{EpochTransitionProgress, Store, TransactionalContext},
 };
 use amaru_ouroboros::{ChainStore, Nonces};
-use amaru_progress_bar::{ProgressBar, new_terminal_progress_bar, no_progress_bar};
+use amaru_progress_bar::new_terminal_progress_bar;
 use amaru_stores::rocksdb::{RocksDB, RocksDbConfig, consensus::RocksDBStore};
 use async_compression::tokio::bufread::GzipDecoder;
 use futures_util::TryStreamExt;
+use indicatif::{ProgressBar, ProgressStyle};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tokio::{
     fs::{self, File},
@@ -77,12 +78,6 @@ pub enum BootstrapError {
     DownloadInvalidStatusCode(String, reqwest::StatusCode),
 }
 
-/// Pick a progress-bar factory that draws to the terminal only when stderr is a TTY,
-/// so non-interactive runs (CI, log capture) stay quiet.
-fn pick_progress_factory() -> fn(usize, &str) -> Box<dyn ProgressBar> {
-    if std::io::stderr().is_terminal() { new_terminal_progress_bar } else { no_progress_bar }
-}
-
 async fn download_snapshots(snapshots_content: Vec<u8>, snapshots_dir: &PathBuf) -> Result<(), BootstrapError> {
     // Create the target directory if it doesn't exist
     fs::create_dir_all(snapshots_dir)
@@ -108,12 +103,9 @@ async fn download_snapshots(snapshots_content: Vec<u8>, snapshots_dir: &PathBuf)
 
         // Skip if file already exists
         if target_path.exists() {
-            eprintln!("  - snapshot {}/{} (epoch {}): already present, skipping", i + 1, total, snapshot.epoch);
             info!(filename=%filename, "Snapshot already exists, skipping");
             continue;
         }
-
-        eprintln!("  - snapshot {}/{} (epoch {}): downloading", i + 1, total, snapshot.epoch);
 
         // Download the file
         let response = client
@@ -125,7 +117,9 @@ async fn download_snapshots(snapshots_content: Vec<u8>, snapshots_dir: &PathBuf)
             return Err(BootstrapError::DownloadInvalidStatusCode(snapshot.url.clone(), response.status()));
         }
 
-        let (tmp_path, file) = uncompress_to_temp_file(&target_path, response).await?;
+        let progress = new_download_progress_bar(response.content_length(), i + 1, total, snapshot.epoch);
+        let (tmp_path, file) = uncompress_to_temp_file(&target_path, response, &progress).await?;
+        progress.finish_and_clear();
 
         file.sync_all().await?;
         tokio::fs::rename(&tmp_path, &target_path).await?;
@@ -137,13 +131,26 @@ async fn download_snapshots(snapshots_content: Vec<u8>, snapshots_dir: &PathBuf)
     Ok(())
 }
 
+#[allow(clippy::expect_used)]
+fn new_download_progress_bar(content_length: Option<u64>, index: usize, total: usize, epoch: u64) -> ProgressBar {
+    let template = "  snapshot {prefix} (epoch {msg}) {bar:40} {bytes:>10}/{total_bytes:<10} {bytes_per_sec:>12}";
+    let style = ProgressStyle::with_template(template).expect("hard-coded progress bar template should parse");
+    let pb = ProgressBar::new(content_length.unwrap_or(0)).with_style(style);
+    pb.set_prefix(format!("{}/{}", index, total));
+    pb.set_message(epoch.to_string());
+    pb
+}
+
 async fn uncompress_to_temp_file(
     target_path: &Path,
     response: reqwest::Response,
+    progress: &ProgressBar,
 ) -> Result<(PathBuf, File), BootstrapError> {
     let tmp_path = target_path.with_extension("partial");
     let mut file = File::create(&tmp_path).await?;
-    let raw_stream_reader = StreamReader::new(response.bytes_stream().map_err(io::Error::other));
+    let raw_stream_reader = StreamReader::new(
+        response.bytes_stream().inspect_ok(|chunk| progress.inc(chunk.len() as u64)).map_err(io::Error::other),
+    );
     let buffered_reader = BufReader::new(raw_stream_reader);
     let mut decoded_stream = GzipDecoder::new(buffered_reader);
     tokio::io::copy(&mut decoded_stream, &mut file).await?;
@@ -157,19 +164,11 @@ pub async fn bootstrap(network: NetworkName, ledger_dir: PathBuf, chain_dir: Pat
     let snapshots_file = get_bootstrap_file(network, snapshot_file_name)?
         .ok_or(BootstrapError::MissingConfigFile(snapshot_file_name.into()))?;
 
-    eprintln!("Downloading snapshots...");
     download_snapshots(snapshots_file, &snapshots_dir).await?;
-
-    eprintln!("Importing ledger snapshots...");
     import_snapshots_from_directory(network, &ledger_dir, &snapshots_dir).await?;
-
-    eprintln!("Importing nonces...");
     import_nonces(network.into(), &chain_dir, default_initial_nonces(network)?).await?;
-
-    eprintln!("Importing headers...");
     import_headers_for_network(&chain_dir, get_bootstrap_headers(network)?.collect::<Vec<_>>()).await?;
 
-    eprintln!("Bootstrap complete.");
     Ok(())
 }
 
@@ -230,15 +229,15 @@ pub async fn import_nonces(
 pub async fn import_headers_for_network(chain_dir: &PathBuf, headers: Vec<Vec<u8>>) -> Result<(), Box<dyn Error>> {
     let db = RocksDBStore::open_and_migrate(&RocksDbConfig::new(chain_dir.into()))?;
 
-    let progress = pick_progress_factory()(headers.len(), "  importing headers {bar:40} {pos}/{len}");
-
     for header in headers {
         let block_header: BlockHeader = from_cbor(&header).unwrap();
+        let hash = block_header.hash();
+
+        info!(hash = hash.to_string().chars().take(8).collect::<String>(), "inserting header");
+
         db.store_header(&block_header)?;
-        progress.tick(1);
     }
 
-    progress.clear();
     Ok(())
 }
 
@@ -274,14 +273,7 @@ pub async fn import_snapshots(
     ledger_dir: &PathBuf,
 ) -> Result<(), Box<dyn std::error::Error>> {
     info!(count = snapshots.len(), "Importing snapshots");
-    let total = snapshots.len();
-    for (i, snapshot) in snapshots.iter().enumerate() {
-        eprintln!(
-            "  - importing snapshot {}/{}: {}",
-            i + 1,
-            total,
-            snapshot.file_name().and_then(|s| s.to_str()).unwrap_or("?")
-        );
+    for snapshot in snapshots {
         import_snapshot(network, snapshot, ledger_dir).await?;
     }
     info!("Imported snapshots");


### PR DESCRIPTION
fixes #773

## Summary

Adds visible progress reporting to the `amaru bootstrap` flow so users can see that long running bootstrap work is still advancing.

The bootstrap command can run for a while without visible terminal feedback, which can make it look stalled. This PR adds lightweight stage-level progress output and reuses the existing `amaru-progress-bar` infrastructure.

## Changes

- Adds progress output for the main bootstrap stages:
  - downloading snapshots
  - importing ledger snapshots
  - importing nonces
  - importing headers
- Reuses the existing `amaru-progress-bar` crate.
- Keeps progress output TTY-gated to avoid noisy output in non-interactive environments.
- Adds clearer stage messages around expensive bootstrap work.

## Example :)

```text
Downloading snapshots...
- snapshot 1/3 (epoch 163): downloading
- snapshot 2/3 (epoch 164): downloading
- snapshot 3/3 (epoch 165): downloading

Importing ledger snapshots...
- importing snapshot 1/3: 69206375....cbor
- importing snapshot 2/3: 69638382....cbor
- importing snapshot 3/3: 70070379....cbor

Importing nonces...
Importing headers...
Bootstrap complete.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-snapshot terminal progress bars for downloads, showing snapshot index and total count.
  * Standardized progress bar styling and messages; decompression now advances the same progress indicator even when content length is unknown.

* **Bug Fixes**
  * Progress bars are properly finalized and cleared after decompression to prevent stale indicators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/802?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->