### PR TITLE
feat: bootstrap adjustments

### DIFF
--- a/crates/amaru-mithril/src/lib.rs
+++ b/crates/amaru-mithril/src/lib.rs
@@ -351,6 +351,32 @@ pub fn get_latest_chunk(immutable_dir: &Path) -> Result<Option<u64>, io::Error> 
         .map(|n| n.saturating_sub(1)))
 }
 
+pub fn first_missing_immutable_chunk(immutable_dir: &Path) -> Result<u64, io::Error> {
+    if !immutable_dir.try_exists()? {
+        return Ok(0);
+    }
+
+    let mut chunk = 0_u64;
+    loop {
+        let chunk_prefix = format!("{chunk:05}");
+        for extension in ["chunk", "primary", "secondary"] {
+            let path = immutable_dir.join(format!("{chunk_prefix}.{extension}"));
+            match fs::metadata(&path) {
+                Ok(metadata) if metadata.is_file() => {}
+                Ok(_) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("expected a regular file at {}", path.display()),
+                    ));
+                }
+                Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(chunk),
+                Err(err) => return Err(err),
+            }
+        }
+        chunk = chunk.checked_add(1).ok_or_else(|| io::Error::other("immutable chunk index overflows u64"))?;
+    }
+}
+
 fn infer_chunk_from_slot(slot: u64) -> u64 {
     slot / 21_600
 }

--- a/crates/amaru/src/bin/amaru/cmd/create_snapshots.rs
+++ b/crates/amaru/src/bin/amaru/cmd/create_snapshots.rs
@@ -20,7 +20,9 @@ use std::{
 
 use amaru::{DEFAULT_NETWORK, default_data_dir, default_snapshots_dir};
 use amaru_kernel::{NetworkName, Point};
-use amaru_mithril::{download_from_mithril, extract_block_header_cbor, get_latest_chunk, parse_header_slot_and_hash};
+use amaru_mithril::{
+    download_from_mithril, extract_block_header_cbor, first_missing_immutable_chunk, parse_header_slot_and_hash,
+};
 use clap::{ArgAction, Parser};
 use serde::{Deserialize, Serialize};
 use tracing::info;
@@ -182,8 +184,7 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         write_epoch_metadata(&metadata_dir, target)?;
     }
 
-    let latest_chunk = get_latest_chunk(&cardano_db_dir.join("immutable"))?;
-    let from_chunk = latest_chunk.unwrap_or(0);
+    let from_chunk = first_missing_immutable_chunk(&cardano_db_dir.join("immutable"))?;
     info!(from_chunk, target_dir = %cardano_db_dir.display(), "synchronizing cardano-db from Mithril");
     download_from_mithril(network, cardano_db_dir.clone(), from_chunk).await?;
 

--- a/crates/amaru/src/lib.rs
+++ b/crates/amaru/src/lib.rs
@@ -57,6 +57,10 @@ const BOOTSTRAP_PATH: &str = "crates/amaru/config/bootstrap";
 static BOOTSTRAP_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/config/bootstrap");
 
 fn source_bootstrap_dir() -> PathBuf {
+    if let Some(path) = std::env::var_os(env_vars::BOOTSTRAP_CONFIG_DIR) {
+        return PathBuf::from(path);
+    }
+
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config/bootstrap")
 }
 
@@ -137,6 +141,9 @@ pub mod value_names {
 
 /// Environment variables used across command-line options.
 pub mod env_vars {
+    /// Runtime bootstrap config directory override.
+    pub const BOOTSTRAP_CONFIG_DIR: &str = "AMARU_BOOTSTRAP_CONFIG_DIR";
+
     /// --cardano-node-config-dir
     pub const CARDANO_NODE_CONFIG_DIR: &str = "AMARU_CARDANO_NODE_CONFIG_DIR";
 


### PR DESCRIPTION
This PR:

 - Allows the user to specify the bootstrap config directory to give more flexibility for demos.
 - Fixes an issue found during the boostrap on `preprod`. If the current db is sparse we need to start from the first missing immutable chunk and not the latest chunk. Does that seem reasonable to you @jeluard ?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow overriding the default bootstrap configuration directory via an environment variable for flexible deployments.

* **Improvements**
  * Mithril download/synchronization now determines the starting point from local immutable data to avoid redundant downloads.
  * Added detection for missing immutable chunk files to make synchronization more robust and fail-safe.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->