### PR TITLE
feat: transaction id display

### DIFF
--- a/crates/amaru-kernel/src/cardano/transaction_id.rs
+++ b/crates/amaru-kernel/src/cardano/transaction_id.rs
@@ -58,7 +58,6 @@ impl<'b> cbor::Decode<'b, ()> for TransactionId {
 
 impl Display for TransactionId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        // 6 first bytes = 12 characters
-        write!(f, "{}", hex::encode(&self.0.as_slice()[..6]))
+        write!(f, "{}", hex::encode(&self.0))
     }
 }

--- a/crates/amaru-kernel/src/cardano/transaction_id.rs
+++ b/crates/amaru-kernel/src/cardano/transaction_id.rs
@@ -30,6 +30,12 @@ impl TransactionId {
     pub fn new(id: Hash<{ TRANSACTION_BODY }>) -> TransactionId {
         TransactionId(id)
     }
+
+    /// Returns a short hex representation (first 6 bytes / 12 chars) suitable for log lines
+    /// and multi-id collection rendering where the full hash would be too noisy.
+    pub fn short(&self) -> String {
+        hex::encode(&self.0.as_slice()[..6])
+    }
 }
 
 impl AsRef<Hash<{ TRANSACTION_BODY }>> for TransactionId {
@@ -58,6 +64,6 @@ impl<'b> cbor::Decode<'b, ()> for TransactionId {
 
 impl Display for TransactionId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(&self.0))
+        write!(f, "{}", hex::encode(self.0))
     }
 }

--- a/crates/amaru-protocols/src/tx_submission/initiator.rs
+++ b/crates/amaru-protocols/src/tx_submission/initiator.rs
@@ -253,11 +253,7 @@ impl Display for InitiatorResult {
                 write!(f, "RequestTxIds(ack: {}, req: {}, blocking: {:?})", ack, req, blocking)
             }
             InitiatorResult::RequestTxs(tx_ids) => {
-                write!(
-                    f,
-                    "RequestTxs(ids: [{}])",
-                    tx_ids.iter().map(|id| format!("{}", id)).collect::<Vec<_>>().join(", ")
-                )
+                write!(f, "RequestTxs(ids: [{}])", display_collection(tx_ids.iter().map(|id| id.short())))
             }
         }
     }
@@ -418,7 +414,7 @@ impl TxSubmissionInitiator {
         mempool: &dyn AsyncMempool,
         tx_ids: Vec<TransactionId>,
     ) -> anyhow::Result<Option<InitiatorAction>> {
-        tracing::debug!(tx_ids = display_collection(&tx_ids), "received RequestTxs");
+        tracing::debug!(tx_ids = display_collection(tx_ids.iter().map(|id| id.short())), "received RequestTxs");
         // Return an error if the peer asked for a tx_id that was not advertised.
         let unavailable: Vec<&TransactionId> =
             tx_ids.iter().filter(|id| !self.window.iter().any(|(wid, _)| wid == *id)).collect();

--- a/crates/amaru-protocols/src/tx_submission/messages.rs
+++ b/crates/amaru-protocols/src/tx_submission/messages.rs
@@ -14,7 +14,9 @@
 
 use std::fmt::Display;
 
-use amaru_kernel::{EraName, NonEmptyBytes, Transaction, TransactionId, cbor, to_cbor};
+use amaru_kernel::{
+    EraName, NonEmptyBytes, Transaction, TransactionId, cbor, to_cbor, utils::string::display_collection,
+};
 
 use crate::tx_submission::Blocking;
 
@@ -355,7 +357,7 @@ impl Display for Message {
                     f,
                     "ReplyTxIds(ids: [{}])",
                     ids.iter()
-                        .map(|(tagged, size)| format!("({}/{}, {})", tagged.era, tagged.id, size))
+                        .map(|(tagged, size)| format!("({}/{}, {})", tagged.era, tagged.id.short(), size))
                         .collect::<Vec<_>>()
                         .join(", ")
                 )
@@ -364,17 +366,18 @@ impl Display for Message {
                 write!(
                     f,
                     "RequestTxs(ids: [{}])",
-                    ids.iter().map(|tagged| format!("{}/{}", tagged.era, tagged.id)).collect::<Vec<_>>().join(", ")
+                    display_collection(ids.iter().map(|tagged| format!("{}/{}", tagged.era, tagged.id.short())))
                 )
             }
             Message::ReplyTxs(txs) => {
                 write!(
                     f,
                     "ReplyTxs(txs: [{}])",
-                    txs.iter()
-                        .map(|tagged| format!("{}/{}", tagged.era, tagged.tx.tx_id()))
-                        .collect::<Vec<_>>()
-                        .join(", ")
+                    display_collection(txs.iter().map(|tagged| format!(
+                        "{}/{}",
+                        tagged.era,
+                        tagged.tx.tx_id().short()
+                    )))
                 )
             }
             Message::Done => write!(f, "Done"),

--- a/crates/amaru-protocols/src/tx_submission/responder.rs
+++ b/crates/amaru-protocols/src/tx_submission/responder.rs
@@ -728,7 +728,15 @@ impl Display for ResponderAction {
                 write!(f, "SendRequestTxIds(ack: {}, req: {}, blocking: {:?})", ack, req, blocking)
             }
             ResponderAction::SendRequestTxs(tx_ids) => {
-                write!(f, "SendRequestTxs(tx_ids: {:?})", tx_ids)
+                write!(
+                    f,
+                    "SendRequestTxs(tx_ids: [{}])",
+                    tx_ids
+                        .iter()
+                        .map(|tagged| format!("{}/{}", tagged.era, tagged.id.short()))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
             }
             ResponderAction::Error(cause) => write!(f, "Error({})", cause),
         }

--- a/crates/amaru/src/submit_api.rs
+++ b/crates/amaru/src/submit_api.rs
@@ -407,7 +407,7 @@ mod tests {
     // This transaction is reconstructed from the transaction contained in the real preprod
     // block fixture `b9bef52dd8dedf992837d20c18399a284d80fde0ae9435f2a33649aaee7c5698`
     // (slot 70175999, block height 2671560).
-    const TX_ID: &str = "43f396b0d5c5";
+    const TX_ID: &str = "43f396b0d5c55e34b507cfe9964672586370cc09912a4790488fba4079f96429";
 
     /// Return a serialized transaction extracted from an actual block
     fn serialized_transaction() -> anyhow::Result<Vec<u8>> {


### PR DESCRIPTION
This PR makes the transaction id `Display` instance display the full id and adds a helper to only display a truncated ids in potentially large lists of ids.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shortened transaction ID display for logs and messages to improve readability.

* **Improvements**
  * Updated messaging and logging across the app to use the shortened transaction ID format while preserving full IDs internally.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->