### PR TITLE
refactor: address mempool review comments

### DIFF
--- a/crates/amaru-consensus/src/stages/mempool/stage.rs
+++ b/crates/amaru-consensus/src/stages/mempool/stage.rs
@@ -15,9 +15,9 @@
 use std::time::Instant;
 
 use amaru_kernel::{Tip, Transaction};
-use amaru_ouroboros::{MempoolError, MempoolMsg, MempoolSeqNo, TxInsertResult, TxOrigin, TxRejectReason};
+use amaru_ouroboros::{MempoolMsg, MempoolSeqNo, TxInsertResult, TxOrigin, TxRejectReason};
 use amaru_protocols::mempool_effects::MemoryPool;
-use pure_stage::{Effects, StageRef, Void};
+use pure_stage::{Effects, StageRef};
 
 use crate::{
     effects::{Ledger, LedgerOps, Metrics},
@@ -71,64 +71,44 @@ pub async fn stage(state: MempoolStageState, msg: MempoolMsg, eff: Effects<Mempo
             let tx_id = tx.tx_id();
             emit_tx_received(&tx_id, &origin);
 
-            match validate_and_insert(&ledger, &memory_pool, tx, &origin).await {
-                Ok(result) => {
-                    record_insert(memory_pool.state().await, &metrics_ops, &origin, &result).await;
-                    match result {
-                        TxInsertResult::Accepted { seq_no, .. } => {
-                            notify_ready_waiters(&mut state, &eff, seq_no).await;
-                        }
-                        TxInsertResult::Rejected { tx_id, ref reason } => {
-                            tracing::info!(%tx_id, %reason, "transaction rejected by mempool");
-                        }
-                    }
-                    eff.send(&caller, Ok(result)).await;
+            let result = validate_and_insert(&ledger, &memory_pool, tx, &origin).await;
+            record_insert(memory_pool.state().await, &metrics_ops, &origin, &result).await;
+            match result {
+                TxInsertResult::Accepted { seq_no, .. } => {
+                    notify_ready_waiters(&mut state, &eff, seq_no).await;
                 }
-                Err(e) => {
-                    tracing::error!(%e, %tx_id, "cannot insert transaction into the mempool");
-                    eff.send(&caller, Err(e)).await;
+                TxInsertResult::Rejected { tx_id, ref reason } => {
+                    tracing::info!(%tx_id, %reason, "transaction rejected by mempool");
                 }
-            };
+            }
+            eff.send(&caller, result).await;
         }
         MempoolMsg::InsertBatch { txs, origin, caller } => {
             let mut results = Vec::with_capacity(txs.len());
             for tx in txs {
                 let tx_id = tx.tx_id();
                 emit_tx_received(&tx_id, &origin);
-                match validate_and_insert(&ledger, &memory_pool, tx, &origin).await {
-                    Ok(result) => {
-                        record_insert(memory_pool.state().await, &metrics_ops, &origin, &result).await;
-                        match result {
-                            TxInsertResult::Accepted { seq_no, .. } => {
-                                notify_ready_waiters(&mut state, &eff, seq_no).await;
-                            }
-                            TxInsertResult::Rejected { tx_id, ref reason } => {
-                                tracing::info!(%tx_id, %reason, "transaction rejected by mempool");
-                            }
-                        }
-                        results.push(result);
+                let result = validate_and_insert(&ledger, &memory_pool, tx, &origin).await;
+                record_insert(memory_pool.state().await, &metrics_ops, &origin, &result).await;
+                match result {
+                    TxInsertResult::Accepted { seq_no, .. } => {
+                        notify_ready_waiters(&mut state, &eff, seq_no).await;
                     }
-                    Err(e) => {
-                        tracing::error!(%e, %tx_id, "cannot insert transaction into the mempool");
-                        eff.send(&caller, Err(e)).await;
-                        return state;
+                    TxInsertResult::Rejected { tx_id, ref reason } => {
+                        tracing::info!(%tx_id, %reason, "transaction rejected by mempool");
                     }
                 }
+                results.push(result);
             }
-            eff.send(&caller, Ok(results)).await;
+            eff.send(&caller, results).await;
         }
-        MempoolMsg::NewTip(tip) => match apply_new_tip(&ledger, &memory_pool, tip).await {
-            Ok(outcome) => {
-                record_revalidation(memory_pool.state().await, &metrics_ops, &outcome).await;
-                if !outcome.evicted_tx_ids.is_empty() {
-                    notify_capacity_waiters(&mut state, &eff).await;
-                }
+        MempoolMsg::NewTip(tip) => {
+            let outcome = apply_new_tip(&ledger, &memory_pool, tip).await;
+            record_revalidation(memory_pool.state().await, &metrics_ops, &outcome).await;
+            if !outcome.evicted_tx_ids.is_empty() {
+                notify_capacity_waiters(&mut state, &eff).await;
             }
-            Err(e) => {
-                tracing::error!(%e, "failed to apply new tip to the mempool");
-                eff.terminate::<Void>().await;
-            }
-        },
+        }
         MempoolMsg::SubscribeCapacity { caller } => {
             state.capacity_waiters.push(caller);
         }
@@ -144,19 +124,15 @@ async fn validate_and_insert(
     memory_pool: &MemoryPool,
     tx: Transaction,
     origin: &TxOrigin,
-) -> Result<TxInsertResult, MempoolError> {
+) -> TxInsertResult {
     match ledger.validate_tx(&tx).await {
         Ok(()) => memory_pool.insert(tx, origin.clone()).await,
-        Err(error) => Ok(TxInsertResult::rejected(tx.tx_id(), TxRejectReason::Invalid(error))),
+        Err(error) => TxInsertResult::rejected(tx.tx_id(), TxRejectReason::Invalid(error)),
     }
 }
 
 /// Revalidate all the mempool transactions when a new tip has been adopted.
-async fn apply_new_tip(
-    ledger: &Ledger,
-    memory_pool: &MemoryPool,
-    tip: Tip,
-) -> Result<RevalidationOutcome, MempoolError> {
+async fn apply_new_tip(ledger: &Ledger, memory_pool: &MemoryPool, tip: Tip) -> RevalidationOutcome {
     let started = Instant::now();
     let txs = memory_pool.mempool_txs().await;
     let total_before = txs.len() as u64;
@@ -169,16 +145,16 @@ async fn apply_new_tip(
     }
 
     if !invalid_tx_ids.is_empty() {
-        memory_pool.remove_txs(&invalid_tx_ids).await?;
+        memory_pool.remove_txs(&invalid_tx_ids).await;
     }
 
     tracing::debug!(%tip, invalidated_txs = invalid_tx_ids.len(), "revalidated mempool after new tip");
-    Ok(RevalidationOutcome {
+    RevalidationOutcome {
         tip_slot: u64::from(tip.slot()),
         total_before,
         evicted_tx_ids: invalid_tx_ids,
         duration_micros: started.elapsed().as_micros() as u64,
-    })
+    }
 }
 
 /// Notify the waiters whose target sequence number has just been reached.

--- a/crates/amaru-consensus/src/stages/mempool/stage.rs
+++ b/crates/amaru-consensus/src/stages/mempool/stage.rs
@@ -28,44 +28,31 @@ use crate::{
 /// transactions into the shared mempool via effects, while managing asynchronous waiter
 /// notifications for sequence number readiness and mempool capacity events.
 ///
-/// It accepts `MempoolMsg` inputs (re-exported from `amaru_ouroboros`):
+/// It accepts `MempoolMsg` messages:
 /// - `Insert { tx, origin, caller }` / `InsertBatch { txs, origin, caller }`: validate each
-///   tx via the `Ledger` effect (`validate_tx`); on success call `MemoryPool::insert`,
-///   on ledger failure construct `TxInsertResult::rejected(..., Invalid(...))`. Successful
-///   `Accepted { seq_no, .. }` results trigger `notify_ready_waiters`. Always reply to the
-///   embedded `caller: StageRef` with `Ok(TxInsertResult)` or `Ok(Vec<TxInsertResult>)` (or
-///   `Err(MempoolInsertError { tx_id, error })` on hard `MempoolError` from insert). Batch
-///   aborts on first hard error after replying Err.
-/// - `WaitForAtLeast { seq_no, caller }`: immediately `send(())` if `memory_pool.last_seq_no() >= seq_no`,
-///   else queue `MempoolWaiter` in state for later notification on an accepting insert.
-/// - `NewTip(tip)`: revalidate all current mempool txs against ledger via `apply_new_tip`,
-///   remove invalid ones (side-effect), notify capacity waiters if any were removed.
-/// - `SubscribeCapacity { caller }`: register `caller: StageRef<()>` for one-shot notification
-///   on future capacity-relieving NewTip.
+///   tx via the `Ledger` effect (`validate_tx`);
+///     - On success the transaction(s) are accepted into the mempool (via `MemoryPool::insert`),
+///     - On failure a rejection result (`TxInsertResult::rejected(..., Invalid(...))`) is returned.
+///     - When a transaction is accepted into the mempool, the waiters are notified (via `notify_ready_waiters`)
+///       in order to transmit available transactions upstream.
 ///
-/// The stage maintains only coordination state (`MempoolStageState`: lists of seq-waiters and
-/// capacity subscribers; serializable). All persistent state and heavy ops live in the
-/// `MemoryPool` and `Ledger` effects (backed by resources like `InMemoryMempool` and tx validators).
-/// No child stages are spawned; work is performed directly in the handler (with awaits on effects).
-/// Results flow back to callers (e.g. tx_submission manager, adopt_chain logic) exclusively via
-/// the `StageRef` callbacks in the messages using `Effects::send`. Side effects are strictly
-/// limited to the two effects; the stage itself is stateless w.r.t. tx contents.
+///   The `caller` gets a `TxInsertResult` reply (or a `Vec<TxInsertResult>` in case of a batch insertion).
+/// - `WaitForAtLeast { seq_no, caller }`: wait until `memory_pool.last_seq_no() >= seq_no`:
+///     - If this is the case when the message is received, the caller gets a reply right away,
+///     - Otherwise, it is queued as a `MempoolWaiter` to get a notification as soon as a transaction is
+///       inserted into the mempool.
 ///
-/// This stage is initialized in the consensus graph (via wiring with default state) and
-/// receives `NewTip` updates on chain adoption (for revalidation/clearing) and insert requests
-/// for tx submission.
+/// - `NewTip(tip)`: revalidate all current mempool txs against ledger via `apply_new_tip`:
+///     - Remove invalid ones (via `Mempool::remove_tx`)
+///     - Notify capacity waiters if any were removed
 ///
-/// ## FIXME: Suspected Issues (isolated analysis)
-/// - **Inconsistent batch error handling + partial side effects**: On hard error in `InsertBatch`, `eff.send(Err(...))` + immediate `return state;`. Prior txs in the same batch already performed `memory_pool.insert` (and seq-waiter notifies if accepted). Caller sees only an error (for the failing `tx_id`), not a partial `Vec` of results. Single-`Insert` path always completes a send. Risk of callers observing inconsistent committed state vs. reply.
-/// - **Test coverage gaps for variants + error paths + deserializer**: Only `InsertBatch` + `NewTip` exercised (with `TxOrigin::Local`, mock rejections leading to in-result `rejected`, and duplicates). No coverage of single `Insert`, `WaitForAtLeast`, `SubscribeCapacity`, or paths that surface top-level `MempoolInsertError` (vs. `TxInsertResult::rejected`). Guard registers only the `Vec<Result<...>>` form; scalar `Insert` reply type is untested and could cause simulation/serde issues.
-/// - **Silent drop on remove failure during reval**: `apply_new_tip` on `memory_pool.remove_txs` error: `tracing::error!` + `return 0` (no capacity notify). Invalid txs may remain in mempool after `NewTip`. Potential for stuck invalid entries post-chain switch.
-/// - **Capacity notifications narrowly scoped + one-shot**: `notify_capacity_waiters` (which drains) *only* on `NewTip` with `removed > 0`. Successful inserts never notify. Docstring notes "Subscribers that still need to be notified after re-evaluating must re-subscribe." Subscribers can easily miss events or leak registrations.
-/// - **No child stages / potential HOL blocking**: Validation, per-tx awaits on effects, full-mempool iteration in `apply_new_tip`, and all notifies happen directly in the handler. No `eff.spawn` for heavy work. Large mempools or slow ledger effects on `NewTip`/batches can block other messages (Insert/Wait/etc.) to this stage.
-/// - **Unbounded waiter accumulation + no cleanup**: `waiters` and `capacity_waiters` `Vec`s grow with no size limits, timeouts, or GC. `MempoolWaiter` holds `StageRef`s. Serializable state means persistence, but restarts lose pending notifications. Risk of unbounded growth or "stuck" waiters.
-/// - **Reply asymmetry and fire-and-forget risks**: Insert*/Wait guarantee one reply. `NewTip`/`Subscribe` are pure side-effect or registration (no direct reply). Waiters rely on later `eff.send(())`; any downstream or effect failure leaves callers hanging with no error surfacing in this stage.
-/// - **Full O(n) revalidation on every NewTip**: `mempool_txs().await` + sequential per-tx `validate_tx` + conditional remove. No sequencing, batching, or incremental logic. Cost scales with mempool size on every tip adoption.
-/// - **Batch aborts remaining work on first hard error**: Loop processes sequentially but `return`s on first `Err` from `validate_and_insert`. No attempt of later txs; caller gets error for the failure point only.
-/// - **Design notes / minor**: Ledger validation failures never produce `MempoolError` (always mapped to `rejected` result — intentional for submission UX). The `return state;` in batch error is functionally equivalent to fallthrough but skips any hypothetical post-match logic. Per-accepted notifies inside batch loop are fine (drain logic handles it).
+///   TODO: optimize this call; it is not necessary to revalidate all the transactions. We can,
+///   in principle build a dependency graph of all the transactions in the mempool and check, level by level,
+///   which parts of the graph are still valid based on the new ledger state.
+///
+/// - `SubscribeCapacity { caller }`: register `caller` for a one-shot notification
+///   when `NewTip` frees some pool capacity.
+///
 pub async fn stage(state: MempoolStageState, msg: MempoolMsg, eff: Effects<MempoolMsg>) -> MempoolStageState {
     let memory_pool = MemoryPool::new(eff.clone());
     let ledger = Ledger::new(eff.clone());

--- a/crates/amaru-consensus/src/stages/mempool/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/mempool/test_setup.rs
@@ -17,7 +17,6 @@ use amaru_kernel::{
 };
 use amaru_metrics::{MetricsEvent, mempool::MempoolMetrics};
 use amaru_ouroboros::{MempoolMsg, MockCanValidateBlocks, ResourceMempool, TxInsertResult, TxOrigin};
-use amaru_ouroboros_traits::MempoolError;
 use amaru_protocols::store_effects::ResourceParameters;
 use pure_stage::{
     DeserializerGuards, Effect, ExternalEffect, StageGraph, UnknownExternalEffect,
@@ -54,7 +53,7 @@ pub fn register_guards() -> DeserializerGuards {
     vec![
         pure_stage::register_data_deserializer::<MempoolStageState>().boxed(),
         pure_stage::register_data_deserializer::<MempoolMsg>().boxed(),
-        pure_stage::register_data_deserializer::<Result<Vec<TxInsertResult>, MempoolError>>().boxed(),
+        pure_stage::register_data_deserializer::<Vec<TxInsertResult>>().boxed(),
         pure_stage::register_effect_deserializer::<ValidateTxEffect>().boxed(),
         pure_stage::register_effect_deserializer::<RecordMetricsEffect>().boxed(),
     ]
@@ -106,11 +105,7 @@ pub fn te_insert(at_stage: &str, tx: &Transaction, tx_origin: TxOrigin) -> Trace
     TraceEntry::suspend(Effect::external(at_stage, effect))
 }
 
-pub fn te_send(
-    from: impl AsRef<str>,
-    to: impl AsRef<str>,
-    msg: Result<Vec<TxInsertResult>, MempoolError>,
-) -> TraceEntry {
+pub fn te_send(from: impl AsRef<str>, to: impl AsRef<str>, msg: Vec<TxInsertResult>) -> TraceEntry {
     TraceEntry::suspend(Effect::send(from, to, Box::new(msg)))
 }
 

--- a/crates/amaru-consensus/src/stages/mempool/tests.rs
+++ b/crates/amaru-consensus/src/stages/mempool/tests.rs
@@ -20,7 +20,7 @@ use amaru_metrics::mempool::{MempoolMetricEvent, MempoolMetrics, TxInsertionOrig
 use amaru_ouroboros::{
     MempoolMsg, MempoolSeqNo, MempoolState, TransactionValidationError, TxInsertResult, TxOrigin, TxRejectReason,
 };
-use amaru_ouroboros_traits::{MempoolError, TxSubmissionMempool};
+use amaru_ouroboros_traits::TxSubmissionMempool;
 use pure_stage::StageRef;
 use tokio::runtime::Builder;
 use tracing::Level;
@@ -80,9 +80,9 @@ fn new_tip_invalidates_transactions_against_current_ledger_state() {
     let tx_1 = create_transaction(1);
     let tx_2 = create_transaction(2);
     let mempool = Arc::new(InMemoryMempool::<Transaction>::default());
-    mempool.insert(tx_0.clone(), TxOrigin::Local).unwrap();
-    mempool.insert(tx_1.clone(), TxOrigin::Local).unwrap();
-    mempool.insert(tx_2.clone(), TxOrigin::Local).unwrap();
+    mempool.insert(tx_0.clone(), TxOrigin::Local);
+    mempool.insert(tx_1.clone(), TxOrigin::Local);
+    mempool.insert(tx_2.clone(), TxOrigin::Local);
     let prep = TestPrep {
         msg: MempoolMsg::NewTip(amaru_kernel::Tip::origin()),
         rt: Builder::new_current_thread().build().unwrap(),
@@ -127,13 +127,13 @@ fn insertion_metric(state: MempoolState, result: TxInsertionResult) -> MempoolMe
     }
 }
 
-fn expected_results(txs: &[Transaction]) -> Result<Vec<TxInsertResult>, MempoolError> {
-    Ok(vec![
+fn expected_results(txs: &[Transaction]) -> Vec<TxInsertResult> {
+    vec![
         TxInsertResult::accepted(txs[0].tx_id(), MempoolSeqNo(1)),
         TxInsertResult::rejected(
             txs[1].tx_id(),
             TxRejectReason::Invalid(anyhow::anyhow!("transaction rejected for testing").into()),
         ),
         TxInsertResult::rejected(txs[2].tx_id(), TxRejectReason::Duplicate),
-    ])
+    ]
 }

--- a/crates/amaru-mempool/src/strategies/in_memory_mempool.rs
+++ b/crates/amaru-mempool/src/strategies/in_memory_mempool.rs
@@ -179,14 +179,14 @@ impl MempoolConfig {
 impl<Tx: Send + Sync + 'static + HasTransactionId + cbor::Encode<()> + Clone> TxSubmissionMempool<Tx>
     for InMemoryMempool<Tx>
 {
-    fn insert(&self, tx: Tx, tx_origin: TxOrigin) -> Result<TxInsertResult, amaru_ouroboros_traits::MempoolError> {
+    fn insert(&self, tx: Tx, tx_origin: TxOrigin) -> TxInsertResult {
         let tx_id = tx.tx_id();
         let mut inner = self.inner.write();
         let res = inner.insert(&self.config, tx, tx_origin);
-        Ok(match res {
+        match res {
             Ok((tx_id, seq_no)) => TxInsertResult::accepted(tx_id, seq_no),
             Err(reason) => TxInsertResult::rejected(tx_id, reason),
-        })
+        }
     }
 
     fn get_tx(&self, tx_id: &TransactionId) -> Option<Tx> {
@@ -205,9 +205,8 @@ impl<Tx: Send + Sync + 'static + HasTransactionId + cbor::Encode<()> + Clone> Tx
         self.inner.read().mempool_txs()
     }
 
-    fn remove_txs(&self, ids: &[TransactionId]) -> Result<(), amaru_ouroboros_traits::MempoolError> {
-        self.inner.write().remove_txs(ids);
-        Ok(())
+    fn remove_txs(&self, ids: &[TransactionId]) {
+        self.inner.write().remove_txs(ids)
     }
 
     fn last_seq_no(&self) -> MempoolSeqNo {
@@ -276,7 +275,7 @@ mod tests {
         let mempool = InMemoryMempool::new(MempoolConfig::default());
         let tx = Tx::from_str("tx1").unwrap();
         let TxInsertResult::Accepted { tx_id, seq_no: seq_nb } =
-            mempool.insert(tx.clone(), TxOrigin::Remote(Peer::new("upstream"))).unwrap()
+            mempool.insert(tx.clone(), TxOrigin::Remote(Peer::new("upstream")))
         else {
             panic!("transaction should be accepted")
         };
@@ -294,10 +293,9 @@ mod tests {
         let max_bytes = to_cbor(&first).len() as u64;
         let mempool = InMemoryMempool::new(MempoolConfig::default().with_max_bytes(max_bytes));
 
-        assert!(matches!(mempool.insert(first, TxOrigin::Local).unwrap(), TxInsertResult::Accepted { .. }));
+        assert!(matches!(mempool.insert(first, TxOrigin::Local), TxInsertResult::Accepted { .. }));
 
-        let TxInsertResult::Rejected { reason, .. } =
-            mempool.insert(Tx::from_str("b").unwrap(), TxOrigin::Local).unwrap()
+        let TxInsertResult::Rejected { reason, .. } = mempool.insert(Tx::from_str("b").unwrap(), TxOrigin::Local)
         else {
             panic!("transaction should be rejected as full");
         };
@@ -310,9 +308,9 @@ mod tests {
         let max_bytes = to_cbor(&first).len() as u64;
         let mempool = InMemoryMempool::new(MempoolConfig::default().with_max_bytes(max_bytes));
 
-        assert!(matches!(mempool.insert(first.clone(), TxOrigin::Local).unwrap(), TxInsertResult::Accepted { .. }));
+        assert!(matches!(mempool.insert(first.clone(), TxOrigin::Local), TxInsertResult::Accepted { .. }));
 
-        let TxInsertResult::Rejected { reason, .. } = mempool.insert(first, TxOrigin::Local).unwrap() else {
+        let TxInsertResult::Rejected { reason, .. } = mempool.insert(first, TxOrigin::Local) else {
             panic!("transaction should be rejected");
         };
         assert!(matches!(reason, TxRejectReason::Duplicate), "unexpected reason: {reason:?}");
@@ -324,14 +322,14 @@ mod tests {
         let max_bytes = to_cbor(&first).len() as u64;
         let mempool = InMemoryMempool::new(MempoolConfig::default().with_max_bytes(max_bytes));
 
-        let TxInsertResult::Accepted { tx_id, .. } = mempool.insert(first, TxOrigin::Local).unwrap() else {
+        let TxInsertResult::Accepted { tx_id, .. } = mempool.insert(first, TxOrigin::Local) else {
             panic!("first insert should succeed");
         };
 
-        mempool.remove_txs(&[tx_id]).unwrap();
+        mempool.remove_txs(&[tx_id]);
 
         let second = Tx::from_str("b").unwrap();
-        assert!(matches!(mempool.insert(second, TxOrigin::Local).unwrap(), TxInsertResult::Accepted { .. }));
+        assert!(matches!(mempool.insert(second, TxOrigin::Local), TxInsertResult::Accepted { .. }));
     }
 
     // HELPERS

--- a/crates/amaru-ouroboros-traits/src/mempool/mempool_traits.rs
+++ b/crates/amaru-ouroboros-traits/src/mempool/mempool_traits.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use amaru_kernel::TransactionId;
 
-use crate::mempool::{MempoolError, MempoolSeqNo, MempoolState, TxInsertResult, TxOrigin};
+use crate::mempool::{MempoolSeqNo, MempoolState, TxInsertResult, TxOrigin};
 
 /// An simple mempool interface to:
 ///
@@ -46,7 +46,7 @@ pub trait TxSubmissionMempool<Tx: Send + Sync + 'static>: Send + Sync {
     /// Insert a transaction into the mempool, specifying its origin.
     /// A TxOrigin::Local origin indicates the transaction was created on the current node,
     /// A TxOrigin::Remote(origin_peer) indicates the transaction was received from a remote peer.
-    fn insert(&self, tx: Tx, tx_origin: TxOrigin) -> Result<TxInsertResult, MempoolError>;
+    fn insert(&self, tx: Tx, tx_origin: TxOrigin) -> TxInsertResult;
 
     /// Retrieve a transaction by its id.
     fn get_tx(&self, tx_id: &TransactionId) -> Option<Tx>;
@@ -66,7 +66,7 @@ pub trait TxSubmissionMempool<Tx: Send + Sync + 'static>: Send + Sync {
     fn mempool_txs(&self) -> Vec<Tx>;
 
     /// Remove transactions from the active relay set.
-    fn remove_txs(&self, _ids: &[TransactionId]) -> Result<(), MempoolError>;
+    fn remove_txs(&self, _ids: &[TransactionId]);
 
     /// Get the last assigned sequence number in the mempool.
     fn last_seq_no(&self) -> MempoolSeqNo;

--- a/crates/amaru-ouroboros-traits/src/mempool/overriding_mempool.rs
+++ b/crates/amaru-ouroboros-traits/src/mempool/overriding_mempool.rs
@@ -17,16 +17,14 @@ use std::sync::Arc;
 use amaru_kernel::TransactionId;
 use parking_lot::Mutex;
 
-use crate::{MempoolError, MempoolSeqNo, MempoolState, TxInsertResult, TxOrigin, TxSubmissionMempool};
+use crate::{MempoolSeqNo, MempoolState, TxInsertResult, TxOrigin, TxSubmissionMempool};
 
 /// Optional method overrides for [`OverridingMempool`].
 /// Each override receives a reference to the underlying mempool and the method arguments.
 /// Overrides are stored in a mutex because they use `FnMut`.
 #[allow(clippy::type_complexity)]
 struct Overrides<Tx: Send + Sync + 'static> {
-    insert: Option<
-        Box<dyn FnMut(&dyn TxSubmissionMempool<Tx>, Tx, TxOrigin) -> Result<TxInsertResult, MempoolError> + Send>,
-    >,
+    insert: Option<Box<dyn FnMut(&dyn TxSubmissionMempool<Tx>, Tx, TxOrigin) -> TxInsertResult + Send>>,
     get_tx: Option<Box<dyn FnMut(&dyn TxSubmissionMempool<Tx>, &TransactionId) -> Option<Tx> + Send>>,
     contains: Option<Box<dyn FnMut(&dyn TxSubmissionMempool<Tx>, &TransactionId) -> bool + Send>>,
     tx_ids_since: Option<
@@ -37,8 +35,7 @@ struct Overrides<Tx: Send + Sync + 'static> {
     >,
     get_txs_for_ids: Option<Box<dyn FnMut(&dyn TxSubmissionMempool<Tx>, &[TransactionId]) -> Vec<Tx> + Send>>,
     mempool_txs: Option<Box<dyn FnMut(&dyn TxSubmissionMempool<Tx>) -> Vec<Tx> + Send>>,
-    remove_txs:
-        Option<Box<dyn FnMut(&dyn TxSubmissionMempool<Tx>, &[TransactionId]) -> Result<(), MempoolError> + Send>>,
+    remove_txs: Option<Box<dyn FnMut(&dyn TxSubmissionMempool<Tx>, &[TransactionId]) + Send>>,
     last_seq_no: Option<Box<dyn FnMut(&dyn TxSubmissionMempool<Tx>) -> MempoolSeqNo + Send>>,
     is_near_capacity: Option<Box<dyn FnMut(&dyn TxSubmissionMempool<Tx>, u64) -> bool + Send>>,
     state: Option<Box<dyn FnMut(&dyn TxSubmissionMempool<Tx>) -> MempoolState + Send>>,
@@ -88,7 +85,7 @@ pub struct OverridingMempoolBuilder<Tx: Send + Sync + 'static> {
 impl<Tx: Send + Sync + 'static> OverridingMempoolBuilder<Tx> {
     pub fn with_insert<F>(mut self, f: F) -> Self
     where
-        F: FnMut(&dyn TxSubmissionMempool<Tx>, Tx, TxOrigin) -> Result<TxInsertResult, MempoolError> + Send + 'static,
+        F: FnMut(&dyn TxSubmissionMempool<Tx>, Tx, TxOrigin) -> TxInsertResult + Send + 'static,
     {
         self.overrides.insert = Some(Box::new(f));
         self
@@ -138,7 +135,7 @@ impl<Tx: Send + Sync + 'static> OverridingMempoolBuilder<Tx> {
 
     pub fn with_remove_txs<F>(mut self, f: F) -> Self
     where
-        F: FnMut(&dyn TxSubmissionMempool<Tx>, &[TransactionId]) -> Result<(), MempoolError> + Send + 'static,
+        F: FnMut(&dyn TxSubmissionMempool<Tx>, &[TransactionId]) + Send + 'static,
     {
         self.overrides.remove_txs = Some(Box::new(f));
         self
@@ -174,7 +171,7 @@ impl<Tx: Send + Sync + 'static> OverridingMempoolBuilder<Tx> {
 }
 
 impl<Tx: Send + Sync + 'static> TxSubmissionMempool<Tx> for OverridingMempool<Tx> {
-    fn insert(&self, tx: Tx, tx_origin: TxOrigin) -> Result<TxInsertResult, MempoolError> {
+    fn insert(&self, tx: Tx, tx_origin: TxOrigin) -> TxInsertResult {
         let mut overrides = self.overrides.lock();
         match &mut overrides.insert {
             Some(f) => f(self.inner.as_ref(), tx, tx_origin),
@@ -222,7 +219,7 @@ impl<Tx: Send + Sync + 'static> TxSubmissionMempool<Tx> for OverridingMempool<Tx
         }
     }
 
-    fn remove_txs(&self, ids: &[TransactionId]) -> Result<(), MempoolError> {
+    fn remove_txs(&self, ids: &[TransactionId]) {
         let mut overrides = self.overrides.lock();
         match &mut overrides.remove_txs {
             Some(f) => f(self.inner.as_ref(), ids),

--- a/crates/amaru-ouroboros-traits/src/mempool/values.rs
+++ b/crates/amaru-ouroboros-traits/src/mempool/values.rs
@@ -103,21 +103,3 @@ impl From<anyhow::Error> for TransactionValidationError {
         TransactionValidationError(error.to_string())
     }
 }
-
-#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[error("MempoolError: {message}")]
-pub struct MempoolError {
-    message: String,
-}
-
-impl MempoolError {
-    pub fn new(message: impl Into<String>) -> Self {
-        Self { message: message.into() }
-    }
-}
-
-impl From<anyhow::Error> for MempoolError {
-    fn from(error: anyhow::Error) -> Self {
-        Self::new(error.to_string())
-    }
-}

--- a/crates/amaru-ouroboros/src/mempool.rs
+++ b/crates/amaru-ouroboros/src/mempool.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use amaru_kernel::{Tip, Transaction, TransactionId};
-use amaru_ouroboros_traits::{MempoolError, MempoolSeqNo, TxInsertResult, TxOrigin, TxRejectReason};
+use amaru_ouroboros_traits::{MempoolSeqNo, TxInsertResult, TxOrigin, TxRejectReason};
 use pure_stage::StageRef;
 
 /// Messages accepted by the mempool stage.
@@ -35,8 +35,8 @@ use pure_stage::StageRef;
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum MempoolMsg {
     WaitForAtLeast { seq_no: MempoolSeqNo, caller: StageRef<()> },
-    Insert { tx: Box<Transaction>, origin: TxOrigin, caller: StageRef<Result<TxInsertResult, MempoolError>> },
-    InsertBatch { txs: Vec<Transaction>, origin: TxOrigin, caller: StageRef<Result<Vec<TxInsertResult>, MempoolError>> },
+    Insert { tx: Box<Transaction>, origin: TxOrigin, caller: StageRef<TxInsertResult> },
+    InsertBatch { txs: Vec<Transaction>, origin: TxOrigin, caller: StageRef<Vec<TxInsertResult>> },
     NewTip(Tip),
     SubscribeCapacity { caller: StageRef<()> },
 }

--- a/crates/amaru-protocols/src/mempool_effects.rs
+++ b/crates/amaru-protocols/src/mempool_effects.rs
@@ -16,7 +16,7 @@ use std::fmt::Debug;
 
 use amaru_kernel::{Transaction, TransactionId};
 use amaru_ouroboros::ResourceMempool;
-use amaru_ouroboros_traits::{MempoolError, MempoolSeqNo, MempoolState, TxInsertResult, TxOrigin, TxSubmissionMempool};
+use amaru_ouroboros_traits::{MempoolSeqNo, MempoolState, TxInsertResult, TxOrigin, TxSubmissionMempool};
 use pure_stage::{BoxFuture, Effects, ExternalEffect, ExternalEffectAPI, Resources, SendData, Void};
 use serde::{Deserialize, Serialize};
 
@@ -32,7 +32,7 @@ pub struct MemoryPool {
 }
 
 pub trait AsyncMempool: Send + Sync {
-    fn insert(&self, tx: Transaction, tx_origin: TxOrigin) -> BoxFuture<'_, Result<TxInsertResult, MempoolError>>;
+    fn insert(&self, tx: Transaction, tx_origin: TxOrigin) -> BoxFuture<'_, TxInsertResult>;
     fn get_tx(&self, tx_id: TransactionId) -> BoxFuture<'_, Option<Transaction>>;
     fn contains(&self, tx_id: &TransactionId) -> BoxFuture<'_, bool>;
     fn tx_ids_since(
@@ -42,7 +42,7 @@ pub trait AsyncMempool: Send + Sync {
     ) -> BoxFuture<'_, Vec<(TransactionId, u32, MempoolSeqNo)>>;
     fn get_txs_for_ids(&self, ids: &[TransactionId]) -> BoxFuture<'_, Vec<Transaction>>;
     fn mempool_txs(&self) -> BoxFuture<'_, Vec<Transaction>>;
-    fn remove_txs(&self, ids: &[TransactionId]) -> BoxFuture<'_, Result<(), MempoolError>>;
+    fn remove_txs(&self, ids: &[TransactionId]) -> BoxFuture<'_, ()>;
     fn last_seq_no(&self) -> BoxFuture<'_, MempoolSeqNo>;
     fn is_near_capacity(&self, additional_bytes: u64) -> BoxFuture<'_, bool>;
     fn state(&self) -> BoxFuture<'_, MempoolState>;
@@ -57,11 +57,7 @@ impl MemoryPool {
         self.effects.external(effect)
     }
 
-    pub fn insert(
-        &self,
-        tx: Transaction,
-        tx_origin: TxOrigin,
-    ) -> BoxFuture<'static, Result<TxInsertResult, MempoolError>> {
+    pub fn insert(&self, tx: Transaction, tx_origin: TxOrigin) -> BoxFuture<'static, TxInsertResult> {
         self.external(Insert::new(tx, tx_origin))
     }
 
@@ -89,7 +85,7 @@ impl MemoryPool {
         self.external(MempoolTxs)
     }
 
-    pub fn remove_txs(&self, ids: &[TransactionId]) -> BoxFuture<'static, Result<(), MempoolError>> {
+    pub fn remove_txs(&self, ids: &[TransactionId]) -> BoxFuture<'static, ()> {
         self.external(RemoveTxs::new(ids))
     }
 
@@ -111,7 +107,7 @@ impl MemoryPool {
 }
 
 impl AsyncMempool for MemoryPool {
-    fn insert(&self, tx: Transaction, tx_origin: TxOrigin) -> BoxFuture<'_, Result<TxInsertResult, MempoolError>> {
+    fn insert(&self, tx: Transaction, tx_origin: TxOrigin) -> BoxFuture<'_, TxInsertResult> {
         MemoryPool::insert(self, tx, tx_origin)
     }
 
@@ -139,7 +135,7 @@ impl AsyncMempool for MemoryPool {
         MemoryPool::mempool_txs(self)
     }
 
-    fn remove_txs(&self, ids: &[TransactionId]) -> BoxFuture<'_, Result<(), MempoolError>> {
+    fn remove_txs(&self, ids: &[TransactionId]) -> BoxFuture<'_, ()> {
         MemoryPool::remove_txs(self, ids)
     }
 
@@ -157,7 +153,7 @@ impl AsyncMempool for MemoryPool {
 }
 
 impl<T: TxSubmissionMempool<Transaction> + ?Sized> AsyncMempool for T {
-    fn insert(&self, tx: Transaction, tx_origin: TxOrigin) -> BoxFuture<'_, Result<TxInsertResult, MempoolError>> {
+    fn insert(&self, tx: Transaction, tx_origin: TxOrigin) -> BoxFuture<'_, TxInsertResult> {
         Box::pin(async move { TxSubmissionMempool::insert(self, tx, tx_origin) })
     }
 
@@ -187,7 +183,7 @@ impl<T: TxSubmissionMempool<Transaction> + ?Sized> AsyncMempool for T {
         Box::pin(async move { TxSubmissionMempool::mempool_txs(self) })
     }
 
-    fn remove_txs(&self, ids: &[TransactionId]) -> BoxFuture<'_, Result<(), MempoolError>> {
+    fn remove_txs(&self, ids: &[TransactionId]) -> BoxFuture<'_, ()> {
         let tx_ids = ids.to_vec();
         Box::pin(async move { TxSubmissionMempool::remove_txs(self, &tx_ids) })
     }
@@ -230,7 +226,7 @@ impl ExternalEffect for Insert {
 }
 
 impl ExternalEffectAPI for Insert {
-    type Response = Result<TxInsertResult, MempoolError>;
+    type Response = TxInsertResult;
 }
 
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -363,7 +359,7 @@ impl RemoveTxs {
 }
 
 impl ExternalEffect for RemoveTxs {
-    #[expect(clippy::expect_used)]
+    #[expect(clippy::expect_used, clippy::unit_arg)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
         Self::wrap_sync({
             let mempool = resources.get::<ResourceMempool<Transaction>>().expect("ResourceMempool requires a mempool");
@@ -373,7 +369,7 @@ impl ExternalEffect for RemoveTxs {
 }
 
 impl ExternalEffectAPI for RemoveTxs {
-    type Response = Result<(), MempoolError>;
+    type Response = ();
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -432,9 +428,7 @@ impl ExternalEffectAPI for State {
 #[cfg(test)]
 mod tests {
     use amaru_kernel::{Transaction, TransactionBody, TransactionId, WitnessSet};
-    use amaru_ouroboros_traits::{
-        MempoolError, MempoolSeqNo, MempoolState, TxInsertResult, TxOrigin, TxSubmissionMempool,
-    };
+    use amaru_ouroboros_traits::{MempoolSeqNo, MempoolState, TxInsertResult, TxOrigin, TxSubmissionMempool};
 
     #[allow(dead_code)]
     pub struct ConstantMempool {
@@ -452,8 +446,8 @@ mod tests {
     }
 
     impl TxSubmissionMempool<Transaction> for ConstantMempool {
-        fn insert(&self, tx: Transaction, _tx_origin: TxOrigin) -> Result<TxInsertResult, MempoolError> {
-            Ok(TxInsertResult::accepted(tx.tx_id(), MempoolSeqNo(1)))
+        fn insert(&self, tx: Transaction, _tx_origin: TxOrigin) -> TxInsertResult {
+            TxInsertResult::accepted(tx.tx_id(), MempoolSeqNo(1))
         }
 
         fn get_tx(&self, _tx_id: &TransactionId) -> Option<Transaction> {
@@ -472,9 +466,7 @@ mod tests {
             vec![self.tx.clone()]
         }
 
-        fn remove_txs(&self, _ids: &[TransactionId]) -> Result<(), MempoolError> {
-            Ok(())
-        }
+        fn remove_txs(&self, _ids: &[TransactionId]) {}
 
         fn last_seq_no(&self) -> MempoolSeqNo {
             MempoolSeqNo(1)

--- a/crates/amaru-protocols/src/tx_submission/initiator.rs
+++ b/crates/amaru-protocols/src/tx_submission/initiator.rs
@@ -564,7 +564,7 @@ mod tests {
         let txs = create_transactions(6);
 
         for tx in txs.iter().take(2) {
-            TxSubmissionMempool::insert(mempool.as_ref(), tx.clone(), TxOrigin::Local)?;
+            TxSubmissionMempool::insert(mempool.as_ref(), tx.clone(), TxOrigin::Local);
         }
 
         // Send requests to retrieve transactions and block until they are available.
@@ -577,7 +577,7 @@ mod tests {
 
         // Refill the mempool with more transactions
         for tx in &txs[2..] {
-            TxSubmissionMempool::insert(mempool.as_ref(), tx.clone(), TxOrigin::Local)?;
+            TxSubmissionMempool::insert(mempool.as_ref(), tx.clone(), TxOrigin::Local);
         }
         let messages = vec![
             request_tx_ids(1, 2, Blocking::Yes),
@@ -617,7 +617,7 @@ mod tests {
         let seq_no = initiator.begin_request_tx_ids_blocking(0, 10).map_err(|error| anyhow::anyhow!(error))?;
 
         assert!(TxSubmissionMempool::last_seq_no(mempool.as_ref()) < seq_no);
-        TxSubmissionMempool::insert(mempool.as_ref(), txs[0].clone(), TxOrigin::Local)?;
+        TxSubmissionMempool::insert(mempool.as_ref(), txs[0].clone(), TxOrigin::Local);
         assert!(TxSubmissionMempool::last_seq_no(mempool.as_ref()) >= seq_no);
         assert_eq!(initiator.complete_request_tx_ids_blocking(mempool.as_ref()).await?, Some(reply_tx_ids(&txs, &[0])));
 
@@ -637,8 +637,8 @@ mod tests {
         let seq_no = initiator.begin_request_tx_ids_blocking(0, 10).map_err(|error| anyhow::anyhow!(error))?;
 
         let tx_id = txs[0].tx_id();
-        TxSubmissionMempool::insert(mempool.as_ref(), txs[0].clone(), TxOrigin::Local)?;
-        TxSubmissionMempool::remove_txs(mempool.as_ref(), &[tx_id])?;
+        TxSubmissionMempool::insert(mempool.as_ref(), txs[0].clone(), TxOrigin::Local);
+        TxSubmissionMempool::remove_txs(mempool.as_ref(), &[tx_id]);
         // the last seq_no is greater than the requested seq_no
         assert!(TxSubmissionMempool::last_seq_no(mempool.as_ref()) >= seq_no);
 
@@ -664,7 +664,7 @@ mod tests {
         let (actions, initiator) = run_stage_and_return_state(mempool.clone(), vec![advertise]).await?;
         assert_actions_eq(&actions, &[reply_tx_ids(&txs, &[0, 1])]);
 
-        TxSubmissionMempool::remove_txs(mempool.as_ref(), &[txs[0].tx_id()])?;
+        TxSubmissionMempool::remove_txs(mempool.as_ref(), &[txs[0].tx_id()]);
 
         let (actions, _) = run_stage_and_return_state_with(initiator, mempool, vec![request_both]).await?;
         assert_actions_eq(&actions, &[reply_txs(&txs, &[1])]);
@@ -684,7 +684,7 @@ mod tests {
         let (actions, initiator) = run_stage_and_return_state(mempool.clone(), vec![advertise]).await?;
         assert_actions_eq(&actions, &[reply_tx_ids(&txs, &[0, 1])]);
 
-        TxSubmissionMempool::remove_txs(mempool.as_ref(), &[txs[0].tx_id(), txs[1].tx_id()])?;
+        TxSubmissionMempool::remove_txs(mempool.as_ref(), &[txs[0].tx_id(), txs[1].tx_id()]);
 
         let (actions, _) = run_stage_and_return_state_with(initiator, mempool, vec![request_both]).await?;
         assert_actions_eq(&actions, &[reply_txs(&txs, &[])]);

--- a/crates/amaru-protocols/src/tx_submission/outcome.rs
+++ b/crates/amaru-protocols/src/tx_submission/outcome.rs
@@ -15,7 +15,6 @@
 use std::fmt::{Display, Formatter};
 
 use amaru_kernel::TransactionId;
-use amaru_ouroboros_traits::MempoolError;
 use serde::{Deserialize, Serialize};
 
 use crate::tx_submission::{ResponderResult, initiator::InitiatorResult};
@@ -41,8 +40,6 @@ pub enum TerminationCause {
     TxFetchTimeout,
     /// Local mempool stage did not respond in time.
     MempoolBatchInsertFailedTimedout,
-    /// Insertion into the mempool failed.
-    MempoolInsertFailed(MempoolError),
 }
 
 /// Peer-misbehavior protocol errors.
@@ -110,7 +107,6 @@ impl Display for TerminationCause {
             TerminationCause::Protocol(err) => write!(f, "{err}"),
             TerminationCause::TxFetchTimeout => write!(f, "peer did not deliver ReplyTxs within timeout"),
             TerminationCause::MempoolBatchInsertFailedTimedout => write!(f, "mempool stage unavailable"),
-            TerminationCause::MempoolInsertFailed(e) => write!(f, "insertion into mempool failed: {e}"),
         }
     }
 }

--- a/crates/amaru-protocols/src/tx_submission/responder.rs
+++ b/crates/amaru-protocols/src/tx_submission/responder.rs
@@ -492,8 +492,7 @@ impl TxSubmissionResponder {
                 tracing::error!("mempool stage did not respond to InsertBatch within timeout");
                 return terminate(MempoolBatchInsertFailedTimedout);
             }
-            Some(Err(error)) => return terminate(MempoolInsertFailed(error)),
-            Some(Ok(results)) => {
+            Some(results) => {
                 // Individual transaction rejection are just logged
                 for result in results {
                     log_insert_result(&result);
@@ -765,7 +764,7 @@ mod tests {
     use amaru_kernel::{EraName, TESTNET_ERA_HISTORY, Transaction};
     use amaru_mempool::strategies::InMemoryMempool;
     use amaru_ouroboros_traits::{
-        MempoolError, MempoolSeqNo, TransactionValidationError, TxInsertResult, TxOrigin, TxRejectReason,
+        MempoolSeqNo, TransactionValidationError, TxInsertResult, TxOrigin, TxRejectReason,
         mempool::overriding_mempool::OverridingMempool,
     };
 
@@ -924,20 +923,6 @@ mod tests {
                 request_txs(&txs, &[2]),
                 error_action(TxNotRequested),
             ],
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn tx_mempool_errors_do_not_terminate_the_protocol() -> anyhow::Result<()> {
-        let txs = create_transactions(2);
-        let mempool = failing_insert_mempool("database unavailable");
-
-        let actions = run_stage(mempool, vec![init(), reply_tx_ids(&txs, &[0, 1]), reply_txs(&txs, &[0, 1])]).await?;
-
-        assert_actions_eq(
-            &actions,
-            &[request_tx_ids(0, 10, Blocking::Yes), request_txs(&txs, &[0, 1]), request_tx_ids(2, 10, Blocking::Yes)],
         );
         Ok(())
     }
@@ -1198,12 +1183,9 @@ mod tests {
                             }
                         }
 
-                        // log errors
                         let origin = responder.origin.clone();
                         for tx in txs {
-                            if let Err(e) = mempool.insert(tx, origin.clone()).await {
-                                tracing::debug!(error = %e, "test harness: mempool insert failed");
-                            }
+                            mempool.insert(tx, origin.clone()).await;
                         }
                         let (ack, req, blocking) = responder.request_tx_ids(mempool).await;
                         Some(ResponderAction::SendRequestTxIds { ack, req, blocking })
@@ -1253,15 +1235,6 @@ mod tests {
         responder.tx_states.insert(tx_id, TxStateEntry { status, refcount: one() });
     }
 
-    /// A mempool that fails every `insert` with the given error message
-    fn failing_insert_mempool(message: &'static str) -> Arc<dyn AsyncMempool> {
-        Arc::new(
-            OverridingMempool::builder(Arc::new(InMemoryMempool::default()))
-                .with_insert(move |_inner, _tx, _origin| Err(MempoolError::new(message)))
-                .build(),
-        )
-    }
-
     /// A mempool whose `insert` returns predetermined results keyed by `TransactionId`.
     /// Each result is consumed on first match.
     fn mock_insert_mempool(results: Vec<TxInsertResult>) -> Arc<dyn AsyncMempool> {
@@ -1271,7 +1244,7 @@ mod tests {
             OverridingMempool::builder(Arc::new(InMemoryMempool::default()))
                 .with_insert(move |_inner, tx: Transaction, _origin| {
                     let tx_id = tx.tx_id();
-                    Ok(by_id.remove(&tx_id).expect("missing insert result for mock mempool test"))
+                    by_id.remove(&tx_id).expect("missing insert result for mock mempool test")
                 })
                 // never report contained txs to force the responder to fetch them.
                 .with_contains(|_inner, _tx_id| false)

--- a/crates/amaru-protocols/src/tx_submission/tests/test_data.rs
+++ b/crates/amaru-protocols/src/tx_submission/tests/test_data.rs
@@ -24,7 +24,7 @@ pub fn create_transactions_in_mempool(mempool: &dyn Mempool<Transaction>, number
     for i in 0..number {
         let tx = create_transaction(i);
         txs.push(tx.clone());
-        mempool.insert(tx, TxOrigin::Local).unwrap();
+        mempool.insert(tx, TxOrigin::Local);
     }
     txs
 }

--- a/crates/amaru/src/submit_api.rs
+++ b/crates/amaru/src/submit_api.rs
@@ -88,8 +88,8 @@ async fn submit_tx(State(mempool_sender): State<SubmitApiState>, headers: Header
         )
         .await
     {
-        Ok(Ok(TxInsertResult::Accepted { tx_id, .. })) => json_response(StatusCode::ACCEPTED, tx_id.to_string()),
-        Ok(Ok(TxInsertResult::Rejected { reason, .. })) => text_response(
+        Ok(TxInsertResult::Accepted { tx_id, .. }) => json_response(StatusCode::ACCEPTED, tx_id.to_string()),
+        Ok(TxInsertResult::Rejected { reason, .. }) => text_response(
             match reason {
                 TxRejectReason::MempoolFull => StatusCode::SERVICE_UNAVAILABLE,
                 TxRejectReason::Duplicate => StatusCode::CONFLICT,
@@ -97,10 +97,6 @@ async fn submit_tx(State(mempool_sender): State<SubmitApiState>, headers: Header
             },
             reason.to_string(),
         ),
-        Ok(Err(error)) => {
-            warn!(%error, "mempool insert failed");
-            text_response(StatusCode::INTERNAL_SERVER_ERROR, "mempool unavailable")
-        }
         Err(CallError::TimedOut) => text_response(StatusCode::SERVICE_UNAVAILABLE, "mempool timed out"),
         Err(CallError::SendFailed) => {
             warn!("mempool send failed");
@@ -127,13 +123,7 @@ fn text_response(status: StatusCode, body: impl Into<String>) -> Response {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        net::SocketAddr,
-        sync::{
-            Arc,
-            atomic::{AtomicUsize, Ordering},
-        },
-    };
+    use std::{net::SocketAddr, sync::Arc};
 
     use amaru_consensus::{
         effects::{ResourceBlockValidation, ResourceEraHistory, ResourceTxValidation},
@@ -143,8 +133,7 @@ mod tests {
     use amaru_mempool::{InMemoryMempool, MempoolConfig};
     use amaru_ouroboros::{MempoolMsg, ResourceMempool};
     use amaru_ouroboros_traits::{
-        MempoolError, MempoolSeqNo, MockCanValidateBlocks, MockCanValidateTxs, TransactionValidationError,
-        TxInsertResult, TxSubmissionMempool, overriding_mempool::OverridingMempool,
+        MockCanValidateBlocks, MockCanValidateTxs, TransactionValidationError, TxSubmissionMempool,
     };
     use amaru_protocols::store_effects::ResourceParameters;
     use axum::{
@@ -273,36 +262,6 @@ mod tests {
         assert_eq!(resp.status(), 500);
         assert_eq!(resp.headers()[CONTENT_TYPE], "text/plain; charset=utf-8");
         assert_eq!(to_bytes(resp.into_body(), usize::MAX).await?, "mempool unavailable");
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_mempool_stage_survives_insert_failure() -> anyhow::Result<()> {
-        let attempts = AtomicUsize::new(0);
-        let mempool: Arc<dyn TxSubmissionMempool<Transaction>> = Arc::new(
-            OverridingMempool::builder(Arc::new(InMemoryMempool::default()))
-                .with_insert(move |_, tx: Transaction, _| {
-                    if attempts.fetch_add(1, Ordering::Relaxed) == 0 {
-                        Err(MempoolError::new("temporary failure"))
-                    } else {
-                        Ok(TxInsertResult::accepted(tx.tx_id(), MempoolSeqNo(1)))
-                    }
-                })
-                .build(),
-        );
-        let first = create_transaction(0);
-        let second = create_transaction(1);
-        let sender = make_mempool_sender(mempool, Arc::new(MockCanValidateTxs));
-        let mut headers = HeaderMap::new();
-        headers.insert(CONTENT_TYPE, "application/cbor".parse()?);
-
-        let resp =
-            super::submit_tx(State(sender.clone()), headers.clone(), Bytes::from(amaru_kernel::to_cbor(&first))).await;
-        assert_eq!(resp.status(), 500);
-        assert_eq!(to_bytes(resp.into_body(), usize::MAX).await?, "mempool unavailable");
-
-        let resp = super::submit_tx(State(sender), headers, Bytes::from(amaru_kernel::to_cbor(&second))).await;
-        assert_eq!(resp.status(), 202);
         Ok(())
     }
 

--- a/crates/amaru/src/tests/test_data.rs
+++ b/crates/amaru/src/tests/test_data.rs
@@ -21,13 +21,12 @@ pub fn create_transactions(number: usize) -> Vec<Transaction> {
     (0..number).map(create_transaction).collect()
 }
 
-#[expect(clippy::unwrap_used)]
 pub fn create_transactions_in_mempool(mempool: Arc<dyn Mempool<Transaction>>, number: usize) -> Vec<Transaction> {
     let mut txs = vec![];
     for i in 0..number {
         let tx = create_transaction(i);
         txs.push(tx.clone());
-        let result = mempool.insert(tx.clone(), TxOrigin::Local).unwrap();
+        let result = mempool.insert(tx.clone(), TxOrigin::Local);
         assert!(matches!(result, TxInsertResult::Accepted { .. }), "transaction {tx:?} was rejected: {result:?}");
     }
     txs


### PR DESCRIPTION
@rkuhn I had a look at the review comments left on the `mempool` stage. The most relevant was connected to the use of a `MempoolError` that was never triggered (that was premature engineering), so I removed it.

I don't think that the other concerns are valid but I'm happy to discuss if you think that this is not the case.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified mempool error handling architecture by removing layered error wrapping in transaction insertion and removal operations.
  * Mempool operations now return results directly, improving code clarity and consistency across the transaction submission pipeline.
  * Enhanced system resilience by preventing mempool failures from prematurely terminating stage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->