### PR TITLE
ci: don't connect to upstream peers for snapshot tests

### DIFF
--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -186,7 +186,7 @@ jobs:
         run: |
           docker pull ghcr.io/intersectmbo/cardano-node:${{ matrix.cardano_node_version }}
           make HASKELL_NODE_CONFIG_DIR=cardano-node-config AMARU_NETWORK=${{ matrix.network.name }} download-haskell-config
-          jq 'del(.bootstrapPeers)' ./cardano-node-config/topology.json > cardano-node-config/topology.patched.json
+          jq 'del(.bootstrapPeers) | del(.peerSnapshotFile) | .useLedgerAfterSlot = -1' ./cardano-node-config/topology.json > cardano-node-config/topology.patched.json
           mv cardano-node-config/topology.patched.json cardano-node-config/topology.json
           docker run -d --name cardano-node \
             -v ${{ runner.temp }}/db-${{ matrix.network.name }}:/db \


### PR DESCRIPTION
This disable upstream peer connections for the cardano-node used in the end-to-end snapshot tests:

 -  `del(.peerSnapshotFile)` don't use the peer snapshot file.
 - `.useLedgerAfterSlot = -1` don't try to get peers from the ledger.

This makes the CI job more robust because otherwise some peers might try to download some blocks that the `cardano-node` doesn't have since it was loaded from a mithril spares snapshot.

The drawback is that the `amaru` node is not running as much logic as before w.r.t the chainsync protocol. But this was not supposed to be the focus of those end to end tests anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced snapshot testing workflow with stricter node initialization configuration parameters. Updated testing framework to enforce additional environment constraints during setup, refining parameter handling and validation. These modifications improve test consistency, reliability, and reproducibility across snapshot test cycles, ensuring more stable and predictable test environment behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/815)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->