### PR TITLE
fix: consume utxo inputs in the current block and volatile state

### DIFF
--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -530,16 +530,20 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
         // TODO: perform lookup in batch, and possibly within the same transaction as other
         // required data pre-fetch.
         for input in inputs {
-            let output = ongoing_state
-                .resolve_input(input)
-                .cloned()
-                .inspect(|_| resolved_from_context += 1)
-                .or_else(|| self.volatile.resolve_input(input).inspect(|_| resolved_from_volatile += 1).cloned())
-                .map(|output| Ok(Some(output)))
-                .unwrap_or_else(|| {
-                    let db = self.stable.lock().unwrap();
-                    db.utxo(input).inspect(|_| resolved_from_db += 1)
-                })?;
+            let output = if ongoing_state.has_consumed_input(input) || self.volatile.has_consumed_input(input) {
+                Ok(None)
+            } else {
+                ongoing_state
+                    .resolve_input(input)
+                    .cloned()
+                    .inspect(|_| resolved_from_context += 1)
+                    .or_else(|| self.volatile.resolve_input(input).inspect(|_| resolved_from_volatile += 1).cloned())
+                    .map(|output| Ok(Some(output)))
+                    .unwrap_or_else(|| {
+                        let db = self.stable.lock().unwrap();
+                        db.utxo(input).inspect(|_| resolved_from_db += 1)
+                    })
+            }?;
 
             result.push((input.clone(), output));
         }

--- a/crates/amaru-ledger/src/state/volatile_db.rs
+++ b/crates/amaru-ledger/src/state/volatile_db.rs
@@ -71,6 +71,10 @@ impl VolatileDB {
         self.cache.utxo.produced.get(input)
     }
 
+    pub fn has_consumed_input(&self, input: &TransactionInput) -> bool {
+        self.cache.utxo.consumed.contains(input)
+    }
+
     pub fn contains(&self, point: &Point) -> bool {
         self.sequence.binary_search_by_key(point, |state| state.anchor.0.point()).is_ok()
     }
@@ -201,6 +205,10 @@ impl VolatileState {
 
     pub fn resolve_input(&self, input: &TransactionInput) -> Option<&MemoizedTransactionOutput> {
         self.utxo.produced.get(input)
+    }
+
+    pub fn has_consumed_input(&self, input: &TransactionInput) -> bool {
+        self.utxo.consumed.contains(input)
     }
 }
 
@@ -454,6 +462,38 @@ mod tests {
         assert_eq!(db.len(), 3, "All elements should be retained");
     }
 
+    #[test]
+    fn test_consumed_input_is_tracked() {
+        let input = test_input(1);
+        let mut state = create_test_state(10, 1);
+        state.state.utxo.consume(input.clone());
+
+        let mut db = VolatileDB::default();
+        db.push_back(state);
+
+        assert!(db.has_consumed_input(&input));
+        assert!(db.resolve_input(&input).is_none());
+    }
+
+    #[test]
+    fn test_rollback_removes_consumed_input_from_cache() {
+        let input = test_input(1);
+        let mut db = VolatileDB::default();
+        let first = create_test_state(10, 1);
+        let first_point = first.anchor.0.point();
+        db.push_back(first);
+
+        let mut second = create_test_state(20, 2);
+        second.state.utxo.consume(input.clone());
+        db.push_back(second);
+
+        assert!(db.has_consumed_input(&input));
+
+        db.rollback_to(&first_point).unwrap();
+
+        assert!(!db.has_consumed_input(&input));
+    }
+
     // HELPERS
 
     fn create_test_state(slot: u64, pool_id: u8) -> AnchoredVolatileState {
@@ -472,5 +512,9 @@ mod tests {
 
         assert_eq!(db.len(), 3);
         db
+    }
+
+    fn test_input(tag: u8) -> TransactionInput {
+        TransactionInput { transaction_id: Hash::new([tag; 32]), index: 0 }
     }
 }


### PR DESCRIPTION
This PR fixes the search for consumed inputs by looking at the consumed inputs inside the current block validation state and the rest of the volatile db.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction input resolution logic to correctly detect and handle already-consumed inputs.
  * Enhanced input tracking within the ledger state to prevent conflicts.

* **Tests**
  * Added comprehensive tests for consumed input tracking and state rollback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->