### PR TITLE
fix: transaction rollback

### DIFF
--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -318,10 +318,8 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
         let StoreUpdate { point: stable_point, issuer: stable_issuer, fees, add, remove, withdrawals } =
             now_stable.into_store_update(current_epoch, &self.protocol_parameters);
 
-        let batch = db.create_transaction();
-
-        batch
-            .save(
+        db.with_transaction::<_, StateError>(|batch| {
+            batch.save(
                 &self.era_history,
                 &self.protocol_parameters,
                 &mut self.governance_activity,
@@ -330,24 +328,23 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
                 add,
                 remove,
                 withdrawals,
-            )
-            .and_then(|()| {
-                batch.with_pots(|mut row| {
-                    row.borrow_mut().fees += fees;
-                })?;
+            )?;
 
-                // Reset the epoch transition progress once we've successfully applied the first
-                // block of the next epoch.
-                if epoch_transitioning {
-                    let success = batch.try_epoch_transition(Some(EpochTransitionProgress::EpochStarted), None)?;
-                    if !success {
-                        unreachable!("epoch transition reset did not succeed after first block!")
-                    }
+            batch.with_pots(|mut row| {
+                row.borrow_mut().fees += fees;
+            })?;
+
+            // Reset the epoch transition progress once we've successfully applied the first
+            // block of the next epoch.
+            if epoch_transitioning {
+                let success = batch.try_epoch_transition(Some(EpochTransitionProgress::EpochStarted), None)?;
+                if !success {
+                    unreachable!("epoch transition reset did not succeed after first block!")
                 }
+            }
 
-                batch.commit()
-            })
-            .map_err(StateError::Storage)?;
+            Ok(())
+        })?;
 
         Ok(())
     }
@@ -368,71 +365,72 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
         let _guard = _span.enter();
 
         // ---------------------------------------------------------------------------- End of epoch
-        let batch = db.create_transaction();
-        let should_end_epoch = batch.try_epoch_transition(None, Some(EpochTransitionProgress::EpochEnded))?;
-        if should_end_epoch {
-            end_epoch(
-                &batch,
-                // FIXME: This should eventually be an '.await', as we always expect to *eventually*
-                // have some rewards summary being available. There's no way to continue progressing
-                // the ledger if we don't.
-                rewards_summary.ok_or(StateError::RewardsSummaryNotReady)?,
-            )
-            .map_err(StateError::Storage)?;
-        }
-        batch.commit()?;
+        db.with_transaction::<_, StateError>(|batch| {
+            let should_end_epoch = batch.try_epoch_transition(None, Some(EpochTransitionProgress::EpochEnded))?;
+            if should_end_epoch {
+                end_epoch(
+                    batch,
+                    // FIXME: This should eventually be an '.await', as we always expect to *eventually*
+                    // have some rewards summary being available. There's no way to continue progressing
+                    // the ledger if we don't.
+                    rewards_summary.ok_or(StateError::RewardsSummaryNotReady)?,
+                )
+                .map_err(StateError::Storage)?;
+            }
+            Ok(())
+        })?;
 
         // -------------------------------------------------------------------------------- Snapshot
-        let batch = db.create_transaction();
-        let should_snapshot = batch.try_epoch_transition(
-            Some(EpochTransitionProgress::EpochEnded),
-            Some(EpochTransitionProgress::SnapshotTaken),
-        )?;
-        let treasury = if should_snapshot {
-            let treasury = db.pots()?.treasury;
-            db.next_snapshot(next_epoch - 1)?;
-            Ok::<_, StateError>(treasury)
-        } else {
-            Ok(snapshots.for_epoch(next_epoch - 1)?.pots()?.treasury)
-        }?;
-        batch.commit()?;
+        let treasury = db.with_transaction::<_, StateError>(|batch| {
+            let should_snapshot = batch.try_epoch_transition(
+                Some(EpochTransitionProgress::EpochEnded),
+                Some(EpochTransitionProgress::SnapshotTaken),
+            )?;
+            if should_snapshot {
+                let treasury = batch.pots()?.treasury;
+                db.next_snapshot(next_epoch - 1)?;
+                Ok(treasury)
+            } else {
+                Ok(snapshots.for_epoch(next_epoch - 1)?.pots()?.treasury)
+            }
+        })?;
         snapshots.prune(next_epoch - MIN_LEDGER_SNAPSHOTS)?;
 
         // -------------------------------------------------------------------------- Start of epoch
-        let batch = db.create_transaction();
-        let should_begin_epoch = batch.try_epoch_transition(
-            Some(EpochTransitionProgress::SnapshotTaken),
-            Some(EpochTransitionProgress::EpochStarted),
-        )?;
+        let protocol_parameters = db.with_transaction::<_, StateError>(|batch| {
+            let should_begin_epoch = batch.try_epoch_transition(
+                Some(EpochTransitionProgress::SnapshotTaken),
+                Some(EpochTransitionProgress::EpochStarted),
+            )?;
 
-        let ratification_context = new_ratification_context(
-            self.snapshots.for_epoch(next_epoch - 2)?,
-            self.stake_distribution(next_epoch - 2)?,
-            self.protocol_parameters.clone(),
-            treasury,
-        )?;
+            let ratification_context = new_ratification_context(
+                self.snapshots.for_epoch(next_epoch - 2)?,
+                self.stake_distribution(next_epoch - 2)?,
+                self.protocol_parameters.clone(),
+                treasury,
+            )?;
 
-        let protocol_parameters = if should_begin_epoch {
-            begin_epoch(
-                &batch,
-                next_epoch,
-                &self.era_history,
-                ratification_context,
-                // Get all proposals to ratify / enact. Note that, even though the ratification happens
-                // with an epoch of delay (and thus, using data from a snapshot), we always use the most
-                // recent set of proposals available. While recently submitted proposals won't have any
-                // votes, they might still end up being pruned due to a previous proposal being enacted.
-                //
-                // FIXME: We shouldn't collect all proposals here, but provides iterators for the
-                // ratification step to go over them lazily.
-                db.iter_proposals()?.collect::<Vec<_>>(),
-                db.proposals_roots()?,
-                &self.protocol_parameters,
-            )
-        } else {
-            Ok(db.protocol_parameters()?)
-        }?;
-        batch.commit()?;
+            if should_begin_epoch {
+                Ok(begin_epoch(
+                    batch,
+                    next_epoch,
+                    &self.era_history,
+                    ratification_context,
+                    // Get all proposals to ratify / enact. Note that, even though the ratification happens
+                    // with an epoch of delay (and thus, using data from a snapshot), we always use the most
+                    // recent set of proposals available. While recently submitted proposals won't have any
+                    // votes, they might still end up being pruned due to a previous proposal being enacted.
+                    //
+                    // FIXME: We shouldn't collect all proposals here, but provides iterators for the
+                    // ratification step to go over them lazily.
+                    batch.iter_proposals()?.collect::<Vec<_>>(),
+                    batch.proposals_roots()?,
+                    &self.protocol_parameters,
+                )?)
+            } else {
+                Ok(batch.protocol_parameters()?)
+            }
+        })?;
 
         Ok(protocol_parameters)
     }

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -177,7 +177,35 @@ pub trait Store: ReadStore {
     fn next_snapshot(&self, epoch: Epoch) -> Result<()>;
 
     /// Create a new transaction context. This is used to perform updates on the store.
+    ///
+    /// Prefer [`Store::with_transaction`] if you can. It ensures the transaction is
+    /// always either committed or rolled back, removing the risk of leaking an open
+    /// transaction on an early `?` return.
     fn create_transaction(&self) -> Self::Transaction<'_>;
+
+    /// Run `f` inside a transaction:
+    ///
+    /// - On `Ok`, the transaction is committed.
+    /// - On `Err`, the transaction is dropped and auto-rolled-back by its `Drop` impl.
+    ///
+    /// This makes it impossible to leak an open transaction through an early `?` return
+    /// between `create_transaction()` and `commit()`.
+    fn with_transaction<R, E>(
+        &self,
+        f: impl FnOnce(&Self::Transaction<'_>) -> std::result::Result<R, E>,
+    ) -> std::result::Result<R, E>
+    where
+        E: From<StoreError>,
+    {
+        let tx = self.create_transaction();
+        match f(&tx) {
+            Ok(result) => {
+                tx.commit()?;
+                Ok(result)
+            }
+            Err(err) => Err(err),
+        }
+    }
 }
 
 // ReadStore

--- a/crates/amaru-stores/src/rocksdb/consensus/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/mod.rs
@@ -448,13 +448,15 @@ impl<H: IsHeader + Clone + Debug + for<'d> cbor::Decode<'d, ()>> ChainStore<H> f
         let _guard = _span.enter();
 
         let hash = header.hash();
-        let tx = self.db.transaction();
         let parent_hash = header.parent().unwrap_or(ORIGIN_HASH);
-        tx.put([&CHILD_PREFIX[..], &parent_hash[..], &hash[..]].concat(), [])
-            .map_err(|e| StoreError::WriteError { error: e.to_string() })?;
-        tx.put([&HEADER_PREFIX[..], &hash[..]].concat(), to_cbor(header))
-            .map_err(|e| StoreError::WriteError { error: e.to_string() })?;
-        tx.commit().map_err(|e| StoreError::WriteError { error: e.to_string() })
+
+        self.with_transaction(|tx| {
+            tx.put([&CHILD_PREFIX[..], &parent_hash[..], &hash[..]].concat(), [])
+                .map_err(|e| StoreError::WriteError { error: e.to_string() })?;
+            tx.put([&HEADER_PREFIX[..], &hash[..]].concat(), to_cbor(header))
+                .map_err(|e| StoreError::WriteError { error: e.to_string() })?;
+            Ok(())
+        })
     }
 
     fn set_block_valid(&self, hash: &HeaderHash, valid: bool) -> Result<(), StoreError> {

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -1148,14 +1148,27 @@ mod tests {
 
     #[test]
     fn dropping_transaction_does_not_leak_ongoing_flag() {
-        let tmp_dir = TempDir::new().expect("failed to create temp dir");
-        let store = RocksDB::empty(&RocksDbConfig::new(tmp_dir.path().into())).expect("failed to open store");
+        let tmp_dir = TempDir::new().unwrap();
+        let store = RocksDB::empty(&RocksDbConfig::new(tmp_dir.path().into())).unwrap();
 
         // Open a transaction and drop it without committing or rolling back.
         drop(store.create_transaction());
 
         // Since the previous transaction is dropped and has been properly cleared, we should be able
         // to create a new one.
+        let _ = store.create_transaction();
+    }
+
+    /// `with_transaction` rolls back the transaction on `Err`.
+    #[test]
+    fn with_transaction_rolls_back_on_err() {
+        let tmp_dir = TempDir::new().unwrap();
+        let store = RocksDB::empty(&RocksDbConfig::new(tmp_dir.path().into())).unwrap();
+
+        let outcome: Result<(), StoreError> = store.with_transaction(|_tx| Err(StoreError::Send));
+        assert!(matches!(outcome, Err(StoreError::Send)));
+
+        // The previous transaction is properly closed so we should be able to create a new one.
         let _ = store.create_transaction();
     }
 

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -534,8 +534,19 @@ pub struct RocksDBTransactionalContext<'a> {
     db: Transaction<'a, OptimisticTransactionDB>,
 }
 
+impl Drop for RocksDBTransactionalContext<'_> {
+    fn drop(&mut self) {
+        // If the context is dropped without an explicit commit/rollback then we clear the host flag
+        // so a subsequent create_transaction() call does not panic.
+        if self.host.ongoing_transaction.get() {
+            warn!("RocksDB transactional context dropped without commit/rollback; auto-rolled-back");
+            self.host.transaction_ended();
+        }
+    }
+}
+
 impl TransactionalContext<'_> for RocksDBTransactionalContext<'_> {
-    fn commit(self) -> Result<(), StoreError> {
+    fn commit(mut self) -> Result<(), StoreError> {
         let _span = trace_span!(
             amaru::stores::rocksdb::COMMIT,
             db_system_name = "rocksdb".to_string(),
@@ -543,7 +554,8 @@ impl TransactionalContext<'_> for RocksDBTransactionalContext<'_> {
         );
         let _guard = _span.enter();
 
-        let res = self.db.commit().map_err(|err| StoreError::Internal(err.into()));
+        let transaction = std::mem::replace(&mut self.db, self.host.db.transaction());
+        let res = transaction.commit().map_err(|err| StoreError::Internal(err.into()));
         self.host.transaction_ended();
         res
     }
@@ -995,7 +1007,7 @@ fn with_prefix_iterator<
 #[cfg(test)]
 mod tests {
     use amaru_kernel::{EraHistory, NetworkName};
-    use amaru_ledger::store::StoreError;
+    use amaru_ledger::store::{Store, StoreError};
     use proptest::test_runner::TestRunner;
     use tempfile::TempDir;
 
@@ -1132,6 +1144,19 @@ mod tests {
     #[ignore]
     fn test_rocksdb_remove_cc_members() {
         unimplemented!()
+    }
+
+    #[test]
+    fn dropping_transaction_does_not_leak_ongoing_flag() {
+        let tmp_dir = TempDir::new().expect("failed to create temp dir");
+        let store = RocksDB::empty(&RocksDbConfig::new(tmp_dir.path().into())).expect("failed to open store");
+
+        // Open a transaction and drop it without committing or rolling back.
+        drop(store.create_transaction());
+
+        // Since the previous transaction is dropped and has been properly cleared, we should be able
+        // to create a new one.
+        let _ = store.create_transaction();
     }
 
     #[test]


### PR DESCRIPTION
This PR fixes #836 by:

 - Adding a `Drop` implementation that rolls back an ongoing transaction.
 - Adding a `with_transaction` helper to run code inside a transaction and make sure that we don't forget to commit.