### PR TITLE
fix: on startup reapply downloaded and valid blocks

### DIFF
--- a/crates/amaru-consensus/benches/stage_msgs.rs
+++ b/crates/amaru-consensus/benches/stage_msgs.rs
@@ -69,9 +69,9 @@ fn stage_msgs(c: &mut Criterion) {
     let msg: Box<dyn SendData> = Box::new(msg);
     group.bench_function("FetchBlocksMsg::NewTip", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
 
-    let msg = FetchBlocksMsg::RecoverStoredBlocks(point.hash());
+    let msg = FetchBlocksMsg::Initialize(point.hash());
     let msg: Box<dyn SendData> = Box::new(msg);
-    group.bench_function("FetchBlocksMsg::RecoverStoredBlocks", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
+    group.bench_function("FetchBlocksMsg::Initialize", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
 
     let msg = FetchBlocksMsg::Timeout(1000);
     let msg: Box<dyn SendData> = Box::new(msg);

--- a/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
@@ -21,10 +21,13 @@ use amaru_ouroboros_traits::{MissingBlocks, MissingBlocksResult};
 use amaru_protocols::{blockfetch::Blocks2, manager::ManagerMessage, store_effects::Store};
 use pure_stage::{Effects, OrTerminateWith, ScheduleId, StageRef, TryInStage};
 
-use crate::stages::{
-    block_source::BlockSourceMsg,
-    peer_selection::PeerSelectionMsg,
-    select_chain::{SelectChainMsg, load_parent_point},
+use crate::{
+    effects::{Ledger, LedgerOps},
+    stages::{
+        block_source::BlockSourceMsg,
+        peer_selection::PeerSelectionMsg,
+        select_chain::{SelectChainMsg, load_parent_point},
+    },
 };
 
 // TODO make configurable
@@ -171,9 +174,19 @@ impl FetchBlocks {
         self.request_missing_blocks(tip, parent, eff).await;
     }
 
-    /// Startup-only recovery: resubmit downloaded blocks whose validity was not
-    /// persisted before shutdown, then fetch from the first missing block.
-    pub async fn recover_stored_blocks(&mut self, eff: Effects<FetchBlocksMsg>, best_hash: HeaderHash) {
+    /// Startup initialization.
+    ///
+    /// At runtime, validity in the chain store and the ledger's applied tip
+    /// advance together: `set_block_valid` is only written after the block has
+    /// been applied to the ledger.
+    ///
+    /// But the ledger keeps the last `k` applied blocks in-memory, so after a restart `ledger.tip()`
+    /// is the stable tip and can be up to `k` blocks behind the chain store's validated tip.
+    ///
+    /// This method re-emits those blocks so the ledger can rebuild its
+    /// volatile state. It also covers blocks that were downloaded but not yet
+    /// validated before shutdown.
+    pub async fn initialize(&mut self, eff: Effects<FetchBlocksMsg>, best_hash: HeaderHash) -> anyhow::Result<()> {
         assert!(
             self.missing.is_none(),
             "there shouldn't be any missing blocks when recovering stored blocks: {:?}",
@@ -183,8 +196,9 @@ impl FetchBlocks {
         let store = Store::new(eff.clone());
         if best_hash == ORIGIN_HASH {
             eff.send(&self.upstream, SelectChainMsg::FetchNextFrom(Point::Origin)).await;
-            return;
+            return Ok(());
         }
+
         let best_tip = store
             .load_header(&best_hash)
             .await
@@ -192,14 +206,23 @@ impl FetchBlocks {
                 tracing::error!(hash = %best_hash, "cannot load header for best candidate");
             })
             .await;
-        let unvalidated = store.unvalidated_ancestor_hashes(best_hash).await.0;
 
+        let ledger = Ledger::new(eff.clone());
         self.block_height = best_tip.block_height().max(self.block_height);
-        let tip = best_tip.tip();
-        tracing::debug!(tip = %tip.point(), "recovering stored blocks");
+
+        // Get all header hashes between the best tip and the ledger immutable tip
+        // and either apply/re-apply blocks or download them in order to apply them
+        let ledger_tip = ledger.immutable_tip().await;
+        let to_apply = ancestor_hashes_down_to(&store, best_tip.hash(), ledger_tip.hash()).await?;
+        tracing::debug!(
+            tip = %best_tip.point(),
+            ledger_tip = %ledger_tip.point(),
+            count = to_apply.len(),
+            "download or validate blocks up to the best tip"
+        );
 
         let mut parent: Option<Point> = None;
-        for hash in unvalidated {
+        for hash in to_apply {
             let Some(header) = store.load_header(&hash).await else {
                 tracing::error!(%hash, "failed to load candidate header");
                 return eff.terminate().await;
@@ -217,7 +240,7 @@ impl FetchBlocks {
                 }
                 Ok(false) => {
                     self.request_missing_blocks(tip, block_parent, eff).await;
-                    return;
+                    return Ok(());
                 }
                 Err(error) => {
                     tracing::error!(%error, %hash, "failed to check stored block");
@@ -226,8 +249,9 @@ impl FetchBlocks {
             }
         }
 
-        tracing::info!(tip = %tip.point(), "no blocks to fetch");
-        eff.send(&self.upstream, SelectChainMsg::FetchNextFrom(tip.point())).await;
+        tracing::info!(tip = %best_tip.point(), "no blocks to fetch");
+        eff.send(&self.upstream, SelectChainMsg::FetchNextFrom(best_tip.point())).await;
+        Ok(())
     }
 
     async fn request_missing_blocks(&mut self, tip: Tip, parent: Point, eff: Effects<FetchBlocksMsg>) {
@@ -347,10 +371,37 @@ impl FetchBlocks {
     }
 }
 
+/// Walk parent pointers from `top` toward `bottom`, returning the visited
+/// hashes oldest-first (excluding `bottom` itself).
+async fn ancestor_hashes_down_to(
+    store: &Store,
+    top: HeaderHash,
+    bottom: HeaderHash,
+) -> anyhow::Result<Vec<HeaderHash>> {
+    let mut result = Vec::new();
+    if top == bottom {
+        return Ok(result);
+    }
+    let mut current = top;
+    while current != bottom {
+        let Some(header) = store.load_header(&current).await else {
+            tracing::error!(%current, %bottom, "ancestor walk: header missing");
+            return Err(anyhow::anyhow!("failed to load header"));
+        };
+        result.push(current);
+        match header.parent_hash() {
+            Some(parent) => current = parent,
+            None => break,
+        }
+    }
+    result.reverse();
+    Ok(result)
+}
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum FetchBlocksMsg {
+    Initialize(HeaderHash),
     NewTip(Tip, Point),
-    RecoverStoredBlocks(HeaderHash),
     Block(Peer, NetworkBlock),
     Timeout(u64),
 }
@@ -361,8 +412,15 @@ pub async fn stage(mut state: FetchBlocks, msg: FetchBlocksMsg, eff: Effects<Fet
     })
     .await;
     match msg {
+        FetchBlocksMsg::Initialize(best_hash) => {
+            state
+                .initialize(eff.clone(), best_hash)
+                .or_terminate_with(&eff, async |error| {
+                    tracing::error!(%error, %best_hash, "failed to initialize");
+                })
+                .await;
+        }
         FetchBlocksMsg::NewTip(tip, parent) => state.new_tip(tip, parent, eff).await,
-        FetchBlocksMsg::RecoverStoredBlocks(best_hash) => state.recover_stored_blocks(eff, best_hash).await,
         FetchBlocksMsg::Block(peer, block) => state.block(peer, block, eff).await,
         FetchBlocksMsg::Timeout(req_id) => state.timeout(req_id, eff).await,
     }

--- a/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
@@ -12,29 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{sync::Arc, time::Duration};
+use std::{collections::BTreeSet, net::SocketAddr, sync::Arc, time::Duration};
 
 use amaru_kernel::{
-    BlockHeader, HeaderHash, Peer, Point, RawBlock, TESTNET_ERA_HISTORY, Tip,
+    Block, BlockHeader, HeaderHash, Peer, Point, RawBlock, TESTNET_ERA_HISTORY, Tip,
     cardano::network_block::{make_block_with_header, make_encoded_block, make_network_block},
 };
-use amaru_ouroboros_traits::{ChainStore, MissingBlocks, StoreError, in_memory_consensus_store::InMemConsensusStore};
+use amaru_metrics::ledger::LedgerMetrics;
+use amaru_ouroboros_traits::{
+    BlockValidationError, CanValidateBlocks, ChainStore, HasStakePools, MissingBlocks, StoreError,
+    in_memory_consensus_store::InMemConsensusStore,
+};
 use amaru_protocols::store_effects::{
     FindMissingBlocksEffect, GetAnchorHashEffect, GetChildrenEffect, HasBlockEffect, LoadHeaderEffect,
     LoadHeaderWithValidityEffect, LoadTipEffect, ResourceHeaderStore, StoreBlockEffect,
-    UnvalidatedAncestorHashesEffect,
 };
 use pure_stage::{
     DeserializerGuards, Effect, Instant, Name, ScheduleId, ScheduleIds, StageGraph, StageRef,
     simulation::SimulationRunning, trace_buffer::TraceEntry,
 };
 use tokio::runtime::{Builder, Runtime};
+use tracing::Level;
+use tracing_subscriber::util::SubscriberInitExt;
 
 use super::*;
-use crate::stages::{
-    block_source::BlockSourceMsg,
-    select_chain::SelectChainMsg,
-    test_utils::{Logs, run_simulation},
+use crate::{
+    effects::{ResourceBlockValidation, ResourceHasStakePools, TipEffect, VolatileTipEffect},
+    stages::{
+        block_source::BlockSourceMsg,
+        select_chain::SelectChainMsg,
+        test_utils::{BufferWriter, Logs, run_simulation},
+    },
 };
 
 pub fn test_peer() -> Peer {
@@ -139,10 +147,57 @@ pub fn register_guards() -> DeserializerGuards {
         pure_stage::register_effect_deserializer::<LoadTipEffect>().boxed(),
         pure_stage::register_effect_deserializer::<StoreBlockEffect>().boxed(),
         pure_stage::register_effect_deserializer::<FindMissingBlocksEffect>().boxed(),
-        pure_stage::register_effect_deserializer::<UnvalidatedAncestorHashesEffect>().boxed(),
+        pure_stage::register_effect_deserializer::<TipEffect>().boxed(),
+        pure_stage::register_effect_deserializer::<VolatileTipEffect>().boxed(),
         pure_stage::register_data_deserializer::<(Vec<HeaderHash>, bool)>().boxed(),
         pure_stage::register_data_deserializer::<Result<Option<MissingBlocks>, StoreError>>().boxed(),
     ]
+}
+
+/// `CanValidateBlocks` implementation that returns the same tip
+#[derive(Clone, Debug, Default)]
+pub struct FixedTipBlocks {
+    pub tip_point: Point,
+}
+
+impl FixedTipBlocks {
+    pub fn new(tip_point: Point) -> Self {
+        Self { tip_point }
+    }
+}
+
+#[async_trait::async_trait]
+impl CanValidateBlocks for FixedTipBlocks {
+    async fn roll_forward_block(
+        &self,
+        _point: &Point,
+        _block: Block,
+    ) -> Result<Result<LedgerMetrics, BlockValidationError>, BlockValidationError> {
+        Ok(Ok(Default::default()))
+    }
+
+    fn rollback_block(&self, _to: &Point) -> Result<(), BlockValidationError> {
+        Ok(())
+    }
+
+    fn contains_point(&self, _point: &Point) -> bool {
+        true
+    }
+
+    fn tip(&self) -> Point {
+        self.tip_point
+    }
+
+    fn volatile_tip(&self) -> Option<Tip> {
+        None
+    }
+}
+
+#[async_trait::async_trait]
+impl HasStakePools for FixedTipBlocks {
+    async fn registered_relay_socket_addrs(&self) -> Result<BTreeSet<SocketAddr>, BlockValidationError> {
+        Ok(BTreeSet::new())
+    }
 }
 
 /// Creates test prep with mocked cleanup_replies (named dummy StageRef).
@@ -167,6 +222,24 @@ pub fn test_prep() -> TestPrep {
 }
 
 pub fn setup(prep: &TestPrep, msg: FetchBlocksMsg) -> (SimulationRunning, DeserializerGuards, Logs) {
+    setup_with_ledger_tip(prep, msg, Point::Origin)
+}
+
+pub fn setup_with_ledger_tip(
+    prep: &TestPrep,
+    msg: FetchBlocksMsg,
+    ledger_tip: Point,
+) -> (SimulationRunning, DeserializerGuards, Logs) {
+    let writer = BufferWriter::new();
+    let mut logs = writer.clone();
+
+    let sub = tracing_subscriber::fmt()
+        .with_max_level(Level::DEBUG)
+        .with_ansi(false)
+        .with_writer(move || writer.clone())
+        .set_default();
+    logs.set_guard(sub);
+
     let guards = register_guards();
 
     run_simulation(
@@ -179,6 +252,9 @@ pub fn setup(prep: &TestPrep, msg: FetchBlocksMsg) -> (SimulationRunning, Deseri
         },
         |resources| {
             resources.put::<ResourceHeaderStore>(prep.store.clone());
+            let block_validation = Arc::new(FixedTipBlocks::new(ledger_tip));
+            resources.put::<ResourceBlockValidation>(block_validation.clone());
+            resources.put::<ResourceHasStakePools>(block_validation);
         },
         |_running| {
             // No additional external effect overrides needed for basic fetch_blocks tests.
@@ -210,8 +286,8 @@ pub fn te_load_tip(at_stage: &str, hash: HeaderHash) -> TraceEntry {
     TraceEntry::suspend(Effect::external(at_stage, Box::new(LoadTipEffect::new(hash))))
 }
 
-pub fn te_unvalidated_ancestor_hashes(at_stage: &str, start: HeaderHash) -> TraceEntry {
-    TraceEntry::suspend(Effect::external(at_stage, Box::new(UnvalidatedAncestorHashesEffect::new(start))))
+pub fn te_tip(at_stage: &str) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(at_stage, Box::new(TipEffect)))
 }
 
 pub fn te_store_block(at_stage: &str, hash: HeaderHash, block: amaru_kernel::RawBlock) -> TraceEntry {

--- a/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
@@ -26,8 +26,8 @@ use tracing::Level;
 use super::*;
 use crate::stages::{
     fetch_blocks::test_setup::{
-        TestPrep, setup, te_cancel_schedule, te_clock, te_find_missing_blocks, te_has_block, te_load_header,
-        te_load_tip, te_schedule, te_store_block, te_unvalidated_ancestor_hashes, test_peer, test_prep,
+        TestPrep, setup, setup_with_ledger_tip, te_cancel_schedule, te_clock, te_find_missing_blocks, te_has_block,
+        te_load_header, te_load_tip, te_schedule, te_store_block, te_tip, test_peer, test_prep,
     },
     test_utils::{assert_trace, te_input, te_send, te_state, te_terminate, te_terminated, tm_state},
 };
@@ -88,7 +88,7 @@ fn test_new_tip_no_blocks_to_fetch() {
 }
 
 #[test]
-fn test_recover_stored_blocks_validates_downloaded_unvalidated_blocks() {
+fn test_initialize_with_downloaded_but_unvalidated_blocks() {
     let prep = test_prep();
     prep.store_headers(&[&prep.headers.h0, &prep.headers.h1, &prep.headers.h2]);
     prep.store_block(&prep.headers.h1);
@@ -96,9 +96,10 @@ fn test_recover_stored_blocks_validates_downloaded_unvalidated_blocks() {
     prep.set_anchor(prep.headers.h0.hash());
     prep.set_validity(prep.headers.h0.hash(), true);
 
-    let msg = FetchBlocksMsg::RecoverStoredBlocks(prep.headers.h2.hash());
+    let msg = FetchBlocksMsg::Initialize(prep.headers.h2.hash());
 
-    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    // The ledger tip is at the anchor
+    let (running, _guards, mut logs) = setup_with_ledger_tip(&prep, msg.clone(), prep.headers.h0.point());
     let expected = prep.state_with_block_height(3);
     assert_trace(
         &running,
@@ -106,7 +107,9 @@ fn test_recover_stored_blocks_validates_downloaded_unvalidated_blocks() {
             te_state("fb-1", &prep.state),
             te_input("fb-1", &msg),
             te_load_header("fb-1", prep.headers.h2.hash(), false),
-            te_unvalidated_ancestor_hashes("fb-1", prep.headers.h2.hash()),
+            te_tip("fb-1"),
+            te_load_header("fb-1", prep.headers.h2.hash(), false),
+            te_load_header("fb-1", prep.headers.h1.hash(), false),
             te_load_header("fb-1", prep.headers.h1.hash(), false),
             te_load_tip("fb-1", prep.headers.h0.hash()),
             te_has_block("fb-1", prep.headers.h1.hash()),
@@ -118,7 +121,50 @@ fn test_recover_stored_blocks_validates_downloaded_unvalidated_blocks() {
             te_state("fb-1", &expected),
         ],
     );
-    logs.assert_and_remove(Level::DEBUG, &["recovering stored blocks"])
+    logs.assert_and_remove(Level::DEBUG, &["download or validate blocks up to the best tip"])
+        .assert_and_remove(Level::DEBUG, &["validating stored block"])
+        .assert_and_remove(Level::DEBUG, &["validating stored block"])
+        .assert_and_remove(Level::INFO, &["no blocks to fetch"])
+        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_initialize_to_reapply_downloaded_and_valid_blocks() {
+    let prep = test_prep();
+    prep.store_headers(&[&prep.headers.h0, &prep.headers.h1, &prep.headers.h2]);
+    prep.store_block(&prep.headers.h0);
+    prep.store_block(&prep.headers.h1);
+    prep.store_block(&prep.headers.h2);
+    prep.set_anchor(prep.headers.h0.hash());
+    prep.set_validity(prep.headers.h0.hash(), true);
+    prep.set_validity(prep.headers.h1.hash(), true);
+    prep.set_validity(prep.headers.h2.hash(), true);
+
+    let msg = FetchBlocksMsg::Initialize(prep.headers.h2.hash());
+
+    let (running, _guards, mut logs) = setup_with_ledger_tip(&prep, msg.clone(), prep.headers.h0.point());
+    let expected = prep.state_with_block_height(3);
+    assert_trace(
+        &running,
+        &[
+            te_state("fb-1", &prep.state),
+            te_input("fb-1", &msg),
+            te_load_header("fb-1", prep.headers.h2.hash(), false),
+            te_tip("fb-1"),
+            te_load_header("fb-1", prep.headers.h2.hash(), false),
+            te_load_header("fb-1", prep.headers.h1.hash(), false),
+            te_load_header("fb-1", prep.headers.h1.hash(), false),
+            te_load_tip("fb-1", prep.headers.h0.hash()),
+            te_has_block("fb-1", prep.headers.h1.hash()),
+            te_send("fb-1", "downstream", (prep.headers.h1.tip(), prep.headers.h0.point(), BlockHeight::from(3))),
+            te_load_header("fb-1", prep.headers.h2.hash(), false),
+            te_has_block("fb-1", prep.headers.h2.hash()),
+            te_send("fb-1", "downstream", (prep.headers.h2.tip(), prep.headers.h1.point(), BlockHeight::from(3))),
+            te_send("fb-1", "upstream", SelectChainMsg::FetchNextFrom(prep.headers.h2.point())),
+            te_state("fb-1", &expected),
+        ],
+    );
+    logs.assert_and_remove(Level::DEBUG, &["download or validate blocks up to the best tip"])
         .assert_and_remove(Level::DEBUG, &["validating stored block"])
         .assert_and_remove(Level::DEBUG, &["validating stored block"])
         .assert_and_remove(Level::INFO, &["no blocks to fetch"])

--- a/crates/amaru-consensus/src/stages/mempool/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/mempool/test_setup.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use amaru_kernel::{
-    Hash, NetworkName, Transaction, TransactionBody, TransactionInput, WitnessSet, size::TRANSACTION_BODY,
+    Hash, NetworkName, Point, Transaction, TransactionBody, TransactionInput, WitnessSet, size::TRANSACTION_BODY,
 };
 use amaru_ouroboros::{
     MempoolInsertError, MempoolMsg, MockCanValidateBlocks, ResourceMempool, TxInsertResult, TxOrigin,
@@ -75,7 +75,9 @@ pub fn setup(prep: &TestPrep) -> (SimulationRunning, DeserializerGuards, Logs) {
     let global_parameters = <&amaru_kernel::GlobalParameters>::from(NetworkName::Preprod);
     network.resources().put::<ResourceParameters>(global_parameters.clone());
     network.resources().put::<ResourceEraHistory>(era_history.clone());
-    network.resources().put::<ResourceBlockValidation>(std::sync::Arc::new(MockCanValidateBlocks));
+    network
+        .resources()
+        .put::<ResourceBlockValidation>(std::sync::Arc::new(MockCanValidateBlocks::with_tip(Point::Origin)));
     network.resources().put::<ResourceMempool<Transaction>>(prep.mempool.clone());
     network.resources().put::<ResourceTxValidation>(prep.validator.clone());
 

--- a/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
@@ -202,7 +202,7 @@ fn setup_base(
         |resources| {
             resources.put::<ResourceHeaderStore>(store.clone());
             resources.put::<ResourceHeaderValidation>(validation);
-            let block_validation = Arc::new(MockCanValidateBlocks);
+            let block_validation = Arc::new(MockCanValidateBlocks::with_tip(Point::Origin));
             resources.put::<ResourceBlockValidation>(block_validation.clone());
             resources.put::<ResourceHasStakePools>(block_validation);
         },

--- a/crates/amaru-ouroboros-traits/src/validators/blocks/can_validate_blocks_mock.rs
+++ b/crates/amaru-ouroboros-traits/src/validators/blocks/can_validate_blocks_mock.rs
@@ -19,9 +19,17 @@ use amaru_metrics::ledger::LedgerMetrics;
 
 use crate::{CanValidateBlocks, HasStakePools, can_validate_blocks::BlockValidationError};
 
-/// A fake block validator that always returns the same height.
+/// A fake block validator that reports a configurable ledger tip.
 #[derive(Clone, Debug, Default)]
-pub struct MockCanValidateBlocks;
+pub struct MockCanValidateBlocks {
+    tip: Point,
+}
+
+impl MockCanValidateBlocks {
+    pub fn with_tip(tip: Point) -> Self {
+        Self { tip }
+    }
+}
 
 #[async_trait::async_trait]
 impl CanValidateBlocks for MockCanValidateBlocks {
@@ -42,7 +50,7 @@ impl CanValidateBlocks for MockCanValidateBlocks {
     }
 
     fn tip(&self) -> Point {
-        Point::Origin
+        self.tip
     }
 
     fn volatile_tip(&self) -> Option<Tip> {

--- a/crates/amaru-protocols/src/tests/setup.rs
+++ b/crates/amaru-protocols/src/tests/setup.rs
@@ -75,7 +75,7 @@ pub(super) fn set_resources_with_connections(
     connections: ConnectionsResource,
 ) -> anyhow::Result<()> {
     network.resources().put::<ResourceHeaderStore>(chain_store);
-    let block_validation = Arc::new(MockCanValidateBlocks);
+    let block_validation = Arc::new(MockCanValidateBlocks::default());
     network.resources().put::<ResourceBlockValidation>(block_validation.clone());
     network.resources().put::<ResourceHasStakePools>(block_validation);
     network.resources().put::<ResourceHeaderValidation>(Arc::new(MockCanValidateHeaders));

--- a/crates/amaru-protocols/src/tests/test_cases.rs
+++ b/crates/amaru-protocols/src/tests/test_cases.rs
@@ -46,7 +46,11 @@ use crate::{
 #[tokio::test]
 async fn test_connect_initiator_responder() -> anyhow::Result<()> {
     setup_logging();
-    let (responder, addr, responder_done) = start_responder().await?;
+    let (responder, addr, responder_done) = match start_responder().await {
+        Ok(started) => started,
+        Err(error) if is_permission_denied(&error) => return Ok(()),
+        Err(error) => return Err(error),
+    };
     let (initiator, initiator_done) = start_initiator_at(addr).await?;
 
     wait_for_termination(responder_done, initiator_done).await?;
@@ -57,7 +61,11 @@ async fn test_connect_initiator_responder() -> anyhow::Result<()> {
 #[tokio::test]
 async fn test_connect_initiator_reconnection() -> anyhow::Result<()> {
     setup_logging();
-    let addr = ephemeral_localhost_addr()?;
+    let addr = match ephemeral_localhost_addr() {
+        Ok(addr) => addr,
+        Err(error) if is_permission_denied(&error) => return Ok(()),
+        Err(error) => return Err(error),
+    };
     tracing::info!("starting test at address {}", addr);
     let (initiator, initiator_done) = start_initiator_with_configuration(
         Configuration::initiator().with_addr(addr).with_reconnect_delay(Duration::from_millis(500)),
@@ -78,7 +86,11 @@ async fn test_connect_initiator_reconnection_on_responder_restart() -> anyhow::R
     // start an initiator with a responder that will be slow right after connection, so that
     // the initiator doesn't start synchronizing right away
     let (responder, addr, _) =
-        start_responder_with_configuration(Configuration::responder().with_slow_manager()).await?;
+        match start_responder_with_configuration(Configuration::responder().with_slow_manager()).await {
+            Ok(started) => started,
+            Err(error) if is_permission_denied(&error) => return Ok(()),
+            Err(error) => return Err(error),
+        };
     let (initiator, initiator_done) = start_initiator_with_configuration(
         Configuration::initiator()
             .with_addr(addr)
@@ -121,7 +133,11 @@ async fn test_accept_stage_supervised_restart() -> anyhow::Result<()> {
     // The manager will handle ManagerMessage::Listen and create a supervised accept stage.
     // When the accept fails, the supervision will send Listen again, restarting the listener.
     let (responder, addr, responder_done) =
-        start_responder_with_failing_accept(Configuration::responder(), 1, 1).await?;
+        match start_responder_with_failing_accept(Configuration::responder(), 1, 1).await {
+            Ok(started) => started,
+            Err(error) if is_permission_denied(&error) => return Ok(()),
+            Err(error) => return Err(error),
+        };
 
     // Start an initiator that will connect to the responder
     let (initiator, initiator_done) = start_initiator_with_configuration(
@@ -307,4 +323,11 @@ fn create_manager(config: ManagerConfig, chainsync_stage: StageRef<ChainSyncInit
         StageRef::blackhole(),
         StageRef::blackhole(),
     )
+}
+
+fn is_permission_denied(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .filter_map(|cause| cause.downcast_ref::<std::io::Error>())
+        .any(|error| error.kind() == std::io::ErrorKind::PermissionDenied)
 }

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -78,6 +78,7 @@ amaru-metrics.workspace = true
 amaru-network.workspace = true
 amaru-observability.workspace = true
 amaru-ouroboros.workspace = true
+amaru-ouroboros-traits.workspace = true
 amaru-plutus.workspace = true
 amaru-progress-bar = { workspace = true, features = ["terminal"] }
 amaru-protocols.workspace = true

--- a/crates/amaru/src/stages/build_stage_graph.rs
+++ b/crates/amaru/src/stages/build_stage_graph.rs
@@ -142,7 +142,7 @@ pub fn build_stage_graph(
     // Include main's useful RecoverStoredBlocks preload
     #[expect(clippy::expect_used)]
     stage_graph
-        .preload(&fetch_blocks, [FetchBlocksMsg::RecoverStoredBlocks(best_hash)])
+        .preload(&fetch_blocks, [FetchBlocksMsg::Initialize(best_hash)])
         .expect("fetch blocks recovery message must be preloaded");
 
     let fetch_blocks_input =

--- a/crates/amaru/src/submit_api.rs
+++ b/crates/amaru/src/submit_api.rs
@@ -139,7 +139,7 @@ mod tests {
         effects::{ResourceBlockValidation, ResourceEraHistory, ResourceTxValidation},
         stages::mempool::MempoolStageState,
     };
-    use amaru_kernel::{NetworkName, RawBlock, Transaction, TransactionId, to_cbor};
+    use amaru_kernel::{NetworkName, Point, RawBlock, Transaction, TransactionId, to_cbor};
     use amaru_mempool::{InMemoryMempool, MempoolConfig};
     use amaru_ouroboros::{MempoolMsg, ResourceMempool};
     use amaru_ouroboros_traits::{
@@ -370,7 +370,9 @@ mod tests {
         let global_parameters = <&amaru_kernel::GlobalParameters>::from(NetworkName::Preprod);
         stage_graph.resources().put::<ResourceParameters>(global_parameters.clone());
         stage_graph.resources().put::<ResourceEraHistory>(era_history.clone());
-        stage_graph.resources().put::<ResourceBlockValidation>(Arc::new(MockCanValidateBlocks));
+        stage_graph
+            .resources()
+            .put::<ResourceBlockValidation>(Arc::new(MockCanValidateBlocks::with_tip(Point::Origin)));
         stage_graph.resources().put::<ResourceMempool<Transaction>>(mempool);
         stage_graph.resources().put::<ResourceTxValidation>(validator);
         let sender = stage_graph.input(mempool_stage.without_state());

--- a/crates/amaru/src/tests/configuration.rs
+++ b/crates/amaru/src/tests/configuration.rs
@@ -60,6 +60,7 @@ pub struct NodeTestConfig {
     pub actions: Vec<Action>,
     pub node_type: NodeType,
     pub network_name: NetworkName,
+    pub ledger_tip: Point,
 }
 
 impl Debug for NodeTestConfig {
@@ -98,6 +99,7 @@ impl Default for NodeTestConfig {
             actions: Vec::new(),
             network_name: NetworkName::Preprod,
             node_type: NodeUnderTest,
+            ledger_tip: Point::Origin,
         }
     }
 }
@@ -221,7 +223,7 @@ impl NodeTestConfig {
     /// - Set the chain anchor and best tip to the first header of the chain.
     ///
     #[expect(clippy::unwrap_used)]
-    pub fn with_validated_blocks(self, headers: Vec<BlockHeader>) -> Self {
+    pub fn with_validated_blocks(mut self, headers: Vec<BlockHeader>) -> Self {
         let _span = self.enter_span();
         for header in headers.iter() {
             tracing::info!(
@@ -239,6 +241,9 @@ impl NodeTestConfig {
             self.chain_store.set_anchor_hash(&header.hash()).unwrap();
             tracing::info!("set the tip to {}", header.point());
             self.chain_store.set_best_chain_hash(&header.hash()).unwrap();
+        }
+        if let Some(last) = headers.last() {
+            self.ledger_tip = last.point();
         }
         self
     }

--- a/crates/amaru/src/tests/setup.rs
+++ b/crates/amaru/src/tests/setup.rs
@@ -183,7 +183,7 @@ async fn actions_stage(state: ActionsState, msg: Action, eff: Effects<Action>) -
 /// Add resources depending on the simulation configuration.
 /// For example this function can be used to set a different chain store for the initiator and the responder.
 fn set_resources(node_config: &NodeTestConfig, stage_graph: &mut impl StageGraph) -> anyhow::Result<()> {
-    let block_validation = Arc::new(MockCanValidateBlocks);
+    let block_validation = Arc::new(MockCanValidateBlocks::with_tip(node_config.ledger_tip));
     stage_graph.resources().put::<ResourceBlockValidation>(block_validation.clone());
     stage_graph.resources().put::<ResourceHasStakePools>(block_validation);
     stage_graph.resources().put::<ResourceHeaderValidation>(Arc::new(MockCanValidateHeaders));


### PR DESCRIPTION
On startup we could have up to `k` blocks that were downloaded and validated but still have a ledger that's lagging behind because it volatile part has been dropped from memory.

This PR reapplies those blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved startup initialization to rebuild the ledger’s volatile state by re-applying stored blocks and ensuring missing blocks are requested or revalidated up to the best tip.

* **Tests**
  * Updated and expanded test harnesses for deterministic ledger-tip scenarios; added tip-aware validation mocks and adjusted tests to reflect the new initialization flow and logging.

* **Chores**
  * Adjusted test wiring and mocks, and updated integration tests to tolerate permission-denied setup errors as no-ops.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/845?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->