### PR TITLE
feat: gliveview docker helper

### DIFF
--- a/crates/amaru/src/metrics.rs
+++ b/crates/amaru/src/metrics.rs
@@ -77,7 +77,7 @@ fn record_build_info(provider: &SdkMeterProvider) {
         1,
         &[
             KeyValue::new("version", built_info::PKG_VERSION),
-            KeyValue::new("git_rev", built_info::GIT_COMMIT_HASH_SHORT.unwrap_or("unknown")),
+            KeyValue::new("revision", built_info::GIT_COMMIT_HASH_SHORT.unwrap_or("unknown")),
             KeyValue::new("dirty", built_info::GIT_DIRTY.unwrap_or(false).to_string()),
             KeyValue::new("os", built_info::CFG_OS),
             KeyValue::new("arch", built_info::CFG_TARGET_ARCH),

--- a/docker/gliveview/Dockerfile
+++ b/docker/gliveview/Dockerfile
@@ -1,0 +1,58 @@
+FROM debian:bookworm-slim
+
+# Install required dependencies
+RUN apt-get update && apt-get install -y \
+    bash \
+    curl \
+    jq \
+    git \
+    bc \
+    gawk \
+    netcat-traditional \
+    procps \
+    iproute2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create work directory
+WORKDIR /opt/cardano
+
+# Download gLiveView and its env file from guild-operators
+RUN git clone --depth 1 https://github.com/cardano-community/guild-operators.git \
+    && cp guild-operators/scripts/cnode-helper-scripts/gLiveView.sh . \
+    && cp guild-operators/scripts/cnode-helper-scripts/env . \
+    && rm -rf guild-operators \
+    && chmod +x gLiveView.sh
+
+# Stub binaries: gLiveView requires cardano-cli and cardano-node to be present.
+# Both report Amaru's version (0.1.2) to match the running version from Prometheus.
+# cardano-cli: only used for version queries.
+# cardano-node: for version queries it prints the version string; for all other
+# invocations (e.g. --port 6000 from entrypoint) it sleeps indefinitely so that
+# gLiveView's `pgrep -fn "cardano-node.*.port <PORT>"` check finds a live process.
+RUN printf '#!/bin/sh\n[ "$1" = "version" ] && echo "cardano-cli 0.1.2 - linux-x86_64" && exit 0\nexit 1\n' \
+        > /usr/local/bin/cardano-cli \
+    && printf '#!/bin/sh\n[ "$1" = "version" ] && echo "cardano-node 0.1.2 - linux-x86_64" && exit 0\nsleep infinity\n' \
+        > /usr/local/bin/cardano-node \
+    && chmod +x /usr/local/bin/cardano-cli /usr/local/bin/cardano-node
+
+# Disable the strict version check in env so the 0.1.2 version string is accepted.
+# versionCheckNode() short-circuits to success when STRICT_VERSION_CHECK=N.
+# Also disable the auto-update check so the container doesn't prompt at startup.
+# Also stub out checkNodeVersion to suppress the deployed/running rev mismatch
+# warning (Amaru doesn't emit a git revision in Prometheus metrics).
+RUN sed -i 's/^#STRICT_VERSION_CHECK=.*/STRICT_VERSION_CHECK="N"/' /opt/cardano/env \
+    && sed -i 's/^#UPDATE_CHECK=.*/UPDATE_CHECK="N"/' /opt/cardano/env \
+    && sed -i 's/^checkNodeVersion$/checkNodeVersion() { return 0; }/' /opt/cardano/gLiveView.sh
+
+# Entrypoint downloads network genesis/config files at runtime then launches gLiveView
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENV NETWORK="preprod" \
+    BLOCKLOG_DIR="/opt/cardano/blocklog" \
+    PROM_HOST="host.docker.internal" \
+    PROM_PORT="8889"
+
+RUN mkdir -p "${BLOCKLOG_DIR}" /opt/logs
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/gliveview/Makefile
+++ b/docker/gliveview/Makefile
@@ -1,0 +1,15 @@
+IMAGE := gliveview
+
+.PHONY: start stop build
+
+start: build
+	docker run --rm -it \
+		--add-host host.docker.internal:host-gateway \
+		-v gliveview-blocklog:/opt/cardano/blocklog \
+		$(IMAGE)
+
+stop:
+	docker stop $$(docker ps -q --filter ancestor=$(IMAGE)) 2>/dev/null || true
+
+build:
+	docker build -t $(IMAGE) .

--- a/docker/gliveview/Makefile
+++ b/docker/gliveview/Makefile
@@ -4,7 +4,6 @@ IMAGE := gliveview
 
 start: build
 	docker run --rm -it \
-		--add-host host.docker.internal:host-gateway \
 		-v gliveview-blocklog:/opt/cardano/blocklog \
 		$(IMAGE)
 

--- a/docker/gliveview/README.md
+++ b/docker/gliveview/README.md
@@ -1,0 +1,29 @@
+# GLiveView
+
+Docker setup for running [GLiveView](https://cardano-community.github.io/guild-operators/Scripts/gliveview/) alongside [Amaru](https://github.com/pragma-org/amaru).
+
+GLiveView relies on prometheus metrics exposed by Amaru to display live chain and peer metrics.
+
+## Prerequisites
+
+- A running Amaru node with an accessible socket file and Prometheus metrics endpoint
+- Docker installed
+
+## Usage
+
+Build and run:
+
+```bash
+docker build --no-cache -t gliveview . && docker run --rm -it gliveview
+```
+
+## Environment Variables
+
+Pass with `-e VAR=value` to override defaults.
+
+| Variable | Default | Description |
+|---|---|---|
+| `NETWORK` | `preprod` | Target network (`mainnet`, `preprod`, `preview`) — used to fetch genesis files |
+| `PROM_HOST` | `host.docker.internal` | Host running Amaru's Prometheus metrics |
+| `PROM_PORT` | `8889` | Prometheus port exposed by the OTLP collector |
+| `BLOCKLOG_DIR` | `/opt/cardano/blocklog` | Block log storage |

--- a/docker/gliveview/README.md
+++ b/docker/gliveview/README.md
@@ -6,7 +6,7 @@ GLiveView relies on prometheus metrics exposed by Amaru to display live chain an
 
 ## Prerequisites
 
-- A running Amaru node with an accessible socket file and Prometheus metrics endpoint
+- A running Amaru node with an accessible Prometheus metrics endpoint
 - Docker installed
 
 ## Usage

--- a/docker/gliveview/docker-compose.yml
+++ b/docker/gliveview/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+services:
+  gliveview:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: gliveview
+    volumes:
+      - gliveview-blocklog:/opt/cardano/blocklog
+    stdin_open: true
+    tty: true
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - monitoring
+
+volumes:
+  gliveview-blocklog:
+
+networks:
+  monitoring:
+    driver: bridge

--- a/docker/gliveview/entrypoint.sh
+++ b/docker/gliveview/entrypoint.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+NETWORK="${NETWORK:-preprod}"
+CONFIGS_URL="https://book.world.dev.cardano.org/environments"
+FILES_DIR="/opt/cardano/files"
+
+case "$NETWORK" in
+  mainnet|preprod|preview) NET_PATH="$NETWORK" ;;
+  *) echo "ERROR: Unknown NETWORK '$NETWORK'. Valid values: mainnet, preprod, preview" && exit 1 ;;
+esac
+
+echo "Fetching $NETWORK node configuration..."
+mkdir -p "$FILES_DIR"
+for f in config.json byron-genesis.json shelley-genesis.json alonzo-genesis.json conway-genesis.json; do
+  curl -sSfL "$CONFIGS_URL/$NET_PATH/$f" -o "$FILES_DIR/$f"
+done
+
+export CONFIG="$FILES_DIR/config.json"
+export SOCKET="${CNODE_SOCKET_PATH:-/opt/cardano/node.socket}"
+
+# gLiveView runs `pgrep -fn "cardano-node.*.port <CNODE_PORT>"` each iteration
+# and increments a fail counter when no matching process is found, eventually
+# exiting with "COULD NOT CONNECT". Start a background stub process whose
+# command line matches the pattern so the PID check always succeeds.
+CNODE_PORT="${CNODE_PORT:-6000}"
+/usr/local/bin/cardano-node --port "$CNODE_PORT" &
+
+# The OTLP collector's Prometheus exporter uses Go's 'g' float format, which
+# produces scientific notation for large numbers (e.g. 7.6137225e+07). bash
+# arithmetic inside gLiveView cannot parse that. Run a proxy on localhost:12798
+# that fetches from the real endpoint and converts 'e+' notation to plain integers.
+REAL_PROM_HOST="${PROM_HOST:-host.docker.internal}"
+REAL_PROM_PORT="${PROM_PORT:-8889}"
+PROXY_PORT=12798
+METRICS_FILE=/tmp/metrics_formatted
+
+(
+    while true; do
+        curl -s "http://${REAL_PROM_HOST}:${REAL_PROM_PORT}/metrics" \
+            | awk '/^[^#]/ && NF > 0 && $NF ~ /[0-9]e\+[0-9]/ { $NF = sprintf("%.0f", $NF + 0) } { print }' \
+            > "${METRICS_FILE}.tmp" \
+            && mv "${METRICS_FILE}.tmp" "$METRICS_FILE"
+        sleep 2
+    done
+) &
+
+(
+    while true; do
+        if [[ -f "$METRICS_FILE" ]]; then
+            {
+                printf "HTTP/1.0 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\n\r\n"
+                cat "$METRICS_FILE"
+            } | nc -l -p "$PROXY_PORT" -q 1 >/dev/null 2>&1 || true
+        else
+            sleep 0.5
+        fi
+    done
+) &
+
+export PROM_HOST=127.0.0.1
+export PROM_PORT=$PROXY_PORT
+
+exec /opt/cardano/gLiveView.sh

--- a/docker/gliveview/entrypoint.sh
+++ b/docker/gliveview/entrypoint.sh
@@ -17,7 +17,6 @@ for f in config.json byron-genesis.json shelley-genesis.json alonzo-genesis.json
 done
 
 export CONFIG="$FILES_DIR/config.json"
-export SOCKET="${CNODE_SOCKET_PATH:-/opt/cardano/node.socket}"
 
 # gLiveView runs `pgrep -fn "cardano-node.*.port <CNODE_PORT>"` each iteration
 # and increments a fail counter when no matching process is found, eventually

--- a/monitoring/basic/otlp-collector.yml
+++ b/monitoring/basic/otlp-collector.yml
@@ -4,13 +4,23 @@ receivers:
       http:
         endpoint: "0.0.0.0:4318"
 
+processors:
+  resource/drop_prometheus_labels:
+    attributes:
+      - key: service.name
+        action: delete
+      - key: service.instance.id
+        action: delete
+
 exporters:
   prometheus:
     endpoint: "0.0.0.0:8889"
     add_metric_suffixes: false
+    without_scope_info: true
 
 service:
   pipelines:
     metrics:
       receivers: [otlp]
+      processors: [resource/drop_prometheus_labels]
       exporters: [prometheus]


### PR DESCRIPTION
Amaru team wants to make sure that well-known cardano tools can work seamlessly with amaru. This is also a way to ensure amaru expose community accepted standard (e.g. metrics).

This introduces a docker based way to start gliveview for the following reasons:
* hard to start on arbitrary env
* unsafe (lots of shell scripts)
* still rely on `cardano-node` specifics (like version numbers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dockerized GLiveView with build/start/stop helpers and a containerized entrypoint for proxied metrics.
* **Bug Fixes**
  * Renamed build-info metric attribute from git_rev to revision for consistency.
  * Drop select Prometheus resource attributes and improve metric export formatting to avoid scientific notation issues.
* **Documentation**
  * Added GLiveView Docker usage guide and environment variable descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pragma-org/amaru/pull/853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->