### PR TITLE
fix: remove optimistic transactions

### DIFF
--- a/crates/amaru-consensus/src/effects/store_effects.rs
+++ b/crates/amaru-consensus/src/effects/store_effects.rs
@@ -36,14 +36,15 @@ impl ExternalEffect for FindBestCandidate {
 }
 
 pub fn find_best_candidate(store: &dyn ReadChainStore) -> Result<HeaderHash, ConsensusError> {
-    let anchor_hash = store.get_anchor_hash();
+    let snapshot = store.snapshot();
+    let anchor_hash = snapshot.get_anchor_hash();
     let mut best_candidate = None;
 
     // ORIGIN_HASH cannot have a block, so we start from its direct children
     let mut to_visit = if anchor_hash == ORIGIN_HASH {
-        store.get_children(&anchor_hash).into_iter().collect()
+        snapshot.get_children(&anchor_hash).into_iter().collect()
     } else {
-        best_candidate = store.load_header(&anchor_hash);
+        best_candidate = snapshot.load_header(&anchor_hash);
         if best_candidate.is_none() {
             return Err(ConsensusError::UnknownPoint(anchor_hash));
         }
@@ -52,14 +53,14 @@ pub fn find_best_candidate(store: &dyn ReadChainStore) -> Result<HeaderHash, Con
     tracing::debug!(?to_visit, ?best_candidate, "starting best_tip_from_store");
 
     while let Some(hash) = to_visit.pop() {
-        let (header, validity) = store.load_header_with_validity(&hash).ok_or(ConsensusError::UnknownPoint(hash))?;
+        let (header, validity) = snapshot.load_header_with_validity(&hash).ok_or(ConsensusError::UnknownPoint(hash))?;
 
         if validity == Some(false) {
             tracing::debug!(%hash, "skipping invalid");
             continue;
         };
 
-        let children = store.get_children(&hash);
+        let children = snapshot.get_children(&hash);
 
         if cmp_tip(Some(&header), best_candidate.as_ref()).is_gt() {
             best_candidate = Some(header);

--- a/crates/amaru-stores/src/rocksdb/consensus/db_ops.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/db_ops.rs
@@ -14,8 +14,7 @@
 
 use amaru_ouroboros_traits::StoreError;
 use rocksdb::{
-    DB, DBCommon, DBIteratorWithThreadMode, DBPinnableSlice, IteratorMode, OptimisticTransactionDB, ReadOptions,
-    SnapshotWithThreadMode,
+    DB, DBCommon, DBIteratorWithThreadMode, DBPinnableSlice, IteratorMode, ReadOptions, SnapshotWithThreadMode,
 };
 
 pub trait DbOps: Sized {
@@ -26,28 +25,6 @@ pub trait DbOps: Sized {
     fn get_pinned(&self, key: &[u8], opts: ReadOptions) -> Result<Option<DBPinnableSlice<'_>>, StoreError>;
     fn multi_get(&self, keys: &[&[u8]], opts: ReadOptions) -> Vec<Result<Option<Vec<u8>>, StoreError>>;
     fn iterator_opt<'a>(&'a self, mode: IteratorMode<'_>, opts: ReadOptions) -> Self::Iter<'a>;
-}
-
-impl DbOps for OptimisticTransactionDB {
-    type Iter<'a>
-        = DBIteratorWithThreadMode<'a, Self>
-    where
-        Self: 'a;
-
-    fn get_pinned(&self, key: &[u8], opts: ReadOptions) -> Result<Option<DBPinnableSlice<'_>>, StoreError> {
-        DBCommon::get_pinned_opt(self, key, &opts).map_err(|e| StoreError::ReadError { error: e.to_string() })
-    }
-
-    fn multi_get(&self, keys: &[&[u8]], opts: ReadOptions) -> Vec<Result<Option<Vec<u8>>, StoreError>> {
-        DBCommon::multi_get_opt(self, keys, &opts)
-            .into_iter()
-            .map(|result| result.map_err(|e| StoreError::ReadError { error: e.to_string() }))
-            .collect()
-    }
-
-    fn iterator_opt<'a>(&'a self, mode: IteratorMode<'_>, opts: ReadOptions) -> Self::Iter<'a> {
-        DBCommon::iterator_opt(self, mode, opts)
-    }
 }
 
 impl DbOps for DB {
@@ -69,33 +46,6 @@ impl DbOps for DB {
 
     fn iterator_opt<'a>(&'a self, mode: IteratorMode<'_>, opts: ReadOptions) -> Self::Iter<'a> {
         DBCommon::iterator_opt(self, mode, opts)
-    }
-}
-
-// FIXME: Switch to full Transaction intead of optimistic?
-//
-// RocksDB iterator errors (transient I/O, corruption) panic the node here.
-// Propagating as StoreError requires changing the `get_children` trait signature
-// across [`BaseReadChainStore`] and all impls/callers. Tracked as follow-up.
-impl DbOps for SnapshotWithThreadMode<'_, OptimisticTransactionDB> {
-    type Iter<'a>
-        = DBIteratorWithThreadMode<'a, OptimisticTransactionDB>
-    where
-        Self: 'a;
-
-    fn get_pinned(&self, key: &[u8], opts: ReadOptions) -> Result<Option<DBPinnableSlice<'_>>, StoreError> {
-        self.get_pinned_opt(key, opts).map_err(|e| StoreError::ReadError { error: e.to_string() })
-    }
-
-    fn multi_get(&self, keys: &[&[u8]], opts: ReadOptions) -> Vec<Result<Option<Vec<u8>>, StoreError>> {
-        self.multi_get_opt(keys, opts)
-            .into_iter()
-            .map(|result| result.map_err(|e| StoreError::ReadError { error: e.to_string() }))
-            .collect()
-    }
-
-    fn iterator_opt<'a>(&'a self, mode: IteratorMode<'_>, opts: ReadOptions) -> Self::Iter<'a> {
-        SnapshotWithThreadMode::iterator_opt(self, mode, opts)
     }
 }
 

--- a/crates/amaru-stores/src/rocksdb/consensus/diagnostic_chain_store.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/diagnostic_chain_store.rs
@@ -14,7 +14,7 @@
 
 use amaru_kernel::{BlockHeader, Hash, HeaderHash, RawBlock, from_cbor, size::HEADER};
 use amaru_ouroboros_traits::{DiagnosticChainStore, Nonces};
-use rocksdb::{DB, IteratorMode, PrefixRange, ReadOptions};
+use rocksdb::{IteratorMode, PrefixRange, ReadOptions};
 
 use crate::rocksdb::consensus::{
     RocksDBStore,
@@ -22,89 +22,6 @@ use crate::rocksdb::consensus::{
 };
 
 impl DiagnosticChainStore for RocksDBStore {
-    #[allow(clippy::panic)]
-    fn load_headers(&self) -> Box<dyn Iterator<Item = BlockHeader> + '_> {
-        Box::new(self.db.prefix_iterator(HEADER_PREFIX).filter_map(|item| match item {
-            Ok((_k, v)) => from_cbor(v.as_ref()),
-            Err(err) => panic!("error iterating over headers: {}", err),
-        }))
-    }
-
-    #[allow(clippy::panic)]
-    fn load_nonces(&self) -> Box<dyn Iterator<Item = (HeaderHash, Nonces)> + '_> {
-        Box::new(self.db.prefix_iterator(NONCES_PREFIX).filter_map(|item| match item {
-            Ok((k, v)) => {
-                let hash = Hash::from(&k[CONSENSUS_PREFIX_LEN..]);
-                from_cbor(&v).map(|nonces| (hash, nonces))
-            }
-            Err(err) => panic!("error iterating over nonces: {}", err),
-        }))
-    }
-
-    #[allow(clippy::panic)]
-    fn load_blocks(&self) -> Box<dyn Iterator<Item = (HeaderHash, RawBlock)> + '_> {
-        let mut opts = ReadOptions::default();
-        opts.set_iterate_range(PrefixRange(&BLOCK_PREFIX[..]));
-        Box::new(self.db.iterator_opt(IteratorMode::Start, opts).map(|item| match item {
-            Ok((k, v)) => {
-                let hash = Hash::from(&k[CONSENSUS_PREFIX_LEN..]);
-                (hash, RawBlock::from(v))
-            }
-            Err(err) => panic!("error iterating over blocks: {}", err),
-        }))
-    }
-
-    #[allow(clippy::expect_used)]
-    fn load_parents_children(&self) -> Box<dyn Iterator<Item = (HeaderHash, Vec<HeaderHash>)> + '_> {
-        let mut groups: Vec<(HeaderHash, Vec<HeaderHash>)> = Vec::new();
-        let mut current_parent: Option<HeaderHash> = None;
-        let mut current_children: Vec<HeaderHash> = Vec::new();
-        let mut opts = ReadOptions::default();
-        opts.set_iterate_range(PrefixRange(&CHILD_PREFIX[..]));
-
-        for kv in self.db.iterator_opt(IteratorMode::Start, opts) {
-            let (k, _v) = kv.expect("error iterating over children keys");
-
-            //Key layout: [CHILD_PREFIX][parent][child]
-            let parent_start = CONSENSUS_PREFIX_LEN;
-            let parent_end = parent_start + HEADER;
-            let child_start = parent_end;
-            let child_end = child_start + HEADER;
-
-            let mut parent_arr = [0u8; HEADER];
-            parent_arr.copy_from_slice(&k[parent_start..parent_end]);
-            let parent_hash = Hash::from(parent_arr);
-
-            let mut child_arr = [0u8; HEADER];
-
-            child_arr.copy_from_slice(&k[child_start..child_end]);
-            let child_hash = Hash::from(child_arr);
-
-            match &current_parent {
-                Some(p) if p == &parent_hash => {
-                    current_children.push(child_hash);
-                }
-                Some(prev_parent) => {
-                    groups.push((*prev_parent, std::mem::take(&mut current_children)));
-                    current_parent = Some(parent_hash);
-                    current_children.push(child_hash);
-                }
-                None => {
-                    current_parent = Some(parent_hash);
-                    current_children.push(child_hash);
-                }
-            }
-        }
-
-        if let Some(p) = current_parent {
-            groups.push((p, current_children));
-        }
-
-        Box::new(groups.into_iter())
-    }
-}
-
-impl DiagnosticChainStore for RocksDBStore<DB> {
     #[allow(clippy::panic)]
     fn load_headers(&self) -> Box<dyn Iterator<Item = BlockHeader> + '_> {
         Box::new(self.db.prefix_iterator(HEADER_PREFIX).filter_map(|item| match item {

--- a/crates/amaru-stores/src/rocksdb/consensus/migration.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/migration.rs
@@ -89,6 +89,7 @@ fn migrate_to_v2(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
     set_version(store, 2)
 }
 
+#[expect(clippy::expect_used)]
 fn migrate_to_v3(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
     // the reason is that v3 stores the block validation result, which cannot be derived from the v2 DB without
     // running the consensus algorithm and ledger validation. previously, blocks were stored before validation,
@@ -97,7 +98,8 @@ fn migrate_to_v3(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
     );
 
     let original_best_chain_point = store.get_best_chain_tip().point();
-    let anchor_point = store.load_header(&store.get_anchor_hash()).map(|h| h.point()).unwrap_or(Point::Origin);
+    let anchor_point =
+        store.load_header(&store.get_anchor_hash()).map(|h| h.point()).expect("the anchor header should always exist");
     store.set_best_chain_hash(&anchor_point.hash())?;
     store.set_block_valid(&anchor_point.hash(), true)?;
 

--- a/crates/amaru-stores/src/rocksdb/consensus/migration.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/migration.rs
@@ -14,14 +14,17 @@
 
 use std::path::Path;
 
-use amaru_kernel::{BlockHeader, Hash, HeaderHash, IsHeader, ORIGIN_HASH, Point, cardano::hash, from_cbor};
-use amaru_ouroboros_traits::StoreError;
+use amaru_kernel::{IsHeader, ORIGIN_HASH, Point};
+use amaru_ouroboros_traits::{BaseReadChainStore, StoreError, WriteChainStore};
 use rocksdb::DB;
 use tracing::info;
 
 use crate::rocksdb::{
     RocksDbConfig,
-    consensus::util::{ANCHOR_PREFIX, BEST_CHAIN_PREFIX, CHAIN_DB_VERSION, CHAIN_PREFIX, HEADER_PREFIX, open_db},
+    consensus::{
+        RocksDBStore,
+        util::{CHAIN_DB_VERSION, CHAIN_PREFIX, open_db},
+    },
 };
 
 /// The version key: __VERSION__
@@ -33,7 +36,7 @@ pub const VERSION_KEY: [u8; 11] = *b"__VERSION__";
 /// migration from version `i` to version `i + 1`.  When modifying the
 /// DB schema, create migration function and add it to this array
 /// bumping its length.
-static MIGRATIONS: [fn(&DB) -> Result<(), StoreError>; CHAIN_DB_VERSION as usize] =
+static MIGRATIONS: [fn(&RocksDBStore<DB>) -> Result<(), StoreError>; CHAIN_DB_VERSION as usize] =
     [migrate_to_v1, migrate_to_v2, migrate_to_v3];
 
 /// Migrate the Chain Database at the given `path` to the current `CHAIN_DB_VERSION`.
@@ -42,115 +45,70 @@ static MIGRATIONS: [fn(&DB) -> Result<(), StoreError>; CHAIN_DB_VERSION as usize
 pub fn migrate_db_path(path: &Path) -> Result<(u16, u16), StoreError> {
     let config = RocksDbConfig::new(path.to_path_buf());
 
-    let (_, db) = open_db(&config)?;
+    let (basedir, db) = open_db(&config)?;
+    let store = RocksDBStore { db, basedir };
 
-    migrate_db(&db)
+    migrate_db(&store)
 }
 
-/// Migrate the given `db` Chain Database to the current `CHAIN_DB_VERSION`.
+/// Migrate the given `store` Chain Database to the current `CHAIN_DB_VERSION`.
 /// Returns the pair of numbers consisting in the initial version of the database and
 /// the current version if migration succeeds, otherwise returns a `StoreError`.
-pub fn migrate_db(db: &DB) -> Result<(u16, u16), StoreError> {
-    let version = get_version(db)?;
+pub fn migrate_db(store: &RocksDBStore<DB>) -> Result<(u16, u16), StoreError> {
+    let version = get_version(store)?;
 
     for n in version..CHAIN_DB_VERSION {
         info!("Migrating Chain database to version {}", n + 1);
-        MIGRATIONS[n as usize](db)?
+        MIGRATIONS[n as usize](store)?
     }
     Ok((version, CHAIN_DB_VERSION))
 }
 
 /// "Migrate" DB to version 1
 /// This simply records the `VERSION_KEY` into the db.
-pub(crate) fn migrate_to_v1(db: &DB) -> Result<(), StoreError> {
-    set_version(db, 1)?;
-    Ok(())
+pub(crate) fn migrate_to_v1(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
+    set_version(store, 1)
 }
 
 /// "Migrate" DB to version 2
 /// Walks the best chain backwards and re-inserts all points.
-fn migrate_to_v2(db: &DB) -> Result<(), StoreError> {
-    let mut hash = match get_best_chain_hash(db) {
-        Some(hash) => hash,
-        // the DB is empty, nothing to do
-        None => return Ok(()),
-    };
+fn migrate_to_v2(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
+    let mut hash = store.get_best_chain_hash();
+    if hash == ORIGIN_HASH {
+        return Ok(());
+    }
 
-    while let Some(header) = load_header(db, &hash) {
-        store_chain_point(db, &header.point())?;
+    while let Some(header) = store.load_header(&hash) {
+        store_chain_point(store, &header.point())?;
         match header.parent() {
             Some(parent) => hash = parent,
             None => break,
         }
     }
 
-    set_version(db, 2)?;
-    Ok(())
+    set_version(store, 2)
 }
 
-fn migrate_to_v3(db: &DB) -> Result<(), StoreError> {
+fn migrate_to_v3(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
     // the reason is that v3 stores the block validation result, which cannot be derived from the v2 DB without
     // running the consensus algorithm and ledger validation. previously, blocks were stored before validation,
     tracing::warn!(
-        "migrating chain DB to version 3 makes possibly incorrect assumption of valid anchor, better start fresh"
+        "migrating chain DB to version 3 makes possibly incorrect assumption of valid best chain, better set it to the anchor hash"
     );
 
-    let (anchor_hash, anchor_point) = if let Some(anchor_hash) = get_anchor_hash(db)
-        && let Some(anchor_header) = load_header(db, &anchor_hash)
-    {
-        (anchor_hash, anchor_header.point())
-    } else {
-        (ORIGIN_HASH, Point::Origin)
-    };
-    let best_chain_point = if let Some(best_chain_hash) = get_best_chain_hash(db)
-        && let Some(best_chain_header) = load_header(db, &best_chain_hash)
-    {
-        best_chain_header.point()
-    } else {
-        Point::Origin
-    };
+    let original_best_chain_point = store.get_best_chain_tip().point();
+    let anchor_point = store.load_header(&store.get_anchor_hash()).map(|h| h.point()).unwrap_or(Point::Origin);
+    store.set_best_chain_hash(&anchor_point.hash())?;
+    store.set_block_valid(&anchor_point.hash(), true)?;
 
-    set_anchor_hash(db, &anchor_hash)?;
-    set_best_chain_hash(db, &anchor_hash)?;
-    set_block_valid(db, &anchor_hash, true)?;
+    tracing::info!(prev_best_chain = %original_best_chain_point, new_best_chain = %anchor_point, "found back best chain to revalidate");
 
-    tracing::info!(prev_best_chain = %best_chain_point, new_best_chain = %anchor_point, "found back best chain to revalidate");
-
-    set_version(db, 3)?;
-    Ok(())
+    set_version(store, 3)
 }
 
-fn load_header(db: &DB, hash: &Hash<32>) -> Option<BlockHeader> {
-    let prefix = [&HEADER_PREFIX[..], &hash[..]].concat();
-    db.get_pinned(prefix).ok().and_then(|bytes| from_cbor(bytes?.as_ref()))
-}
-
-fn get_best_chain_hash(db: &DB) -> Option<HeaderHash> {
-    let bytes = db.get_pinned(BEST_CHAIN_PREFIX).ok().flatten()?;
-    if bytes.len() == hash::size::HEADER { Some(Hash::from(bytes.as_ref())) } else { None }
-}
-
-fn get_anchor_hash(db: &DB) -> Option<HeaderHash> {
-    let bytes = db.get_pinned(ANCHOR_PREFIX).ok().flatten()?;
-    if bytes.len() == hash::size::HEADER { Some(Hash::from(bytes.as_ref())) } else { None }
-}
-
-fn set_best_chain_hash(db: &DB, hash: &HeaderHash) -> Result<(), StoreError> {
-    db.put(BEST_CHAIN_PREFIX, hash.as_ref()).map_err(|e| StoreError::WriteError { error: e.to_string() })
-}
-
-fn set_anchor_hash(db: &DB, hash: &HeaderHash) -> Result<(), StoreError> {
-    db.put(ANCHOR_PREFIX, hash.as_ref()).map_err(|e| StoreError::WriteError { error: e.to_string() })
-}
-
-fn set_block_valid(db: &DB, hash: &HeaderHash, valid: bool) -> Result<(), StoreError> {
-    db.put([&HEADER_PREFIX[..], &hash[..], &[0]].concat(), [valid as u8])
-        .map_err(|e| StoreError::WriteError { error: e.to_string() })
-}
-
-/// Check the version stored in the `db` matches `CHAIN_DB_VERSION`.
-pub fn check_db_version(db: &DB) -> Result<(), StoreError> {
-    get_version(db).and_then(|stored| {
+/// Check the version stored in the `store` matches `CHAIN_DB_VERSION`.
+pub fn check_db_version(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
+    get_version(store).and_then(|stored| {
         if stored != CHAIN_DB_VERSION {
             Err(StoreError::IncompatibleChainStoreVersions { stored, current: CHAIN_DB_VERSION })
         } else {
@@ -159,10 +117,10 @@ pub fn check_db_version(db: &DB) -> Result<(), StoreError> {
     })
 }
 
-/// Retrieve the version of the Chain DB stored in the given `db`.
+/// Retrieve the version of the Chain DB stored in the given `store`.
 /// If no version is stored, returns 0.
-pub fn get_version(db: &DB) -> Result<u16, StoreError> {
-    let raw_version = db.get(VERSION_KEY).map_err(|e| StoreError::OpenError { error: e.to_string() })?;
+pub fn get_version(store: &RocksDBStore<DB>) -> Result<u16, StoreError> {
+    let raw_version = store.db.get(VERSION_KEY).map_err(|e| StoreError::OpenError { error: e.to_string() })?;
 
     match raw_version {
         None => Ok(0),
@@ -173,15 +131,17 @@ pub fn get_version(db: &DB) -> Result<u16, StoreError> {
     }
 }
 
-/// Set the version of the Chain DB stored in the given `db` to the
+/// Set the version of the Chain DB stored in the given `store` to the
 /// current `CHAIN_DB_VERSION`.
-pub fn set_version(db: &DB, version: u16) -> Result<(), StoreError> {
+pub fn set_version(store: &RocksDBStore<DB>, version: u16) -> Result<(), StoreError> {
     let bytes = version.to_be_bytes();
-    db.put(VERSION_KEY, bytes).map_err(|e| StoreError::WriteError { error: e.to_string() })
+    store.db.put(VERSION_KEY, bytes).map_err(|e| StoreError::WriteError { error: e.to_string() })
 }
 
-fn store_chain_point(db: &DB, point: &Point) -> Result<(), StoreError> {
+fn store_chain_point(store: &RocksDBStore<DB>, point: &Point) -> Result<(), StoreError> {
     let slot = u64::from(point.slot_or_default()).to_be_bytes();
-    db.put([&CHAIN_PREFIX[..], &slot[..]].concat(), point.hash().as_ref())
+    store
+        .db
+        .put([&CHAIN_PREFIX[..], &slot[..]].concat(), point.hash().as_ref())
         .map_err(|e| StoreError::WriteError { error: e.to_string() })
 }

--- a/crates/amaru-stores/src/rocksdb/consensus/migration.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/migration.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 
 use amaru_kernel::{BlockHeader, Hash, HeaderHash, IsHeader, ORIGIN_HASH, Point, cardano::hash, from_cbor};
 use amaru_ouroboros_traits::StoreError;
-use rocksdb::OptimisticTransactionDB;
+use rocksdb::DB;
 use tracing::info;
 
 use crate::rocksdb::{
@@ -33,7 +33,7 @@ pub const VERSION_KEY: [u8; 11] = *b"__VERSION__";
 /// migration from version `i` to version `i + 1`.  When modifying the
 /// DB schema, create migration function and add it to this array
 /// bumping its length.
-static MIGRATIONS: [fn(&OptimisticTransactionDB) -> Result<(), StoreError>; CHAIN_DB_VERSION as usize] =
+static MIGRATIONS: [fn(&DB) -> Result<(), StoreError>; CHAIN_DB_VERSION as usize] =
     [migrate_to_v1, migrate_to_v2, migrate_to_v3];
 
 /// Migrate the Chain Database at the given `path` to the current `CHAIN_DB_VERSION`.
@@ -50,7 +50,7 @@ pub fn migrate_db_path(path: &Path) -> Result<(u16, u16), StoreError> {
 /// Migrate the given `db` Chain Database to the current `CHAIN_DB_VERSION`.
 /// Returns the pair of numbers consisting in the initial version of the database and
 /// the current version if migration succeeds, otherwise returns a `StoreError`.
-pub fn migrate_db(db: &OptimisticTransactionDB) -> Result<(u16, u16), StoreError> {
+pub fn migrate_db(db: &DB) -> Result<(u16, u16), StoreError> {
     let version = get_version(db)?;
 
     for n in version..CHAIN_DB_VERSION {
@@ -62,14 +62,14 @@ pub fn migrate_db(db: &OptimisticTransactionDB) -> Result<(u16, u16), StoreError
 
 /// "Migrate" DB to version 1
 /// This simply records the `VERSION_KEY` into the db.
-pub(crate) fn migrate_to_v1(db: &OptimisticTransactionDB) -> Result<(), StoreError> {
+pub(crate) fn migrate_to_v1(db: &DB) -> Result<(), StoreError> {
     set_version(db, 1)?;
     Ok(())
 }
 
 /// "Migrate" DB to version 2
 /// Walks the best chain backwards and re-inserts all points.
-fn migrate_to_v2(db: &OptimisticTransactionDB) -> Result<(), StoreError> {
+fn migrate_to_v2(db: &DB) -> Result<(), StoreError> {
     let mut hash = match get_best_chain_hash(db) {
         Some(hash) => hash,
         // the DB is empty, nothing to do
@@ -88,7 +88,7 @@ fn migrate_to_v2(db: &OptimisticTransactionDB) -> Result<(), StoreError> {
     Ok(())
 }
 
-fn migrate_to_v3(db: &OptimisticTransactionDB) -> Result<(), StoreError> {
+fn migrate_to_v3(db: &DB) -> Result<(), StoreError> {
     // the reason is that v3 stores the block validation result, which cannot be derived from the v2 DB without
     // running the consensus algorithm and ledger validation. previously, blocks were stored before validation,
     tracing::warn!(
@@ -120,42 +120,36 @@ fn migrate_to_v3(db: &OptimisticTransactionDB) -> Result<(), StoreError> {
     Ok(())
 }
 
-// TODO: Less code duplication
-//
-// This function and the following duplicate code in mod.rs The
-// problem is that we need it to be polymorphic in the type of DB but
-// we have 2 different incompatible types, DB and
-// OptimisticTransactionDB.
-fn load_header(db: &OptimisticTransactionDB, hash: &Hash<32>) -> Option<BlockHeader> {
+fn load_header(db: &DB, hash: &Hash<32>) -> Option<BlockHeader> {
     let prefix = [&HEADER_PREFIX[..], &hash[..]].concat();
     db.get_pinned(prefix).ok().and_then(|bytes| from_cbor(bytes?.as_ref()))
 }
 
-fn get_best_chain_hash(db: &OptimisticTransactionDB) -> Option<HeaderHash> {
+fn get_best_chain_hash(db: &DB) -> Option<HeaderHash> {
     let bytes = db.get_pinned(BEST_CHAIN_PREFIX).ok().flatten()?;
     if bytes.len() == hash::size::HEADER { Some(Hash::from(bytes.as_ref())) } else { None }
 }
 
-fn get_anchor_hash(db: &OptimisticTransactionDB) -> Option<HeaderHash> {
+fn get_anchor_hash(db: &DB) -> Option<HeaderHash> {
     let bytes = db.get_pinned(ANCHOR_PREFIX).ok().flatten()?;
     if bytes.len() == hash::size::HEADER { Some(Hash::from(bytes.as_ref())) } else { None }
 }
 
-fn set_best_chain_hash(db: &OptimisticTransactionDB, hash: &HeaderHash) -> Result<(), StoreError> {
+fn set_best_chain_hash(db: &DB, hash: &HeaderHash) -> Result<(), StoreError> {
     db.put(BEST_CHAIN_PREFIX, hash.as_ref()).map_err(|e| StoreError::WriteError { error: e.to_string() })
 }
 
-fn set_anchor_hash(db: &OptimisticTransactionDB, hash: &HeaderHash) -> Result<(), StoreError> {
+fn set_anchor_hash(db: &DB, hash: &HeaderHash) -> Result<(), StoreError> {
     db.put(ANCHOR_PREFIX, hash.as_ref()).map_err(|e| StoreError::WriteError { error: e.to_string() })
 }
 
-fn set_block_valid(db: &OptimisticTransactionDB, hash: &HeaderHash, valid: bool) -> Result<(), StoreError> {
+fn set_block_valid(db: &DB, hash: &HeaderHash, valid: bool) -> Result<(), StoreError> {
     db.put([&HEADER_PREFIX[..], &hash[..], &[0]].concat(), [valid as u8])
         .map_err(|e| StoreError::WriteError { error: e.to_string() })
 }
 
 /// Check the version stored in the `db` matches `CHAIN_DB_VERSION`.
-pub fn check_db_version(db: &OptimisticTransactionDB) -> Result<(), StoreError> {
+pub fn check_db_version(db: &DB) -> Result<(), StoreError> {
     get_version(db).and_then(|stored| {
         if stored != CHAIN_DB_VERSION {
             Err(StoreError::IncompatibleChainStoreVersions { stored, current: CHAIN_DB_VERSION })
@@ -167,7 +161,7 @@ pub fn check_db_version(db: &OptimisticTransactionDB) -> Result<(), StoreError> 
 
 /// Retrieve the version of the Chain DB stored in the given `db`.
 /// If no version is stored, returns 0.
-pub fn get_version(db: &OptimisticTransactionDB) -> Result<u16, StoreError> {
+pub fn get_version(db: &DB) -> Result<u16, StoreError> {
     let raw_version = db.get(VERSION_KEY).map_err(|e| StoreError::OpenError { error: e.to_string() })?;
 
     match raw_version {
@@ -181,12 +175,12 @@ pub fn get_version(db: &OptimisticTransactionDB) -> Result<u16, StoreError> {
 
 /// Set the version of the Chain DB stored in the given `db` to the
 /// current `CHAIN_DB_VERSION`.
-pub fn set_version(db: &OptimisticTransactionDB, version: u16) -> Result<(), StoreError> {
+pub fn set_version(db: &DB, version: u16) -> Result<(), StoreError> {
     let bytes = version.to_be_bytes();
     db.put(VERSION_KEY, bytes).map_err(|e| StoreError::WriteError { error: e.to_string() })
 }
 
-fn store_chain_point(db: &OptimisticTransactionDB, point: &Point) -> Result<(), StoreError> {
+fn store_chain_point(db: &DB, point: &Point) -> Result<(), StoreError> {
     let slot = u64::from(point.slot_or_default()).to_be_bytes();
     db.put([&CHAIN_PREFIX[..], &slot[..]].concat(), point.hash().as_ref())
         .map_err(|e| StoreError::WriteError { error: e.to_string() })

--- a/crates/amaru-stores/src/rocksdb/consensus/migration.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/migration.rs
@@ -89,7 +89,7 @@ fn migrate_to_v2(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
     set_version(store, 2)
 }
 
-#[expect(clippy::expect_used)]
+#[expect(clippy::panic)]
 fn migrate_to_v3(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
     // the reason is that v3 stores the block validation result, which cannot be derived from the v2 DB without
     // running the consensus algorithm and ledger validation. previously, blocks were stored before validation,
@@ -98,8 +98,17 @@ fn migrate_to_v3(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
     );
 
     let original_best_chain_point = store.get_best_chain_tip().point();
-    let anchor_point =
-        store.load_header(&store.get_anchor_hash()).map(|h| h.point()).expect("the anchor header should always exist");
+    let anchor_hash = store.get_anchor_hash();
+    let anchor_point = match store.load_header(&anchor_hash) {
+        Some(header) => header.point(),
+        None => {
+            if anchor_hash == Point::Origin.hash() {
+                Point::Origin
+            } else {
+                panic!("no header found for anchor hash {}", anchor_hash)
+            }
+        }
+    };
     store.set_best_chain_hash(&anchor_point.hash())?;
     store.set_block_valid(&anchor_point.hash(), true)?;
 

--- a/crates/amaru-stores/src/rocksdb/consensus/read_chain_store.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/read_chain_store.rs
@@ -13,15 +13,9 @@
 // limitations under the License.
 
 use amaru_ouroboros_traits::{BaseReadChainStore, ReadChainStore};
-use rocksdb::{DB, OptimisticTransactionDB};
+use rocksdb::DB;
 
 use crate::rocksdb::consensus::RocksDBStore;
-
-impl ReadChainStore for RocksDBStore<OptimisticTransactionDB> {
-    fn snapshot(&self) -> Box<dyn BaseReadChainStore + '_> {
-        Box::new(RocksDBStore { basedir: self.basedir.clone(), db: self.db.snapshot() })
-    }
-}
 
 impl ReadChainStore for RocksDBStore<DB> {
     fn snapshot(&self) -> Box<dyn BaseReadChainStore + '_> {

--- a/crates/amaru-stores/src/rocksdb/consensus/rocksdb_store.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/rocksdb_store.rs
@@ -109,24 +109,23 @@ impl RocksDBStore<DB> {
     }
 
     pub fn remove_block(&self, hash: &HeaderHash) -> Result<(), StoreError> {
-        self.db
-            .delete([&BLOCK_PREFIX[..], &hash[..]].concat())
-            .map_err(|e| StoreError::WriteError { error: e.to_string() })?;
-        self.remove_block_valid(hash)?;
-        Ok(())
+        self.with_batch(|batch| {
+            batch.delete([&BLOCK_PREFIX[..], &hash[..]].concat());
+            batch.delete([&HEADER_PREFIX[..], &hash[..], &[0]].concat());
+            Ok(())
+        })
     }
 
     pub fn remove_header(&self, hash: &HeaderHash) -> Result<(), StoreError> {
         let parent = self.load_header(hash).and_then(|h| h.parent());
-        if let Some(parent) = parent {
-            self.db
-                .delete([&CHILD_PREFIX[..], &parent[..], &hash[..]].concat())
-                .map_err(|e| StoreError::WriteError { error: e.to_string() })?;
-        }
-        self.db
-            .delete([&HEADER_PREFIX[..], &hash[..]].concat())
-            .map_err(|e| StoreError::WriteError { error: e.to_string() })?;
-        self.remove_block(hash)?;
-        Ok(())
+        self.with_batch(|batch| {
+            if let Some(parent) = parent {
+                batch.delete([&CHILD_PREFIX[..], &parent[..], &hash[..]].concat());
+            }
+            batch.delete([&HEADER_PREFIX[..], &hash[..]].concat());
+            batch.delete([&BLOCK_PREFIX[..], &hash[..]].concat());
+            batch.delete([&HEADER_PREFIX[..], &hash[..], &[0]].concat());
+            Ok(())
+        })
     }
 }

--- a/crates/amaru-stores/src/rocksdb/consensus/rocksdb_store.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/rocksdb_store.rs
@@ -16,14 +16,14 @@ use std::{fs, path::PathBuf};
 
 use amaru_kernel::{HeaderHash, IsHeader as _};
 use amaru_ouroboros_traits::{BaseReadChainStore, StoreError};
-use rocksdb::{Options, WriteBatch, DB};
+use rocksdb::{DB, Options, WriteBatch};
 
 use crate::rocksdb::{
-    consensus::{
-        check_db_version, migrate_db, set_version, util::{open_db, open_or_create_db, BLOCK_PREFIX, CHAIN_DB_VERSION, CHILD_PREFIX, HEADER_PREFIX},
-        DbOps,
-    },
     RocksDbConfig,
+    consensus::{
+        DbOps, check_db_version, migrate_db, set_version,
+        util::{BLOCK_PREFIX, CHAIN_DB_VERSION, CHILD_PREFIX, HEADER_PREFIX, open_db, open_or_create_db},
+    },
 };
 
 pub struct RocksDBStore<T: DbOps = DB> {
@@ -39,8 +39,9 @@ impl RocksDBStore<DB> {
     /// * the DB exists but with an incompatible version
     pub fn open(config: &RocksDbConfig) -> Result<Self, StoreError> {
         let (basedir, db) = open_db(config)?;
-        check_db_version(&db)?;
-        Ok(Self { db, basedir })
+        let store = Self { db, basedir };
+        check_db_version(&store)?;
+        Ok(store)
     }
 
     /// Create a `RocksDBStore` with given configuration.
@@ -61,9 +62,10 @@ impl RocksDBStore<DB> {
         }
 
         let (_, db) = open_or_create_db(&config)?;
-        set_version(&db, CHAIN_DB_VERSION)?;
+        let store = Self { db, basedir };
+        set_version(&store, CHAIN_DB_VERSION)?;
 
-        Ok(Self { db, basedir })
+        Ok(store)
     }
 
     /// Open or create a `RocksDBStore` with given configuration.
@@ -72,10 +74,11 @@ impl RocksDBStore<DB> {
     /// DB it opens or creates which can potentially causes data corruption.
     pub fn open_and_migrate(config: &RocksDbConfig) -> Result<Self, StoreError> {
         let (basedir, db) = open_or_create_db(config)?;
+        let store = Self { db, basedir };
 
-        migrate_db(&db)?;
+        migrate_db(&store)?;
 
-        Ok(Self { db, basedir })
+        Ok(store)
     }
 
     pub fn open_for_readonly(config: &RocksDbConfig) -> Result<Self, StoreError> {

--- a/crates/amaru-stores/src/rocksdb/consensus/rocksdb_store.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/rocksdb_store.rs
@@ -16,22 +16,22 @@ use std::{fs, path::PathBuf};
 
 use amaru_kernel::{HeaderHash, IsHeader as _};
 use amaru_ouroboros_traits::{BaseReadChainStore, StoreError};
-use rocksdb::{DB, OptimisticTransactionDB, Options};
+use rocksdb::{Options, WriteBatch, DB};
 
 use crate::rocksdb::{
-    RocksDbConfig,
     consensus::{
-        DbOps, check_db_version, migrate_db, set_version,
-        util::{BLOCK_PREFIX, CHAIN_DB_VERSION, CHILD_PREFIX, HEADER_PREFIX, open_db, open_or_create_db},
+        check_db_version, migrate_db, set_version, util::{open_db, open_or_create_db, BLOCK_PREFIX, CHAIN_DB_VERSION, CHILD_PREFIX, HEADER_PREFIX},
+        DbOps,
     },
+    RocksDbConfig,
 };
 
-pub struct RocksDBStore<T: DbOps = OptimisticTransactionDB> {
+pub struct RocksDBStore<T: DbOps = DB> {
     pub basedir: PathBuf,
     pub db: T,
 }
 
-impl RocksDBStore<OptimisticTransactionDB> {
+impl RocksDBStore<DB> {
     /// Open an existing `RocksDBStore` with given configuration.
     ///
     /// This function will fail if:
@@ -78,26 +78,25 @@ impl RocksDBStore<OptimisticTransactionDB> {
         Ok(Self { db, basedir })
     }
 
-    pub fn create_transaction(&self) -> rocksdb::Transaction<'_, OptimisticTransactionDB> {
-        self.db.transaction()
+    pub fn open_for_readonly(config: &RocksDbConfig) -> Result<Self, StoreError> {
+        let basedir = config.dir.clone();
+        let opts: Options = config.into();
+        let db = DB::open_for_read_only(&opts, &basedir, false)
+            .map_err(|e| StoreError::OpenError { error: e.to_string() })?;
+        Ok(Self { db, basedir })
     }
 
-    /// Runs the provided closure within a transaction.
+    /// Runs the provided closure with a fresh `WriteBatch`, then commits it atomically.
     ///
-    /// The transaction is committed if the closure returns `Ok`, otherwise it is rolled back.
-    /// Note the `commit` itself can also fail which is reported as a `StoreError::WriteError`.
-    pub fn with_transaction<R, F>(&self, f: F) -> Result<R, StoreError>
+    /// All puts/deletes accumulated in the batch are executed atomically (or not at all).
+    /// If the closure short-circuits by returning `Err` then nothing is written.
+    pub fn with_batch<F>(&self, f: F) -> Result<(), StoreError>
     where
-        F: FnOnce(&rocksdb::Transaction<'_, OptimisticTransactionDB>) -> Result<R, StoreError>,
+        F: FnOnce(&mut WriteBatch) -> Result<(), StoreError>,
     {
-        let tx = self.db.transaction();
-        match f(&tx) {
-            Ok(result) => {
-                tx.commit().map_err(|e| StoreError::WriteError { error: e.to_string() })?;
-                Ok(result)
-            }
-            Err(err) => Err(err),
-        }
+        let mut batch = WriteBatch::default();
+        f(&mut batch)?;
+        self.db.write(batch).map_err(|e| StoreError::WriteError { error: e.to_string() })
     }
 
     pub fn remove_block_valid(&self, hash: &HeaderHash) -> Result<(), StoreError> {
@@ -126,15 +125,5 @@ impl RocksDBStore<OptimisticTransactionDB> {
             .map_err(|e| StoreError::WriteError { error: e.to_string() })?;
         self.remove_block(hash)?;
         Ok(())
-    }
-}
-
-impl RocksDBStore<DB> {
-    pub fn open_for_readonly(config: &RocksDbConfig) -> Result<Self, StoreError> {
-        let basedir = config.dir.clone();
-        let opts: Options = config.into();
-        let db = DB::open_for_read_only(&opts, &basedir, false)
-            .map_err(|e| StoreError::OpenError { error: e.to_string() })?;
-        Ok(Self { db, basedir })
     }
 }

--- a/crates/amaru-stores/src/rocksdb/consensus/tests.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/tests.rs
@@ -1160,7 +1160,7 @@ fn creates_a_database_with_current_version_given_directory_is_empty() {
     let basedir = init_dir(path);
 
     let store = RocksDBStore::create(RocksDbConfig::new(basedir)).expect("should create DB successfully");
-    let version = get_version(&store.db).expect("should read version successfully");
+    let version = get_version(&store).expect("should read version successfully");
 
     assert_eq!(version, CHAIN_DB_VERSION);
 }
@@ -1175,10 +1175,12 @@ fn can_convert_v0_sample_db_to_v1() {
 
     copy_recursively(source, target).unwrap();
 
-    let (_, db) = open_db(&config).expect("cannot open sample v0 DB");
-    migrate_to_v1(&db).expect("Migration should succeed");
+    let (basedir, db) = open_db(&config).expect("cannot open sample v0 DB");
+    let store = RocksDBStore { db, basedir };
+    migrate_to_v1(&store).expect("Migration should succeed");
 
-    let header: Option<BlockHeader> = db
+    let header: Option<BlockHeader> = store
+        .db
         .get_pinned([&HEADER_PREFIX[..], hex::decode(SAMPLE_HASH).unwrap().as_slice()].concat())
         .ok()
         .and_then(|bytes| from_cbor(bytes?.as_ref()));
@@ -1236,7 +1238,7 @@ fn open_or_create_succeeds_given_directory_exists() {
     copy_recursively(source, target).unwrap();
 
     let store = RocksDBStore::open_and_migrate(&config).expect("should create DB successfully");
-    let version = get_version(&store.db).expect("should read version successfully");
+    let version = get_version(&store).expect("should read version successfully");
 
     assert_eq!(version, CHAIN_DB_VERSION);
 }

--- a/crates/amaru-stores/src/rocksdb/consensus/util.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/util.rs
@@ -15,7 +15,7 @@
 use std::path::PathBuf;
 
 use amaru_ouroboros_traits::StoreError;
-use rocksdb::{OptimisticTransactionDB, Options};
+use rocksdb::{DB, Options};
 
 use crate::rocksdb::RocksDbConfig;
 
@@ -37,7 +37,7 @@ pub(crate) const NONCES_PREFIX: [u8; CONSENSUS_PREFIX_LEN] = *b"nonce";
 
 /// Open a Chain DB for reading and writing.
 /// The DB _must_ exist otherwise the function will return an error.
-pub fn open_db(config: &RocksDbConfig) -> Result<(PathBuf, OptimisticTransactionDB), StoreError> {
+pub fn open_db(config: &RocksDbConfig) -> Result<(PathBuf, DB), StoreError> {
     let basedir = config.dir.clone();
     let mut opts: Options = config.into();
     opts.create_if_missing(false);
@@ -47,7 +47,7 @@ pub fn open_db(config: &RocksDbConfig) -> Result<(PathBuf, OptimisticTransaction
 
 /// Create or open a Chain DB for reading and writing.
 /// The DB _may_ exist, if it does not it will be created.
-pub fn open_or_create_db(config: &RocksDbConfig) -> Result<(PathBuf, OptimisticTransactionDB), StoreError> {
+pub fn open_or_create_db(config: &RocksDbConfig) -> Result<(PathBuf, DB), StoreError> {
     let basedir = config.dir.clone();
     let mut opts: Options = config.into();
     opts.create_if_missing(true);
@@ -55,9 +55,8 @@ pub fn open_or_create_db(config: &RocksDbConfig) -> Result<(PathBuf, OptimisticT
     Ok((basedir, db))
 }
 
-fn do_open_rocks_db(basedir: &PathBuf, mut opts: Options) -> Result<OptimisticTransactionDB, StoreError> {
+fn do_open_rocks_db(basedir: &PathBuf, mut opts: Options) -> Result<DB, StoreError> {
     opts.set_prefix_extractor(rocksdb::SliceTransform::create_fixed_prefix(CONSENSUS_PREFIX_LEN));
-    let db =
-        OptimisticTransactionDB::open(&opts, basedir).map_err(|e| StoreError::OpenError { error: e.to_string() })?;
+    let db = DB::open(&opts, basedir).map_err(|e| StoreError::OpenError { error: e.to_string() })?;
     Ok(db)
 }

--- a/crates/amaru-stores/src/rocksdb/consensus/write_chain_store.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/write_chain_store.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{BlockHeader, HeaderHash, IsHeader, ORIGIN_HASH, Point, RawBlock, size::HEADER, to_cbor};
+use amaru_kernel::{size::HEADER, to_cbor, BlockHeader, HeaderHash, IsHeader, Point, RawBlock, ORIGIN_HASH};
 use amaru_observability::trace_span;
 use amaru_ouroboros_traits::{Nonces, StoreError, WriteChainStore};
 use rocksdb::{IteratorMode, PrefixRange, ReadOptions};
 
 use crate::rocksdb::consensus::{
-    RocksDBStore,
     util::{ANCHOR_PREFIX, BEST_CHAIN_PREFIX, BLOCK_PREFIX, CHAIN_PREFIX, CHILD_PREFIX, HEADER_PREFIX, NONCES_PREFIX},
+    RocksDBStore,
 };
 
 impl WriteChainStore for RocksDBStore {
@@ -36,11 +36,9 @@ impl WriteChainStore for RocksDBStore {
         let hash = header.hash();
         let parent_hash = header.parent().unwrap_or(ORIGIN_HASH);
 
-        self.with_transaction(|tx| {
-            tx.put([&CHILD_PREFIX[..], &parent_hash[..], &hash[..]].concat(), [])
-                .map_err(|e| StoreError::WriteError { error: e.to_string() })?;
-            tx.put([&HEADER_PREFIX[..], &hash[..]].concat(), to_cbor(header))
-                .map_err(|e| StoreError::WriteError { error: e.to_string() })?;
+        self.with_batch(|batch| {
+            batch.put([&CHILD_PREFIX[..], &parent_hash[..], &hash[..]].concat(), []);
+            batch.put([&HEADER_PREFIX[..], &hash[..]].concat(), to_cbor(header));
             Ok(())
         })
     }
@@ -95,49 +93,45 @@ impl WriteChainStore for RocksDBStore {
         let fork_slot = u64::from(fork_point.slot_or_default()).to_be_bytes();
         let fork_key = [&CHAIN_PREFIX[..], &fork_slot[..]].concat();
 
+        // `adopt_chain` is the only writer of `CHAIN_PREFIX`/`BEST_CHAIN_PREFIX` and processes its
+        // mailbox sequentially, so the read here and the subsequent batch write below cannot race.
+        let existing = self.db.get_pinned(&fork_key).map_err(|e| StoreError::ReadError { error: e.to_string() })?;
+        let matches = existing
+            .as_ref()
+            .map(|bytes| bytes.len() == HEADER && bytes.as_ref() == fork_point.hash().as_ref())
+            .unwrap_or(false);
+        if !matches {
+            return Err(StoreError::ReadError {
+                error: format!(
+                    "Cannot switch to a fork from point {:?} as it does not exist on the best chain",
+                    fork_point
+                ),
+            });
+        }
+
         let slot = (u64::from(fork_point.slot_or_default()) + 1).to_be_bytes();
         let mut opts = ReadOptions::default();
         opts.set_iterate_range(PrefixRange(&CHAIN_PREFIX[..]));
         let starting_point = [&CHAIN_PREFIX[..], &slot[..]].concat();
         let mode = IteratorMode::From(starting_point.as_slice(), rocksdb::Direction::Forward);
 
-        self.with_transaction(|tx| {
-            // Validate the fork point *inside* the transaction using `get_for_update`, so any
-            // concurrent writer that deletes or overwrites the fork-point chain entry causes
-            // this transaction to conflict on commit rather than silently succeeding against
-            // stale state.
-            let existing =
-                tx.get_for_update(&fork_key, true).map_err(|e| StoreError::ReadError { error: e.to_string() })?;
-            let matches = existing
-                .as_ref()
-                .map(|bytes| bytes.len() == HEADER && bytes.as_slice() == fork_point.hash().as_ref())
-                .unwrap_or(false);
-            if !matches {
-                return Err(StoreError::ReadError {
-                    error: format!(
-                        "Cannot switch to a fork from point {:?} as it does not exist on the best chain",
-                        fork_point
-                    ),
-                });
-            }
+        let keys_to_delete: Vec<_> = self
+            .db
+            .iterator_opt(mode, opts)
+            .map(|kv| kv.map(|(key, _)| key).map_err(|e| StoreError::ReadError { error: e.to_string() }))
+            .collect::<Result<_, _>>()?;
 
-            let keys_to_delete: Vec<_> = tx
-                .iterator_opt(mode, opts)
-                .map(|kv| kv.map(|(key, _)| key).map_err(|e| StoreError::ReadError { error: e.to_string() }))
-                .collect::<Result<_, _>>()?;
-
+        self.with_batch(|batch| {
             for key in keys_to_delete {
-                tx.delete(key).map_err(|e| StoreError::WriteError { error: e.to_string() })?;
+                batch.delete(key);
             }
 
             for point in forward_points.iter() {
                 let slot = u64::from(point.slot_or_default()).to_be_bytes();
-                tx.put([&CHAIN_PREFIX[..], &slot[..]].concat(), point.hash().as_ref())
-                    .map_err(|e| StoreError::WriteError { error: e.to_string() })?;
+                batch.put([&CHAIN_PREFIX[..], &slot[..]].concat(), point.hash().as_ref());
             }
 
-            tx.put(BEST_CHAIN_PREFIX, forward_points.last().unwrap_or(fork_point).hash().as_ref())
-                .map_err(|e| StoreError::WriteError { error: e.to_string() })?;
+            batch.put(BEST_CHAIN_PREFIX, forward_points.last().unwrap_or(fork_point).hash().as_ref());
 
             Ok(())
         })
@@ -154,12 +148,10 @@ impl WriteChainStore for RocksDBStore {
         );
         let _guard = _span.enter();
 
-        self.with_transaction(|tx| {
+        self.with_batch(|batch| {
             let slot = u64::from(point.slot_or_default()).to_be_bytes();
-            tx.put([&CHAIN_PREFIX[..], &slot[..]].concat(), point.hash().as_ref())
-                .map_err(|e| StoreError::WriteError { error: e.to_string() })?;
-            tx.put(BEST_CHAIN_PREFIX, point.hash().as_ref())
-                .map_err(|e| StoreError::WriteError { error: e.to_string() })?;
+            batch.put([&CHAIN_PREFIX[..], &slot[..]].concat(), point.hash().as_ref());
+            batch.put(BEST_CHAIN_PREFIX, point.hash().as_ref());
             Ok(())
         })
     }

--- a/crates/amaru-stores/src/rocksdb/consensus/write_chain_store.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/write_chain_store.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{size::HEADER, to_cbor, BlockHeader, HeaderHash, IsHeader, Point, RawBlock, ORIGIN_HASH};
+use amaru_kernel::{BlockHeader, HeaderHash, IsHeader, ORIGIN_HASH, Point, RawBlock, size::HEADER, to_cbor};
 use amaru_observability::trace_span;
 use amaru_ouroboros_traits::{Nonces, StoreError, WriteChainStore};
 use rocksdb::{IteratorMode, PrefixRange, ReadOptions};
 
 use crate::rocksdb::consensus::{
-    util::{ANCHOR_PREFIX, BEST_CHAIN_PREFIX, BLOCK_PREFIX, CHAIN_PREFIX, CHILD_PREFIX, HEADER_PREFIX, NONCES_PREFIX},
     RocksDBStore,
+    util::{ANCHOR_PREFIX, BEST_CHAIN_PREFIX, BLOCK_PREFIX, CHAIN_PREFIX, CHILD_PREFIX, HEADER_PREFIX, NONCES_PREFIX},
 };
 
 impl WriteChainStore for RocksDBStore {

--- a/crates/amaru/src/bin/amaru/cmd/migrate_chain_db.rs
+++ b/crates/amaru/src/bin/amaru/cmd/migrate_chain_db.rs
@@ -20,7 +20,7 @@ use amaru_observability::{MIGRATING_DATABASE, OPENING_CHAIN_DB};
 use amaru_ouroboros::StoreError;
 use amaru_stores::rocksdb::{
     RocksDbConfig,
-    consensus::{check_db_version, migrate_db, util::open_db},
+    consensus::{RocksDBStore, check_db_version, migrate_db, util::open_db},
 };
 use clap::Parser;
 use tracing::{error, info, info_span};
@@ -58,14 +58,15 @@ pub async fn run(args: Args) -> Result<(), Box<dyn Error>> {
     );
 
     Ok(info_span!(OPENING_CHAIN_DB, path = %config.dir.display()).in_scope(|| {
-        let (_, db) = open_db(&config)?;
-        match check_db_version(&db) {
+        let (basedir, db) = open_db(&config)?;
+        let store = RocksDBStore { db, basedir };
+        match check_db_version(&store) {
             Ok(()) => {
                 info!("already up to date, no migration needed.");
                 Ok(())
             }
             Err(StoreError::IncompatibleChainStoreVersions { stored, current }) => {
-                info_span!(MIGRATING_DATABASE, from = stored, to = current).in_scope(|| migrate_db(&db))?;
+                info_span!(MIGRATING_DATABASE, from = stored, to = current).in_scope(|| migrate_db(&store))?;
                 Ok(())
             }
             Err(e) => {


### PR DESCRIPTION
This PR removes the need for dealing with optimistic transactions inside RockDB.

The consensus stages are designed so that concurrent writes the same type of data cannot occur so there is no need to retry a failed optimistic transaction. However this PR used batched writes to make sure that related writes to the database are still made atomically.

There is also a small fix included to use a snapshot for `find_best_candidate`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consensus DB now uses a unified store wrapper and defaults to a simpler DB backend; transaction APIs replaced by atomic batch writes for more predictable updates.

* **New Features**
  * Migration tooling and CLI updated to run migrations through the store wrapper, improving upgrade reliability and version handling.

* **Bug Fixes**
  * Snapshot/read and fork/traversal logic adjusted to reduce edge-case inconsistencies when reading, migrating, and selecting best candidates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->