### PR TITLE
fix: machete must run if code changed too

### DIFF
--- a/.github/workflows/coding-practices.yml
+++ b/.github/workflows/coding-practices.yml
@@ -36,8 +36,6 @@ jobs:
               - "crates/**/Cargo.lock"
 
   unused-dependencies:
-    needs: changes
-    if: ${{ needs.changes.outputs.dependencies == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,7 +347,6 @@ dependencies = [
  "amaru-metrics",
  "anyhow",
  "async-trait",
- "hex",
  "parking_lot",
  "rand 0.9.2",
  "serde",

--- a/crates/amaru-ouroboros-traits/Cargo.toml
+++ b/crates/amaru-ouroboros-traits/Cargo.toml
@@ -22,7 +22,6 @@ test-utils = ["dep:rand"]
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-hex.workspace = true
 parking_lot.workspace = true
 rand = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Always machete :D Unused deps appear when code doesn't use them anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified CI workflow configuration to adjust the execution behavior of dependency validation checks in the pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/828)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->