### PR TITLE
docs: mention docker in top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@
 > integration of components, so that progress is instantly visible, even though
 > features might be limited or incomplete.
 
+> [!NOTE]
+> **Prefer not to install Rust locally?** We provide a Docker-based build and run path.
+> See [docker/README.md](./docker/README.md) for instructions on using Docker instead.
+
 ### Installing
 
 ```console

--- a/README.md
+++ b/README.md
@@ -23,15 +23,39 @@
 > integration of components, so that progress is instantly visible, even though
 > features might be limited or incomplete.
 
-> [!NOTE]
-> **Prefer not to install Rust locally?** We provide a Docker-based build and run path.
-> See [docker/README.md](./docker/README.md) for instructions on using Docker instead.
-
 ### Installing
+
+#### Pre-compiled executables
+
+We regularly push pre-compiled (statically linked) executables to [Github
+Pages](https://pragma-org.github.io/amaru/) for the following platforms:
+
+| Platform | Arch      |
+| ---      | ---       |
+| Linux    | `x86_64`  |
+| Linux    | `aarch64` |
+| MacOS    | `aarch64` |
+
+We also _in theory_ support Windows (64-bit) as well as WASM and RISC-V for
+certain components (e.g. amaru-ledger, amaru-consensus, ...). The support there
+is preliminary and mostly experimental.
+
+
+#### Docker Images (arm64 / amd64)
+
+```console
+docker pull ghcr.io/pragma-org/amaru:latest
+```
+
+#### Building from sources
 
 ```console
 make build
 ```
+
+> [!TIP]
+> **Prefer not to install Rust locally?** We provide a Docker-based build and run path.
+> See [docker/README.md](./docker/README.md) for instructions on using Docker instead.
 
 ### Running
 
@@ -39,8 +63,7 @@ make build
 > These instructions assume one starts from scratch, and has access to a synced [cardano-node](https://github.com/IntersectMBO/cardano-node/)
 on the selected network (e.g. [preprod](https://book.world.dev.cardano.org/env-preprod.html)).
 >
-> To run a local peer, refer to [Cardano's developers portal](https://developers.cardano.org/docs/get-started/cardano-node/running-cardano).
-> Make sure your peer listens to port `3001` or adapt the `AMARU_PEER_ADDRESS` environment variable (e.g. `export AMARU_PEER_ADDRESS=127.0.0.1:3002`)
+> Although you may explicitly provide peers, Amaru will automatically infer some peers from the ledger state. To run a local peer, refer to [Cardano's developers portal](https://developers.cardano.org/docs/get-started/cardano-node/running-cardano).
 
 1. Bootstrap the node:
 
@@ -60,12 +83,8 @@ docker-compose -f monitoring/jaeger/docker-compose.yml up
 make AMARU_NETWORK=preprod start
 ```
 
-Replace `--peer-address` with your Cardano node peer address. It can be either
-a local or remote node (i.e. any existing node relay), and you can even add
-multiple peers by replicating the option.
-
 > [!TIP]
-> To ensure logs are forwarded to telemetry backend, set `AMARU_WITH_OPEN_TELEMETRY=true`:
+> To ensure logs are forwarded to an OpenTelemetry backend, set `AMARU_WITH_OPEN_TELEMETRY=true`:
 >
 > ```console
 > make AMARU_NETWORK=preprod AMARU_WITH_OPEN_TELEMETRY=true start

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,14 +1,32 @@
-This directory contains development related docker informations.
+## For Users
 
-## TL;DR
+Docker images are available on our [Github registry](https://github.com/pragma-org/amaru/pkgs/container/amaru):
+
+```console
+docker pull ghcr.io/pragma-org/amaru:latest
+```
+
+New images are published on every change to the `main` branch; with the tag
+`:latest`. Those pertaining to releases are tagged accordingly.
+
+> [!TIP]
+> Images are multi-arch (amd64 / arm64) by default. So they should work on any _reasonable_ 64-bit system.
+
+## For Developers/Maintainers
+
+The following instructions contains detail on how to build a Docker image by
+yourself and/or, how to setup a small development cluster of Amaru and Haskell
+nodes. The described setup is mostly meant for development and toying around.
+
+### TL;DR
 
 ```bash
 cd docker/cluster
-echo AMARU_NETWORK=preprod >.env
-docker compose up --build
+echo AMARU_NETWORK=preprod > .env
+docker compose up
 ```
 
-## Building a development optimized image
+### Building a development optimized image
 
 `Dockerfile.amaru` helps create a docker image of Amaru. Do not use in production.
 
@@ -33,7 +51,7 @@ To build the image, from the project's root directory:
 docker build . -f docker/Dockerfile.amaru -t dev_amaru
 ```
 
-## Starting a development cluster
+### Starting a development cluster
 
 The `cluster/docker-compose.yml` file defines a development cluster. It is composed of:
 
@@ -57,7 +75,7 @@ account:
 docker compose up -d --build amaru
 ```
 
-## Limitations
+### Limitations
 
 At this time, changing the network once you've started the cluster could be problematic.
 The amaru (or cardano) node relies on a docker volume and stores its data in a single


### PR DESCRIPTION
Fixes https://github.com/pragma-org/amaru/issues/771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a TIP in Getting Started recommending a Docker-based build/run workflow and linking to the Docker guide.
  * Rewrote and reorganized the Docker guide: where to pull published images, guidance on multi-arch images, and a clearer user vs. developer section.
  * Clarified telemetry guidance to explicitly mention forwarding logs to an OpenTelemetry backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->