### PR TITLE
fix ledger rollback_to when target==ledger_tip

### DIFF
--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -761,42 +761,25 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             || {
                 // NOTE: Rolling back to the tip of the immutable
                 //
-                // On start-up where the consensus layer will typically ask the ledger to rollback
-                // to the last known point, which ought to be the tip of the (immutable) database.
-                //
-                // Said differently, if the volatile db is empty, the rollback point MUST be the
-                // tip of the immutable.
-                let tip = match self.volatile_tip() {
-                    Some(volatile_tip) => volatile_tip.point(),
-                    None => {
-                        let immutable_tip = self.immutable_tip();
+                // All rollback points within the volatile part are handled by `VolatileDB`, but there is one more
+                // legal rollback target, which is the `immutable_tip()`, in which case the VolatileDB is cleared.
+                let immutable_tip = self.immutable_tip();
+                if *to == immutable_tip {
+                    self.volatile.clear();
+                    return Ok(());
+                }
+                if *to < immutable_tip {
+                    return Err(BackwardError::UnknownRollbackPoint { rollback_point: *to, tip: immutable_tip });
+                }
+                let tip = self.volatile_tip().map(|t| t.point()).unwrap_or(immutable_tip);
 
-                        if &immutable_tip != to {
-                            return Err(BackwardError::UnknownRollbackPoint {
-                                rollback_point: *to,
-                                tip: immutable_tip,
-                            });
-                        }
-
-                        immutable_tip
-                    }
-                };
-
-                // Would still be caught by the next check, but this is a special case for which we
-                // can provide a better error.
-                if to > &tip {
+                if *to > tip {
                     return Err(BackwardError::RollbackPointInFuture { rollback_point: *to, tip });
                 }
-
-                if to == &tip {
-                    self.volatile.clear();
-                    Ok(())
-                } else {
-                    self.volatile.rollback_to(to).map_err(|rollback_point| BackwardError::UnknownRollbackPoint {
-                        rollback_point: *rollback_point,
-                        tip,
-                    })
-                }
+                self.volatile.rollback_to(to).map_err(|rollback_point| BackwardError::UnknownRollbackPoint {
+                    rollback_point: *rollback_point,
+                    tip,
+                })
             },
         )
     }

--- a/crates/amaru-ledger/tests/state_rollback.rs
+++ b/crates/amaru-ledger/tests/state_rollback.rs
@@ -19,7 +19,7 @@ use amaru_kernel::{
 };
 use amaru_ledger::{
     state::{BackwardError, State, VolatileState},
-    store::GovernanceActivity,
+    store::{GovernanceActivity, ReadStore, Store, StoreError},
 };
 use amaru_stores::rocksdb::{RocksDB, RocksDBHistoricalStores, RocksDbConfig};
 
@@ -29,12 +29,20 @@ fn rollback_to_a_volatile_common_ancestor_succeeds() {
     let earlier = point(100, 1);
     let later = point(200, 2);
 
+    assert_eq!(*state.tip(), Point::Origin);
+
     forward_to(&mut state, earlier, 1);
     forward_to(&mut state, later, 2);
     assert_eq!(*state.tip(), later);
 
+    state.rollback_to(&later).unwrap();
+    assert_eq!(*state.tip(), later);
+
     state.rollback_to(&earlier).unwrap();
     assert_eq!(*state.tip(), earlier);
+
+    state.rollback_to(&Point::Origin).unwrap();
+    assert_eq!(*state.tip(), Point::Origin);
 }
 
 #[test]
@@ -100,7 +108,7 @@ fn rollback_after_volatile_front_is_rejected() {
 
 /// Create an initial ledger state
 #[expect(clippy::expect_used)]
-fn make_state() -> State<RocksDB, RocksDBHistoricalStores> {
+fn make_state() -> State<MockStore, RocksDBHistoricalStores> {
     let network = NetworkName::Preprod;
     let era_history: EraHistory = <&EraHistory>::from(network).clone();
     let global_parameters: GlobalParameters = <&GlobalParameters>::from(network).clone();
@@ -113,7 +121,7 @@ fn make_state() -> State<RocksDB, RocksDBHistoricalStores> {
     let snapshots = RocksDBHistoricalStores::new(&cfg, 0);
 
     State::new_with(
-        store,
+        MockStore(store),
         snapshots,
         network,
         era_history,
@@ -126,7 +134,7 @@ fn make_state() -> State<RocksDB, RocksDBHistoricalStores> {
 
 /// Forward the ldeger to a given point
 #[expect(clippy::expect_used)]
-fn forward_to(state: &mut State<RocksDB, RocksDBHistoricalStores>, point: Point, height: u64) {
+fn forward_to(state: &mut State<MockStore, RocksDBHistoricalStores>, point: Point, height: u64) {
     let issuer = Hash::new([0u8; 28]);
     state
         .forward(VolatileState::default().anchor(Tip::new(point, BlockHeight::from(height)), issuer))
@@ -135,4 +143,134 @@ fn forward_to(state: &mut State<RocksDB, RocksDBHistoricalStores>, point: Point,
 
 fn point(slot: u64, tag: u8) -> Point {
     Point::Specific(Slot::from(slot), Hash::new([tag; 32]))
+}
+
+struct MockStore(RocksDB);
+
+#[expect(unused_variables)]
+impl ReadStore for MockStore {
+    fn tip(&self) -> amaru_ledger::store::Result<Point> {
+        Ok(Point::Origin)
+    }
+
+    fn protocol_parameters(&self) -> amaru_ledger::store::Result<ProtocolParameters> {
+        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn pool(
+        &self,
+        pool: &amaru_kernel::PoolId,
+    ) -> amaru_ledger::store::Result<Option<amaru_ledger::store::columns::pools::Row>> {
+        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn account(
+        &self,
+        credential: &amaru_kernel::StakeCredential,
+    ) -> amaru_ledger::store::Result<Option<amaru_ledger::store::columns::accounts::Row>> {
+        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn utxo(
+        &self,
+        input: &amaru_kernel::TransactionInput,
+    ) -> amaru_ledger::store::Result<Option<amaru_kernel::MemoizedTransactionOutput>> {
+        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn pots(&self) -> amaru_ledger::store::Result<amaru_ledger::summary::Pots> {
+        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn constitutional_committee(&self) -> amaru_ledger::store::Result<amaru_kernel::ConstitutionalCommitteeStatus> {
+        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn constitution(&self) -> amaru_ledger::store::Result<amaru_kernel::Constitution> {
+        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn proposals_roots(&self) -> amaru_ledger::store::Result<amaru_ledger::governance::ratification::ProposalsRoots> {
+        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn governance_activity(&self) -> amaru_ledger::store::Result<GovernanceActivity> {
+        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn iter_utxos(
+        &self,
+    ) -> amaru_ledger::store::Result<
+        impl Iterator<Item = (amaru_ledger::store::columns::utxo::Key, amaru_ledger::store::columns::utxo::Value)>,
+    > {
+        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn iter_block_issuers(
+        &self,
+    ) -> amaru_ledger::store::Result<
+        impl Iterator<Item = (amaru_ledger::store::columns::slots::Key, amaru_ledger::store::columns::slots::Value)>,
+    > {
+        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn iter_pools(
+        &self,
+    ) -> amaru_ledger::store::Result<
+        impl Iterator<Item = (amaru_ledger::store::columns::pools::Key, amaru_ledger::store::columns::pools::Row)>,
+    > {
+        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn iter_accounts(
+        &self,
+    ) -> amaru_ledger::store::Result<
+        impl Iterator<Item = (amaru_ledger::store::columns::accounts::Key, amaru_ledger::store::columns::accounts::Row)>,
+    > {
+        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn iter_dreps(
+        &self,
+    ) -> amaru_ledger::store::Result<
+        impl Iterator<Item = (amaru_ledger::store::columns::dreps::Key, amaru_ledger::store::columns::dreps::Row)>,
+    > {
+        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn iter_proposals(
+        &self,
+    ) -> amaru_ledger::store::Result<
+        impl Iterator<Item = (amaru_ledger::store::columns::proposals::Key, amaru_ledger::store::columns::proposals::Row)>,
+    > {
+        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn iter_cc_members(
+        &self,
+    ) -> amaru_ledger::store::Result<
+        impl Iterator<Item = (amaru_ledger::store::columns::cc_members::Key, amaru_ledger::store::columns::cc_members::Row)>,
+    > {
+        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn iter_votes(
+        &self,
+    ) -> amaru_ledger::store::Result<
+        impl Iterator<Item = (amaru_ledger::store::columns::votes::Key, amaru_ledger::store::columns::votes::Row)>,
+    > {
+        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+}
+
+impl Store for MockStore {
+    type Transaction<'a> = <RocksDB as Store>::Transaction<'a>;
+
+    fn next_snapshot(&self, epoch: amaru_kernel::Epoch) -> amaru_ledger::store::Result<()> {
+        self.0.next_snapshot(epoch)
+    }
+
+    fn create_transaction(&self) -> Self::Transaction<'_> {
+        self.0.create_transaction()
+    }
 }


### PR DESCRIPTION
My previous fix in #756 was faulty, it only worked correctly when rolling back to `immutable_tip()`.
Now I extended a testcase to check that this behaviour stays fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved rollback mechanism validation to properly handle edge cases and distinguish between different error scenarios with more accurate error reporting.

* **Tests**
  * Refactored test infrastructure and setup helpers for enhanced maintainability.
  * Strengthened rollback tests with comprehensive validation assertions to verify correct behavior across various rollback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->