### PR TITLE
fix: include the era tag in the transactions serialization

### DIFF
--- a/crates/amaru-kernel/src/cardano/era_history.rs
+++ b/crates/amaru-kernel/src/cardano/era_history.rs
@@ -630,6 +630,15 @@ impl EraHistory {
         let era_index = self.slot_to_era_index(slot)?;
         Ok(self.eras[era_index].params.era_name)
     }
+
+    /// Return the era tag of the currently active era (the last era in the history).
+    ///
+    /// The last era is the one without an upper bound and corresponds to the era the
+    /// network is currently in.
+    pub fn current_era_tag(&self) -> EraName {
+        #[expect(clippy::expect_used)]
+        self.eras.last().expect("EraHistory cannot be empty").params.era_name
+    }
 }
 
 /// Compute the time in milliseconds between the start of the system and the given slot.

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -259,8 +259,15 @@ async fn do_handshake(
     };
 
     let keepalive = register_keepalive(*role, muxer.clone(), &eff).await;
-    let tx_submission =
-        register_tx_submission(*role, muxer.clone(), &eff, TxOrigin::Remote(peer.clone()), mempool_stage.clone()).await;
+    let tx_submission = register_tx_submission(
+        *role,
+        muxer.clone(),
+        &eff,
+        TxOrigin::Remote(peer.clone()),
+        mempool_stage.clone(),
+        era_history.clone(),
+    )
+    .await;
 
     if *role == Role::Initiator {
         let chainsync_initiator = register_chainsync_initiator(&muxer, peer.clone(), *conn_id, pipeline, &eff).await;

--- a/crates/amaru-protocols/src/tx_submission/initiator.rs
+++ b/crates/amaru-protocols/src/tx_submission/initiator.rs
@@ -48,10 +48,13 @@
 /// - Only advertised transaction IDs are requested
 /// - Appropriate blocking/non-blocking requests based on acknowledgment state
 use std::collections::VecDeque;
-use std::fmt::{Debug, Display};
+use std::{
+    fmt::{Debug, Display},
+    sync::Arc,
+};
 
 use ProtocolError::*;
-use amaru_kernel::{Transaction, TransactionId, utils::string::display_collection};
+use amaru_kernel::{EraHistory, Transaction, TransactionId, utils::string::display_collection};
 use amaru_observability::trace_span;
 use amaru_ouroboros::{MempoolMsg, MempoolSeqNo};
 use pure_stage::{DeserializerGuards, Effects, StageRef, Void};
@@ -63,7 +66,7 @@ use crate::{
     protocol::{
         Initiator, Inputs, Miniprotocol, Outcome, PROTO_N2N_TX_SUB, ProtocolState, StageState, miniprotocol, outcome,
     },
-    tx_submission::{Blocking, Message, ProtocolError, State},
+    tx_submission::{Blocking, EraTaggedTx, EraTaggedTxId, Message, ProtocolError, State},
 };
 
 const MAX_REQUESTED_TX_IDS: u16 = 10;
@@ -161,8 +164,9 @@ impl ProtocolState<Initiator> for State {
                     State::TxIdsNonBlocking,
                 )
             }
-            (State::Idle, Message::RequestTxs(tx_ids)) => {
-                tracing::debug!(tx_ids_nb = tx_ids.len(), "received RequestTxs");
+            (State::Idle, Message::RequestTxs(tagged_ids)) => {
+                tracing::debug!(tx_ids_nb = tagged_ids.len(), "received RequestTxs");
+                let tx_ids = tagged_ids.into_iter().map(|t| t.id).collect();
                 (outcome().result(InitiatorResult::RequestTxs(tx_ids)), State::Txs)
             }
             (this, input) => anyhow::bail!("invalid state: {:?} <- {:?}", this, input),
@@ -187,10 +191,14 @@ impl ProtocolState<Initiator> for State {
     }
 }
 
+/// Actions produced by the initiator stage.
+///
+/// `SendReplyTxIds` / `SendReplyTxs` carry lists where each item is tagged with the era it
+/// was created in via [`EraTaggedTxId`] / [`EraTaggedTx`].
 #[derive(Debug, PartialEq, Eq)]
 pub enum InitiatorAction {
-    SendReplyTxIds(Vec<(TransactionId, u32)>),
-    SendReplyTxs(Vec<Transaction>),
+    SendReplyTxIds(Vec<(EraTaggedTxId, u32)>),
+    SendReplyTxs(Vec<EraTaggedTx>),
     Error(ProtocolError),
     Done,
 }
@@ -253,10 +261,16 @@ pub struct TxSubmissionInitiator {
     mempool_stage: StageRef<MempoolMsg>,
     wait_for_at_least_callback: StageRef<()>,
     muxer: StageRef<MuxMessage>,
+    /// Era history used to derive the current era tag for outgoing wire messages.
+    era_history: Arc<EraHistory>,
 }
 
 impl TxSubmissionInitiator {
-    pub fn new(muxer: StageRef<MuxMessage>, mempool_stage: StageRef<MempoolMsg>) -> (State, Self) {
+    pub fn new(
+        muxer: StageRef<MuxMessage>,
+        mempool_stage: StageRef<MempoolMsg>,
+        era_history: Arc<EraHistory>,
+    ) -> (State, Self) {
         (
             State::Init,
             Self {
@@ -266,8 +280,21 @@ impl TxSubmissionInitiator {
                 mempool_stage,
                 wait_for_at_least_callback: StageRef::blackhole(),
                 muxer,
+                era_history,
             },
         )
+    }
+
+    /// Wrap each `(tx_id, size)` pair with the current era tag for outgoing wire messages.
+    fn tag_ids(&self, items: Vec<(TransactionId, u32)>) -> Vec<(EraTaggedTxId, u32)> {
+        let era = self.era_history.current_era_tag();
+        items.into_iter().map(|(id, size)| (EraTaggedTxId { era, id }, size)).collect()
+    }
+
+    /// Wrap each transaction with the current era tag for outgoing wire messages.
+    fn tag_txs(&self, items: Vec<Transaction>) -> Vec<EraTaggedTx> {
+        let era = self.era_history.current_era_tag();
+        items.into_iter().map(|tx| EraTaggedTx { era, tx }).collect()
     }
 
     async fn request_tx_ids_blocking(
@@ -333,7 +360,7 @@ impl TxSubmissionInitiator {
         };
 
         let tx_ids = self.get_next_tx_ids(mempool, req).await?;
-        Ok(Some(InitiatorAction::SendReplyTxIds(tx_ids)))
+        Ok(Some(InitiatorAction::SendReplyTxIds(self.tag_ids(tx_ids))))
     }
 
     async fn request_tx_ids_non_blocking(
@@ -356,7 +383,8 @@ impl TxSubmissionInitiator {
 
         // update the window by discarding acknowledged tx ids and update the last_seq
         self.discard(ack);
-        Ok(Some(InitiatorAction::SendReplyTxIds(self.get_next_tx_ids(mempool, req).await?)))
+        let tx_ids = self.get_next_tx_ids(mempool, req).await?;
+        Ok(Some(InitiatorAction::SendReplyTxIds(self.tag_ids(tx_ids))))
     }
 
     async fn request_txs(
@@ -375,7 +403,7 @@ impl TxSubmissionInitiator {
         if txs.is_empty() {
             protocol_error(UnknownTxsRequested(tx_ids))
         } else {
-            Ok(Some(InitiatorAction::SendReplyTxs(txs)))
+            Ok(Some(InitiatorAction::SendReplyTxs(self.tag_txs(txs))))
         }
     }
 
@@ -451,12 +479,16 @@ impl AsRef<StageRef<MuxMessage>> for TxSubmissionInitiator {
 mod tests {
     use std::sync::Arc;
 
-    use amaru_kernel::to_cbor;
+    use amaru_kernel::{EraName, TESTNET_ERA_HISTORY, to_cbor};
     use amaru_mempool::{InMemoryMempool, MempoolConfig};
     use amaru_ouroboros_traits::{TxOrigin, TxSubmissionMempool};
 
     use super::*;
     use crate::tx_submission::{assert_actions_eq, create_transactions_in_mempool, tests::create_transactions};
+
+    fn test_era() -> EraName {
+        TESTNET_ERA_HISTORY.current_era_tag()
+    }
 
     #[tokio::test]
     async fn serve_transactions() -> anyhow::Result<()> {
@@ -748,7 +780,12 @@ mod tests {
         results: Vec<InitiatorResult>,
     ) -> anyhow::Result<(Vec<InitiatorAction>, TxSubmissionInitiator)> {
         run_stage_and_return_state_with(
-            TxSubmissionInitiator::new(StageRef::named_for_tests("muxer"), StageRef::blackhole()).1,
+            TxSubmissionInitiator::new(
+                StageRef::named_for_tests("muxer"),
+                StageRef::blackhole(),
+                Arc::new(TESTNET_ERA_HISTORY.clone()),
+            )
+            .1,
             mempool,
             results,
         )
@@ -795,13 +832,18 @@ mod tests {
     }
 
     fn reply_tx_ids(txs: &[Transaction], ids: &[usize]) -> InitiatorAction {
-        InitiatorAction::SendReplyTxIds(
-            ids.iter().map(|id| (txs[*id].tx_id(), to_cbor(&txs[*id]).len() as u32)).collect(),
-        )
+        let era = test_era();
+        let pairs: Vec<(EraTaggedTxId, u32)> = ids
+            .iter()
+            .map(|id| (EraTaggedTxId { era, id: txs[*id].tx_id() }, to_cbor(&txs[*id]).len() as u32))
+            .collect();
+        InitiatorAction::SendReplyTxIds(pairs)
     }
 
     fn reply_txs(txs: &[Transaction], ids: &[usize]) -> InitiatorAction {
-        InitiatorAction::SendReplyTxs(ids.iter().map(|id| txs[*id].clone()).collect())
+        let era = test_era();
+        let payload: Vec<EraTaggedTx> = ids.iter().map(|id| EraTaggedTx { era, tx: txs[*id].clone() }).collect();
+        InitiatorAction::SendReplyTxs(payload)
     }
 
     fn request_tx_ids(ack: u16, req: u16, blocking: Blocking) -> InitiatorResult {

--- a/crates/amaru-protocols/src/tx_submission/messages.rs
+++ b/crates/amaru-protocols/src/tx_submission/messages.rs
@@ -14,20 +14,38 @@
 
 use std::fmt::Display;
 
-use amaru_kernel::{NonEmptyBytes, Transaction, TransactionId, cbor, to_cbor};
+use amaru_kernel::{EraName, NonEmptyBytes, Transaction, TransactionId, cbor, to_cbor};
 
 use crate::tx_submission::Blocking;
 
+/// A transaction id paired with the era it was created in. Encoded on the wire as
+/// `[era_index, tx_id]`, matching the Haskell hard-fork combinator's `GenTxId` shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+pub struct EraTaggedTxId {
+    pub era: EraName,
+    pub id: TransactionId,
+}
+
+/// A transaction paired with the era it was created in. Encoded on the wire as
+/// `[era_index, cbor tx]`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct EraTaggedTx {
+    pub era: EraName,
+    pub tx: Transaction,
+}
+
 /// Messages for the txsubmission mini-protocol.
+///
+/// Each item carries its own era tag via [`EraTaggedTxId`] / [`EraTaggedTx`].
 #[derive(Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
 #[repr(u8)]
 pub enum Message {
     Init,
     RequestTxIdsBlocking(u16, u16),
     RequestTxIdsNonBlocking(u16, u16),
-    RequestTxs(Vec<TransactionId>),
-    ReplyTxIds(Vec<(TransactionId, u32)>),
-    ReplyTxs(Vec<Transaction>),
+    RequestTxs(Vec<EraTaggedTxId>),
+    ReplyTxIds(Vec<(EraTaggedTxId, u32)>),
+    ReplyTxs(Vec<EraTaggedTx>),
     Done,
 }
 
@@ -106,24 +124,28 @@ impl cbor::Encode<()> for Message {
             Message::ReplyTxIds(ids) => {
                 e.array(2)?.u16(1)?;
                 e.begin_array()?;
-                for id in ids {
+                for (id, size) in ids {
+                    e.array(2)?;
                     e.encode(id)?;
+                    e.u32(*size)?;
                 }
                 e.end()?;
             }
             Message::RequestTxs(ids) => {
                 e.array(2)?.u16(2)?;
-                e.array(ids.len() as u64)?;
+                e.begin_array()?;
                 for id in ids {
                     e.encode(id)?;
                 }
+                e.end()?;
             }
             Message::ReplyTxs(txs) => {
                 e.array(2)?.u16(3)?;
-                e.array(txs.len() as u64)?;
+                e.begin_array()?;
                 for tx in txs {
                     e.encode(tx)?;
                 }
+                e.end()?;
             }
             Message::Done => {
                 e.array(1)?.u16(4)?;
@@ -154,17 +176,15 @@ impl<'b> cbor::Decode<'b, ()> for Message {
             }
             1 => {
                 cbor::check_tagged_array_length(1, len, 2)?;
-                let items = d.decode()?;
-                Ok(Message::ReplyTxIds(items))
+                Ok(Message::ReplyTxIds(decode_reply_tx_ids(d)?))
             }
             2 => {
                 cbor::check_tagged_array_length(2, len, 2)?;
-                let ids = d.decode()?;
-                Ok(Message::RequestTxs(ids))
+                Ok(Message::RequestTxs(decode_list(d)?))
             }
             3 => {
                 cbor::check_tagged_array_length(3, len, 2)?;
-                Ok(Message::ReplyTxs(d.array_iter()?.collect::<Result<_, _>>()?))
+                Ok(Message::ReplyTxs(decode_list(d)?))
             }
             4 => {
                 cbor::check_tagged_array_length(4, len, 1)?;
@@ -177,6 +197,147 @@ impl<'b> cbor::Decode<'b, ()> for Message {
             _ => Err(cbor::decode::Error::message("unknown variant for txsubmission message")),
         }
     }
+}
+
+impl cbor::Encode<()> for EraTaggedTxId {
+    fn encode<W: cbor::encode::Write>(
+        &self,
+        e: &mut cbor::Encoder<W>,
+        _ctx: &mut (),
+    ) -> Result<(), cbor::encode::Error<W::Error>> {
+        e.array(2)?.u16(self.era.header_variant() as u16)?.encode(self.id)?;
+        Ok(())
+    }
+}
+
+impl<'b> cbor::Decode<'b, ()> for EraTaggedTxId {
+    fn decode(d: &mut cbor::Decoder<'b>, _ctx: &mut ()) -> Result<Self, cbor::decode::Error> {
+        let era = decode_era_tag(d)?;
+        let id = d.decode()?;
+        Ok(EraTaggedTxId { era, id })
+    }
+}
+
+impl cbor::Encode<()> for EraTaggedTx {
+    fn encode<W: cbor::encode::Write>(
+        &self,
+        e: &mut cbor::Encoder<W>,
+        _ctx: &mut (),
+    ) -> Result<(), cbor::encode::Error<W::Error>> {
+        let bytes = encode_tx(&self.tx).map_err(|_| cbor::encode::Error::message("failed to encode transaction"))?;
+        e.array(2)?.u16(self.era.header_variant() as u16)?.tag(cbor::IanaTag::Cbor)?.bytes(&bytes)?;
+        Ok(())
+    }
+}
+
+impl<'b> cbor::Decode<'b, ()> for EraTaggedTx {
+    fn decode(d: &mut cbor::Decoder<'b>, _ctx: &mut ()) -> Result<Self, cbor::decode::Error> {
+        let era = decode_era_tag(d)?;
+        let tag = d.tag()?;
+        if tag != cbor::IanaTag::Cbor.tag() {
+            return Err(cbor::decode::Error::message(format!(
+                "unexpected tag for txsubmission transaction: expected {}, got {}",
+                cbor::IanaTag::Cbor.tag(),
+                tag
+            )));
+        }
+        let tx = decode_tx(d.bytes()?)?;
+        Ok(EraTaggedTx { era, tx })
+    }
+}
+
+/// Encode the inner transaction body: `[body, witnesses, is_valid, auxiliary_data]`.
+fn encode_tx(tx: &Transaction) -> Result<Vec<u8>, cbor::encode::Error<std::convert::Infallible>> {
+    let mut bytes = Vec::new();
+    let mut e = cbor::Encoder::new(&mut bytes);
+    e.array(4)?.encode(&tx.body)?.encode(&tx.witnesses)?.bool(tx.is_expected_valid)?.encode(&tx.auxiliary_data)?;
+    Ok(bytes)
+}
+
+/// Decode the `[era_index, _]` prefix and return the era. Leaves the decoder positioned at the
+/// inner payload of the 2-element array.
+///
+/// For now we only support the Conway era
+fn decode_era_tag(d: &mut cbor::Decoder<'_>) -> Result<EraName, cbor::decode::Error> {
+    let len = d.array()?;
+    cbor::check_tagged_array_length(0, len, 2)?;
+    let variant: u8 = d.u16()?.try_into().map_err(|_| cbor::decode::Error::message("invalid txsubmission era tag"))?;
+    let era_name = EraName::from_header_variant(variant).map_err(|e| cbor::decode::Error::message(format!("{e}")))?;
+    if era_name != EraName::Conway {
+        Err(cbor::decode::Error::message(format!("unsupported era tag {variant}: only Conway is supported")))
+    } else {
+        Ok(era_name)
+    }
+}
+
+/// Decode the inner transaction body produced by [`encode_tx`], asserting that
+/// no trailing bytes follow the four-element array.
+fn decode_tx(bytes: &[u8]) -> Result<Transaction, cbor::decode::Error> {
+    let mut d = cbor::Decoder::new(bytes);
+    let len = d.array()?;
+    cbor::check_tagged_array_length(0, len, 4)?;
+    let body = d.decode()?;
+    let witnesses = d.decode()?;
+    let is_expected_valid = d.bool()?;
+    let auxiliary_data = d.decode()?;
+    if !d.datatype().is_err_and(|e| e.is_end_of_input()) {
+        return Err(cbor::decode::Error::message(format!(
+            "leftovers bytes after txsubmission transaction at position {}",
+            d.position()
+        )));
+    }
+    Ok(Transaction { body, witnesses, is_expected_valid, auxiliary_data })
+}
+
+/// Decode a CBOR array — definite or indefinite-length — of items implementing `Decode`.
+fn decode_list<'b, T>(d: &mut cbor::Decoder<'b>) -> Result<Vec<T>, cbor::decode::Error>
+where
+    T: cbor::Decode<'b, ()>,
+{
+    let len = d.array()?;
+    let mut items = Vec::new();
+    match len {
+        Some(len) => {
+            for _ in 0..len {
+                items.push(d.decode()?);
+            }
+        }
+        None => {
+            while d.datatype()? != cbor::data::Type::Break {
+                items.push(d.decode()?);
+            }
+            d.skip()?;
+        }
+    }
+    Ok(items)
+}
+
+/// Decode the payload of a `ReplyTxIds` message: a (possibly indefinite-length) array of
+/// `[[era_index, tx_id], size]` pairs.
+fn decode_reply_tx_ids(d: &mut cbor::Decoder<'_>) -> Result<Vec<(EraTaggedTxId, u32)>, cbor::decode::Error> {
+    let len = d.array()?;
+    let mut items = Vec::new();
+    match len {
+        Some(len) => {
+            for _ in 0..len {
+                items.push(decode_reply_tx_id(d)?);
+            }
+        }
+        None => {
+            while d.datatype()? != cbor::data::Type::Break {
+                items.push(decode_reply_tx_id(d)?);
+            }
+            d.skip()?;
+        }
+    }
+    Ok(items)
+}
+
+/// Decode a single `[[era_index, tx_id], size]` pair from a `ReplyTxIds` payload.
+fn decode_reply_tx_id(d: &mut cbor::Decoder<'_>) -> Result<(EraTaggedTxId, u32), cbor::decode::Error> {
+    let pair_len = d.array()?;
+    cbor::check_tagged_array_length(0, pair_len, 2)?;
+    Ok((d.decode()?, d.u32()?))
 }
 
 impl Display for Message {
@@ -193,21 +354,27 @@ impl Display for Message {
                 write!(
                     f,
                     "ReplyTxIds(ids: [{}])",
-                    ids.iter().map(|(id, size)| format!("({}, {})", id, size)).collect::<Vec<_>>().join(", ")
+                    ids.iter()
+                        .map(|(tagged, size)| format!("({}/{}, {})", tagged.era, tagged.id, size))
+                        .collect::<Vec<_>>()
+                        .join(", ")
                 )
             }
             Message::RequestTxs(ids) => {
                 write!(
                     f,
                     "RequestTxs(ids: [{}])",
-                    ids.iter().map(|id| format!("{}", id)).collect::<Vec<_>>().join(", ")
+                    ids.iter().map(|tagged| format!("{}/{}", tagged.era, tagged.id)).collect::<Vec<_>>().join(", ")
                 )
             }
             Message::ReplyTxs(txs) => {
                 write!(
                     f,
                     "ReplyTxs(txs: [{}])",
-                    txs.iter().map(|tx| format!("{}", tx.tx_id())).collect::<Vec<_>>().join(", ")
+                    txs.iter()
+                        .map(|tagged| format!("{}/{}", tagged.era, tagged.tx.tx_id()))
+                        .collect::<Vec<_>>()
+                        .join(", ")
                 )
             }
             Message::Done => write!(f, "Done"),
@@ -225,7 +392,7 @@ pub enum TxSubmissionMessage {
 /// Roundtrip property tests for txsubmission messages.
 #[cfg(test)]
 mod tests {
-    use amaru_kernel::{Hash, Transaction, prop_cbor_roundtrip};
+    use amaru_kernel::{Hash, prop_cbor_roundtrip, to_cbor};
     use prop::collection::vec;
     use proptest::{prelude::*, prop_compose};
 
@@ -243,6 +410,135 @@ mod tests {
     mod blocking {
         use super::*;
         prop_cbor_roundtrip!(Blocking, any_blocking());
+    }
+
+    #[test]
+    fn reply_txs_decoding() {
+        let tx = create_transaction(0);
+        let message = Message::ReplyTxs(vec![EraTaggedTx { era: EraName::Conway, tx }]);
+        let encoded = to_cbor(&message);
+
+        let mut d = cbor::Decoder::new(&encoded);
+        assert_eq!(d.array().unwrap(), Some(2)); // definite array length
+        assert_eq!(d.u16().unwrap(), 3); // reply_txs message tag
+        assert_eq!(d.array().unwrap(), None); // indefinite-length array is next
+
+        let era = decode_era_tag(&mut d).unwrap();
+        assert_eq!(era, EraName::Conway);
+        assert_eq!(d.tag().unwrap(), cbor::IanaTag::Cbor.tag()); // cbor-in-cbor tag
+        let tx_bytes = d.bytes().unwrap();
+
+        assert_eq!(tx_bytes[0], 0x84); // definite-length array of size 4
+        let mut inner = cbor::Decoder::new(tx_bytes);
+        assert_eq!(inner.array().unwrap(), Some(4)); // [body, witnesses, is_valid, aux]
+        inner.skip().unwrap(); // body
+        inner.skip().unwrap(); // witnesses
+        inner.bool().unwrap(); // is_expected_valid
+        inner.skip().unwrap(); // auxiliary_data
+        assert_eq!(inner.position(), tx_bytes.len()); // inner tx fully consumed
+
+        assert_eq!(d.datatype().unwrap(), cbor::data::Type::Break); // end of indefinite array
+        d.skip().unwrap(); // consume the break
+        assert_eq!(d.position(), encoded.len()); // outer message fully consumed
+    }
+
+    #[test]
+    fn reply_tx_ids_decoding() {
+        let ids = vec![(EraTaggedTxId { era: EraName::Conway, id: TransactionId::new(Hash::new([1u8; 32])) }, 42)];
+        let encoded = to_cbor(&Message::ReplyTxIds(ids));
+
+        let mut d = cbor::Decoder::new(&encoded);
+        assert_eq!(d.array().unwrap(), Some(2)); // outer definite array
+        assert_eq!(d.u16().unwrap(), 1); // reply_tx_ids message tag
+        assert_eq!(d.array().unwrap(), None); // indefinite-length array of items is next
+
+        let expected_era = EraName::Conway;
+        assert_eq!(d.array().unwrap(), Some(2)); // per-item [tagged_id, size]
+        assert_eq!(decode_era_tag(&mut d).unwrap(), expected_era);
+        d.skip().unwrap(); // tx_id bytes
+        d.u32().unwrap(); // size
+
+        assert_eq!(d.datatype().unwrap(), cbor::data::Type::Break); // end of indefinite array
+        d.skip().unwrap(); // consume the break
+        assert_eq!(d.position(), encoded.len()); // outer message fully consumed
+    }
+
+    #[test]
+    fn request_txs_decoding() {
+        let ids = vec![EraTaggedTxId { era: EraName::Conway, id: TransactionId::new(Hash::new([3u8; 32])) }];
+        let encoded = to_cbor(&Message::RequestTxs(ids));
+
+        let mut d = cbor::Decoder::new(&encoded);
+        assert_eq!(d.array().unwrap(), Some(2)); // outer definite array
+        assert_eq!(d.u16().unwrap(), 2); // request_txs message tag
+        assert_eq!(d.array().unwrap(), None); // indefinite-length array of ids is next
+
+        let expected_era = EraName::Conway;
+        assert_eq!(decode_era_tag(&mut d).unwrap(), expected_era);
+        d.skip().unwrap(); // tx_id bytes
+
+        assert_eq!(d.datatype().unwrap(), cbor::data::Type::Break); // end of indefinite array
+        d.skip().unwrap(); // consume the break
+        assert_eq!(d.position(), encoded.len()); // outer message fully consumed
+    }
+
+    #[test]
+    fn init_roundtrip() {
+        assert_roundtrip(Message::Init);
+    }
+
+    #[test]
+    fn done_roundtrip() {
+        assert_roundtrip(Message::Done);
+    }
+
+    #[test]
+    fn request_tx_ids_blocking_roundtrip() {
+        assert_roundtrip(Message::RequestTxIdsBlocking(3, 7));
+    }
+
+    #[test]
+    fn request_tx_ids_non_blocking_roundtrip() {
+        assert_roundtrip(Message::RequestTxIdsNonBlocking(2, 5));
+    }
+
+    #[test]
+    fn reply_tx_ids_non_empty_roundtrip() {
+        let ids = vec![
+            (EraTaggedTxId { era: EraName::Conway, id: TransactionId::new(Hash::new([1u8; 32])) }, 42),
+            (EraTaggedTxId { era: EraName::Conway, id: TransactionId::new(Hash::new([2u8; 32])) }, 99),
+        ];
+        assert_roundtrip(Message::ReplyTxIds(ids));
+    }
+
+    #[test]
+    fn reply_tx_ids_empty_roundtrip() {
+        assert_roundtrip(Message::ReplyTxIds(vec![]));
+    }
+
+    #[test]
+    fn request_txs_non_empty_roundtrip() {
+        let ids = vec![
+            EraTaggedTxId { era: EraName::Conway, id: TransactionId::new(Hash::new([3u8; 32])) },
+            EraTaggedTxId { era: EraName::Conway, id: TransactionId::new(Hash::new([4u8; 32])) },
+        ];
+        assert_roundtrip(Message::RequestTxs(ids));
+    }
+
+    #[test]
+    fn request_txs_empty_roundtrip() {
+        assert_roundtrip(Message::RequestTxs(vec![]));
+    }
+
+    #[test]
+    fn reply_txs_empty_roundtrip() {
+        assert_roundtrip(Message::ReplyTxs(vec![]));
+    }
+
+    #[test]
+    fn reply_tx_ids_mixed_eras_roundtrip() {
+        let ids = vec![(EraTaggedTxId { era: EraName::Conway, id: TransactionId::new(Hash::new([1u8; 32])) }, 42)];
+        assert_roundtrip(Message::ReplyTxIds(ids));
     }
 
     // HELPERS
@@ -270,26 +566,35 @@ mod tests {
     }
 
     prop_compose! {
-        fn any_tx_id_and_sizes_vec()(ids in vec(any_tx_id(), 0..20), sizes in vec(any::<u32>(), 0..20)) -> Vec<(TransactionId, u32)> {
-            ids.iter().zip(sizes).map(|(id, size)| (*id, size)).collect()
+        fn any_era_tagged_tx_id()(id in any_tx_id()) -> EraTaggedTxId {
+            EraTaggedTxId { era: EraName::Conway, id }
         }
     }
 
     prop_compose! {
-        fn any_tx_id_vec()(ids in prop::collection::vec(any_tx_id(), 0..20)) -> Vec<TransactionId> {
+        fn any_tagged_id_and_sizes_vec()(
+            ids in vec(any_era_tagged_tx_id(), 0..20),
+            sizes in vec(any::<u32>(), 0..20),
+        ) -> Vec<(EraTaggedTxId, u32)> {
+            ids.into_iter().zip(sizes).collect()
+        }
+    }
+
+    prop_compose! {
+        fn any_tagged_id_vec()(ids in vec(any_era_tagged_tx_id(), 0..20)) -> Vec<EraTaggedTxId> {
             ids
         }
     }
 
     prop_compose! {
-        fn any_tx_vec()(txs in prop::collection::vec(any_tx(), 0..10)) -> Vec<Transaction> {
+        fn any_tagged_tx_vec()(txs in vec(any_tagged_tx(), 0..10)) -> Vec<EraTaggedTx> {
             txs
         }
     }
 
     prop_compose! {
-        fn any_tx()(n in 0u64..=1000) -> Transaction {
-            create_transaction(n)
+        fn any_tagged_tx()(n in 0u64..=1000) -> EraTaggedTx {
+            EraTaggedTx { era: EraName::Conway, tx: create_transaction(n) }
         }
     }
 
@@ -307,19 +612,19 @@ mod tests {
     }
 
     prop_compose! {
-        fn reply_tx_ids_message()(ids in any_tx_id_and_sizes_vec()) -> Message {
+        fn reply_tx_ids_message()(ids in any_tagged_id_and_sizes_vec()) -> Message {
             Message::ReplyTxIds(ids)
         }
     }
 
     prop_compose! {
-        fn request_txs_message()(ids in any_tx_id_vec()) -> Message {
+        fn request_txs_message()(ids in any_tagged_id_vec()) -> Message {
             Message::RequestTxs(ids)
         }
     }
 
     prop_compose! {
-        fn reply_txs_message()(txs in any_tx_vec()) -> Message {
+        fn reply_txs_message()(txs in any_tagged_tx_vec()) -> Message {
             Message::ReplyTxs(txs)
         }
     }
@@ -337,5 +642,11 @@ mod tests {
             3 => reply_txs_message(),
             1 => done_message(),
         ]
+    }
+
+    fn assert_roundtrip(message: Message) {
+        let encoded = to_cbor(&message);
+        let decoded: Message = cbor::decode(&encoded).expect("decoding should succeed");
+        assert_eq!(message, decoded);
     }
 }

--- a/crates/amaru-protocols/src/tx_submission/mod.rs
+++ b/crates/amaru-protocols/src/tx_submission/mod.rs
@@ -27,6 +27,9 @@ pub use outcome::*;
 #[cfg(test)]
 mod tests;
 
+use std::sync::Arc;
+
+use amaru_kernel::EraHistory;
 use amaru_ouroboros::{MempoolMsg, TxOrigin};
 pub use initiator::initiator;
 use pure_stage::{Effects, StageRef, Void};
@@ -74,14 +77,20 @@ pub async fn register_tx_submission(
     eff: &Effects<ConnectionMessage>,
     origin: TxOrigin,
     mempool_stage: StageRef<MempoolMsg>,
+    era_history: Arc<EraHistory>,
 ) -> StageRef<mux::HandlerMessage> {
     let tx_submission = if role == Role::Initiator {
-        let (state, stage) = initiator::TxSubmissionInitiator::new(muxer.clone(), mempool_stage.clone());
+        let (state, stage) = initiator::TxSubmissionInitiator::new(muxer.clone(), mempool_stage.clone(), era_history);
         let tx_submission = eff.wire_up(eff.stage("tx_submission", initiator::initiator()).await, (state, stage)).await;
         eff.contramap(&tx_submission, "tx_submission_handler", Inputs::<initiator::InitiatorLocalIn>::Network).await
     } else {
-        let (state, stage) =
-            responder::TxSubmissionResponder::new(muxer.clone(), ResponderParams::new(2, 3), origin, mempool_stage);
+        let (state, stage) = responder::TxSubmissionResponder::new(
+            muxer.clone(),
+            ResponderParams::new(2, 3),
+            origin,
+            mempool_stage,
+            era_history,
+        );
         let tx_submission = eff.wire_up(eff.stage("tx_submission", responder::responder()).await, (state, stage)).await;
         eff.contramap(&tx_submission, "tx_submission_handler", Inputs::<Void>::Network).await
     };

--- a/crates/amaru-protocols/src/tx_submission/responder.rs
+++ b/crates/amaru-protocols/src/tx_submission/responder.rs
@@ -15,11 +15,12 @@
 use std::{
     collections::{BTreeSet, VecDeque},
     fmt::Display,
+    sync::Arc,
     time::Duration,
 };
 
 use ProtocolError::*;
-use amaru_kernel::{Transaction, TransactionId};
+use amaru_kernel::{EraHistory, Transaction, TransactionId};
 use amaru_observability::trace_span;
 use amaru_ouroboros::{MempoolInsertError, MempoolMsg, MempoolSeqNo};
 use amaru_ouroboros_traits::{TxInsertResult, TxOrigin, TxRejectReason};
@@ -32,7 +33,7 @@ use crate::{
     protocol::{
         Inputs, Miniprotocol, Outcome, PROTO_N2N_TX_SUB, ProtocolState, Responder, StageState, miniprotocol, outcome,
     },
-    tx_submission::{Blocking, Message, ProtocolError, ResponderParams, State},
+    tx_submission::{Blocking, EraTaggedTxId, Message, ProtocolError, ResponderParams, State},
 };
 
 pub const MEMPOOL_INSERT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -113,10 +114,14 @@ impl ProtocolState<Responder> for State {
         let _guard = _span.enter();
         Ok(match (self, input) {
             (State::Init, Message::Init) => (outcome().result(ResponderResult::Init), State::Idle),
-            (State::TxIdsBlocking | State::TxIdsNonBlocking, Message::ReplyTxIds(tx_ids)) => {
+            (State::TxIdsBlocking | State::TxIdsNonBlocking, Message::ReplyTxIds(tagged_ids)) => {
+                let tx_ids = tagged_ids.into_iter().map(|(t, size)| (t.id, size)).collect();
                 (outcome().result(ResponderResult::ReplyTxIds(tx_ids)), State::Idle)
             }
-            (State::Txs, Message::ReplyTxs(txs)) => (outcome().result(ResponderResult::ReplyTxs(txs)), State::Idle),
+            (State::Txs, Message::ReplyTxs(tagged_txs)) => {
+                let txs = tagged_txs.into_iter().map(|t| t.tx).collect();
+                (outcome().result(ResponderResult::ReplyTxs(txs)), State::Idle)
+            }
             (State::TxIdsBlocking, Message::Done) => (outcome().result(ResponderResult::Done), State::Done),
             (this, input) => anyhow::bail!("invalid state: {:?} <- {:?}", this, input),
         })
@@ -193,6 +198,8 @@ pub struct TxSubmissionResponder {
     muxer: StageRef<MuxMessage>,
     /// Reference to the mempool stage for batch transaction insertion.
     mempool_stage: StageRef<MempoolMsg>,
+    /// Era history used to derive the current era tag for outgoing wire messages.
+    era_history: Arc<EraHistory>,
 }
 
 impl TxSubmissionResponder {
@@ -201,6 +208,7 @@ impl TxSubmissionResponder {
         params: ResponderParams,
         origin: TxOrigin,
         mempool_stage: StageRef<MempoolMsg>,
+        era_history: Arc<EraHistory>,
     ) -> (State, Self) {
         (
             State::Init,
@@ -213,6 +221,7 @@ impl TxSubmissionResponder {
                 origin,
                 muxer,
                 mempool_stage,
+                era_history,
             },
         )
     }
@@ -241,7 +250,9 @@ impl TxSubmissionResponder {
             let (ack, req, blocking) = self.request_tx_ids(mempool).await;
             Ok(Some(ResponderAction::SendRequestTxIds { ack, req, blocking }))
         } else {
-            Ok(Some(ResponderAction::SendRequestTxs(txs)))
+            let era = self.era_history.current_era_tag();
+            let tagged = txs.into_iter().map(|id| EraTaggedTxId { era, id }).collect();
+            Ok(Some(ResponderAction::SendRequestTxs(tagged)))
         }
     }
 
@@ -465,10 +476,14 @@ impl AsRef<StageRef<MuxMessage>> for TxSubmissionResponder {
     }
 }
 
+/// Actions produced by the responder stage.
+///
+/// `SendRequestTxs` carries a list of [`EraTaggedTxId`]s — each id is tagged with the era
+/// the responder will request it in.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ResponderAction {
     SendRequestTxIds { ack: u16, req: u16, blocking: Blocking },
-    SendRequestTxs(Vec<TransactionId>),
+    SendRequestTxs(Vec<EraTaggedTxId>),
     Error(ProtocolError),
 }
 
@@ -509,7 +524,7 @@ mod tests {
 
     use std::{collections::BTreeMap, sync::Arc};
 
-    use amaru_kernel::Transaction;
+    use amaru_kernel::{EraName, TESTNET_ERA_HISTORY, Transaction};
     use amaru_mempool::strategies::InMemoryMempool;
     use amaru_ouroboros_traits::{
         MempoolError, MempoolSeqNo, TransactionValidationError, TxInsertResult, TxOrigin, TxRejectReason,
@@ -518,6 +533,10 @@ mod tests {
 
     use super::*;
     use crate::tx_submission::{assert_actions_eq, tests::create_transactions};
+
+    fn test_era() -> EraName {
+        TESTNET_ERA_HISTORY.current_era_tag()
+    }
 
     #[tokio::test]
     async fn test_responder() -> anyhow::Result<()> {
@@ -696,6 +715,7 @@ mod tests {
                 ResponderParams::default(),
                 TxOrigin::Local,
                 StageRef::blackhole(),
+                Arc::new(TESTNET_ERA_HISTORY.clone()),
             )
             .1,
             mempool,
@@ -752,7 +772,9 @@ mod tests {
     }
 
     fn request_txs(txs: &[Transaction], ids: &[usize]) -> ResponderAction {
-        ResponderAction::SendRequestTxs(ids.iter().map(|id| txs[*id].tx_id()).collect())
+        let era = test_era();
+        let payload: Vec<EraTaggedTxId> = ids.iter().map(|id| EraTaggedTxId { era, id: txs[*id].tx_id() }).collect();
+        ResponderAction::SendRequestTxs(payload)
     }
 
     fn error_action(error: ProtocolError) -> ResponderAction {


### PR DESCRIPTION
The serialization of transactions was missing the era tag. I did not notice that before because I was only testing `amaru` with `amaru` :-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction submission is now era-aware: txs and tx-ids carry the current Cardano era tag for correct era-scoped handling.

* **Protocol / Wire**
  * CBOR wire format updated to encode per-item era metadata; decoders validate era prefixes and CBOR-wrapped tx bytes.

* **Tests**
  * Tests expanded to cover era-tagged message encoding/decoding, CBOR roundtrips, and protocol behavior with tagged payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/812)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->