### PR TITLE
fix: validate downloaded but still unvalidated blocks in fetch_blocks

### DIFF
--- a/crates/amaru-consensus/benches/stage_msgs.rs
+++ b/crates/amaru-consensus/benches/stage_msgs.rs
@@ -64,6 +64,10 @@ fn stage_msgs(c: &mut Criterion) {
     let msg: Box<dyn SendData> = Box::new(msg);
     group.bench_function("FetchBlocksMsg::NewTip", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
 
+    let msg = FetchBlocksMsg::RecoverStoredBlocks;
+    let msg: Box<dyn SendData> = Box::new(msg);
+    group.bench_function("FetchBlocksMsg::RecoverStoredBlocks", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
+
     let msg = FetchBlocksMsg::Timeout(1000);
     let msg: Box<dyn SendData> = Box::new(msg);
     group.bench_function("FetchBlocksMsg::Timeout", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));

--- a/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
@@ -113,20 +113,25 @@ impl FetchBlocks {
         let tip = best_tip.tip();
         tracing::debug!(tip = %tip.point(), "recovering stored blocks");
 
+        let mut parent: Option<Point> = None;
         for hash in unvalidated {
             let Some(header) = store.load_header(&hash).await else {
                 tracing::error!(%hash, "failed to load candidate header");
                 return eff.terminate().await;
             };
             let tip = header.tip();
-            let parent = load_parent_point(&eff, store.clone(), &header).await;
+            let block_parent = match parent {
+                Some(p) => p,
+                None => load_parent_point(&eff, store.clone(), &header).await,
+            };
             match store.has_block(&hash).await {
                 Ok(true) => {
                     tracing::debug!(point = %tip.point(), "validating stored block");
-                    eff.send(&self.downstream, (tip, parent, self.block_height)).await;
+                    eff.send(&self.downstream, (tip, block_parent, self.block_height)).await;
+                    parent = Some(tip.point());
                 }
                 Ok(false) => {
-                    self.request_missing_blocks(tip, parent, eff).await;
+                    self.request_missing_blocks(tip, block_parent, eff).await;
                     return;
                 }
                 Err(error) => {

--- a/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
@@ -19,7 +19,7 @@ use amaru_ouroboros_traits::{MissingBlocks, MissingBlocksResult};
 use amaru_protocols::{blockfetch::Blocks2, manager::ManagerMessage, store_effects::Store};
 use pure_stage::{Effects, OrTerminateWith, ScheduleId, StageRef};
 
-use crate::stages::select_chain::SelectChainMsg;
+use crate::stages::select_chain::{SelectChainMsg, best_tip_from_store, load_parent_point};
 
 // TODO make configurable
 const MAX_MISSING_BLOCKS_PER_BATCH: usize = 25;
@@ -78,13 +78,70 @@ impl FetchBlocks {
         self.block_height = tip.block_height().max(self.block_height);
 
         tracing::debug!(tip = %tip.point(), parent = %parent, "fetching blocks");
-        let store = Store::new(eff.clone());
         assert!(
             self.missing.is_none(),
             "there shouldn't be any missing blocks when starting a new tip: {:?}",
             self.missing
         );
 
+        self.request_missing_blocks(tip, parent, eff).await;
+    }
+
+    /// Startup-only recovery: resubmit downloaded blocks whose validity was not
+    /// persisted before shutdown, then fetch from the first missing block.
+    pub async fn recover_stored_blocks(&mut self, eff: Effects<FetchBlocksMsg>) {
+        assert!(
+            self.missing.is_none(),
+            "there shouldn't be any missing blocks when recovering stored blocks: {:?}",
+            self.missing
+        );
+
+        let store = Store::new(eff.clone());
+        let (best_tip, unvalidated) = match best_tip_from_store(&store).await {
+            Ok(Some(candidate)) => candidate,
+            Ok(None) => {
+                eff.send(&self.upstream, SelectChainMsg::FetchNextFrom(Point::Origin)).await;
+                return;
+            }
+            Err(error) => {
+                tracing::error!(%error, "failed to find best tip from store");
+                return eff.terminate().await;
+            }
+        };
+
+        self.block_height = best_tip.block_height().max(self.block_height);
+        let tip = best_tip.tip();
+        tracing::debug!(tip = %tip.point(), "recovering stored blocks");
+
+        for hash in unvalidated {
+            let Some(header) = store.load_header(&hash).await else {
+                tracing::error!(%hash, "failed to load candidate header");
+                return eff.terminate().await;
+            };
+            let tip = header.tip();
+            let parent = load_parent_point(&eff, store.clone(), &header).await;
+            match store.has_block(&hash).await {
+                Ok(true) => {
+                    tracing::debug!(point = %tip.point(), "validating stored block");
+                    eff.send(&self.downstream, (tip, parent, self.block_height)).await;
+                }
+                Ok(false) => {
+                    self.request_missing_blocks(tip, parent, eff).await;
+                    return;
+                }
+                Err(error) => {
+                    tracing::error!(%error, %hash, "failed to check stored block");
+                    return eff.terminate().await;
+                }
+            }
+        }
+
+        tracing::info!(tip = %tip.point(), "no blocks to fetch");
+        eff.send(&self.upstream, SelectChainMsg::FetchNextFrom(tip.point())).await;
+    }
+
+    async fn request_missing_blocks(&mut self, tip: Tip, parent: Point, eff: Effects<FetchBlocksMsg>) {
+        let store = Store::new(eff.clone());
         match store.find_missing_blocks(tip.hash(), MAX_MISSING_BLOCKS_PER_BATCH).await {
             Ok(MissingBlocksResult::StartHeaderNotFound) => {
                 tracing::error!("failed to load initial header");
@@ -203,6 +260,7 @@ impl FetchBlocks {
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum FetchBlocksMsg {
     NewTip(Tip, Point),
+    RecoverStoredBlocks,
     Block(NetworkBlock),
     Timeout(u64),
 }
@@ -214,6 +272,7 @@ pub async fn stage(mut state: FetchBlocks, msg: FetchBlocksMsg, eff: Effects<Fet
     }
     match msg {
         FetchBlocksMsg::NewTip(tip, parent) => state.new_tip(tip, parent, eff).await,
+        FetchBlocksMsg::RecoverStoredBlocks => state.recover_stored_blocks(eff).await,
         FetchBlocksMsg::Block(block) => state.block(block, eff).await,
         FetchBlocksMsg::Timeout(req_id) => state.timeout(req_id, eff).await,
     }

--- a/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
@@ -20,8 +20,9 @@ use amaru_kernel::{
 };
 use amaru_ouroboros_traits::{ChainStore, MissingBlocks, StoreError, in_memory_consensus_store::InMemConsensusStore};
 use amaru_protocols::store_effects::{
-    FindMissingBlocksEffect, GetAnchorHashEffect, LoadBlockEffect, LoadHeaderEffect, ResourceHeaderStore,
-    StoreBlockEffect,
+    FindMissingBlocksEffect, GetAnchorHashEffect, GetChildrenEffect, HasBlockEffect, LoadHeaderEffect,
+    LoadHeaderWithValidityEffect, LoadTipEffect, ResourceHeaderStore, StoreBlockEffect,
+    UnvalidatedAncestorHashesEffect,
 };
 use pure_stage::{
     DeserializerGuards, Effect, Instant, Name, ScheduleId, ScheduleIds, StageGraph, StageRef, TerminationReason,
@@ -100,6 +101,10 @@ impl TestPrep {
         self.store.set_anchor_hash(&hash).unwrap();
     }
 
+    pub fn set_validity(&self, hash: HeaderHash, valid: bool) {
+        self.store.set_block_valid(&hash, valid).unwrap();
+    }
+
     pub fn schedule_at(&self, duration: Duration) -> ScheduleId {
         ScheduleIds::default().next_at(Instant::at_offset(duration))
     }
@@ -122,10 +127,15 @@ pub fn register_guards() -> DeserializerGuards {
         pure_stage::register_data_deserializer::<amaru_kernel::cardano::network_block::NetworkBlock>().boxed(),
         pure_stage::register_data_deserializer::<(Tip, Point, BlockHeight)>().boxed(),
         pure_stage::register_effect_deserializer::<LoadHeaderEffect>().boxed(),
-        pure_stage::register_effect_deserializer::<LoadBlockEffect>().boxed(),
+        pure_stage::register_effect_deserializer::<LoadHeaderWithValidityEffect>().boxed(),
+        pure_stage::register_effect_deserializer::<HasBlockEffect>().boxed(),
         pure_stage::register_effect_deserializer::<GetAnchorHashEffect>().boxed(),
+        pure_stage::register_effect_deserializer::<GetChildrenEffect>().boxed(),
+        pure_stage::register_effect_deserializer::<LoadTipEffect>().boxed(),
         pure_stage::register_effect_deserializer::<StoreBlockEffect>().boxed(),
         pure_stage::register_effect_deserializer::<FindMissingBlocksEffect>().boxed(),
+        pure_stage::register_effect_deserializer::<UnvalidatedAncestorHashesEffect>().boxed(),
+        pure_stage::register_data_deserializer::<(Vec<HeaderHash>, bool)>().boxed(),
         pure_stage::register_data_deserializer::<Result<Option<MissingBlocks>, StoreError>>().boxed(),
     ]
 }
@@ -176,6 +186,37 @@ pub fn setup(prep: &TestPrep, msg: FetchBlocksMsg) -> (SimulationRunning, Deseri
 
 pub fn te_find_missing_blocks(at_stage: &str, start: HeaderHash, limit: usize) -> TraceEntry {
     TraceEntry::suspend(Effect::external(at_stage, Box::new(FindMissingBlocksEffect::new(start, limit))))
+}
+
+pub fn te_get_anchor_hash(at_stage: &str) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(at_stage, Box::new(GetAnchorHashEffect::new())))
+}
+
+pub fn te_get_children(at_stage: &str, hash: HeaderHash) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(at_stage, Box::new(GetChildrenEffect::new(hash))))
+}
+
+pub fn te_has_block(at_stage: &str, hash: HeaderHash) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(at_stage, Box::new(HasBlockEffect::new(hash))))
+}
+
+pub fn te_load_header(at_stage: &str, hash: HeaderHash, with_validity: bool) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(
+        at_stage,
+        if with_validity {
+            Box::new(LoadHeaderWithValidityEffect::new(hash))
+        } else {
+            Box::new(LoadHeaderEffect::new(hash))
+        },
+    ))
+}
+
+pub fn te_load_tip(at_stage: &str, hash: HeaderHash) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(at_stage, Box::new(LoadTipEffect::new(hash))))
+}
+
+pub fn te_unvalidated_ancestor_hashes(at_stage: &str, start: HeaderHash) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(at_stage, Box::new(UnvalidatedAncestorHashesEffect::new(start))))
 }
 
 pub fn te_store_block(at_stage: &str, hash: HeaderHash, block: amaru_kernel::RawBlock) -> TraceEntry {

--- a/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
@@ -115,7 +115,6 @@ fn test_recover_stored_blocks_validates_downloaded_unvalidated_blocks() {
             te_has_block("fb-1", prep.headers.h1.hash()),
             te_send("fb-1", "downstream", (prep.headers.h1.tip(), prep.headers.h0.point(), BlockHeight::from(3))),
             te_load_header("fb-1", prep.headers.h2.hash(), false),
-            te_load_tip("fb-1", prep.headers.h1.hash()),
             te_has_block("fb-1", prep.headers.h2.hash()),
             te_send("fb-1", "downstream", (prep.headers.h2.tip(), prep.headers.h1.point(), BlockHeight::from(3))),
             te_send("fb-1", "upstream", SelectChainMsg::FetchNextFrom(prep.headers.h2.point())),

--- a/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
@@ -21,8 +21,9 @@ use tracing::Level;
 use super::*;
 use crate::stages::{
     fetch_blocks::test_setup::{
-        TestPrep, assert_trace, setup, te_cancel_schedule, te_clock, te_find_missing_blocks, te_schedule, te_send,
-        te_store_block, te_terminate, te_terminated, test_prep,
+        TestPrep, assert_trace, setup, te_cancel_schedule, te_clock, te_find_missing_blocks, te_get_anchor_hash,
+        te_get_children, te_has_block, te_load_header, te_load_tip, te_schedule, te_send, te_store_block, te_terminate,
+        te_terminated, te_unvalidated_ancestor_hashes, test_prep,
     },
     test_utils::{te_input, te_state},
 };
@@ -80,6 +81,52 @@ fn test_new_tip_no_blocks_to_fetch() {
         Level::WARN,
         Level::ERROR,
     ]);
+}
+
+#[test]
+fn test_recover_stored_blocks_validates_downloaded_unvalidated_blocks() {
+    let prep = test_prep();
+    prep.store_headers(&[&prep.headers.h0, &prep.headers.h1, &prep.headers.h2]);
+    prep.store_block(&prep.headers.h1);
+    prep.store_block(&prep.headers.h2);
+    prep.set_anchor(prep.headers.h0.hash());
+    prep.set_validity(prep.headers.h0.hash(), true);
+
+    let msg = FetchBlocksMsg::RecoverStoredBlocks;
+
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    let expected = prep.state_with_block_height(3);
+    assert_trace(
+        &running,
+        &[
+            te_state("fb-1", &prep.state),
+            te_input("fb-1", &msg),
+            te_get_anchor_hash("fb-1"),
+            te_load_header("fb-1", prep.headers.h0.hash(), false),
+            te_load_header("fb-1", prep.headers.h0.hash(), true),
+            te_get_children("fb-1", prep.headers.h0.hash()),
+            te_load_header("fb-1", prep.headers.h1.hash(), true),
+            te_get_children("fb-1", prep.headers.h1.hash()),
+            te_load_header("fb-1", prep.headers.h2.hash(), true),
+            te_get_children("fb-1", prep.headers.h2.hash()),
+            te_unvalidated_ancestor_hashes("fb-1", prep.headers.h2.hash()),
+            te_load_header("fb-1", prep.headers.h1.hash(), false),
+            te_load_tip("fb-1", prep.headers.h0.hash()),
+            te_has_block("fb-1", prep.headers.h1.hash()),
+            te_send("fb-1", "downstream", (prep.headers.h1.tip(), prep.headers.h0.point(), BlockHeight::from(3))),
+            te_load_header("fb-1", prep.headers.h2.hash(), false),
+            te_load_tip("fb-1", prep.headers.h1.hash()),
+            te_has_block("fb-1", prep.headers.h2.hash()),
+            te_send("fb-1", "downstream", (prep.headers.h2.tip(), prep.headers.h1.point(), BlockHeight::from(3))),
+            te_send("fb-1", "upstream", SelectChainMsg::FetchNextFrom(prep.headers.h2.point())),
+            te_state("fb-1", &expected),
+        ],
+    );
+    logs.assert_and_remove(Level::DEBUG, &["recovering stored blocks"])
+        .assert_and_remove(Level::DEBUG, &["validating stored block"])
+        .assert_and_remove(Level::DEBUG, &["validating stored block"])
+        .assert_and_remove(Level::INFO, &["no blocks to fetch"])
+        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 
 #[test]

--- a/crates/amaru-consensus/src/stages/select_chain/mod.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/mod.rs
@@ -290,7 +290,11 @@ pub async fn best_tip_from_store(store: &Store) -> anyhow::Result<Option<(BlockH
 
 /// Return the point of the parent of `header`, or `Point::Origin` if it has no parent.
 /// The parent header must be present in the store otherwise the stage is terminated.
-async fn load_parent_point(eff: &Effects<SelectChainMsg>, store: Store, header: &BlockHeader) -> Point {
+pub async fn load_parent_point<T: Send + Sync + 'static>(
+    eff: &Effects<T>,
+    store: Store,
+    header: &BlockHeader,
+) -> Point {
     if let Some(parent) = header.parent() {
         store
             .load_tip(&parent)

--- a/crates/amaru-ouroboros-traits/src/stores/consensus/in_memory_consensus_store.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/consensus/in_memory_consensus_store.rs
@@ -100,6 +100,12 @@ impl<H: IsHeader + Clone + Send + Sync + 'static> ReadOnlyChainStore<H> for InMe
     }
 
     #[expect(clippy::unwrap_used)]
+    fn has_block(&self, hash: &HeaderHash) -> Result<bool, StoreError> {
+        let inner = self.inner.lock().unwrap();
+        Ok(inner.blocks.contains_key(hash))
+    }
+
+    #[expect(clippy::unwrap_used)]
     fn has_header(&self, hash: &HeaderHash) -> bool {
         let inner = self.inner.lock().unwrap();
         inner.headers.contains_key(hash)
@@ -258,6 +264,10 @@ impl<H: IsHeader + Clone + Send + Sync + 'static> ReadOnlyChainStore<H> for InMe
 
     fn load_block(&self, hash: &HeaderHash) -> Result<Option<RawBlock>, StoreError> {
         Ok(self.blocks.get(hash).cloned())
+    }
+
+    fn has_block(&self, hash: &HeaderHash) -> Result<bool, StoreError> {
+        Ok(self.blocks.contains_key(hash))
     }
 
     fn has_header(&self, hash: &HeaderHash) -> bool {

--- a/crates/amaru-ouroboros-traits/src/stores/consensus/mod.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/consensus/mod.rs
@@ -49,6 +49,7 @@ where
     fn next_best_chain(&self, point: &Point) -> Option<Point>;
 
     fn load_block(&self, hash: &HeaderHash) -> Result<Option<RawBlock>, StoreError>;
+    fn has_block(&self, hash: &HeaderHash) -> Result<bool, StoreError>;
     fn get_nonces(&self, header: &HeaderHash) -> Option<Nonces>;
     fn has_header(&self, hash: &HeaderHash) -> bool;
 
@@ -180,6 +181,10 @@ impl<H: IsHeader> ReadOnlyChainStore<H> for Box<dyn ChainStore<H>> {
         self.as_ref().load_block(hash)
     }
 
+    fn has_block(&self, hash: &HeaderHash) -> Result<bool, StoreError> {
+        self.as_ref().has_block(hash)
+    }
+
     fn get_nonces(&self, header: &HeaderHash) -> Option<Nonces> {
         self.as_ref().get_nonces(header)
     }
@@ -220,6 +225,10 @@ impl<H: IsHeader> ReadOnlyChainStore<H> for Box<dyn ReadOnlyChainStore<H> + '_> 
 
     fn load_block(&self, hash: &HeaderHash) -> Result<Option<RawBlock>, StoreError> {
         self.as_ref().load_block(hash)
+    }
+
+    fn has_block(&self, hash: &HeaderHash) -> Result<bool, StoreError> {
+        self.as_ref().has_block(hash)
     }
 
     fn get_nonces(&self, header: &HeaderHash) -> Option<Nonces> {
@@ -489,8 +498,7 @@ where
         let anchor = snapshot.get_anchor_hash();
         let mut missing = Vec::new();
         for header in snapshot.ancestors(start) {
-            let block = snapshot.load_block(&header.hash())?;
-            if block.is_some() || header.hash() == anchor {
+            if snapshot.has_block(&header.hash())? || header.hash() == anchor {
                 missing.reverse();
                 missing.truncate(limit);
                 return Ok(Found(MissingBlocks::new(header.point(), missing)));

--- a/crates/amaru-ouroboros-traits/src/stores/consensus/overriding_consensus_store.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/consensus/overriding_consensus_store.rs
@@ -33,6 +33,7 @@ struct Overrides<H> {
     load_from_best_chain: Option<Box<dyn FnMut(&dyn ChainStore<H>, &Point) -> Option<HeaderHash> + Send>>,
     next_best_chain: Option<Box<dyn FnMut(&dyn ChainStore<H>, &Point) -> Option<Point> + Send>>,
     load_block: Option<Box<dyn FnMut(&dyn ChainStore<H>, &HeaderHash) -> Result<Option<RawBlock>, StoreError> + Send>>,
+    has_block: Option<Box<dyn FnMut(&dyn ChainStore<H>, &HeaderHash) -> Result<bool, StoreError> + Send>>,
     get_nonces: Option<Box<dyn FnMut(&dyn ChainStore<H>, &HeaderHash) -> Option<Nonces> + Send>>,
     has_header: Option<Box<dyn FnMut(&dyn ChainStore<H>, &HeaderHash) -> bool + Send>>,
     store_header: Option<Box<dyn FnMut(&dyn ChainStore<H>, &H) -> Result<(), StoreError> + Send>>,
@@ -57,6 +58,7 @@ impl<H> Default for Overrides<H> {
             load_from_best_chain: None,
             next_best_chain: None,
             load_block: None,
+            has_block: None,
             get_nonces: None,
             has_header: None,
             store_header: None,
@@ -162,6 +164,14 @@ impl<H: IsHeader + Send + Sync + 'static> OverridingChainStoreBuilder<H> {
         F: FnMut(&dyn ChainStore<H>, &HeaderHash) -> Result<Option<RawBlock>, StoreError> + Send + 'static,
     {
         self.overrides.load_block = Some(Box::new(f));
+        self
+    }
+
+    pub fn with_has_block<F>(mut self, f: F) -> Self
+    where
+        F: FnMut(&dyn ChainStore<H>, &HeaderHash) -> Result<bool, StoreError> + Send + 'static,
+    {
+        self.overrides.has_block = Some(Box::new(f));
         self
     }
 
@@ -315,6 +325,14 @@ impl<H: IsHeader + Send + Sync + 'static> ReadOnlyChainStore<H> for OverridingCh
         }
     }
 
+    fn has_block(&self, hash: &HeaderHash) -> Result<bool, StoreError> {
+        let mut overrides = self.overrides.lock();
+        match &mut overrides.has_block {
+            Some(f) => f(self.inner.as_ref(), hash),
+            None => self.inner.has_block(hash),
+        }
+    }
+
     fn get_nonces(&self, header: &HeaderHash) -> Option<Nonces> {
         let mut overrides = self.overrides.lock();
         match &mut overrides.get_nonces {
@@ -394,6 +412,14 @@ impl<H: IsHeader + Send + Sync + 'static> ReadOnlyChainStore<H> for OverridingCh
         match &mut overrides.load_block {
             Some(f) => f(self.parent.inner.as_ref(), hash),
             None => self.inner.load_block(hash),
+        }
+    }
+
+    fn has_block(&self, hash: &HeaderHash) -> Result<bool, StoreError> {
+        let mut overrides = self.parent.overrides.lock();
+        match &mut overrides.has_block {
+            Some(f) => f(self.parent.inner.as_ref(), hash),
+            None => self.inner.has_block(hash),
         }
     }
 

--- a/crates/amaru-protocols/src/store_effects.rs
+++ b/crates/amaru-protocols/src/store_effects.rs
@@ -65,6 +65,10 @@ impl Store {
         self.effects.external(LoadBlockEffect::new(*hash))
     }
 
+    pub fn has_block(&self, hash: &HeaderHash) -> BoxFuture<'static, Result<bool, StoreError>> {
+        self.effects.external(HasBlockEffect::new(*hash))
+    }
+
     pub fn get_nonces(&self, hash: &HeaderHash) -> BoxFuture<'static, Option<Nonces>> {
         self.effects.external(GetNoncesEffect::new(*hash))
     }
@@ -193,6 +197,7 @@ pub fn register_deserializers() -> DeserializerGuards {
         pure_stage::register_effect_deserializer::<GetBestChainHashEffect>().boxed(),
         pure_stage::register_effect_deserializer::<GetBestChainTipEffect>().boxed(),
         pure_stage::register_effect_deserializer::<LoadBlockEffect>().boxed(),
+        pure_stage::register_effect_deserializer::<HasBlockEffect>().boxed(),
         pure_stage::register_effect_deserializer::<GetNoncesEffect>().boxed(),
         pure_stage::register_effect_deserializer::<SwitchToForkEffect>().boxed(),
         pure_stage::register_effect_deserializer::<RollForwardChainEffect>().boxed(),
@@ -672,6 +677,31 @@ impl ExternalEffect for LoadBlockEffect {
 
 impl ExternalEffectAPI for LoadBlockEffect {
     type Response = Result<Option<RawBlock>, StoreError>;
+}
+
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct HasBlockEffect {
+    hash: HeaderHash,
+}
+
+impl HasBlockEffect {
+    pub fn new(hash: HeaderHash) -> Self {
+        Self { hash }
+    }
+}
+
+impl ExternalEffect for HasBlockEffect {
+    #[expect(clippy::expect_used)]
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        Self::wrap_sync({
+            let store = resources.get::<ResourceHeaderStore>().expect("HasBlockEffect requires a chain store").clone();
+            store.has_block(&self.hash)
+        })
+    }
+}
+
+impl ExternalEffectAPI for HasBlockEffect {
+    type Response = Result<bool, StoreError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/crates/amaru-stores/src/rocksdb/consensus/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/mod.rs
@@ -291,6 +291,11 @@ where
             .map(|bytes| bytes.as_ref().into()))
     }
 
+    fn has_block(&self, hash: &HeaderHash) -> Result<bool, StoreError> {
+        let prefix = [&BLOCK_PREFIX[..], &hash[..]].concat();
+        self.db.get_pinned(&prefix, ReadOptions::default()).map(|opt| opt.is_some())
+    }
+
     fn load_from_best_chain(&self, point: &Point) -> Option<HeaderHash> {
         let slot = u64::from(point.slot_or_default()).to_be_bytes();
         self.db.get_pinned(&[&CHAIN_PREFIX[..], &slot[..]].concat(), ReadOptions::default()).ok().flatten().and_then(
@@ -621,6 +626,18 @@ pub mod test {
             db.store_block(&hash, &block).unwrap();
             let block2 = db.load_block(&hash).unwrap();
             assert_eq!(Some(block), block2);
+        })
+    }
+
+    #[test]
+    fn rocksdb_chain_store_can_check_if_block_exists() {
+        with_db(|db| {
+            let hash: HeaderHash = random_bytes(32).as_slice().into();
+            let block = RawBlock::from(&*vec![1; 64]);
+
+            assert!(!db.has_block(&hash).unwrap());
+            db.store_block(&hash, &block).unwrap();
+            assert!(db.has_block(&hash).unwrap());
         })
     }
 

--- a/crates/amaru/src/stages/build_node.rs
+++ b/crates/amaru/src/stages/build_node.rs
@@ -188,13 +188,14 @@ fn initialize_chain_store(config: &Config, ledger_tip: Point) -> anyhow::Result<
         StoreType::RocksDb(ref rocks_db_config) => Arc::new(RocksDBStore::open(rocks_db_config)?),
     };
 
-    if chain_store.get_anchor_hash() == ORIGIN_HASH {
-        tracing::info!(anchor = %ledger_tip, "setting anchor hash");
+    let anchor_hash = chain_store.get_anchor_hash();
+
+    // This corresponds to a bootstrap, we need to correctly initialize the chain store
+    if anchor_hash == ORIGIN_HASH {
+        tracing::info!(anchor = %ledger_tip, "first initialization - setting anchor and best chain");
         chain_store.set_anchor_hash(&ledger_tip.hash())?;
-    }
-    if chain_store.get_best_chain_hash() == ORIGIN_HASH {
-        tracing::info!(best_chain = %ledger_tip, "setting best chain hash");
-        chain_store.set_best_chain_hash(&ledger_tip.hash())?;
+        chain_store.set_block_valid(&ledger_tip.hash(), true)?;
+        chain_store.roll_forward_chain(&ledger_tip)?;
     }
 
     Ok(chain_store)

--- a/crates/amaru/src/stages/build_stage_graph.rs
+++ b/crates/amaru/src/stages/build_stage_graph.rs
@@ -22,7 +22,7 @@ use amaru_consensus::stages::{
     track_peers::{self, TrackPeers, TrackPeersMsg},
     validate_block::{self, ValidateBlock, ValidateBlockMsg},
 };
-use amaru_kernel::{EraHistory, GlobalParameters, Point, Tip};
+use amaru_kernel::{EraHistory, GlobalParameters, Tip};
 use amaru_ouroboros::MempoolMsg;
 use amaru_protocols::{
     manager,
@@ -78,14 +78,16 @@ pub fn build_stage_graph(
 
     let fetch_blocks = stage_graph
         .wire_up(fetch_blocks, FetchBlocks::new(validate_block_input, select_chain.sender(), manager.sender()));
+    #[expect(clippy::expect_used)]
+    stage_graph
+        .preload(&fetch_blocks, [FetchBlocksMsg::RecoverStoredBlocks])
+        .expect("fetch blocks recovery message must be preloaded");
     let fetch_blocks_input =
         stage_graph.contramap(fetch_blocks, "fetch_blocks_input", |(tip, parent)| FetchBlocksMsg::NewTip(tip, parent));
 
     let select_chain = stage_graph.wire_up(select_chain, SelectChain::new(fetch_blocks_input));
     #[expect(clippy::expect_used)]
-    stage_graph
-        .preload(&select_chain, [SelectChainMsg::Initialize, SelectChainMsg::FetchNextFrom(Point::Origin)])
-        .expect("initialization message must be preloaded");
+    stage_graph.preload(&select_chain, [SelectChainMsg::Initialize]).expect("initialization message must be preloaded");
     let select_chain_input = stage_graph
         .contramap(select_chain, "select_chain_input", |(tip, parent)| SelectChainMsg::TipFromUpstream(tip, parent));
 


### PR DESCRIPTION
This PR fixes the case where the `fetch_block` stage might have downloaded blocks that were not yet validated before. Without it, we could have an inconsistent state on restart.

It also sets the proper chain store values for the anchor and best hash when we start from a bootstrapped state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added block recovery during consensus initialization to resubmit stored but unvalidated blocks before resuming synchronization.

* **Improvements**
  * Optimized block existence validation checks for better performance.
  * Enhanced chain store initialization and anchor management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/805)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->