### PR TITLE
Reduce dependencies on MemoryStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "serde",
+ "tempfile",
  "test-case",
  "thiserror 2.0.17",
  "toml",

--- a/crates/amaru-ledger/Cargo.toml
+++ b/crates/amaru-ledger/Cargo.toml
@@ -47,6 +47,7 @@ once_cell.workspace = true
 proptest.workspace = true
 test-case.workspace = true
 toml.workspace = true
+tempfile.workspace = true
 
 # Internal dependencies ───────────────────────────────────────────────────────┐
 amaru-kernel = { workspace = true, features = ["test-utils"] }

--- a/crates/amaru-ledger/tests/state_rollback.rs
+++ b/crates/amaru-ledger/tests/state_rollback.rs
@@ -21,7 +21,7 @@ use amaru_ledger::{
     state::{BackwardError, State, VolatileState},
     store::GovernanceActivity,
 };
-use amaru_stores::in_memory::MemoryStore;
+use amaru_stores::rocksdb::{RocksDB, RocksDBHistoricalStores, RocksDbConfig};
 
 #[test]
 fn rollback_to_a_volatile_common_ancestor_succeeds() {
@@ -100,15 +100,17 @@ fn rollback_after_volatile_front_is_rejected() {
 
 /// Create an initial ledger state
 #[expect(clippy::expect_used)]
-fn make_state() -> State<MemoryStore, MemoryStore> {
+fn make_state() -> State<RocksDB, RocksDBHistoricalStores> {
     let network = NetworkName::Preprod;
     let era_history: EraHistory = <&EraHistory>::from(network).clone();
     let global_parameters: GlobalParameters = <&GlobalParameters>::from(network).clone();
     let protocol_parameters: ProtocolParameters =
         <&ProtocolParameters>::try_from(network).expect("preprod parameters available").clone();
 
-    let store = MemoryStore::new(era_history.clone(), protocol_parameters.clone());
-    let snapshots = MemoryStore::new(era_history.clone(), protocol_parameters.clone());
+    let tmp = tempfile::tempdir().expect("tempdir creation succeeds");
+    let cfg = RocksDbConfig::new(tmp.path().to_path_buf());
+    let store = RocksDB::empty(&cfg).expect("RocksDB::empty succeeds");
+    let snapshots = RocksDBHistoricalStores::new(&cfg, 0);
 
     State::new_with(
         store,
@@ -124,7 +126,7 @@ fn make_state() -> State<MemoryStore, MemoryStore> {
 
 /// Forward the ldeger to a given point
 #[expect(clippy::expect_used)]
-fn forward_to(state: &mut State<MemoryStore, MemoryStore>, point: Point, height: u64) {
+fn forward_to(state: &mut State<RocksDB, RocksDBHistoricalStores>, point: Point, height: u64) {
     let issuer = Hash::new([0u8; 28]);
     state
         .forward(VolatileState::default().anchor(Tip::new(point, BlockHeight::from(height)), issuer))

--- a/crates/amaru-ledger/tests/state_rollback.rs
+++ b/crates/amaru-ledger/tests/state_rollback.rs
@@ -107,8 +107,8 @@ fn make_state() -> State<RocksDB, RocksDBHistoricalStores> {
     let protocol_parameters: ProtocolParameters =
         <&ProtocolParameters>::try_from(network).expect("preprod parameters available").clone();
 
-    let tmp = tempfile::tempdir().expect("tempdir creation succeeds");
-    let cfg = RocksDbConfig::new(tmp.path().to_path_buf());
+    let ledger_dir = tempfile::tempdir().expect("tempdir creation succeeds").keep();
+    let cfg = RocksDbConfig::new(ledger_dir);
     let store = RocksDB::empty(&cfg).expect("RocksDB::empty succeeds");
     let snapshots = RocksDBHistoricalStores::new(&cfg, 0);
 

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -57,6 +57,7 @@ serde.workspace = true
 serde_json.workspace = true
 sysinfo.workspace = true
 tar.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = [
   "fs",
@@ -95,7 +96,6 @@ mithril = ["dep:mithril-client"]
 [dev-dependencies]
 # External dependencies ───────────────────────────────────────────────────────┐
 insta = { workspace = true, features = ["json"] }
-tempfile.workspace = true
 test-case.workspace = true
 rocksdb.workspace = true
 quote.workspace = true

--- a/crates/amaru/src/bin/amaru/cmd/run.rs
+++ b/crates/amaru/src/bin/amaru/cmd/run.rs
@@ -304,7 +304,7 @@ fn parse_args(args: Args) -> Result<Config, Box<dyn std::error::Error>> {
     );
 
     Ok(Config {
-        ledger_store: StoreType::RocksDb(RocksDbConfig::new(ledger_dir).with_shared_env()),
+        ledger_store: RocksDbConfig::new(ledger_dir).with_shared_env(),
         chain_store: StoreType::RocksDb(RocksDbConfig::new(chain_dir).with_shared_env()),
         upstream_peers: args.peer_address,
         network: args.network,

--- a/crates/amaru/src/stages/config.rs
+++ b/crates/amaru/src/stages/config.rs
@@ -16,12 +16,12 @@ use std::{fmt::Display, net::SocketAddr, path::PathBuf, sync::Arc};
 
 use amaru_kernel::{BlockHeader, NetworkMagic, NetworkName};
 use amaru_ouroboros::ChainStore;
-use amaru_stores::{in_memory::MemoryStore, rocksdb::RocksDbConfig};
+use amaru_stores::rocksdb::RocksDbConfig;
 use anyhow::Context;
 
 /// Configuration for the Amaru node, including storage options, network settings, and other parameters.
 pub struct Config {
-    pub ledger_store: StoreType<MemoryStore>,
+    pub ledger_store: RocksDbConfig,
     pub chain_store: StoreType<Arc<dyn ChainStore<BlockHeader>>>,
     pub upstream_peers: Vec<String>,
     pub network: NetworkName,
@@ -69,7 +69,7 @@ impl Config {
 impl Default for Config {
     fn default() -> Config {
         Config {
-            ledger_store: StoreType::RocksDb(RocksDbConfig::new(PathBuf::from("./ledger.db"))),
+            ledger_store: RocksDbConfig::new(PathBuf::from("./ledger.db")),
             chain_store: StoreType::RocksDb(RocksDbConfig::new(PathBuf::from("./chain.db"))),
             upstream_peers: vec![],
             network: NetworkName::Preprod,

--- a/crates/amaru/src/stages/ledger.rs
+++ b/crates/amaru/src/stages/ledger.rs
@@ -18,19 +18,12 @@ use amaru_kernel::{EraHistory, GlobalParameters, Point};
 use amaru_ledger::block_validator::BlockValidator;
 use amaru_ouroboros::{CanValidateBlocks, CanValidateTxs, HasStakeDistribution, HasStakePools};
 use amaru_plutus::arena_pool::ArenaPool;
-use amaru_stores::{
-    in_memory::MemoryStore,
-    rocksdb::{RocksDB, RocksDBHistoricalStores},
-};
+use amaru_stores::rocksdb::{RocksDB, RocksDBHistoricalStores};
 
-use crate::stages::config::{Config, StoreType};
+use crate::stages::config::Config;
 
 /// Representation of the ledger as used by the consensus stages.
-/// It is either implemented in memory for tests or on disk for production.
-pub enum Ledger {
-    InMemLedger(BlockValidator<MemoryStore, MemoryStore>),
-    OnDiskLedger(BlockValidator<RocksDB, RocksDBHistoricalStores>),
-}
+pub struct Ledger(BlockValidator<RocksDB, RocksDBHistoricalStores>);
 
 impl Ledger {
     pub fn new(
@@ -40,74 +33,39 @@ impl Ledger {
     ) -> anyhow::Result<Ledger> {
         let vm_eval_pool = ArenaPool::new(config.ledger_vm_alloc_arena_count, config.ledger_vm_alloc_arena_size);
 
-        match &config.ledger_store {
-            StoreType::InMem(store) => {
-                let ledger = BlockValidator::new(
-                    store.clone(),
-                    store.clone(),
-                    vm_eval_pool,
-                    config.network,
-                    era_history,
-                    global_parameters,
-                )?;
-                Ok(Ledger::InMemLedger(ledger))
-            }
-            StoreType::RocksDb(rocks_db_config) => {
-                let ledger = BlockValidator::new(
-                    RocksDB::new(rocks_db_config)?,
-                    RocksDBHistoricalStores::new(rocks_db_config, u64::from(config.max_extra_ledger_snapshots)),
-                    vm_eval_pool,
-                    config.network,
-                    era_history,
-                    global_parameters,
-                )?;
-                Ok(Ledger::OnDiskLedger(ledger))
-            }
-        }
+        let ledger = BlockValidator::new(
+            RocksDB::new(&config.ledger_store)?,
+            RocksDBHistoricalStores::new(&config.ledger_store, u64::from(config.max_extra_ledger_snapshots)),
+            vm_eval_pool,
+            config.network,
+            era_history,
+            global_parameters,
+        )?;
+        Ok(Ledger(ledger))
     }
 
     /// Return the current ledger tip.
     pub fn get_tip(&self) -> Point {
-        match self {
-            Ledger::InMemLedger(stage) => stage.get_tip(),
-            Ledger::OnDiskLedger(stage) => stage.get_tip(),
-        }
+        self.0.get_tip()
     }
 
     /// Return the current stake distribution.
     /// It used to validate header nonces.
     pub fn get_stake_distribution(&self) -> anyhow::Result<Arc<dyn HasStakeDistribution>> {
-        match self {
-            Ledger::InMemLedger(stage) => {
-                let state = stage.state.lock().map_err(|e| anyhow::anyhow!("{:?}", e))?;
-                Ok(Arc::new(state.view_stake_distribution()))
-            }
-            Ledger::OnDiskLedger(stage) => {
-                let state = stage.state.lock().map_err(|e| anyhow::anyhow!("{:?}", e))?;
-                Ok(Arc::new(state.view_stake_distribution()))
-            }
-        }
+        let state = self.0.state.lock().map_err(|e| anyhow::anyhow!("{:?}", e))?;
+        Ok(Arc::new(state.view_stake_distribution()))
     }
 
     /// Return the ledger as a capability for validating blocks.
     pub fn get_block_validation(&self) -> Arc<dyn CanValidateBlocks + Send + Sync> {
-        match self {
-            Ledger::InMemLedger(stage) => Arc::new((*stage).clone()),
-            Ledger::OnDiskLedger(stage) => Arc::new((*stage).clone()),
-        }
+        Arc::new(self.0.clone())
     }
 
     pub fn get_stake_pools(&self) -> Arc<dyn HasStakePools + Send + Sync> {
-        match self {
-            Ledger::InMemLedger(stage) => Arc::new((*stage).clone()),
-            Ledger::OnDiskLedger(stage) => Arc::new((*stage).clone()),
-        }
+        Arc::new(self.0.clone())
     }
 
     pub fn get_tx_validation(&self) -> Arc<dyn CanValidateTxs + Send + Sync> {
-        match self {
-            Ledger::InMemLedger(stage) => Arc::new((*stage).clone()),
-            Ledger::OnDiskLedger(stage) => Arc::new((*stage).clone()),
-        }
+        Arc::new(self.0.clone())
     }
 }

--- a/crates/amaru/src/tests/configuration.rs
+++ b/crates/amaru/src/tests/configuration.rs
@@ -19,12 +19,13 @@ use std::{
 
 use amaru_consensus::headers_tree::data_generation::Action;
 use amaru_kernel::{
-    BlockHeader, EraHistory, IsHeader, NetworkName, Peer, Point, ProtocolParameters, Transaction,
+    BlockHeader, Epoch, EraHistory, IsHeader, NetworkName, Peer, Point, ProtocolParameters, Transaction,
     cardano::network_block::make_encoded_block,
 };
+use amaru_ledger::store::{Columns, GovernanceActivity, Store, TransactionalContext};
 use amaru_mempool::InMemoryMempool;
 use amaru_ouroboros::{ChainStore, ConnectionsResource, TxId, in_memory_consensus_store::InMemConsensusStore};
-use amaru_stores::in_memory::MemoryStore;
+use amaru_stores::rocksdb::{RocksDB, RocksDbConfig};
 use anyhow::anyhow;
 use parking_lot::Mutex;
 use pure_stage::trace_buffer::TraceBuffer;
@@ -255,19 +256,46 @@ impl NodeTestConfig {
 
         config.listen_address = self.listen_address.clone();
 
-        // Create the ledger store and set its tip to match the chain store's anchor.
+        // Bootstrap a temp RocksDB ledger store whose tip matches the chain store's anchor.
         // This ensures that build_node's initialize_chain_store won't reset the
         // chain store's best_chain_hash (only the anchor will be set, which is already
         // the same as the ledger tip).
-        let ledger_store = MemoryStore::new(self.era_history().clone(), self.protocol_parameters()?.clone());
         let chain_anchor = self
             .chain_store
             .load_header(&self.chain_store.get_anchor_hash())
             .map(|h| h.point())
             .unwrap_or(Point::Origin);
-        ledger_store.set_tip(chain_anchor);
 
-        config.ledger_store = StoreType::InMem(ledger_store);
+        // The tempdir is leaked so it survives for the duration of the test process;
+        // Config (and the Ledger it bootstraps) only sees the path.
+        let ledger_dir = tempfile::tempdir()?.keep();
+        let ledger_store_config = RocksDbConfig::new(ledger_dir);
+        {
+            let store = RocksDB::empty(&ledger_store_config)?;
+            let mut governance_activity = GovernanceActivity { consecutive_dormant_epochs: 0 };
+            let pp = self.protocol_parameters()?;
+            let tx = store.create_transaction();
+            tx.save(
+                self.era_history(),
+                pp,
+                &mut governance_activity,
+                &chain_anchor,
+                None,
+                Columns::empty(),
+                Columns::empty(),
+                std::iter::empty(),
+            )?;
+            tx.set_protocol_parameters(pp)?;
+            tx.set_governance_activity(&governance_activity)?;
+            tx.commit()?;
+            // initial_stake_distributions needs snapshots at most_recent, most_recent - 1, and
+            // most_recent - 2; take three so that for_epoch(0) and for_epoch(1) both succeed.
+            store.next_snapshot(Epoch::from(0u64))?;
+            store.next_snapshot(Epoch::from(1u64))?;
+            store.next_snapshot(Epoch::from(2u64))?;
+        }
+
+        config.ledger_store = ledger_store_config;
         config.chain_store = StoreType::InMem(self.chain_store.clone());
         Ok(config)
     }


### PR DESCRIPTION
It is not entirely straightforward to remove it entirely, since RocksDB cannot compile to WASM, and we need some storage solution for the nodejs examples we provide.

I'm opening this PR now to showcase one option of how we want to handle the memory store. Ongoing discussion around this (more broadly, not these specific code changes) is happening here: https://github.com/pragma-org/amaru/issues/795.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Ledger storage unified to always use on-disk RocksDB; configuration and runtime paths simplified to remove branching between in-memory and on-disk implementations.

* **Tests**
  * Test harnesses updated to exercise the RocksDB-backed ledger store instead of in-memory stores.

* **Chores**
  * Dependency declarations adjusted to ensure tempfile is available where needed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/811)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->