### PR TITLE
fix: terminate the adopt_chain stage if invariants are broken

### DIFF
--- a/crates/amaru-consensus/src/stages/adopt_chain/mod.rs
+++ b/crates/amaru-consensus/src/stages/adopt_chain/mod.rs
@@ -118,6 +118,17 @@ pub async fn stage(mut state: AdoptChain, msg: AdoptChainMsg, eff: Effects<Adopt
                 tracing::error!(error = %error, tip = %msg, "failed to adopt tip");
             })
             .await;
+        match adopt_result {
+            AdoptTipResult::BestChainRolledForward | AdoptTipResult::BestChainSwitched => {}
+            AdoptTipResult::HeaderNotFound => {
+                tracing::error!(tip = %msg, "invariant violated: incoming header was loaded but find_ancestor_on_best_chain reports it missing");
+                return eff.terminate().await;
+            }
+            AdoptTipResult::AncestorOnBestChainNotFound => {
+                tracing::error!(tip = %msg, "invariant violated: incoming chain shares no ancestor with the best chain");
+                return eff.terminate().await;
+            }
+        }
     } else {
         store
             .roll_forward_chain(&incoming_header.point())

--- a/crates/amaru-consensus/src/stages/adopt_chain/mod.rs
+++ b/crates/amaru-consensus/src/stages/adopt_chain/mod.rs
@@ -113,7 +113,7 @@ pub async fn stage(mut state: AdoptChain, msg: AdoptChainMsg, eff: Effects<Adopt
     }
 
     if let Some(current_best) = current_best.as_ref() {
-        adopt_tip(&store, &incoming_header, current_best)
+        let adopt_result = adopt_tip(&store, &incoming_header, current_best)
             .or_terminate_with(&eff, async |error| {
                 tracing::error!(error = %error, tip = %msg, "failed to adopt tip");
             })


### PR DESCRIPTION
This PR makes sure that we terminate the node in case we broke some invariants in the `adopt_chain` stage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in chain adoption: invariant-violation conditions now log errors and terminate the affected stage immediately instead of continuing silently. This prevents potential silent failures, reduces risk of inconsistent states, and makes issues more observable and actionable for operators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->