### PR TITLE
feat: defer the validation of a header when the stake distribution is not available yet

### DIFF
--- a/crates/amaru-consensus/src/stages/adopt_chain/mod.rs
+++ b/crates/amaru-consensus/src/stages/adopt_chain/mod.rs
@@ -20,7 +20,7 @@ use amaru_ouroboros_traits::{FindAncestorOnBestChainResult, StoreError};
 use amaru_protocols::{manager::ManagerMessage, store_effects::Store};
 use pure_stage::{Effects, Instant, OrTerminateWith, StageRef};
 
-use crate::stages::select_chain::cmp_tip;
+use crate::stages::{select_chain::cmp_tip, track_peers::TrackPeersMsg};
 
 /// This stage receives validated chains in the form of a Tip and decides
 /// whether to adopt that tip as the new downstream tip.
@@ -37,6 +37,7 @@ use crate::stages::select_chain::cmp_tip;
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct AdoptChain {
     downstream: StageRef<ManagerMessage>,
+    track_peers: StageRef<TrackPeersMsg>,
     mempool: StageRef<MempoolMsg>,
     consensus_security_param: u64,
     current_best_tip: Tip,
@@ -48,12 +49,14 @@ pub struct AdoptChain {
 impl AdoptChain {
     pub fn new(
         downstream: StageRef<ManagerMessage>,
+        track_peers: StageRef<TrackPeersMsg>,
         mempool: StageRef<MempoolMsg>,
         consensus_security_param: u64,
         current_best_tip: Tip,
     ) -> Self {
         Self {
             downstream,
+            track_peers,
             mempool,
             consensus_security_param,
             current_best_tip,
@@ -145,6 +148,8 @@ pub async fn stage(mut state: AdoptChain, msg: AdoptChainMsg, eff: Effects<Adopt
     }
     eff.send(&state.mempool, MempoolMsg::NewTip(msg)).await;
     eff.send(&state.downstream, ManagerMessage::NewTip(msg)).await;
+    // Tell track_peers that a block has been applied so it can wake any deferred header validations.
+    eff.send(&state.track_peers, TrackPeersMsg::BlockApplied(msg)).await;
     state.current_best_tip = msg;
     state
 }

--- a/crates/amaru-consensus/src/stages/adopt_chain/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/adopt_chain/test_setup.rs
@@ -134,6 +134,7 @@ pub fn register_guards() -> DeserializerGuards {
         pure_stage::register_data_deserializer::<AdoptChain>().boxed(),
         pure_stage::register_data_deserializer::<Tip>().boxed(),
         pure_stage::register_data_deserializer::<ManagerMessage>().boxed(),
+        pure_stage::register_data_deserializer::<crate::stages::track_peers::TrackPeersMsg>().boxed(),
         pure_stage::register_data_deserializer::<MempoolMsg>().boxed(),
         pure_stage::register_data_deserializer::<AdoptChainMsg>().boxed(),
         pure_stage::register_data_deserializer::<Option<BlockHeader>>().boxed(),
@@ -156,9 +157,10 @@ pub fn register_guards() -> DeserializerGuards {
 
 pub fn test_prep(consensus_security_param: u64) -> TestPrep {
     let downstream = StageRef::named_for_tests("downstream");
+    let track_peers = StageRef::named_for_tests("track_peers");
     let mempool = StageRef::named_for_tests("mempool");
     let headers = HeaderTree::new();
-    let state = AdoptChain::new(downstream, mempool, consensus_security_param, Tip::origin());
+    let state = AdoptChain::new(downstream, track_peers, mempool, consensus_security_param, Tip::origin());
     TestPrep {
         state,
         rt: Builder::new_current_thread().build().unwrap(),

--- a/crates/amaru-consensus/src/stages/adopt_chain/tests.rs
+++ b/crates/amaru-consensus/src/stages/adopt_chain/tests.rs
@@ -26,6 +26,7 @@ use crate::stages::{
         te_clock, te_find_anchor_at_height, te_roll_forward_chain, te_send, te_set_anchor_hash, te_switch_to_fork,
     },
     test_utils::{te_input, te_state},
+    track_peers::TrackPeersMsg,
 };
 
 /// Incoming tip not in store -> terminate.
@@ -137,6 +138,7 @@ fn test_extension_adopts_and_sends() {
             te_clock("ac-1"),
             te_send("ac-1", "mempool", MempoolMsg::NewTip(tip)),
             te_send("ac-1", "downstream", ManagerMessage::NewTip(tip)),
+            te_send("ac-1", "track_peers", TrackPeersMsg::BlockApplied(tip)),
             te_state("ac-1", &expected),
         ],
     );
@@ -187,6 +189,7 @@ fn test_fork_switch_adopts_and_sends() {
             te_clock("ac-1"),
             te_send("ac-1", "mempool", MempoolMsg::NewTip(tip)),
             te_send("ac-1", "downstream", ManagerMessage::NewTip(tip)),
+            te_send("ac-1", "track_peers", TrackPeersMsg::BlockApplied(tip)),
             te_state("ac-1", &expected),
         ],
     );
@@ -230,6 +233,7 @@ fn test_fork_switch_opcert_hacked() {
             te_clock("ac-1"),
             te_send("ac-1", "mempool", MempoolMsg::NewTip(tip)),
             te_send("ac-1", "downstream", ManagerMessage::NewTip(tip)),
+            te_send("ac-1", "track_peers", TrackPeersMsg::BlockApplied(tip)),
             te_state("ac-1", &expected),
         ],
     );

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -17,7 +17,8 @@ mod defer_req_next;
 use std::{collections::BTreeMap, time::Duration};
 
 use amaru_kernel::{
-    BlockHeader, BlockHeight, EraHistory, EraName, IsHeader, ORIGIN_HASH, Peer, Point, Tip, from_cbor_no_leftovers,
+    BlockHeader, BlockHeight, Epoch, EraHistory, EraName, IsHeader, ORIGIN_HASH, Peer, Point, Tip,
+    from_cbor_no_leftovers,
 };
 use amaru_observability::trace_span;
 use amaru_protocols::{
@@ -61,6 +62,10 @@ pub struct TrackPeers {
     /// Lazily populated via [`Effects::stage`](pure_stage::Effects::stage) on first deferred `RequestNext`.
     defer_req_next: StageRef<DeferReqNextMsg>,
     defer_req_next_poll_ms: u64,
+    /// Headers whose validation failed because the ledger had not yet computed the required
+    /// stake distribution. Drained on every `BlockApplied` and re-validated against the
+    /// now-advanced ledger state.
+    pending_validations: Vec<PendingValidation>,
     ledger_applied_block_height: BlockHeight,
     ledger_last_checked_at: Instant,
 }
@@ -71,9 +76,23 @@ struct PerPeer {
     highest: Tip,
 }
 
+/// A header whose validation failed transiently and must be retried once the ledger has
+/// caught up far enough to compute the required stake distribution.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+struct PendingValidation {
+    peer: Peer,
+    handler: StageRef<chainsync::InitiatorMessage>,
+    variant: EraName,
+    header: BlockHeader,
+    tip: Tip,
+    missing_epoch: Epoch,
+}
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum TrackPeersMsg {
     FromUpstream(ChainSyncInitiatorMsg),
+    /// Sent by `adopt_chain` after a block has been adopted. This is used to re-validate pending headers.
+    BlockApplied(Tip),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -88,6 +107,25 @@ pub async fn stage(mut state: TrackPeers, msg: TrackPeersMsg, eff: Effects<Track
     match msg {
         TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg { peer, conn_id: _, handler, msg }) => {
             state.handle_from_upstream(peer, handler, msg, eff).await;
+        }
+        TrackPeersMsg::BlockApplied(tip) => {
+            // Only retry pending validations whose `missing_epoch` boundary has been crossed by
+            // the applied tip. Entries still waiting are kept and reconsidered on the next
+            // `BlockApplied`.
+            match state.era_history.slot_to_epoch_unchecked_horizon(tip.slot()) {
+                Ok(applied_epoch) => {
+                    let (ready, still_pending) = std::mem::take(&mut state.pending_validations)
+                        .into_iter()
+                        .partition::<Vec<_>, _>(|p| applied_epoch > p.missing_epoch);
+                    state.pending_validations = still_pending;
+                    for pending in ready {
+                        state.handle_retry_validation(pending, eff.clone()).await;
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "track_peers.block_applied.slot_to_epoch_failed");
+                }
+            }
         }
     }
     state
@@ -109,6 +147,7 @@ impl TrackPeers {
             consensus_security_parameter,
             defer_req_next: StageRef::blackhole(),
             defer_req_next_poll_ms,
+            pending_validations: Vec::new(),
             ledger_applied_block_height: BlockHeight::from(0),
             ledger_last_checked_at: Instant::at_offset(Duration::from_secs(0)),
         }
@@ -123,6 +162,46 @@ impl TrackPeers {
         let wired = eff.wire_up(defer_b, state).await;
         self.defer_req_next = wired;
         eff.send(&self.defer_req_next, DeferReqNextMsg::Poll).await;
+    }
+
+    /// Retry a previously deferred header validation.
+    async fn handle_retry_validation(&mut self, pending: PendingValidation, eff: Effects<TrackPeersMsg>) {
+        let mode = self.compute_rollforward_mode(pending.header.block_height(), &eff).await;
+        self.execute_roll_forward(
+            pending.peer,
+            pending.handler,
+            pending.variant,
+            pending.header,
+            pending.tip,
+            mode,
+            eff,
+        )
+        .await;
+    }
+
+    /// Decide whether to pipeline the next `RequestNext` or defer it, based on how far the
+    /// ledger applied tip is behind the header being processed. Refreshes the cached
+    /// `ledger_applied_block_height` if it might be stale and the comparison is close.
+    async fn compute_rollforward_mode(
+        &mut self,
+        header_block_height: BlockHeight,
+        eff: &Effects<TrackPeersMsg>,
+    ) -> RollForwardMode {
+        let min_ledger_height = header_block_height - self.consensus_security_parameter;
+        if min_ledger_height > self.ledger_applied_block_height {
+            let now = eff.clock().await;
+            if now.saturating_since(self.ledger_last_checked_at) > Duration::from_secs(5)
+                || self.ledger_applied_block_height == BlockHeight::from(0)
+            {
+                self.ledger_last_checked_at = now;
+                self.ledger_applied_block_height = ledger_applied_block_height(eff).await;
+            }
+        }
+        if self.ledger_applied_block_height < min_ledger_height {
+            RollForwardMode::DeferTrailingRequestNext { min_ledger_height }
+        } else {
+            RollForwardMode::PipelineRequestNext
+        }
     }
 
     /// Insert or replace a peer's current and highest tip. For use in tests.
@@ -235,22 +314,55 @@ impl TrackPeers {
         mode: RollForwardMode,
         eff: Effects<TrackPeersMsg>,
     ) {
-        if matches!(mode, RollForwardMode::PipelineRequestNext) {
-            eff.send(&handler, chainsync::InitiatorMessage::RequestNext).await;
-        }
-
         let ledger = Ledger::new(eff.clone());
         let store = Store::new(eff.clone());
-        let header = self.validate_header(&peer, variant, header, tip, &ledger).await;
-        let (header, parent) = match header {
+        // Validate before sending `RequestNext` so a transient validation failure does not
+        // leave us with the next header in flight that we have no way to validate either.
+        let header_for_retry = header.clone();
+        let result = self.validate_header(&peer, variant, header, tip, &ledger).await;
+        let (header, parent) = match result {
             Ok(header) => header,
             Err(error) => {
+                if let Some(epoch) = missing_stake_distribution(&error) {
+                    // Transient issue: the ledger has not yet computed the stake distribution we need
+                    // to validate this header. Keep the peer and stash the header so it can be
+                    // retried once the ledger catches up. `per_peer.current` is unchanged so the
+                    // retry sees the same predecessor.
+                    tracing::debug!(
+                        %peer, %epoch,
+                        "chain_sync.validate_header.pending_stake_distribution"
+                    );
+                    self.pending_validations.push(PendingValidation {
+                        peer,
+                        handler,
+                        variant,
+                        header: header_for_retry,
+                        tip,
+                        missing_epoch: epoch,
+                    });
+                    return;
+                }
                 tracing::error!(%error, %peer, "chain_sync.validate_header.failed");
                 self.upstream.remove(&peer);
                 eff.send(&self.manager, ManagerMessage::RemovePeer(peer)).await;
                 return;
             }
         };
+
+        // Ask for the next header, if the ledger is not too far off.
+        match mode {
+            RollForwardMode::PipelineRequestNext => {
+                eff.send(&handler, chainsync::InitiatorMessage::RequestNext).await;
+            }
+            RollForwardMode::DeferTrailingRequestNext { min_ledger_height } => {
+                self.ensure_defer_req_next_stage(&eff).await;
+                eff.send(
+                    &self.defer_req_next,
+                    DeferReqNextMsg::Register { handler: handler.clone(), min_ledger_height },
+                )
+                .await;
+            }
+        }
 
         let tip_point = header.point();
         let tip = self.roll_forward(&peer, header, tip, &store).await;
@@ -269,11 +381,6 @@ impl TrackPeers {
             eff.send(&self.downstream, (tip, parent)).await;
         } else {
             tracing::debug!(%peer, tip = %tip_point, "roll forward, header already stored");
-        }
-
-        if let RollForwardMode::DeferTrailingRequestNext { min_ledger_height } = mode {
-            self.ensure_defer_req_next_stage(&eff).await;
-            eff.send(&self.defer_req_next, DeferReqNextMsg::Register { handler, min_ledger_height }).await;
         }
     }
 
@@ -319,16 +426,8 @@ impl TrackPeers {
                     }
                 };
 
-                let min_ledger_height = header.block_height() - self.consensus_security_parameter;
-                if min_ledger_height > self.ledger_applied_block_height
-                    && let now = eff.clock().await
-                    && (now.saturating_since(self.ledger_last_checked_at) > Duration::from_secs(5)
-                        || self.ledger_applied_block_height == BlockHeight::from(0))
-                {
-                    self.ledger_last_checked_at = now;
-                    self.ledger_applied_block_height = ledger_applied_block_height(&eff).await;
-                }
-                let mode = if self.ledger_applied_block_height < min_ledger_height {
+                let mode = self.compute_rollforward_mode(header.block_height(), &eff).await;
+                if let RollForwardMode::DeferTrailingRequestNext { min_ledger_height } = mode {
                     tracing::debug!(
                         %peer,
                         header_height = %header.block_height(),
@@ -336,10 +435,7 @@ impl TrackPeers {
                         limit = %min_ledger_height,
                         "track_peers.defer_request_next",
                     );
-                    RollForwardMode::DeferTrailingRequestNext { min_ledger_height }
-                } else {
-                    RollForwardMode::PipelineRequestNext
-                };
+                }
 
                 self.execute_roll_forward(peer, handler, variant, header, tip, mode, eff).await;
             }
@@ -367,6 +463,16 @@ pub fn decode_header(raw_header: HeaderContent, peer: &Peer) -> Result<BlockHead
     }
     from_cbor_no_leftovers(&raw_header.cbor)
         .map_err(|reason| ConsensusError::CannotDecodeHeader { header: raw_header.cbor, reason: reason.to_string() })
+}
+
+/// Inspect a `ConsensusError` and, if it carries a transient "stake distribution not available" error,
+/// return the epoch whose distribution is missing. Otherwise return `None`.
+#[expect(clippy::wildcard_enum_match_arm)]
+fn missing_stake_distribution(error: &ConsensusError) -> Option<Epoch> {
+    match error {
+        ConsensusError::InvalidHeader(_, e) => e.as_missing_stake_distribution(),
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
@@ -114,6 +114,8 @@ fn register_guards() -> DeserializerGuards {
     vec![
         pure_stage::register_data_deserializer::<TrackPeers>().boxed(),
         pure_stage::register_data_deserializer::<TrackPeersMsg>().boxed(),
+        pure_stage::register_data_deserializer::<super::defer_req_next::DeferReqNext>().boxed(),
+        pure_stage::register_data_deserializer::<super::DeferReqNextMsg>().boxed(),
         pure_stage::register_data_deserializer::<InitiatorMessage>().boxed(),
         pure_stage::register_data_deserializer::<ManagerMessage>().boxed(),
         pure_stage::register_data_deserializer::<Tip>().boxed(),
@@ -178,7 +180,19 @@ pub struct FailingHeaderValidation;
 
 impl CanValidateHeaders for FailingHeaderValidation {
     fn validate_header(&self, _header: &BlockHeader) -> Result<(), HeaderValidationError> {
-        Err(HeaderValidationError::new(anyhow!("header validation failed: booyah!")))
+        Err(HeaderValidationError::Other(anyhow!("header validation failed: booyah!")))
+    }
+}
+
+/// Header validation mock that always fails with the transient
+/// "stake distribution not available" condition for the given epoch.
+pub struct TransientHeaderValidation {
+    pub epoch: amaru_kernel::Epoch,
+}
+
+impl CanValidateHeaders for TransientHeaderValidation {
+    fn validate_header(&self, _header: &BlockHeader) -> Result<(), HeaderValidationError> {
+        Err(HeaderValidationError::MissingStakeDistribution(self.epoch))
     }
 }
 

--- a/crates/amaru-consensus/src/stages/track_peers/tests.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/tests.rs
@@ -14,7 +14,7 @@
 
 use std::{slice, sync::Arc};
 
-use amaru_kernel::{BlockHeight, EraName, HeaderHash, IsHeader, Peer, Point, Tip};
+use amaru_kernel::{BlockHeight, Epoch, EraName, HeaderHash, IsHeader, Peer, Point, Tip};
 use amaru_protocols::{
     chainsync::{self, ChainSyncInitiatorMsg, HeaderContent, InitiatorMessage::RequestNext},
     manager::ManagerMessage,
@@ -23,10 +23,10 @@ use pure_stage::trace_buffer::TraceEntry;
 use tracing::Level;
 
 use crate::stages::track_peers::{
-    TrackPeersMsg,
+    PendingValidation, TrackPeersMsg,
     test_setup::{
-        FailingHeaderValidation, assert_trace, build_store, make_block_header, setup, setup_with_validation,
-        te_has_header, te_load_tip, te_send, te_store_header, te_validate_header, test_prep,
+        FailingHeaderValidation, TransientHeaderValidation, assert_trace, build_store, make_block_header, setup,
+        setup_with_validation, te_has_header, te_load_tip, te_send, te_store_header, te_validate_header, test_prep,
     },
 };
 
@@ -231,7 +231,6 @@ fn test_roll_forward_unknown_peer_removes_peer() {
         &[
             TraceEntry::state("tp-1", Box::new(state.clone())),
             TraceEntry::input("tp-1", Box::new(msg)),
-            te_send("tp-1", &prep.handler, RequestNext),
             te_send("tp-1", "manager", ManagerMessage::RemovePeer(peer)),
             TraceEntry::state("tp-1", Box::new(state)),
         ],
@@ -266,8 +265,8 @@ fn test_roll_forward_known_peer_header_already_stored() {
         &[
             TraceEntry::state("tp-1", Box::new(state)),
             TraceEntry::input("tp-1", Box::new(msg)),
-            te_send("tp-1", &prep.handler, RequestNext),
             te_validate_header("tp-1", header.clone()),
+            te_send("tp-1", &prep.handler, RequestNext),
             te_has_header("tp-1", header.hash()),
             TraceEntry::state("tp-1", Box::new(expected)),
         ],
@@ -304,8 +303,8 @@ fn test_roll_forward_known_peer_new_header_forwards_tip() {
         &[
             TraceEntry::state("tp-1", Box::new(state)),
             TraceEntry::input("tp-1", Box::new(msg)),
-            te_send("tp-1", &prep.handler, RequestNext),
             te_validate_header("tp-1", header.clone()),
+            te_send("tp-1", &prep.handler, RequestNext),
             te_has_header("tp-1", header.hash()),
             te_store_header("tp-1", header.clone()),
             te_send("tp-1", "downstream", (header.tip(), parent.point())),
@@ -406,7 +405,6 @@ fn test_roll_forward_invalid_parent_removes_peer() {
         &[
             TraceEntry::state("tp-1", Box::new(state)),
             TraceEntry::input("tp-1", Box::new(msg)),
-            te_send("tp-1", &prep.handler, RequestNext),
             te_send("tp-1", "manager", ManagerMessage::RemovePeer(peer)),
             TraceEntry::state("tp-1", Box::new(expected)),
         ],
@@ -438,7 +436,6 @@ fn test_roll_forward_invalid_height_removes_peer() {
         &[
             TraceEntry::state("tp-1", Box::new(state)),
             TraceEntry::input("tp-1", Box::new(msg)),
-            te_send("tp-1", &prep.handler, RequestNext),
             te_send("tp-1", "manager", ManagerMessage::RemovePeer(peer)),
             TraceEntry::state("tp-1", Box::new(expected)),
         ],
@@ -470,7 +467,6 @@ fn test_roll_forward_invalid_point_removes_peer() {
         &[
             TraceEntry::state("tp-1", Box::new(state)),
             TraceEntry::input("tp-1", Box::new(msg)),
-            te_send("tp-1", &prep.handler, RequestNext),
             te_send("tp-1", "manager", ManagerMessage::RemovePeer(peer)),
             TraceEntry::state("tp-1", Box::new(expected)),
         ],
@@ -514,9 +510,59 @@ fn test_roll_forward_header_validation_failure_removes_peer() {
         &[
             TraceEntry::state("tp-1", Box::new(state)),
             TraceEntry::input("tp-1", Box::new(msg)),
-            te_send("tp-1", &prep.handler, RequestNext),
             te_validate_header("tp-1", header.clone()),
             te_send("tp-1", "manager", ManagerMessage::RemovePeer(peer)),
+            TraceEntry::state("tp-1", Box::new(expected)),
+        ],
+    );
+}
+
+#[test]
+fn test_roll_forward_transient_validation_failure_keeps_peer() {
+    // When a header cannot be validated because the stake distribution needed for its validation
+    // is not yet available, we should keep the peer and queue the header for retry.
+    let prep = test_prep();
+    let peer = Peer::new("peer1");
+    let parent = &prep.headers[0];
+    let header = &prep.headers[1];
+    let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
+        peer: peer.clone(),
+        conn_id: prep.conn_id,
+        handler: prep.handler.clone(),
+        msg: chainsync::InitiatorResult::RollForward(HeaderContent::new(header, EraName::Conway), header.tip()),
+    });
+
+    let missing_epoch = Epoch::from(286);
+    let mut state = prep.state.clone();
+    state.insert_peer(peer.clone(), parent.tip(), header.tip());
+
+    let mut expected = state.clone();
+    expected.pending_validations.push(PendingValidation {
+        peer: peer.clone(),
+        handler: prep.handler.clone(),
+        variant: EraName::Conway,
+        header: header.clone(),
+        tip: header.tip(),
+        missing_epoch,
+    });
+
+    let (running, _guards, mut logs) = setup_with_validation(
+        &prep.rt_handle(),
+        state.clone(),
+        msg.clone(),
+        build_store(&[]),
+        Arc::new(TransientHeaderValidation { epoch: missing_epoch }),
+    );
+
+    logs.assert_and_remove(Level::DEBUG, &["chain_sync.validate_header.pending_stake_distribution"])
+        .assert_no_remaining_at([Level::WARN, Level::ERROR]);
+
+    assert_trace(
+        &running,
+        &[
+            TraceEntry::state("tp-1", Box::new(state)),
+            TraceEntry::input("tp-1", Box::new(msg)),
+            te_validate_header("tp-1", header.clone()),
             TraceEntry::state("tp-1", Box::new(expected)),
         ],
     );

--- a/crates/amaru-consensus/src/validate_header.rs
+++ b/crates/amaru-consensus/src/validate_header.rs
@@ -16,8 +16,11 @@ use std::{fmt, sync::Arc};
 
 use amaru_kernel::{BlockHeader, ConsensusParameters, IsHeader, Nonce, to_cbor};
 use amaru_observability::trace_span;
-use amaru_ouroboros::praos;
-use amaru_ouroboros_traits::{CanValidateHeaders, ChainStore, HasStakeDistribution, HeaderValidationError, Praos};
+use amaru_ouroboros::praos::{self, header::AssertHeaderError};
+use amaru_ouroboros_traits::{
+    CanValidateHeaders, ChainStore, HasStakeDistribution, HeaderValidationError, Praos,
+    has_stake_distribution::GetPoolError,
+};
 use anyhow::anyhow;
 
 use crate::{errors::ConsensusError, store::PraosChainStore};
@@ -83,12 +86,28 @@ impl ValidateHeader {
             use rayon::prelude::*;
             assertions.into_par_iter().try_for_each(|assert| assert())
         })
-        .map_err(|e| ConsensusError::InvalidHeader(header.point(), HeaderValidationError::new(anyhow!(e))))
+        .map_err(|e| ConsensusError::InvalidHeader(header.point(), into_header_validation_error(e)))
+    }
+}
+
+/// Convert an [`AssertHeaderError`] into a [`HeaderValidationError`], keeping the
+/// "stake distribution not available" case separate so that it can be handled as a transient error.
+#[expect(clippy::wildcard_enum_match_arm)]
+fn into_header_validation_error(error: AssertHeaderError) -> HeaderValidationError {
+    match error {
+        AssertHeaderError::PoolError(GetPoolError::StakeDistributionNotAvailable(epoch)) => {
+            HeaderValidationError::MissingStakeDistribution(epoch)
+        }
+        other => HeaderValidationError::Other(anyhow!(other)),
     }
 }
 
 impl CanValidateHeaders for ValidateHeader {
+    #[expect(clippy::wildcard_enum_match_arm)]
     fn validate_header(&self, header: &BlockHeader) -> Result<(), HeaderValidationError> {
-        self.validate(header).map_err(|e| HeaderValidationError::new(anyhow!(e)))
+        self.validate(header).map_err(|e| match e {
+            ConsensusError::InvalidHeader(_, inner) => inner,
+            other => HeaderValidationError::Other(anyhow!(other)),
+        })
     }
 }

--- a/crates/amaru-ouroboros-traits/src/validators/headers/can_validate_headers.rs
+++ b/crates/amaru-ouroboros-traits/src/validators/headers/can_validate_headers.rs
@@ -14,43 +14,49 @@
 
 use std::fmt::{Debug, Display, Formatter};
 
-use amaru_kernel::BlockHeader;
+use amaru_kernel::{BlockHeader, Epoch};
 use serde::{Deserialize, Serialize};
 
 pub trait CanValidateHeaders: Send + Sync {
     fn validate_header(&self, header: &BlockHeader) -> Result<(), HeaderValidationError>;
 }
 
+/// An error reported by header validation.
+///
+/// The `MissingStakeDistribution` variant flags a transient condition: the ledger has not yet
+/// computed the stake distribution required to validate this header. In that case we need to wait
+/// until the ledger has caught up to revalidate the header.
 #[derive(Debug)]
-pub struct HeaderValidationError(anyhow::Error);
+pub enum HeaderValidationError {
+    MissingStakeDistribution(Epoch),
+    Other(anyhow::Error),
+}
 
 impl HeaderValidationError {
-    pub fn new(err: anyhow::Error) -> Self {
-        HeaderValidationError(err)
-    }
-
-    pub fn to_anyhow(self) -> anyhow::Error {
-        self.0
-    }
-
-    pub fn downcast<T: std::error::Error + Debug + Send + Sync + 'static>(self) -> Result<T, anyhow::Error> {
-        self.0.downcast::<T>()
-    }
-
-    pub fn downcast_ref<T: std::error::Error + Debug + Send + Sync + 'static>(&self) -> Option<&T> {
-        self.0.downcast_ref::<T>()
+    /// If this error was caused by a missing stake distribution, return the epoch whose
+    /// distribution is missing. Returns `None` for all other errors.
+    pub fn as_missing_stake_distribution(&self) -> Option<Epoch> {
+        match self {
+            Self::MissingStakeDistribution(epoch) => Some(*epoch),
+            Self::Other(_) => None,
+        }
     }
 }
 
 impl From<anyhow::Error> for HeaderValidationError {
     fn from(err: anyhow::Error) -> Self {
-        HeaderValidationError::new(err)
+        Self::Other(err)
     }
 }
 
 impl Display for HeaderValidationError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "HeaderValidationError: {}", self.0)
+        match self {
+            Self::MissingStakeDistribution(epoch) => {
+                write!(f, "HeaderValidationError: no stake distribution available for epoch {}.", epoch)
+            }
+            Self::Other(err) => write!(f, "HeaderValidationError: {}", err),
+        }
     }
 }
 
@@ -59,25 +65,28 @@ impl Serialize for HeaderValidationError {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.0.to_string())
+        serializer.serialize_str(&self.to_string())
     }
 }
 
-/// This deserialization implementation is a best-effort attempt to
-/// recover the error message. The original error type is lost during
-/// serialization, so we can only reconstruct the error message as a string.
+/// Best-effort deserialization: the original error type is lost during serialization, so
+/// any recovered value lands in the `Other` variant carrying the error message as a string.
 impl<'de> Deserialize<'de> for HeaderValidationError {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        Ok(HeaderValidationError::new(anyhow::anyhow!(s)))
+        Ok(Self::Other(anyhow::anyhow!(s)))
     }
 }
 
 impl PartialEq for HeaderValidationError {
     fn eq(&self, other: &Self) -> bool {
-        self.0.to_string() == other.0.to_string()
+        match (self, other) {
+            (Self::MissingStakeDistribution(a), Self::MissingStakeDistribution(b)) => a == b,
+            (Self::Other(a), Self::Other(b)) => a.to_string() == b.to_string(),
+            _ => false,
+        }
     }
 }

--- a/crates/amaru/src/stages/build_stage_graph.rs
+++ b/crates/amaru/src/stages/build_stage_graph.rs
@@ -66,8 +66,10 @@ pub fn build_stage_graph(
             .expect("consensus security param will not be larger than u64::MAX")
     };
     let mempool_stage = stage_graph.wire_up(mempool_stage, MempoolStageState::default()).without_state();
-    let adopt_chain =
-        stage_graph.wire_up(adopt_chain, AdoptChain::new(manager.sender(), mempool_stage.clone(), k, ledger_tip));
+    let adopt_chain = stage_graph.wire_up(
+        adopt_chain,
+        AdoptChain::new(manager.sender(), track_peers.sender(), mempool_stage.clone(), k, ledger_tip),
+    );
 
     let validate_block = stage_graph.wire_up(
         validate_block,


### PR DESCRIPTION
This PR fixes a header validation issue that appeared during testing:
```

┌────────────────────────────── ┬───────────────┬───────────────────────────────────────────────────────────────────────────────────────┐
│           State.              │     Value     │                               Description                                             │
├────────────────────────────── ┼───────────────┼───────────────────────────────────────────────────────────────────────────────────────┤
│ Most recent snapshot on disk  │ 286           │ Taken when the ledger crossed 286 -> 287                                              │
├────────────────────────────── ┼───────────────┼───────────────────────────────────────────────────────────────────────────────────────┤
│ Snapshots on disk             │ 284, 285, 286 │ MIN_LEDGER_SNAPSHOTS = 3 keeps the latest three                                       │
├────────────────────────────── ┼───────────────┼───────────────────────────────────────────────────────────────────────────────────────┤
│ Ledger stable tip.            │ 122_767_427   │ Inside epoch 287. ~ 7000 slots before the 287 / 288 boundary at slot 122_774_400      │
├────────────────────────────── ┼───────────────┼───────────────────────────────────────────────────────────────────────────────────────┤
│ In-memory stake distributions │ 285, 284      │                                                                                       |
├────────────────────────────── ┼───────────────┼───────────────────────────────────────────────────────────────────────────────────────┤
│ Peer's tip                    │ 122_899_069   │ Inside epoch 288. It streamed headers cross the 287 / 288 boundary almost immediately │
└────────────────────────────── ┴───────────────┴───────────────────────────────────────────────────────────────────────────────────────┘
```

In that situation the upstream peer sent us a header that could not be validated and the peer was unduly removed.

This PR fixes this situation by:

 1. Tracking validation errors due to missing stake distributions. The error includes the epoch where the stake distribution will be available.
 2. Keeping peers as pending until the ledger catches up.
 3. Receiving `BlockApplied` events in the `track_peers` stage to know if we have reached an epoch that allows us to validate pending headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adopt-chain now notifies peer-tracking when a new tip is applied, enabling automatic retries of previously deferred header validations after new blocks arrive.
  * Peer-tracking gains a transient retry queue so deferred validations are re-attempted when applicable.

* **Bug Fixes**
  * Transient header-validation failures no longer cause peer removals; peers are kept and retried, improving chain-sync stability and recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->