### PR TITLE
properly wipe key material in kes::SecretKey::from_bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,12 @@ following type:
 - Security: in case of vulnerabilities.
 -->
 
-## [Unreleased]
+## [Unreleased; planned for 2026-06-11]
 
 ### Added
 
-- Basic networking capabilities, pulling blocks from a (trusted) remote peer.
-- Rudimentary command-line interface to start Amaru as a background Daemon.
-- Preliminary "ledger" keeping track of UTxO in-memory and performing phase-2
-  validations.
-
 ### Removed
 
-- Removed the standalone `import-headers` and `import-nonces` CLI commands in
-  favour of the unified bootstrap flow.
+### Fixed
+
+- amaru-ouroboros: properly wipe KES key material in unused method `SecretKey::from_bytes` (#881)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tracing-subscriber",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ tracing-subscriber = { version = "0.3.20", features = [
   "json",
 ] }
 typetag = "0.2.21"
+zeroize = "1.8.2"
 
 # Internal dependencies
 amaru = { path = "crates/amaru", version = "0.1.2" }

--- a/crates/amaru-ouroboros/Cargo.toml
+++ b/crates/amaru-ouroboros/Cargo.toml
@@ -27,6 +27,7 @@ pure-stage.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 vrf_dalek.workspace = true
+zeroize.workspace = true
 
 # Internal dependencies ───────────────────────────────────────────────────────┐
 amaru-kernel.workspace = true

--- a/crates/amaru-ouroboros/src/kes/mod.rs
+++ b/crates/amaru-ouroboros/src/kes/mod.rs
@@ -20,6 +20,7 @@ use kes_summed_ed25519::{
     traits::{KesSig, KesSk},
 };
 use thiserror::Error;
+use zeroize::{Zeroize, Zeroizing};
 
 // ------------------------------------------------------------------- SecretKey
 
@@ -29,9 +30,15 @@ pub struct SecretKey<'a>(Sum6Kes<'a>);
 impl SecretKey<'_> {
     /// Create a new KES secret key
     pub fn from_bytes(sk_bytes: &mut Vec<u8>) -> Result<SecretKey<'_>, Error> {
-        // FIXME: Avoid leaking KES secret keys
-        // extend() could potentially re-allocate memory to a new location and copy the sk_bytes.
-        // This would leave the original memory containing the secret key without being wiped.
+        // NOTE: we need to ensure that there is enough capacity to append the period (4 bytes) to the secret key bytes.
+        // Just using `.extend()` to add the period bytes may cause a re-allocation of the `Vec<u8>`, which would leave
+        // the original memory containing the secret key without being wiped.
+        if sk_bytes.capacity() - sk_bytes.len() < 4 {
+            let stash = Zeroizing::new(sk_bytes.as_slice().to_vec());
+            sk_bytes.zeroize();
+            sk_bytes.reserve(4);
+            sk_bytes.copy_from_slice(&stash);
+        }
         sk_bytes.extend([0u8; 4]); // default to period = 0
         let sum_6_kes = Sum6Kes::from_bytes(sk_bytes.as_mut_slice())?;
         Ok(SecretKey(sum_6_kes))


### PR DESCRIPTION
fixes #881



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret key memory management to ensure cryptographic key material is securely and consistently cleared from memory during operations. This enhancement strengthens protection against memory-based attacks and provides better security guarantees for sensitive private key data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->