### PR TITLE
fix: avoid writing to CI cache by default, make it explicit.

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -5,7 +5,7 @@ description: Restore/save Rust cache
 inputs:
   mode:
     description: 'Cache mode: READ or WRITE; default to READ on branches and WRITE on main.'
-    default: ''
+    default: 'READ'
   suffix:
     description: 'An optional suffix to add to the cache name, to have multiple different cache on same arch and OS.'
     default: ''
@@ -16,7 +16,6 @@ runs:
     - name: Configure env
       shell: bash
       run: |
-        echo "CACHE_MODE=${{ inputs.mode || (github.ref == 'refs/heads/main' && 'WRITE' || 'READ') }}" >> "$GITHUB_ENV"
         echo "CACHE_PRIMARY_KEY=cargo-${{ runner.arch }}-${{ runner.os }}${{ inputs.suffix }}-$(/bin/date -u '+%Y%m%d-%H%M%S')" >> "$GITHUB_ENV"
         echo "CACHE_RESTORE_KEY_1=cargo-${{ runner.arch }}-${{ runner.os }}${{ inputs.suffix }}" >> "$GITHUB_ENV"
         echo "CACHE_RESTORE_KEY_2=cargo-${{ runner.arch }}-${{ runner.os }}" >> "$GITHUB_ENV"
@@ -41,7 +40,7 @@ runs:
     #    with a new set of dependencies, it would constantly push caches that would
     #    force other to rebuild. It's annoying.
     - name: Read cache
-      if: ${{ env.CACHE_MODE == 'READ' }}
+      if: ${{ inputs.mode == 'READ' }}
       uses: actions/cache/restore@v5
       with:
         path: ${{ env.RUST_CACHE_PATHS }}
@@ -60,7 +59,7 @@ runs:
     # alphabetically sorted for a given prefix; which ensures they're used in
     # priority (and thus, let github evicts the others).
     - name: Write cache
-      if: ${{ env.CACHE_MODE == 'WRITE' }}
+      if: ${{ inputs.mode == 'WRITE' }}
       uses: actions/cache@v5
       with:
         path: ${{ env.RUST_CACHE_PATHS }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,19 +43,23 @@ jobs:
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             title: x86_64/linux
+            cache_mode: ${{ github.ref == 'refs/heads/main' && 'WRITE' || 'READ' }}
 
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             title: aarch64/linux
+            cache_mode: ${{ github.ref == 'refs/heads/main' && 'WRITE' || 'READ' }}
 
           - runner: macos-15
             target: aarch64-apple-darwin
             title: aarch64/macos
+            cache_mode: ${{ github.ref == 'refs/heads/main' && 'WRITE' || 'READ' }}
 
           - runner: windows-2025
             target: x86_64-pc-windows-msvc
             title: x86_64/windows
             command: test --tests --workspace --profile dev-debug
+            cache_mode: ${{ github.ref == 'refs/heads/main' && 'WRITE' || 'READ' }}
 
           - runner: ubuntu-24.04
             target: wasm32-unknown-unknown
@@ -91,14 +95,14 @@ jobs:
           submodules: true
       - uses: ./.github/actions/cache
         with:
-          mode: ${{ matrix.environments.cache_mode || '' }}
+          mode: ${{ matrix.environments.cache_mode }}
       - name: Run build
         shell: bash
         run: |
           set -e
           EXTRA_ARGS="${{ matrix.environments.extra-args || '' }}"
           SCOPE="${{ matrix.environments.packages || '' }}"
-          COMMAND="${{ matrix.environments.command  || 'test --workspace' }}"
+          COMMAND="${{ matrix.environments.command || 'test --workspace' }}"
 
           if [[ -n "${{ matrix.environments.setup }}" ]]; then
             echo "Running setup command: ${{ matrix.environments.setup }}"
@@ -134,6 +138,7 @@ jobs:
       - uses: ./.github/actions/cache
         with:
           suffix: "-coverage"
+          mode: ${{ github.ref == 'refs/heads/main' && 'WRITE' || 'READ' }}
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
@@ -177,6 +182,7 @@ jobs:
       - uses: ./.github/actions/cache
         with:
           suffix: "-bench"
+          mode: ${{ github.ref == 'refs/heads/main' && 'WRITE' || 'READ' }}
       - name: Run amaru-consensus benches
         shell: bash
         run: cargo bench --bench headers_tree --features="test-utils profiling"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,6 @@ jobs:
         with:
           submodules: true
 
-      - uses: ./.github/actions/cache
-
       - name: build metadata
         id: meta
         shell: bash


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made CI caching branch-aware: build, coverage, and bench jobs now use per-branch read/write cache modes to improve build efficiency.
  * Adjusted default cache behavior to prefer reads by default.
  * Simplified release workflow by removing an extra local cache step, reducing redundant work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/824)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->