### PR TITLE
fix: use 'cargo run' for generating and validating trace schemas + revert sccache

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -4,40 +4,64 @@ description: Restore/save Rust cache
 
 inputs:
   mode:
-    description: 'Cache mode: READ_ONLY or READ_WRITE'
-    default: READ_ONLY
+    description: 'Cache mode: READ or WRITE; default to READ on branches and WRITE on main.'
+    default: ''
   suffix:
-    description: 'An optionnal suffix to add to the cache name'
+    description: 'An optional suffix to add to the cache name, to have multiple different cache on same arch and OS.'
     default: ''
 
 runs:
   using: composite
   steps:
-    - name: Configure sccache env
+    - name: Configure env
       shell: bash
       run: |
-        echo "SCCACHE_DIR=${{ github.workspace }}/.sccache" >> "$GITHUB_ENV"
-        echo "SCCACHE_LOCAL_RW_MODE=${{ inputs.mode }}" >> "$GITHUB_ENV"
-        echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+        echo "CACHE_MODE=${{ inputs.mode || (github.ref == 'refs/heads/main' && 'WRITE' || 'READ') }}" >> "$GITHUB_ENV"
+        echo "CACHE_PRIMARY_KEY=cargo-${{ runner.arch }}-${{ runner.os }}${{ inputs.suffix }}-$(/bin/date -u '+%Y%m%d-%H%M%S')" >> "$GITHUB_ENV"
+        echo "CACHE_RESTORE_KEY_1=cargo-${{ runner.arch }}-${{ runner.os }}${{ inputs.suffix }}" >> "$GITHUB_ENV"
+        echo "CACHE_RESTORE_KEY_2=cargo-${{ runner.arch }}-${{ runner.os }}" >> "$GITHUB_ENV"
+        {
+          echo 'RUST_CACHE_PATHS<<EOF'
+          echo '~/.cargo/bin/'
+          echo '~/.cargo/registry/index/'
+          echo '~/.cargo/registry/cache/'
+          echo '~/.cargo/git/db/'
+          echo 'target/'
+          echo 'EOF'
+        } >> "$GITHUB_ENV"
 
-    - name: Restore cache
-      if: ${{ inputs.mode == 'READ_ONLY' }}
+    # Only read from an existing cache. We tightly control who can write to
+    # the cache (here, only workflow executing on 'main') for mostly two
+    # reasons:
+    #
+    # 1. It avoid concurrency conflicts where multiple parallel job would have
+    #    grabbed the same cache and then both try to write a new update.
+    #
+    # 2. It prevents one PR from interfering with other PRs; if someone is working
+    #    with a new set of dependencies, it would constantly push caches that would
+    #    force other to rebuild. It's annoying.
+    - name: Read cache
+      if: ${{ env.CACHE_MODE == 'READ' }}
       uses: actions/cache/restore@v5
       with:
-        path: ${{ env.SCCACHE_DIR }}
-        key: sccache-${{ runner.arch }}-${{ runner.os }}${{ inputs.suffix }}
+        path: ${{ env.RUST_CACHE_PATHS }}
+        key: ${{ env.CACHE_PRIMARY_KEY }}
         restore-keys: |
-          sccache-${{ runner.arch }}-${{ runner.os }}${{ inputs.suffix }}
-          sccache-${{ runner.arch }}-${{ runner.os }}
+          ${{ env.CACHE_RESTORE_KEY_1 }}
+          ${{ env.CACHE_RESTORE_KEY_2 }}
 
-    - name: Restore and save cache
-      if: ${{ inputs.mode == 'READ_WRITE' }}
+    # Invalidate and rewrite the cache. Note that because the primary key holds
+    # a timestamp, there will never be a cache hit here. It's not a bug, it's a
+    # feature. Those cache have a tendency to grow large, because `rustc`
+    # accumulates stuff over time.
+    #
+    # So, when we build on `main/`, we always build without cache, to rewrite a
+    # clean, pruned one for PRs. The timestamp allows to keep caches
+    # alphabetically sorted for a given prefix; which ensures they're used in
+    # priority (and thus, let github evicts the others).
+    - name: Write cache
+      if: ${{ env.CACHE_MODE == 'WRITE' }}
       uses: actions/cache@v5
       with:
-        path: ${{ env.SCCACHE_DIR }}
-        key: sccache-${{ runner.arch }}-${{ runner.os }}${{ inputs.suffix }}
-        restore-keys: |
-          sccache-${{ runner.arch }}-${{ runner.os }}${{ inputs.suffix }}
-          sccache-${{ runner.arch }}-${{ runner.os }}
-
-    - uses: mozilla-actions/sccache-action@v0.0.10
+        path: ${{ env.RUST_CACHE_PATHS }}
+        key: ${{ env.CACHE_PRIMARY_KEY }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -111,9 +111,6 @@ jobs:
 
           cargo $EXTRA_ARGS $COMMAND $SCOPE --locked --target ${{ matrix.environments.target }}
 
-          # Run doc tests separately as --doc can't be used with --all-targets
-          cargo test --doc
-
       - name: Upload test artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,30 +43,26 @@ jobs:
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             title: x86_64/linux
-            cache_mode: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
 
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             title: aarch64/linux
-            cache_mode: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
 
           - runner: macos-15
             target: aarch64-apple-darwin
             title: aarch64/macos
-            cache_mode: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
 
           - runner: windows-2025
             target: x86_64-pc-windows-msvc
             title: x86_64/windows
             command: test --tests --workspace --profile dev-debug
-            cache_mode: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
 
           - runner: ubuntu-24.04
             target: wasm32-unknown-unknown
             title: wasm32
             packages: -p amaru-consensus -p amaru-ledger -p pure-stage
             command: build
-            cache_mode: READ_ONLY
+            cache_mode: READ
             setup: rustup target add wasm32-unknown-unknown
 
           # When targetting RISC-V, the uplc-turbo crate fails to compile.
@@ -77,7 +73,7 @@ jobs:
             packages: -p amaru-ledger
             extra-args: +$RUST_NIGHTLY_TOOLCHAIN -Zbuild-std=std,panic_abort
             command: build
-            cache_mode: READ_ONLY
+            cache_mode: READ
             setup: |
               rustup component add rust-src --toolchain "$RUST_NIGHTLY_TOOLCHAIN"
               curl -L -o riscv32-glibc-llvm.tar.xz \
@@ -95,14 +91,14 @@ jobs:
           submodules: true
       - uses: ./.github/actions/cache
         with:
-          mode: ${{ matrix.environments.cache_mode }}
+          mode: ${{ matrix.environments.cache_mode || '' }}
       - name: Run build
         shell: bash
         run: |
           set -e
           EXTRA_ARGS="${{ matrix.environments.extra-args || '' }}"
           SCOPE="${{ matrix.environments.packages || '' }}"
-          COMMAND="${{ matrix.environments.command  || 'test --workspace --all-targets' }}"
+          COMMAND="${{ matrix.environments.command  || 'test --workspace' }}"
 
           if [[ -n "${{ matrix.environments.setup }}" ]]; then
             echo "Running setup command: ${{ matrix.environments.setup }}"
@@ -138,7 +134,6 @@ jobs:
       - uses: ./.github/actions/cache
         with:
           suffix: "-coverage"
-          mode: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
@@ -182,7 +177,6 @@ jobs:
       - uses: ./.github/actions/cache
         with:
           suffix: "-bench"
-          mode: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
       - name: Run amaru-consensus benches
         shell: bash
         run: cargo bench --bench headers_tree --features="test-utils profiling"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -222,8 +222,6 @@ jobs:
         with:
           name: schema-diff
           path: /tmp/schemas.diff
-      - name: Build amaru release binary
-        run: cargo build --bin amaru --quiet
       - name: Generate current TRACES.md
         run: |
           ./scripts/generate-traces-doc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,10 +135,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           pattern: amaru-*-${{ matrix.os }}-${{ matrix.arch == 'amd64' && 'x86_64' || 'aarch64' }}
-
-      - name: Rename artifact
-        run: |
-          mv amaru-*-${{ matrix.os }}-${{ matrix.arch == 'amd64' && 'x86_64' || 'aarch64' }} dist
+          path: dist
 
       - name: Build and push
         id: build

--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -175,9 +175,6 @@ jobs:
               --topology /config/topology.json
 
       - uses: ./.github/actions/cache
-        with:
-          suffix: "-test"
-          mode: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
 
       - name: Build Amaru
         shell: bash
@@ -239,7 +236,7 @@ jobs:
           echo "RUN_UNTIL_TARGET_EPOCH=$RUN_UNTIL_TARGET_EPOCH" >> "$GITHUB_ENV"
 
       - name: Run until target epoch
-        if: github.ref != 'refs/heads/main'
+        if: matrix.network.name != 'preprod' || github.ref != 'refs/heads/main'
         timeout-minutes: ${{ fromJSON(env.TIMEOUT_RUN || inputs.default_timeout) }}
         shell: bash
         run: |

--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -144,8 +144,7 @@ jobs:
       - name: Reclaim Disk Space
         run: |
           chmod +x ./scripts/cleanup-runner.sh
-          ./scripts/cleanup-runner.sh 1>cleanup-runner.log 2>&1 &
-          echo $! > cleanup-runner.pid
+          ./scripts/cleanup-runner.sh
 
       - name: Download (Haskell) cardano-node's db
         shell: bash

--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -144,7 +144,8 @@ jobs:
       - name: Reclaim Disk Space
         run: |
           chmod +x ./scripts/cleanup-runner.sh
-          ./scripts/cleanup-runner.sh
+          ./scripts/cleanup-runner.sh 1>cleanup-runner.log 2>&1 &
+          echo $! > cleanup-runner.pid
 
       - name: Download (Haskell) cardano-node's db
         shell: bash

--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -240,11 +240,11 @@ jobs:
           echo "RUN_UNTIL_TARGET_EPOCH=$RUN_UNTIL_TARGET_EPOCH" >> "$GITHUB_ENV"
 
       - name: Run until target epoch
+        if: github.ref != 'refs/heads/main'
         timeout-minutes: ${{ fromJSON(env.TIMEOUT_RUN || inputs.default_timeout) }}
         shell: bash
         run: |
           set -euo pipefail
-
           AMARU_TRACE=amaru=info \
           make AMARU_MAX_EXTRA_LEDGER_SNAPSHOTS=all run-until
 
@@ -253,7 +253,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-
           rm -f "$TRACE_COMPARE_LOG"
           AMARU_TRACE=amaru=trace \
           make RUN_UNTIL_TARGET_EPOCH="$TRACE_COMPARE_TARGET_EPOCH" AMARU_MAX_EXTRA_LEDGER_SNAPSHOTS=all run-until | tee "$TRACE_COMPARE_LOG"

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,7 @@ serve-traces-doc: generate-traces-doc ## &build Regenerate traces docs and serve
 	@python3 -m http.server $(TRACES_PORT) --directory docs
 
 validate-trace-schemas: ## &test Validate generated trace schemas against docs/traces-schema.json
-	@cargo build --bin amaru --quiet
-	@./target/debug/amaru dump-traces-schema 2> /tmp/schemas-current.json
+	@cargo run --bin amaru --quiet -- dump-traces-schema 2> /tmp/schemas-current.json
 	@./scripts/unused-schemas
 	@set -eu; \
 	jq -S 'walk(if type == "object" then del(.private) else . end)' docs/traces-schema.json > /tmp/expected.json; \

--- a/scripts/cleanup-runner.sh
+++ b/scripts/cleanup-runner.sh
@@ -166,47 +166,6 @@ execAndMeasureSpaceChange() {
     printSavedSpace "$before" "$title"
 }
 
-# Remove large packages
-# REF: https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
-cleanPackages() {
-    local packages=(
-        '^aspnetcore-.*'
-        '^dotnet-.*'
-        '^mongodb-.*'
-        'firefox'
-        'libgl1-mesa-dri'
-        'mono-devel'
-        'php.*'
-    )
-
-    if isGitHubRunner; then
-        packages+=(
-            azure-cli
-        )
-
-        if isX86; then
-            packages+=(
-                'google-chrome-stable'
-                'google-cloud-cli'
-                'google-cloud-sdk'
-                'powershell'
-            )
-        fi
-    else
-        packages+=(
-            'google-chrome-stable'
-        )
-    fi
-
-    WAIT_DPKG_LOCK="-o DPkg::Lock::Timeout=60"
-    sudo apt-get ${WAIT_DPKG_LOCK} -qq remove -y --fix-missing "${packages[@]}"
-
-    sudo apt-get ${WAIT_DPKG_LOCK} autoremove -y \
-        || echo "::warning::The command [sudo apt-get autoremove -y] failed"
-    sudo apt-get ${WAIT_DPKG_LOCK} clean \
-        || echo "::warning::The command [sudo apt-get clean] failed"
-}
-
 # Remove Docker images.
 # Ubuntu 22 runners have docker images already installed.
 # They aren't present in ubuntu 24 runners.
@@ -217,22 +176,13 @@ cleanDocker() {
     sudo docker image prune --all --force || true
 }
 
-# Remove Swap storage
-cleanSwap() {
-    sudo swapoff -a || true
-    sudo rm -rf /mnt/swapfile || true
-    free -h
-}
-
 # Display initial disk space stats
 
 AVAILABLE_INITIAL=$(getAvailableSpace)
 
 printDF "BEFORE CLEAN-UP:"
 echo ""
-execAndMeasureSpaceChange cleanPackages "Unused packages"
 execAndMeasureSpaceChange cleanDocker "Docker images"
-execAndMeasureSpaceChange cleanSwap "Swap storage"
 execAndMeasureSpaceChange removeUnusedFilesAndDirs "Unused files and directories"
 
 # Output saved space statistic

--- a/scripts/generate-traces-doc
+++ b/scripts/generate-traces-doc
@@ -15,18 +15,7 @@ SCHEMAS_FILE="${DOCS_DIR}/traces-schema.json"
 trap "rm -f ${SCHEMAS_JSON}" EXIT
 
 # Ensure the amaru binary is up to date
-AMARU_BIN="${REPO_ROOT}/target/release/amaru"
-echo "Building amaru binary if needed..." >&2
-cd "$REPO_ROOT"
-cargo build --bin amaru --quiet
-cd - > /dev/null
-
-if [ ! -f "$AMARU_BIN" ]; then
-  echo "Error: Failed to build amaru binary" >&2
-  exit 1
-fi
-
-"$AMARU_BIN" dump-traces-schema 2> "${SCHEMAS_JSON}" || {
+cargo run --quiet --bin amaru -- dump-traces-schema 2> "${SCHEMAS_JSON}" || {
   echo "Error generating schemas:" >&2
   cat "${SCHEMAS_JSON}" >&2
   exit 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined CI and release pipelines by removing redundant steps and simplifying artifact handling.
  * Simplified trace schema generation and validation to run directly without separate prebuilds.
  * Revised caching behavior and defaults to improve build consistency.
  * Adjusted snapshot test flow to gate a timing step off main and relax a strict failure mode.
  * Runner cleanup now focuses on Docker images and unused files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/822)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->