### PR TITLE
feat: add new metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,7 @@ version = "0.1.2"
 dependencies = [
  "amaru-kernel",
  "amaru-mempool",
+ "amaru-metrics",
  "amaru-network",
  "amaru-observability",
  "amaru-ouroboros",

--- a/crates/amaru-consensus/src/stages/adopt_chain/mod.rs
+++ b/crates/amaru-consensus/src/stages/adopt_chain/mod.rs
@@ -14,11 +14,13 @@
 
 use std::{cmp::Ordering, time::Duration};
 
-use amaru_kernel::{BlockHeader, BlockHeight, IsHeader, Tip};
+use amaru_kernel::{BlockHeader, BlockHeight, Hasher, IsHeader, ORIGIN_HASH, Tip};
+use amaru_metrics::protocol::TipBlockMetrics;
 use amaru_ouroboros_traits::{ChainStore, ReadOnlyChainStore, StoreError};
 use amaru_protocols::{manager::ManagerMessage, store_effects::Store};
 use pure_stage::{Effects, Instant, StageRef, TryInStage};
 
+use crate::effects::{Metrics, MetricsOps};
 use crate::stages::select_chain::cmp_tip;
 
 /// This stage receives validated chains in the form of a Tip and decides
@@ -111,6 +113,8 @@ pub async fn stage(mut state: AdoptChain, msg: AdoptChainMsg, eff: Effects<Adopt
         })
         .await;
 
+    Metrics::new(store.eff()).record(tip_block_metrics(&incoming_header).into()).await;
+
     // do not print every single block while catching up
     let now = store.eff().clock().await;
     if now.saturating_since(state.last_printed) >= Duration::from_secs(1) {
@@ -141,6 +145,14 @@ fn adopt_tip(
 
     store.set_best_chain_hash(&incoming_header.hash())?;
     Ok(())
+}
+
+fn tip_block_metrics(header: &BlockHeader) -> TipBlockMetrics {
+    TipBlockMetrics {
+        hash: header.hash().to_string(),
+        parent_hash: header.parent_hash().unwrap_or(ORIGIN_HASH).to_string(),
+        issuer_verification_key_hash: Hasher::<224>::hash(&header.header_body().issuer_vkey[..]).to_string(),
+    }
 }
 
 /// Find the youngest point on the current best chain that is an ancestor of

--- a/crates/amaru-consensus/src/stages/adopt_chain/mod.rs
+++ b/crates/amaru-consensus/src/stages/adopt_chain/mod.rs
@@ -20,8 +20,10 @@ use amaru_ouroboros_traits::{ChainStore, ReadOnlyChainStore, StoreError};
 use amaru_protocols::{manager::ManagerMessage, store_effects::Store};
 use pure_stage::{Effects, Instant, StageRef, TryInStage};
 
-use crate::effects::{Metrics, MetricsOps};
-use crate::stages::select_chain::cmp_tip;
+use crate::{
+    effects::{Metrics, MetricsOps},
+    stages::select_chain::cmp_tip,
+};
 
 /// This stage receives validated chains in the form of a Tip and decides
 /// whether to adopt that tip as the new downstream tip.

--- a/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
@@ -14,11 +14,14 @@
 
 use std::time::Duration;
 
-use amaru_kernel::{BlockHeader, BlockHeight, IsHeader, Point, Tip, cardano::network_block::NetworkBlock};
+use amaru_kernel::{BlockHeader, BlockHeight, EraHistory, IsHeader, Point, Tip, cardano::network_block::NetworkBlock};
+use amaru_metrics::protocol::BlockfetchClientMetrics;
 use amaru_ouroboros::{ChainStore, ReadOnlyChainStore};
 use amaru_protocols::{blockfetch::Blocks2, manager::ManagerMessage, store_effects::Store};
 use pure_stage::{Effects, ScheduleId, StageRef, TryInStage};
 
+#[cfg(not(test))]
+use crate::effects::{Metrics, MetricsOps};
 use crate::stages::select_chain::SelectChainMsg;
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -31,6 +34,13 @@ pub struct FetchBlocks {
     cleanup_replies: StageRef<Blocks2>,
     timeout: Option<ScheduleId>,
     block_height: BlockHeight,
+    era_history: EraHistory,
+    system_start_ms: u64,
+    block_delay_samples: u64,
+    block_delay_under_one_second: u64,
+    block_delay_under_three_seconds: u64,
+    block_delay_under_five_seconds: u64,
+    block_delay_over_five_seconds: u64,
 }
 
 impl FetchBlocks {
@@ -38,6 +48,8 @@ impl FetchBlocks {
         downstream: StageRef<(Tip, Point, BlockHeight)>,
         upstream: StageRef<SelectChainMsg>,
         manager: StageRef<ManagerMessage>,
+        era_history: EraHistory,
+        system_start_ms: u64,
     ) -> Self {
         Self {
             downstream,
@@ -48,6 +60,13 @@ impl FetchBlocks {
             cleanup_replies: StageRef::blackhole(),
             timeout: None,
             block_height: BlockHeight::from(0),
+            era_history,
+            system_start_ms,
+            block_delay_samples: 0,
+            block_delay_under_one_second: 0,
+            block_delay_under_three_seconds: 0,
+            block_delay_under_five_seconds: 0,
+            block_delay_over_five_seconds: 0,
         }
     }
 
@@ -58,6 +77,8 @@ impl FetchBlocks {
         upstream: StageRef<SelectChainMsg>,
         manager: StageRef<ManagerMessage>,
         cleanup_replies: StageRef<Blocks2>,
+        era_history: EraHistory,
+        system_start_ms: u64,
     ) -> Self {
         Self {
             downstream,
@@ -68,7 +89,60 @@ impl FetchBlocks {
             cleanup_replies,
             timeout: None,
             block_height: BlockHeight::from(0),
+            era_history,
+            system_start_ms,
+            block_delay_samples: 0,
+            block_delay_under_one_second: 0,
+            block_delay_under_three_seconds: 0,
+            block_delay_under_five_seconds: 0,
+            block_delay_over_five_seconds: 0,
         }
+    }
+
+    fn observe_blockfetch_metrics(&mut self, block_delay: f64, block_size: u64) -> BlockfetchClientMetrics {
+        self.block_delay_samples += 1;
+        self.block_delay_under_one_second += u64::from(block_delay <= 1.0);
+        self.block_delay_under_three_seconds += u64::from(block_delay <= 3.0);
+        self.block_delay_under_five_seconds += u64::from(block_delay <= 5.0);
+        self.block_delay_over_five_seconds += u64::from(block_delay > 5.0);
+
+        let block_delay_samples = self.block_delay_samples as f64;
+
+        BlockfetchClientMetrics {
+            block_delay,
+            block_delay_cdf_one: self.block_delay_under_one_second as f64 / block_delay_samples,
+            block_delay_cdf_three: self.block_delay_under_three_seconds as f64 / block_delay_samples,
+            block_delay_cdf_five: self.block_delay_under_five_seconds as f64 / block_delay_samples,
+            block_size,
+            late_blocks: self.block_delay_over_five_seconds,
+        }
+    }
+
+    #[cfg(not(test))]
+    async fn record_blockfetch_metrics(
+        &mut self,
+        slot: amaru_kernel::Slot,
+        block_size: u64,
+        eff: &Effects<FetchBlocksMsg>,
+    ) {
+        let system_start = std::time::SystemTime::UNIX_EPOCH + Duration::from_millis(self.system_start_ms);
+        let Ok(expected_time) = self.era_history.slot_to_posix_time(slot, slot, system_start) else {
+            return;
+        };
+
+        let block_delay = std::time::SystemTime::now().duration_since(expected_time).unwrap_or_default().as_secs_f64();
+        let blockfetch_metrics = self.observe_blockfetch_metrics(block_delay, block_size);
+
+        Metrics::new(eff).record(blockfetch_metrics.into()).await;
+    }
+
+    #[cfg(test)]
+    async fn record_blockfetch_metrics(
+        &mut self,
+        _slot: amaru_kernel::Slot,
+        _block_size: u64,
+        _eff: &Effects<FetchBlocksMsg>,
+    ) {
     }
 
     #[expect(clippy::expect_used)]
@@ -160,12 +234,15 @@ impl FetchBlocks {
         }
 
         let parent = self.missing.remove(0);
+        let raw_block = network_block.raw_block();
+        let block_size = raw_block.len() as u64;
         store
-            .store_block(&point.hash(), &network_block.raw_block())
+            .store_block(&point.hash(), &raw_block)
             .or_terminate(store.eff(), async |error| {
                 tracing::error!(%error, "failed to store block");
             })
             .await;
+        self.record_blockfetch_metrics(header.slot(), block_size, store.eff()).await;
         let tip = Tip::new(point, block.header.header_body.block_number.into());
         store.eff().send(&self.downstream, (tip, parent, self.block_height)).await;
 

--- a/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use amaru_kernel::{
-    BlockHeader, HeaderHash, Point, RawBlock, TESTNET_ERA_HISTORY, Tip,
+    BlockHeader, HeaderHash, Point, RawBlock, TESTNET_ERA_HISTORY, TESTNET_GLOBAL_PARAMETERS, Tip,
     cardano::network_block::{make_block_with_header, make_encoded_block, make_network_block},
 };
 use amaru_ouroboros_traits::{ChainStore, in_memory_consensus_store::InMemConsensusStore};
@@ -134,7 +134,14 @@ pub fn test_prep() -> TestPrep {
     let manager = StageRef::named_for_tests("manager");
     let cleanup_replies = StageRef::named_for_tests("cleanup_replies");
 
-    let state = FetchBlocks::for_tests(downstream, upstream, manager, cleanup_replies.clone());
+    let state = FetchBlocks::for_tests(
+        downstream,
+        upstream,
+        manager,
+        cleanup_replies.clone(),
+        TESTNET_ERA_HISTORY.clone(),
+        TESTNET_GLOBAL_PARAMETERS.system_start,
+    );
 
     TestPrep {
         state,

--- a/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
@@ -14,6 +14,7 @@
 
 use std::time::Duration;
 
+use amaru_metrics::protocol::BlockfetchClientMetrics;
 use pure_stage::{Instant, ScheduleIds, trace_buffer::TerminationReason};
 use tracing::Level;
 
@@ -219,4 +220,33 @@ fn test_block2_received() {
         Level::WARN,
         Level::ERROR,
     ]);
+}
+
+#[test]
+fn test_observe_blockfetch_metrics_tracks_running_cdfs() {
+    let mut state = test_prep().state;
+
+    assert_eq!(
+        state.observe_blockfetch_metrics(0.5, 100),
+        BlockfetchClientMetrics {
+            block_delay: 0.5,
+            block_delay_cdf_one: 1.0,
+            block_delay_cdf_three: 1.0,
+            block_delay_cdf_five: 1.0,
+            block_size: 100,
+            late_blocks: 0,
+        }
+    );
+
+    assert_eq!(
+        state.observe_blockfetch_metrics(4.0, 200),
+        BlockfetchClientMetrics {
+            block_delay: 4.0,
+            block_delay_cdf_one: 0.5,
+            block_delay_cdf_three: 0.5,
+            block_delay_cdf_five: 1.0,
+            block_size: 200,
+            late_blocks: 0,
+        }
+    );
 }

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -645,8 +645,8 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
                 let density = self.chain_density(point);
 
                 let current_kes_period = slot / self.global_parameters.slots_per_kes_period;
-                let remaining_kes_periods = (self.global_parameters.max_kes_evolution as u64)
-                    .saturating_sub(current_kes_period);
+                let remaining_kes_periods =
+                    (self.global_parameters.max_kes_evolution as u64).saturating_sub(current_kes_period);
 
                 let metrics = LedgerMetrics {
                     block_height,

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -644,7 +644,20 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
 
                 let density = self.chain_density(point);
 
-                let metrics = LedgerMetrics { block_height, txs_processed, slot, slot_in_epoch, epoch, density };
+                let current_kes_period = slot / self.global_parameters.slots_per_kes_period;
+                let remaining_kes_periods = (self.global_parameters.max_kes_evolution as u64)
+                    .saturating_sub(current_kes_period);
+
+                let metrics = LedgerMetrics {
+                    block_height,
+                    txs_processed,
+                    slot,
+                    slot_in_epoch,
+                    epoch,
+                    density,
+                    current_kes_period,
+                    remaining_kes_periods,
+                };
 
                 let tip = Tip::new(*point, block_height.into());
                 match self.forward(state.anchor(tip, issuer)) {

--- a/crates/amaru-metrics/Cargo.toml
+++ b/crates/amaru-metrics/Cargo.toml
@@ -18,6 +18,6 @@ categories.workspace = true
 
 [dependencies]
 # External Dependencies
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive", "std"] }
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
 opentelemetry.workspace = true

--- a/crates/amaru-metrics/src/ledger.rs
+++ b/crates/amaru-metrics/src/ledger.rs
@@ -27,6 +27,8 @@ pub struct LedgerMetrics {
     pub slot_in_epoch: u64,
     pub epoch: u64,
     pub density: f64,
+    pub current_kes_period: u64,
+    pub remaining_kes_periods: u64,
 }
 
 impl Default for LedgerMetrics {
@@ -38,6 +40,8 @@ impl Default for LedgerMetrics {
             slot_in_epoch: Default::default(),
             epoch: Default::default(),
             density: Default::default(),
+            current_kes_period: Default::default(),
+            remaining_kes_periods: Default::default(),
         }
     }
 }
@@ -59,6 +63,8 @@ impl MetricRecorder for LedgerMetrics {
         static SLOT_IN_EPOCH: OnceLock<Gauge<u64>> = OnceLock::new();
         static EPOCH: OnceLock<Gauge<u64>> = OnceLock::new();
         static DENSITY: OnceLock<Gauge<f64>> = OnceLock::new();
+        static CURRENT_KES_PERIOD: OnceLock<Gauge<u64>> = OnceLock::new();
+        static REMAINING_KES_PERIODS: OnceLock<Gauge<u64>> = OnceLock::new();
 
         let block_height = BLOCK_HEIGHT.get_or_init(|| {
             meter
@@ -102,6 +108,20 @@ impl MetricRecorder for LedgerMetrics {
                 .with_unit("real")
                 .build()
         });
+        let current_kes_period = CURRENT_KES_PERIOD.get_or_init(|| {
+            meter
+                .u64_gauge("cardano_node_metrics_currentKESPeriod_int")
+                .with_description("current KES (Key Evolving Signature) period")
+                .with_unit("int")
+                .build()
+        });
+        let remaining_kes_periods = REMAINING_KES_PERIODS.get_or_init(|| {
+            meter
+                .u64_gauge("cardano_node_metrics_remainingKESPeriods_int")
+                .with_description("number of remaining KES periods before the key becomes invalid")
+                .with_unit("int")
+                .build()
+        });
 
         block_height.record(self.block_height, &[]);
         txs_processed.add(self.txs_processed, &[]);
@@ -109,6 +129,8 @@ impl MetricRecorder for LedgerMetrics {
         epoch.record(self.epoch, &[]);
         slot_in_epoch.record(self.slot_in_epoch, &[]);
         density.record(self.density, &[]);
+        current_kes_period.record(self.current_kes_period, &[]);
+        remaining_kes_periods.record(self.remaining_kes_periods, &[]);
     }
 }
 

--- a/crates/amaru-metrics/src/lib.rs
+++ b/crates/amaru-metrics/src/lib.rs
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::ledger::LedgerMetrics;
 pub use crate::metrics::{Counter, Gauge, Meter};
+use crate::{ledger::LedgerMetrics, protocol::ProtocolMetrics};
 pub mod ledger;
 pub mod metrics;
+pub mod protocol;
 
 pub const METRICS_METER_NAME: &str = "cardano_node_metrics";
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum MetricsEvent {
     LedgerMetrics(LedgerMetrics),
+    ProtocolMetrics(ProtocolMetrics),
 }
 
 pub trait MetricRecorder {
@@ -32,6 +34,7 @@ impl MetricRecorder for MetricsEvent {
     fn record_to_meter(&self, meter: &Meter) {
         match self {
             MetricsEvent::LedgerMetrics(ledger_metrics) => ledger_metrics.record_to_meter(meter),
+            MetricsEvent::ProtocolMetrics(protocol_metrics) => protocol_metrics.record_to_meter(meter),
         }
     }
 }

--- a/crates/amaru-metrics/src/protocol.rs
+++ b/crates/amaru-metrics/src/protocol.rs
@@ -18,12 +18,15 @@ use std::sync::OnceLock;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::{Counter, Gauge};
 use crate::{Meter, MetricRecorder, MetricsEvent};
+#[cfg(not(target_arch = "wasm32"))]
+use opentelemetry::KeyValue;
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum ProtocolMetrics {
     ConnectionManager(ConnectionManagerMetrics),
     ServedBlockCount(ServedBlockCountMetrics),
     ServedHeaderCount(ServedHeaderCountMetrics),
+    TipBlock(TipBlockMetrics),
     BlockfetchClient(BlockfetchClientMetrics),
 }
 
@@ -44,6 +47,13 @@ pub struct ServedBlockCountMetrics {
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ServedHeaderCountMetrics {
     pub count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct TipBlockMetrics {
+    pub hash: String,
+    pub parent_hash: String,
+    pub issuer_verification_key_hash: String,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -68,6 +78,7 @@ impl MetricRecorder for ProtocolMetrics {
             ProtocolMetrics::ConnectionManager(metrics) => metrics.record_to_meter(meter),
             ProtocolMetrics::ServedBlockCount(metrics) => metrics.record_to_meter(meter),
             ProtocolMetrics::ServedHeaderCount(metrics) => metrics.record_to_meter(meter),
+            ProtocolMetrics::TipBlock(metrics) => metrics.record_to_meter(meter),
             ProtocolMetrics::BlockfetchClient(metrics) => metrics.record_to_meter(meter),
         }
     }
@@ -176,6 +187,34 @@ impl MetricRecorder for ServedHeaderCountMetrics {
 }
 
 #[cfg(target_arch = "wasm32")]
+impl MetricRecorder for TipBlockMetrics {
+    fn record_to_meter(&self, _meter: &Meter) {}
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl MetricRecorder for TipBlockMetrics {
+    fn record_to_meter(&self, meter: &Meter) {
+        static TIP_BLOCK: OnceLock<Gauge<u64>> = OnceLock::new();
+
+        let tip_block = TIP_BLOCK.get_or_init(|| {
+            meter
+                .u64_gauge("cardano_node_metrics_tipBlock")
+                .with_description("current adopted tip block identity")
+                .build()
+        });
+
+        tip_block.record(
+            1,
+            &[
+                KeyValue::new("hash", self.hash.clone()),
+                KeyValue::new("parent_hash", self.parent_hash.clone()),
+                KeyValue::new("issuer_verification_key_hash", self.issuer_verification_key_hash.clone()),
+            ],
+        );
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
 impl MetricRecorder for BlockfetchClientMetrics {
     fn record_to_meter(&self, _meter: &Meter) {}
 }
@@ -263,6 +302,12 @@ impl From<ServedBlockCountMetrics> for MetricsEvent {
 impl From<ServedHeaderCountMetrics> for MetricsEvent {
     fn from(value: ServedHeaderCountMetrics) -> Self {
         MetricsEvent::ProtocolMetrics(ProtocolMetrics::ServedHeaderCount(value))
+    }
+}
+
+impl From<TipBlockMetrics> for MetricsEvent {
+    fn from(value: TipBlockMetrics) -> Self {
+        MetricsEvent::ProtocolMetrics(ProtocolMetrics::TipBlock(value))
     }
 }
 

--- a/crates/amaru-metrics/src/protocol.rs
+++ b/crates/amaru-metrics/src/protocol.rs
@@ -16,10 +16,11 @@
 use std::sync::OnceLock;
 
 #[cfg(not(target_arch = "wasm32"))]
+use opentelemetry::KeyValue;
+
+#[cfg(not(target_arch = "wasm32"))]
 use crate::{Counter, Gauge};
 use crate::{Meter, MetricRecorder, MetricsEvent};
-#[cfg(not(target_arch = "wasm32"))]
-use opentelemetry::KeyValue;
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum ProtocolMetrics {
@@ -32,8 +33,6 @@ pub enum ProtocolMetrics {
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ConnectionManagerMetrics {
-    pub duplex_connections: u64,
-    pub full_duplex_connections: u64,
     pub inbound_connections: u64,
     pub outbound_connections: u64,
     pub unidirectional_connections: u64,
@@ -92,26 +91,10 @@ impl MetricRecorder for ConnectionManagerMetrics {
 #[cfg(not(target_arch = "wasm32"))]
 impl MetricRecorder for ConnectionManagerMetrics {
     fn record_to_meter(&self, meter: &Meter) {
-        static DUPLEX_CONNECTIONS: OnceLock<Gauge<u64>> = OnceLock::new();
-        static FULL_DUPLEX_CONNECTIONS: OnceLock<Gauge<u64>> = OnceLock::new();
         static INBOUND_CONNECTIONS: OnceLock<Gauge<u64>> = OnceLock::new();
         static OUTBOUND_CONNECTIONS: OnceLock<Gauge<u64>> = OnceLock::new();
         static UNIDIRECTIONAL_CONNECTIONS: OnceLock<Gauge<u64>> = OnceLock::new();
 
-        let duplex_connections = DUPLEX_CONNECTIONS.get_or_init(|| {
-            meter
-                .u64_gauge("cardano_node_metrics_connectionManager_duplexConns_int")
-                .with_description("current number of duplex connections")
-                .with_unit("int")
-                .build()
-        });
-        let full_duplex_connections = FULL_DUPLEX_CONNECTIONS.get_or_init(|| {
-            meter
-                .u64_gauge("cardano_node_metrics_connectionManager_fullDuplexConns_int")
-                .with_description("current number of full duplex connections")
-                .with_unit("int")
-                .build()
-        });
         let inbound_connections = INBOUND_CONNECTIONS.get_or_init(|| {
             meter
                 .u64_gauge("cardano_node_metrics_connectionManager_inboundConns_int")
@@ -134,8 +117,6 @@ impl MetricRecorder for ConnectionManagerMetrics {
                 .build()
         });
 
-        duplex_connections.record(self.duplex_connections, &[]);
-        full_duplex_connections.record(self.full_duplex_connections, &[]);
         inbound_connections.record(self.inbound_connections, &[]);
         outbound_connections.record(self.outbound_connections, &[]);
         unidirectional_connections.record(self.unidirectional_connections, &[]);

--- a/crates/amaru-metrics/src/protocol.rs
+++ b/crates/amaru-metrics/src/protocol.rs
@@ -1,0 +1,153 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::OnceLock;
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::{Counter, Gauge};
+use crate::{Meter, MetricRecorder, MetricsEvent};
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum ProtocolMetrics {
+    ConnectionManager(ConnectionManagerMetrics),
+    ServedBlockCount(ServedBlockCountMetrics),
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ConnectionManagerMetrics {
+    pub duplex_connections: u64,
+    pub full_duplex_connections: u64,
+    pub inbound_connections: u64,
+    pub outbound_connections: u64,
+    pub unidirectional_connections: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ServedBlockCountMetrics {
+    pub count: u64,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl MetricRecorder for ProtocolMetrics {
+    fn record_to_meter(&self, _meter: &Meter) {}
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl MetricRecorder for ProtocolMetrics {
+    fn record_to_meter(&self, meter: &Meter) {
+        match self {
+            ProtocolMetrics::ConnectionManager(metrics) => metrics.record_to_meter(meter),
+            ProtocolMetrics::ServedBlockCount(metrics) => metrics.record_to_meter(meter),
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl MetricRecorder for ConnectionManagerMetrics {
+    fn record_to_meter(&self, _meter: &Meter) {}
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl MetricRecorder for ConnectionManagerMetrics {
+    fn record_to_meter(&self, meter: &Meter) {
+        static DUPLEX_CONNECTIONS: OnceLock<Gauge<u64>> = OnceLock::new();
+        static FULL_DUPLEX_CONNECTIONS: OnceLock<Gauge<u64>> = OnceLock::new();
+        static INBOUND_CONNECTIONS: OnceLock<Gauge<u64>> = OnceLock::new();
+        static OUTBOUND_CONNECTIONS: OnceLock<Gauge<u64>> = OnceLock::new();
+        static UNIDIRECTIONAL_CONNECTIONS: OnceLock<Gauge<u64>> = OnceLock::new();
+
+        let duplex_connections = DUPLEX_CONNECTIONS.get_or_init(|| {
+            meter
+                .u64_gauge("cardano_node_metrics_connectionManager_duplexConns_int")
+                .with_description("current number of duplex connections")
+                .with_unit("int")
+                .build()
+        });
+        let full_duplex_connections = FULL_DUPLEX_CONNECTIONS.get_or_init(|| {
+            meter
+                .u64_gauge("cardano_node_metrics_connectionManager_fullDuplexConns_int")
+                .with_description("current number of full duplex connections")
+                .with_unit("int")
+                .build()
+        });
+        let inbound_connections = INBOUND_CONNECTIONS.get_or_init(|| {
+            meter
+                .u64_gauge("cardano_node_metrics_connectionManager_inboundConns_int")
+                .with_description("current number of inbound connections")
+                .with_unit("int")
+                .build()
+        });
+        let outbound_connections = OUTBOUND_CONNECTIONS.get_or_init(|| {
+            meter
+                .u64_gauge("cardano_node_metrics_connectionManager_outboundConns_int")
+                .with_description("current number of outbound connections")
+                .with_unit("int")
+                .build()
+        });
+        let unidirectional_connections = UNIDIRECTIONAL_CONNECTIONS.get_or_init(|| {
+            meter
+                .u64_gauge("cardano_node_metrics_connectionManager_unidirectionalConns_int")
+                .with_description("current number of unidirectional connections")
+                .with_unit("int")
+                .build()
+        });
+
+        duplex_connections.record(self.duplex_connections, &[]);
+        full_duplex_connections.record(self.full_duplex_connections, &[]);
+        inbound_connections.record(self.inbound_connections, &[]);
+        outbound_connections.record(self.outbound_connections, &[]);
+        unidirectional_connections.record(self.unidirectional_connections, &[]);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl MetricRecorder for ServedBlockCountMetrics {
+    fn record_to_meter(&self, _meter: &Meter) {}
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl MetricRecorder for ServedBlockCountMetrics {
+    fn record_to_meter(&self, meter: &Meter) {
+        static SERVED_BLOCK_COUNT: OnceLock<Counter<u64>> = OnceLock::new();
+
+        let served_block_count = SERVED_BLOCK_COUNT.get_or_init(|| {
+            meter
+                .u64_counter("cardano_node_metrics_served_block_count_int")
+                .with_description("total number of blocks served to peers")
+                .with_unit("int")
+                .build()
+        });
+
+        served_block_count.add(self.count, &[]);
+    }
+}
+
+impl From<ProtocolMetrics> for MetricsEvent {
+    fn from(value: ProtocolMetrics) -> Self {
+        MetricsEvent::ProtocolMetrics(value)
+    }
+}
+
+impl From<ConnectionManagerMetrics> for MetricsEvent {
+    fn from(value: ConnectionManagerMetrics) -> Self {
+        MetricsEvent::ProtocolMetrics(ProtocolMetrics::ConnectionManager(value))
+    }
+}
+
+impl From<ServedBlockCountMetrics> for MetricsEvent {
+    fn from(value: ServedBlockCountMetrics) -> Self {
+        MetricsEvent::ProtocolMetrics(ProtocolMetrics::ServedBlockCount(value))
+    }
+}

--- a/crates/amaru-metrics/src/protocol.rs
+++ b/crates/amaru-metrics/src/protocol.rs
@@ -23,6 +23,8 @@ use crate::{Meter, MetricRecorder, MetricsEvent};
 pub enum ProtocolMetrics {
     ConnectionManager(ConnectionManagerMetrics),
     ServedBlockCount(ServedBlockCountMetrics),
+    ServedHeaderCount(ServedHeaderCountMetrics),
+    BlockfetchClient(BlockfetchClientMetrics),
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -39,6 +41,21 @@ pub struct ServedBlockCountMetrics {
     pub count: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ServedHeaderCountMetrics {
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct BlockfetchClientMetrics {
+    pub block_delay: f64,
+    pub block_delay_cdf_one: f64,
+    pub block_delay_cdf_three: f64,
+    pub block_delay_cdf_five: f64,
+    pub block_size: u64,
+    pub late_blocks: u64,
+}
+
 #[cfg(target_arch = "wasm32")]
 impl MetricRecorder for ProtocolMetrics {
     fn record_to_meter(&self, _meter: &Meter) {}
@@ -50,6 +67,8 @@ impl MetricRecorder for ProtocolMetrics {
         match self {
             ProtocolMetrics::ConnectionManager(metrics) => metrics.record_to_meter(meter),
             ProtocolMetrics::ServedBlockCount(metrics) => metrics.record_to_meter(meter),
+            ProtocolMetrics::ServedHeaderCount(metrics) => metrics.record_to_meter(meter),
+            ProtocolMetrics::BlockfetchClient(metrics) => metrics.record_to_meter(meter),
         }
     }
 }
@@ -134,6 +153,95 @@ impl MetricRecorder for ServedBlockCountMetrics {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
+impl MetricRecorder for ServedHeaderCountMetrics {
+    fn record_to_meter(&self, _meter: &Meter) {}
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl MetricRecorder for ServedHeaderCountMetrics {
+    fn record_to_meter(&self, meter: &Meter) {
+        static SERVED_HEADER_COUNT: OnceLock<Counter<u64>> = OnceLock::new();
+
+        let served_header_count = SERVED_HEADER_COUNT.get_or_init(|| {
+            meter
+                .u64_counter("cardano_node_metrics_ChainSync_HeadersServed_counter")
+                .with_description("total number of chain sync headers served to peers")
+                .with_unit("count")
+                .build()
+        });
+
+        served_header_count.add(self.count, &[]);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl MetricRecorder for BlockfetchClientMetrics {
+    fn record_to_meter(&self, _meter: &Meter) {}
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl MetricRecorder for BlockfetchClientMetrics {
+    fn record_to_meter(&self, meter: &Meter) {
+        static BLOCK_DELAY: OnceLock<Gauge<f64>> = OnceLock::new();
+        static BLOCK_DELAY_CDF_ONE: OnceLock<Gauge<f64>> = OnceLock::new();
+        static BLOCK_DELAY_CDF_THREE: OnceLock<Gauge<f64>> = OnceLock::new();
+        static BLOCK_DELAY_CDF_FIVE: OnceLock<Gauge<f64>> = OnceLock::new();
+        static BLOCK_SIZE: OnceLock<Gauge<u64>> = OnceLock::new();
+        static LATE_BLOCKS: OnceLock<Counter<u64>> = OnceLock::new();
+
+        let block_delay = BLOCK_DELAY.get_or_init(|| {
+            meter
+                .f64_gauge("cardano_node_metrics_blockfetchclient_blockdelay_real")
+                .with_description("delay in seconds between a block's slot time and when it is received")
+                .with_unit("real")
+                .build()
+        });
+        let block_delay_cdf_one = BLOCK_DELAY_CDF_ONE.get_or_init(|| {
+            meter
+                .f64_gauge("cardano_node_metrics_blockfetchclient_blockdelay_cdfOne_real")
+                .with_description("fraction of fetched blocks received within 1 second of their slot time")
+                .with_unit("real")
+                .build()
+        });
+        let block_delay_cdf_three = BLOCK_DELAY_CDF_THREE.get_or_init(|| {
+            meter
+                .f64_gauge("cardano_node_metrics_blockfetchclient_blockdelay_cdfThree_real")
+                .with_description("fraction of fetched blocks received within 3 seconds of their slot time")
+                .with_unit("real")
+                .build()
+        });
+        let block_delay_cdf_five = BLOCK_DELAY_CDF_FIVE.get_or_init(|| {
+            meter
+                .f64_gauge("cardano_node_metrics_blockfetchclient_blockdelay_cdfFive_real")
+                .with_description("fraction of fetched blocks received within 5 seconds of their slot time")
+                .with_unit("real")
+                .build()
+        });
+        let block_size = BLOCK_SIZE.get_or_init(|| {
+            meter
+                .u64_gauge("cardano_node_metrics_blockfetchclient_blocksize_int")
+                .with_description("size in bytes of the most recently fetched block")
+                .with_unit("int")
+                .build()
+        });
+        let late_blocks = LATE_BLOCKS.get_or_init(|| {
+            meter
+                .u64_counter("cardano_node_metrics_blockfetchclient_lateblocks_counter")
+                .with_description("total number of blocks received more than 5 seconds after their slot time")
+                .with_unit("count")
+                .build()
+        });
+
+        block_delay.record(self.block_delay, &[]);
+        block_delay_cdf_one.record(self.block_delay_cdf_one, &[]);
+        block_delay_cdf_three.record(self.block_delay_cdf_three, &[]);
+        block_delay_cdf_five.record(self.block_delay_cdf_five, &[]);
+        block_size.record(self.block_size, &[]);
+        late_blocks.add(self.late_blocks, &[]);
+    }
+}
+
 impl From<ProtocolMetrics> for MetricsEvent {
     fn from(value: ProtocolMetrics) -> Self {
         MetricsEvent::ProtocolMetrics(value)
@@ -149,5 +257,17 @@ impl From<ConnectionManagerMetrics> for MetricsEvent {
 impl From<ServedBlockCountMetrics> for MetricsEvent {
     fn from(value: ServedBlockCountMetrics) -> Self {
         MetricsEvent::ProtocolMetrics(ProtocolMetrics::ServedBlockCount(value))
+    }
+}
+
+impl From<ServedHeaderCountMetrics> for MetricsEvent {
+    fn from(value: ServedHeaderCountMetrics) -> Self {
+        MetricsEvent::ProtocolMetrics(ProtocolMetrics::ServedHeaderCount(value))
+    }
+}
+
+impl From<BlockfetchClientMetrics> for MetricsEvent {
+    fn from(value: BlockfetchClientMetrics) -> Self {
+        MetricsEvent::ProtocolMetrics(ProtocolMetrics::BlockfetchClient(value))
     }
 }

--- a/crates/amaru-protocols/Cargo.toml
+++ b/crates/amaru-protocols/Cargo.toml
@@ -28,6 +28,7 @@ serde.workspace = true
 tracing.workspace = true
 
 amaru-kernel = { "workspace" = true, features = ["test-utils"] }
+amaru-metrics.workspace = true
 amaru-observability.workspace = true
 amaru-ouroboros.workspace = true
 amaru-ouroboros-traits = { "workspace" = true, features = ["test-utils"] }

--- a/crates/amaru-protocols/src/blockfetch/responder.rs
+++ b/crates/amaru-protocols/src/blockfetch/responder.rs
@@ -15,6 +15,7 @@
 use std::fmt::Debug;
 
 use amaru_kernel::{BlockHeader, IsHeader, NonEmptyVec, Point, RawBlock};
+use amaru_metrics::protocol::ServedBlockCountMetrics;
 use amaru_observability::trace_span;
 use amaru_ouroboros_traits::ChainStore;
 use pure_stage::{DeserializerGuards, Effects, StageRef, Void};
@@ -22,6 +23,7 @@ use tracing::Instrument;
 
 use crate::{
     blockfetch::{State, messages::Message},
+    metrics_effects::{Metrics, MetricsOps},
     mux::MuxMessage,
     protocol::{
         Inputs, Miniprotocol, Outcome, PROTO_N2N_BLOCK_FETCH, ProtocolState, Responder, StageState, miniprotocol,
@@ -173,6 +175,7 @@ impl StageState<State, Responder> for BlockFetchResponder {
             StreamBlocks::Done => Ok((Some(ResponderAction::BatchDone), self)),
             StreamBlocks::More(points_range) => {
                 let (block, points_range) = points_range.next_block(&store)?;
+                Metrics::new(eff).record(ServedBlockCountMetrics { count: 1 }.into()).await;
                 // recurse if there are more blocks to fetch or signal that streaming is done
                 if let Some(points_range) = points_range {
                     eff.send(eff.me_ref(), Inputs::Local(StreamBlocks::More(points_range))).await;

--- a/crates/amaru-protocols/src/chainsync/responder.rs
+++ b/crates/amaru-protocols/src/chainsync/responder.rs
@@ -15,6 +15,7 @@
 use std::cmp::Reverse;
 
 use amaru_kernel::{BlockHeader, EraName, IsHeader, ORIGIN_HASH, Peer, Point, Tip};
+use amaru_metrics::protocol::ServedHeaderCountMetrics;
 use amaru_observability::trace_span;
 use amaru_ouroboros::{ConnectionId, ReadOnlyChainStore};
 use anyhow::{Context, ensure};
@@ -23,6 +24,7 @@ use tracing::Instrument;
 
 use crate::{
     chainsync::messages::{HeaderContent, Message},
+    metrics_effects::{Metrics, MetricsOps},
     mux::MuxMessage,
     protocol::{
         Inputs, Miniprotocol, Outcome, PROTO_N2N_CHAIN_SYNC, ProtocolState, Responder, StageState, miniprotocol,
@@ -83,6 +85,9 @@ impl StageState<ResponderState, Responder> for ChainSyncResponder {
                 self.upstream = tip;
                 let action = next_header(*proto, &mut self.pointer, &Store::new(eff.clone()), self.upstream)
                     .context("failed to get next header")?;
+                if matches!(action, Some(ResponderAction::RollForward(..))) {
+                    Metrics::new(eff).record(ServedHeaderCountMetrics { count: 1 }.into()).await;
+                }
                 Ok((action, self))
             }
         }
@@ -109,6 +114,9 @@ impl StageState<ResponderState, Responder> for ChainSyncResponder {
                 ResponderResult::RequestNext => {
                     let action = next_header(*proto, &mut self.pointer, &Store::new(eff.clone()), self.upstream)
                         .context("failed to get next header")?;
+                    if matches!(action, Some(ResponderAction::RollForward(..))) {
+                        Metrics::new(eff).record(ServedHeaderCountMetrics { count: 1 }.into()).await;
+                    }
                     Ok((action, self))
                 }
                 ResponderResult::Done => {

--- a/crates/amaru-protocols/src/lib.rs
+++ b/crates/amaru-protocols/src/lib.rs
@@ -23,6 +23,7 @@ pub mod handshake;
 pub mod keepalive;
 pub mod manager;
 pub mod mempool_effects;
+pub mod metrics_effects;
 pub mod mux;
 pub mod network_effects;
 pub mod protocol;

--- a/crates/amaru-protocols/src/manager.rs
+++ b/crates/amaru-protocols/src/manager.rs
@@ -248,6 +248,7 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
                         manager.peers.remove(&peer);
                     }
                 }
+                record_connection_metrics(&manager, &eff).await;
             }
             ManagerMessage::ConnectionDied(peer, conn_id, role) => {
                 let _span = trace_span!(amaru_observability::amaru::protocols::manager::CONNECTION_DIED, peer = peer.to_string(), conn_id = conn_id.to_string(), role = role.to_string());
@@ -377,16 +378,13 @@ async fn start_connection_stage(
 }
 
 fn connection_manager_metrics(manager: &Manager) -> ConnectionManagerMetrics {
-    let (connected_connections, inbound_connections, outbound_connections) =
-        manager.peers.values().fold((0, 0, 0), |acc, state| match state {
-            ConnectionState::Connected { role: Role::Responder, .. } => (acc.0 + 1, acc.1 + 1, acc.2),
-            ConnectionState::Connected { role: Role::Initiator, .. } => (acc.0 + 1, acc.1, acc.2 + 1),
-            ConnectionState::Scheduled | ConnectionState::Disconnecting => acc,
-        });
+    let (inbound_connections, outbound_connections) = manager.peers.values().fold((0, 0), |acc, state| match state {
+        ConnectionState::Connected { role: Role::Responder, .. } => (acc.0 + 1, acc.1),
+        ConnectionState::Connected { role: Role::Initiator, .. } => (acc.0, acc.1 + 1),
+        ConnectionState::Scheduled | ConnectionState::Disconnecting => acc,
+    });
 
     ConnectionManagerMetrics {
-        duplex_connections: connected_connections,
-        full_duplex_connections: connected_connections,
         inbound_connections,
         outbound_connections,
         unidirectional_connections: inbound_connections + outbound_connections,

--- a/crates/amaru-protocols/src/manager.rs
+++ b/crates/amaru-protocols/src/manager.rs
@@ -15,6 +15,7 @@
 use std::{collections::BTreeMap, net::SocketAddr, sync::Arc, time::Duration};
 
 use amaru_kernel::{EraHistory, NetworkMagic, Peer, Point, Tip};
+use amaru_metrics::protocol::ConnectionManagerMetrics;
 use amaru_observability::trace_span;
 use amaru_ouroboros::{ConnectionId, MempoolMsg, ToSocketAddrs};
 use pure_stage::{DeserializerGuards, Effects, StageRef, register_data_deserializer};
@@ -26,6 +27,7 @@ use crate::{
     blockfetch::{Blocks, Blocks2},
     chainsync::ChainSyncInitiatorMsg,
     connection::{self, ConnectionMessage},
+    metrics_effects::{Metrics, MetricsOps},
     network_effects::{Network, NetworkOps},
     protocol::Role,
 };
@@ -88,7 +90,7 @@ pub struct Manager {
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 enum ConnectionState {
     Scheduled,
-    Connected(ConnectionId, StageRef<ConnectionMessage>),
+    Connected { conn_id: ConnectionId, connection: StageRef<ConnectionMessage>, role: Role },
     // Does not contain the connection ID because that will be received in the ConnectionDied message.
     Disconnecting,
 }
@@ -160,7 +162,7 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
                 let _span = trace_span!(amaru_observability::amaru::protocols::manager::ADD_PEER, peer = peer.to_string());
                 let _guard = _span.enter();
                 match manager.peers.get_mut(&peer) {
-                    Some(ConnectionState::Connected(..) | ConnectionState::Scheduled) => {
+                    Some(ConnectionState::Connected { .. } | ConnectionState::Scheduled) => {
                         tracing::info!(%peer, "discarding connection request, already connected or scheduled");
                         return manager;
                     }
@@ -179,7 +181,7 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
                 let _span = trace_span!(amaru_observability::amaru::protocols::manager::CONNECT, peer = peer.to_string());
                 let _guard = _span.enter();
                 let entry = match manager.peers.get_mut(&peer) {
-                    Some(ConnectionState::Connected(..)) => {
+                    Some(ConnectionState::Connected { .. }) => {
                         tracing::debug!(%peer, "discarding connection request, already connected");
                         return manager;
                     }
@@ -210,7 +212,7 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
                 let _span = trace_span!(amaru_observability::amaru::protocols::manager::ACCEPTED, peer = peer.to_string(), conn_id = conn_id.to_string());
                 let _guard = _span.enter();
                 match manager.peers.get(&peer) {
-                    Some(ConnectionState::Connected(..)) => {
+                    Some(ConnectionState::Connected { .. }) => {
                         tracing::debug!(%peer, "already connected. Closing the newly accepted connection");
                         close_connection(&eff, &peer, conn_id).await;
                         return manager;
@@ -237,7 +239,7 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
                     return manager;
                 };
                 match entry {
-                    ConnectionState::Connected(_conn_id, connection) => {
+                    ConnectionState::Connected { connection, .. } => {
                         eff.send(connection, ConnectionMessage::Disconnect).await;
                         *entry = ConnectionState::Disconnecting;
                     }
@@ -256,10 +258,10 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
                     return manager;
                 };
                 match peer_state {
-                    ConnectionState::Connected(conn_id_new, ..) if *conn_id_new != conn_id => {
+                    ConnectionState::Connected { conn_id: conn_id_new, .. } if *conn_id_new != conn_id => {
                         tracing::debug!(%peer, "previously terminated connection closed");
                     }
-                    ConnectionState::Connected(..) => {
+                    ConnectionState::Connected { .. } => {
                         if role == Role::Initiator {
                             tracing::info!(%peer, reconnecting_in=?manager.config.reconnect_delay, "initiator connection died, scheduling reconnect");
                             eff.schedule_after(ManagerMessage::Connect(peer), manager.config.reconnect_delay).await;
@@ -277,10 +279,11 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
                         manager.peers.remove(&peer);
                     }
                 }
+                record_connection_metrics(&manager, &eff).await;
             }
             ManagerMessage::FetchBlocks { peer, from, through, cr } => {
                 tracing::trace!(?from, ?through, %peer, "fetching blocks");
-                if let Some(ConnectionState::Connected(_, connection)) = manager.peers.get(&peer) {
+                if let Some(ConnectionState::Connected { connection, .. }) = manager.peers.get(&peer) {
                     eff.send(connection, ConnectionMessage::FetchBlocks { from, through, cr }).await;
                 } else {
                     tracing::error!(%peer, "peer not found");
@@ -307,7 +310,7 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
             }
             ManagerMessage::NewTip(tip) => {
                 for conn in manager.peers.values() {
-                    if let ConnectionState::Connected(_, connection) = conn {
+                    if let ConnectionState::Connected { connection, .. } = conn {
                         eff.send(connection, ConnectionMessage::NewTip(tip)).await;
                     }
                 }
@@ -320,7 +323,7 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
             }
             tracing::debug!(?from, ?through, "fetching blocks");
             for state in manager.peers.values() {
-                let ConnectionState::Connected(_conn_id, connection) = state else {
+                let ConnectionState::Connected { connection, .. } = state else {
                     continue;
                 };
                 eff.send(connection, ConnectionMessage::FetchBlocks2 { from, through, cr: cr.clone(), id }).await;
@@ -369,7 +372,28 @@ async fn start_connection_stage(
         )
         .await;
     eff.send(&connection, ConnectionMessage::Initialize).await;
-    manager.peers.insert(peer, ConnectionState::Connected(conn_id, connection));
+    manager.peers.insert(peer, ConnectionState::Connected { conn_id, connection, role });
+    record_connection_metrics(manager, eff).await;
+}
+
+fn connection_manager_metrics(manager: &Manager) -> ConnectionManagerMetrics {
+    let (incoming_connections, outgoing_connections) = manager.peers.values().fold((0, 0), |acc, state| match state {
+        ConnectionState::Connected { role: Role::Responder, .. } => (acc.0 + 1, acc.1),
+        ConnectionState::Connected { role: Role::Initiator, .. } => (acc.0, acc.1 + 1),
+        ConnectionState::Scheduled | ConnectionState::Disconnecting => acc,
+    });
+
+    ConnectionManagerMetrics {
+        duplex_connections: 0,
+        full_duplex_connections: 0,
+        inbound_connections: incoming_connections,
+        outbound_connections: outgoing_connections,
+        unidirectional_connections: incoming_connections + outgoing_connections,
+    }
+}
+
+async fn record_connection_metrics(manager: &Manager, eff: &Effects<ManagerMessage>) {
+    Metrics::new(eff).record(connection_manager_metrics(manager).into()).await;
 }
 
 pub fn register_deserializers() -> DeserializerGuards {

--- a/crates/amaru-protocols/src/manager.rs
+++ b/crates/amaru-protocols/src/manager.rs
@@ -316,20 +316,20 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
                 }
             }
             ManagerMessage::FetchBlocks2 { from, through, cr, id } => {
-            if manager.peers.is_empty() {
-                tracing::warn!("no peers to fetch blocks");
-                eff.send(&cr, Blocks2::NoBlocks(id)).await;
-                return manager;
-            }
-            tracing::debug!(?from, ?through, "fetching blocks");
-            for state in manager.peers.values() {
-                let ConnectionState::Connected { connection, .. } = state else {
-                    continue;
-                };
-                eff.send(connection, ConnectionMessage::FetchBlocks2 { from, through, cr: cr.clone(), id }).await;
+                if manager.peers.is_empty() {
+                    tracing::warn!("no peers to fetch blocks");
+                    eff.send(&cr, Blocks2::NoBlocks(id)).await;
+                    return manager;
+                }
+                tracing::debug!(?from, ?through, "fetching blocks");
+                for state in manager.peers.values() {
+                    let ConnectionState::Connected { connection, .. } = state else {
+                        continue;
+                    };
+                    eff.send(connection, ConnectionMessage::FetchBlocks2 { from, through, cr: cr.clone(), id }).await;
+                }
             }
         }
-    }
         manager
     }
     .instrument(trace_span!(
@@ -377,18 +377,19 @@ async fn start_connection_stage(
 }
 
 fn connection_manager_metrics(manager: &Manager) -> ConnectionManagerMetrics {
-    let (incoming_connections, outgoing_connections) = manager.peers.values().fold((0, 0), |acc, state| match state {
-        ConnectionState::Connected { role: Role::Responder, .. } => (acc.0 + 1, acc.1),
-        ConnectionState::Connected { role: Role::Initiator, .. } => (acc.0, acc.1 + 1),
-        ConnectionState::Scheduled | ConnectionState::Disconnecting => acc,
-    });
+    let (connected_connections, inbound_connections, outbound_connections) =
+        manager.peers.values().fold((0, 0, 0), |acc, state| match state {
+            ConnectionState::Connected { role: Role::Responder, .. } => (acc.0 + 1, acc.1 + 1, acc.2),
+            ConnectionState::Connected { role: Role::Initiator, .. } => (acc.0 + 1, acc.1, acc.2 + 1),
+            ConnectionState::Scheduled | ConnectionState::Disconnecting => acc,
+        });
 
     ConnectionManagerMetrics {
-        duplex_connections: 0,
-        full_duplex_connections: 0,
-        inbound_connections: incoming_connections,
-        outbound_connections: outgoing_connections,
-        unidirectional_connections: incoming_connections + outgoing_connections,
+        duplex_connections: connected_connections,
+        full_duplex_connections: connected_connections,
+        inbound_connections,
+        outbound_connections,
+        unidirectional_connections: inbound_connections + outbound_connections,
     }
 }
 

--- a/crates/amaru-protocols/src/metrics_effects.rs
+++ b/crates/amaru-protocols/src/metrics_effects.rs
@@ -1,0 +1,72 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use amaru_metrics::{Meter, MetricRecorder, MetricsEvent};
+use pure_stage::{BoxFuture, Effects, ExternalEffect, ExternalEffectAPI, ExternalEffectSync, Resources, SendData};
+
+pub trait MetricsOps: Clone + Send {
+    fn record(&self, event: MetricsEvent) -> BoxFuture<'static, ()>;
+}
+
+pub struct Metrics<'a, T>(&'a Effects<T>);
+
+impl<'a, T> Clone for Metrics<'a, T> {
+    fn clone(&self) -> Self {
+        Self(self.0)
+    }
+}
+
+impl<'a, T> Metrics<'a, T> {
+    pub fn new(eff: &'a Effects<T>) -> Metrics<'a, T> {
+        Metrics(eff)
+    }
+}
+
+impl<T: SendData + Sync> MetricsOps for Metrics<'_, T> {
+    fn record(&self, event: MetricsEvent) -> BoxFuture<'static, ()> {
+        self.0.external(RecordMetricsEffect::new(event))
+    }
+}
+
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RecordMetricsEffect {
+    event: MetricsEvent,
+}
+
+impl RecordMetricsEffect {
+    pub fn new(event: MetricsEvent) -> Self {
+        Self { event }
+    }
+}
+
+pub type ResourceMeter = Arc<Meter>;
+
+impl ExternalEffect for RecordMetricsEffect {
+    #[allow(clippy::unit_arg)]
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        Self::wrap_sync({
+            if let Ok(meter) = resources.get::<ResourceMeter>() {
+                self.event.record_to_meter(&meter);
+            }
+        })
+    }
+}
+
+impl ExternalEffectAPI for RecordMetricsEffect {
+    type Response = ();
+}
+
+impl ExternalEffectSync for RecordMetricsEffect {}

--- a/crates/amaru/src/metrics.rs
+++ b/crates/amaru/src/metrics.rs
@@ -14,7 +14,9 @@
 
 use std::{sync::LazyLock, time::Duration};
 
+use amaru_metrics::METRICS_METER_NAME;
 use anyhow::anyhow;
+use opentelemetry::KeyValue;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use sysinfo::{CpuRefreshKind, MemoryRefreshKind, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System};
 use tokio::task::JoinHandle;
@@ -22,8 +24,14 @@ use tracing::error;
 
 static METRICS_POLL_DELAY: LazyLock<Duration> = LazyLock::new(|| Duration::from_secs(1));
 
+mod built_info {
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
 pub fn track_system_metrics(provider: SdkMeterProvider) -> Result<JoinHandle<()>, Box<dyn std::error::Error>> {
     use internals::*;
+
+    record_build_info(&provider);
 
     let mut sys = System::new_with_specifics(
         RefreshKind::nothing()
@@ -53,6 +61,55 @@ pub fn track_system_metrics(provider: SdkMeterProvider) -> Result<JoinHandle<()>
             }
         }
     }))
+}
+
+fn record_build_info(provider: &SdkMeterProvider) {
+    use opentelemetry::metrics::MeterProvider;
+
+    let meter = provider.meter(METRICS_METER_NAME);
+
+    let build_info = meter
+        .u64_gauge("cardano_node_metrics_cardano_build_info")
+        .with_description("build information for the running amaru node")
+        .build();
+
+    build_info.record(
+        1,
+        &[
+            KeyValue::new("version", built_info::PKG_VERSION),
+            KeyValue::new("git_rev", built_info::GIT_COMMIT_HASH_SHORT.unwrap_or("unknown")),
+            KeyValue::new("dirty", built_info::GIT_DIRTY.unwrap_or(false).to_string()),
+            KeyValue::new("os", built_info::CFG_OS),
+            KeyValue::new("arch", built_info::CFG_TARGET_ARCH),
+        ],
+    );
+
+    let version_major = meter
+        .u64_gauge("cardano_node_metrics_cardano_version_major_int")
+        .with_description("Major version number")
+        .build();
+
+    let version_minor = meter
+        .u64_gauge("cardano_node_metrics_cardano_version_minor_int")
+        .with_description("Minor version number")
+        .build();
+
+    let version_patch = meter
+        .u64_gauge("cardano_node_metrics_cardano_version_patch_int")
+        .with_description("Patch version number")
+        .build();
+
+    let version_parts: Vec<&str> = built_info::PKG_VERSION.split('.').collect();
+
+    if let Some(major) = version_parts.get(0).and_then(|v| v.parse::<u64>().ok()) {
+        version_major.record(major, &[]);
+    }
+    if let Some(minor) = version_parts.get(1).and_then(|v| v.parse::<u64>().ok()) {
+        version_minor.record(minor, &[]);
+    }
+    if let Some(patch) = version_parts.get(2).and_then(|v| v.parse::<u64>().ok()) {
+        version_patch.record(patch, &[]);
+    }
 }
 
 mod internals {

--- a/crates/amaru/src/metrics.rs
+++ b/crates/amaru/src/metrics.rs
@@ -68,48 +68,57 @@ fn record_build_info(provider: &SdkMeterProvider) {
 
     let meter = provider.meter(METRICS_METER_NAME);
 
-    let build_info = meter
-        .u64_gauge("cardano_node_metrics_cardano_build_info")
+    let _ = meter
+        .u64_observable_gauge("cardano_node_metrics_cardano_build_info")
         .with_description("build information for the running amaru node")
-        .build();
-
-    build_info.record(
-        1,
-        &[
-            KeyValue::new("version", built_info::PKG_VERSION),
-            KeyValue::new("git_rev", built_info::GIT_COMMIT_HASH_SHORT.unwrap_or("unknown")),
-            KeyValue::new("dirty", built_info::GIT_DIRTY.unwrap_or(false).to_string()),
-            KeyValue::new("os", built_info::CFG_OS),
-            KeyValue::new("arch", built_info::CFG_TARGET_ARCH),
-        ],
-    );
-
-    let version_major = meter
-        .u64_gauge("cardano_node_metrics_cardano_version_major_int")
-        .with_description("Major version number")
-        .build();
-
-    let version_minor = meter
-        .u64_gauge("cardano_node_metrics_cardano_version_minor_int")
-        .with_description("Minor version number")
-        .build();
-
-    let version_patch = meter
-        .u64_gauge("cardano_node_metrics_cardano_version_patch_int")
-        .with_description("Patch version number")
+        .with_callback(|observer| {
+            observer.observe(
+                1,
+                &[
+                    KeyValue::new("version", built_info::PKG_VERSION),
+                    KeyValue::new("git_rev", built_info::GIT_COMMIT_HASH_SHORT.unwrap_or("unknown")),
+                    KeyValue::new("dirty", built_info::GIT_DIRTY.unwrap_or(false).to_string()),
+                    KeyValue::new("os", built_info::CFG_OS),
+                    KeyValue::new("arch", built_info::CFG_TARGET_ARCH),
+                ],
+            );
+        })
         .build();
 
     let version_parts: Vec<&str> = built_info::PKG_VERSION.split('.').collect();
+    let major = version_parts.first().and_then(|v| v.parse::<u64>().ok());
+    let minor = version_parts.get(1).and_then(|v| v.parse::<u64>().ok());
+    let patch = version_parts.get(2).and_then(|v| v.parse::<u64>().ok());
 
-    if let Some(major) = version_parts.first().and_then(|v| v.parse::<u64>().ok()) {
-        version_major.record(major, &[]);
-    }
-    if let Some(minor) = version_parts.get(1).and_then(|v| v.parse::<u64>().ok()) {
-        version_minor.record(minor, &[]);
-    }
-    if let Some(patch) = version_parts.get(2).and_then(|v| v.parse::<u64>().ok()) {
-        version_patch.record(patch, &[]);
-    }
+    let _ = meter
+        .u64_observable_gauge("cardano_node_metrics_cardano_version_major_int")
+        .with_description("Major version number")
+        .with_callback(move |observer| {
+            if let Some(major) = major {
+                observer.observe(major, &[]);
+            }
+        })
+        .build();
+
+    let _ = meter
+        .u64_observable_gauge("cardano_node_metrics_cardano_version_minor_int")
+        .with_description("Minor version number")
+        .with_callback(move |observer| {
+            if let Some(minor) = minor {
+                observer.observe(minor, &[]);
+            }
+        })
+        .build();
+
+    let _ = meter
+        .u64_observable_gauge("cardano_node_metrics_cardano_version_patch_int")
+        .with_description("Patch version number")
+        .with_callback(move |observer| {
+            if let Some(patch) = patch {
+                observer.observe(patch, &[]);
+            }
+        })
+        .build();
 }
 
 mod internals {

--- a/crates/amaru/src/metrics.rs
+++ b/crates/amaru/src/metrics.rs
@@ -101,7 +101,7 @@ fn record_build_info(provider: &SdkMeterProvider) {
 
     let version_parts: Vec<&str> = built_info::PKG_VERSION.split('.').collect();
 
-    if let Some(major) = version_parts.get(0).and_then(|v| v.parse::<u64>().ok()) {
+    if let Some(major) = version_parts.first().and_then(|v| v.parse::<u64>().ok()) {
         version_major.record(major, &[]);
     }
     if let Some(minor) = version_parts.get(1).and_then(|v| v.parse::<u64>().ok()) {

--- a/crates/amaru/src/stages/build_stage_graph.rs
+++ b/crates/amaru/src/stages/build_stage_graph.rs
@@ -77,8 +77,16 @@ pub fn build_stage_graph(
             ValidateBlockMsg::new(tip, parent, max_block_height)
         });
 
-    let fetch_blocks = stage_graph
-        .wire_up(fetch_blocks, FetchBlocks::new(validate_block_input, select_chain.sender(), manager.sender()));
+    let fetch_blocks = stage_graph.wire_up(
+        fetch_blocks,
+        FetchBlocks::new(
+            validate_block_input,
+            select_chain.sender(),
+            manager.sender(),
+            era_history.clone(),
+            global_parameters.system_start,
+        ),
+    );
     let fetch_blocks_input =
         stage_graph.contramap(fetch_blocks, "fetch_blocks_input", |(tip, parent)| FetchBlocksMsg::NewTip(tip, parent));
 


### PR DESCRIPTION
Add new metrics. Goal is to reach `cardano_node` parity.
We ignore metrics related to:
* peer selection
* block forging
* `cardano_node` / haskell internals related

Fixes https://github.com/pragma-org/amaru/issues/754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded observability: protocol-layer metrics (connection manager, served blocks/headers, tip/block identity, blockfetch client latency/CDFs and sizes).
  * Ledger metrics augmented with KES period and remaining periods.
  * Runtime build/version info and semantic version gauges recorded.

* **Tests**
  * Added unit test validating blockfetch CDF computations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->