### PR TITLE
feat: workflow to create and publish bootstrap snapshots

### DIFF
--- a/.github/workflows/publish-bootstrap-snapshots.yml
+++ b/.github/workflows/publish-bootstrap-snapshots.yml
@@ -1,0 +1,225 @@
+name: Publish Bootstrap Snapshots
+
+# See docs/PUBLISHING_SNAPSHOTS.md for runner provisioning and operations.
+
+on:
+  workflow_dispatch:
+    inputs:
+      network:
+        description: "Network to publish snapshots for"
+        required: true
+        type: choice
+        options:
+          - preprod
+          - preview
+          - mainnet
+          - all
+        default: preprod
+      epoch:
+        description: "Start epoch of the three-epoch snapshot set (defaults to the last three completed epochs)"
+        required: false
+        type: string
+        default: ""
+      skip_verification:
+        description: "Skip the bootstrap smoke test against the published snapshots"
+        required: false
+        type: boolean
+        default: false
+      cardano_node_version:
+        description: "cardano-node release tag to download db-analyser from (must be a published release tag, e.g. 11.0.1)"
+        required: false
+        type: string
+        default: "11.0.1"
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTUP_LOG: error
+  CARDANO_NODE_VERSION: ${{ inputs.cardano_node_version }}
+
+jobs:
+  publish:
+    name: Create & publish ${{ matrix.network }} bootstrap snapshots
+    runs-on: [self-hosted, snapshots]
+    timeout-minutes: 2880
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        network: ${{ inputs.network == 'all' && fromJSON('["preview", "preprod", "mainnet"]') || fromJSON(format('["{0}"]', inputs.network)) }}
+    concurrency:
+      group: publish-snapshots-${{ matrix.network }}
+      cancel-in-progress: false
+    env:
+      AMARU_NETWORK: ${{ matrix.network }}
+      INPUT_EPOCH: ${{ inputs.epoch }}
+      MANIFEST: crates/amaru/config/bootstrap/${{ matrix.network }}/snapshots.json
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Preflight checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -n "$INPUT_EPOCH" ]; then
+            if ! [[ "$INPUT_EPOCH" =~ ^[0-9]+$ ]] || [ "$INPUT_EPOCH" -eq 0 ]; then
+              echo "::error::epoch must be a positive integer (non-zero), got '$INPUT_EPOCH'" >&2
+              exit 1
+            fi
+          fi
+
+      - name: Resolve persistent cache directories
+        shell: bash
+        run: |
+          set -euo pipefail
+          CACHE_ROOT="${{ vars.SNAPSHOTS_CACHE_DIR || '' }}"
+          if [ -z "$CACHE_ROOT" ]; then
+            CACHE_ROOT="$HOME/amaru-snapshots"
+          fi
+          mkdir -p "$CACHE_ROOT/$AMARU_NETWORK"
+          echo "CACHE_ROOT=$CACHE_ROOT" >> "$GITHUB_ENV"
+          echo "AMARU_DIST_DIR=$CACHE_ROOT/$AMARU_NETWORK/dist" >> "$GITHUB_ENV"
+          echo "AMARU_SNAPSHOTS_DIR=$CACHE_ROOT/$AMARU_NETWORK/snapshots" >> "$GITHUB_ENV"
+
+      - name: Install db-analyser
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$(uname -s)" in
+            Linux) os=linux ;;
+            Darwin) os=macos ;;
+            *) echo "::error::unsupported operating system: $(uname -s)" >&2; exit 1 ;;
+          esac
+          case "$(uname -m)" in
+            x86_64 | amd64) arch=amd64 ;;
+            arm64 | aarch64) arch=arm64 ;;
+            *) echo "::error::unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+          esac
+
+          asset="cardano-node-$CARDANO_NODE_VERSION-$os-$arch.tar.gz"
+          base_url="https://github.com/IntersectMBO/cardano-node/releases/download/$CARDANO_NODE_VERSION"
+          tmp="$(mktemp -d)"
+          echo "DB_ANALYSER_TMP=$tmp" >> "$GITHUB_ENV"
+          echo "downloading $base_url/$asset"
+          curl -fsSL -o "$tmp/$asset" "$base_url/$asset"
+          curl -fsSL -o "$tmp/sums.txt" "$base_url/cardano-node-$CARDANO_NODE_VERSION-sha256sums.txt"
+          (cd "$tmp" && grep " $asset\$" sums.txt | (sha256sum -c - 2>/dev/null || shasum -a 256 -c -))
+          tar -xzf "$tmp/$asset" -C "$tmp" --strip-components 1
+          rm "$tmp/$asset" "$tmp/sums.txt"
+          echo "$tmp/bin" >> "$GITHUB_PATH"
+
+      - name: Build amaru
+        shell: bash
+        run: |
+          cargo build --release --bin amaru
+
+      - name: Create snapshots
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./target/release/amaru create-snapshots \
+            --network "$AMARU_NETWORK" \
+            --force \
+            ${INPUT_EPOCH:+--epoch "$INPUT_EPOCH"}
+
+      - name: Publish snapshots to R2 and update manifest
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+          BUCKET_NAME: ${{ secrets.SNAPSHOTS_BUCKET_NAME }}
+          PUBLIC_URL_BASE: ${{ vars.SNAPSHOTS_PUBLIC_URL_BASE || secrets.SNAPSHOTS_PUBLIC_URL_BASE || '' }}
+        run: |
+          set -euo pipefail
+          bash ./scripts/publish-bootstrap-snapshots ${INPUT_EPOCH:+"$INPUT_EPOCH"}
+          git --no-pager diff -- "$MANIFEST"
+
+      - name: Verify published snapshots with a full bootstrap
+        if: ${{ !inputs.skip_verification }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          SCRATCH="$(mktemp -d)"
+          echo "SCRATCH=$SCRATCH" >> "$GITHUB_ENV"
+          cd "$SCRATCH"
+          AMARU_BOOTSTRAP_CONFIG_DIR="$GITHUB_WORKSPACE/crates/amaru/config/bootstrap" \
+          "$GITHUB_WORKSPACE/target/release/amaru" bootstrap \
+            --network "$AMARU_NETWORK" \
+            --ledger-dir "$SCRATCH/ledger.db" \
+            --chain-dir "$SCRATCH/chain.db" \
+            ${INPUT_EPOCH:+--epoch "$INPUT_EPOCH"}
+          test -d "$SCRATCH/ledger.db"
+          test -d "$SCRATCH/chain.db"
+
+      - name: Clean up smoke test scratch directory
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          if [ -n "${SCRATCH:-}" ]; then
+            rm -rf "$SCRATCH"
+          fi
+          if [ -n "${DB_ANALYSER_TMP:-}" ]; then
+            rm -rf "$DB_ANALYSER_TMP"
+          fi
+
+      - name: Open pull request updating the manifest
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- "$MANIFEST"; then
+            echo "$MANIFEST unchanged; snapshots were already published"
+            exit 0
+          fi
+
+          EPOCHS="$(jq -r '[.[-3:][].epoch | tostring] | join(", ")' "$MANIFEST")"
+          TITLE="chore: update $AMARU_NETWORK bootstrap snapshots (epochs $EPOCHS)"
+          BRANCH="snapshots/$AMARU_NETWORK-$(date -u +%Y%m%d%H%M%S)"
+          HEAD_SHA="$(git rev-parse HEAD)"
+
+          gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/heads/$BRANCH" \
+            -f sha="$HEAD_SHA"
+
+          gh api graphql \
+            -f query='mutation($input: CreateCommitOnBranchInput!) {
+              createCommitOnBranch(input: $input) { commit { oid } }
+            }' \
+            -F 'input[branch][repositoryNameWithOwner]'="$GITHUB_REPOSITORY" \
+            -F 'input[branch][branchName]'="$BRANCH" \
+            -F 'input[expectedHeadOid]'="$HEAD_SHA" \
+            -F 'input[message][headline]'="$TITLE" \
+            -F 'input[message][body]'="Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>" \
+            -F 'input[fileChanges][additions][][path]'="$MANIFEST" \
+            -F 'input[fileChanges][additions][][contents]'="$(base64 < "$MANIFEST" | tr -d '\n')"
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "$TITLE" \
+            --body "$(cat <<EOF
+          Automated bootstrap snapshot publication for \`$AMARU_NETWORK\` (epochs $EPOCHS).
+
+          The archives referenced by this manifest were uploaded to R2, checked for public
+          reachability and verified with a full \`amaru bootstrap\` smoke test by
+          [this workflow run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID).
+
+          CI was dispatched explicitly on this branch (pull requests opened with
+          \`GITHUB_TOKEN\` do not trigger \`pull_request\` workflows on their own).
+          EOF
+          )"
+
+          gh workflow run continuous-integration.yml --ref "$BRANCH" \
+            || echo "::warning::failed to dispatch continuous-integration.yml on $BRANCH"
+          gh workflow run coding-practices.yml --ref "$BRANCH" \
+            || echo "::warning::failed to dispatch coding-practices.yml on $BRANCH"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Other guiding principles:
 
 - **amaru-ledger**: add more state to `ValidationContext`, enabling the introduction of ledger predicates that depend on state such as pools, governance, and more. ([#975][])
 
+- **workflows**: dedicated workflow to create and publish bootstrapping snapshots for all networks. ([#951][])
+
 ### Changed
 
 - **amaru-ledger**: redesigned the `VolatileDB`, providing faster lookups and a design that is easier to reason about. ([#963][], [#983][])
@@ -95,6 +97,7 @@ Other guiding principles:
 [#778]: https://github.com/pragma-org/amaru/issues/778
 [#886]: https://github.com/pragma-org/amaru/pull/886
 [#942]: https://github.com/pragma-org/amaru/pull/942
+[#951]: https://github.com/pragma-org/amaru/pull/951
 [#953]: https://github.com/pragma-org/amaru/pull/953
 [#954]: https://github.com/pragma-org/amaru/pull/954
 [#959]: https://github.com/pragma-org/amaru/pull/959

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,7 @@ name = "amaru-mithril"
 version = "0.1.2"
 dependencies = [
  "amaru-kernel",
+ "anyhow",
  "async-trait",
  "flate2",
  "indicatif",

--- a/crates/amaru-mithril/Cargo.toml
+++ b/crates/amaru-mithril/Cargo.toml
@@ -17,6 +17,7 @@ categories.workspace = true
 
 [dependencies]
 # External dependencies ───────────────────────────────────────────────────────┐
+anyhow.workspace = true
 async-trait.workspace = true
 flate2.workspace = true
 indicatif.workspace = true

--- a/crates/amaru-mithril/src/lib.rs
+++ b/crates/amaru-mithril/src/lib.rs
@@ -21,7 +21,7 @@ use std::{
     sync::Arc,
 };
 
-use amaru_kernel::{Hasher, NetworkName, Point, Slot, cbor};
+use amaru_kernel::{GlobalParameters, Hasher, NetworkName, Point, cbor};
 use async_trait::async_trait;
 use flate2::{Compression, GzBuilder};
 use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
@@ -377,12 +377,16 @@ pub fn first_missing_immutable_chunk(immutable_dir: &Path) -> Result<u64, io::Er
     }
 }
 
-pub fn chunk_for_slot(slot: Slot) -> u64 {
-    u64::from(slot) / 21_600
+pub fn chunk_for_slot(network: NetworkName, slot: u64) -> u64 {
+    // Immutable chunks span one Byron epoch, i.e. 10 * k slots: 21600 on
+    // mainnet and preprod (k = 2160), 4320 on preview (k = 432).
+    let global_parameters: &GlobalParameters = network.into();
+    let slots_per_chunk = 10 * global_parameters.consensus_security_param as u64;
+    slot / slots_per_chunk
 }
 
-pub fn from_chunk_for_resume_point(latest_chunk: Option<u64>, resume_point: Point) -> u64 {
-    latest_chunk.unwrap_or_else(|| chunk_for_slot(resume_point.slot_or_default()).saturating_sub(1))
+pub fn from_chunk_for_resume_point(network: NetworkName, latest_chunk: Option<u64>, resume_point: Point) -> u64 {
+    latest_chunk.unwrap_or_else(|| chunk_for_slot(network, resume_point.slot_or_default().into()).saturating_sub(1))
 }
 
 #[cfg(test)]

--- a/crates/amaru-mithril/src/lib.rs
+++ b/crates/amaru-mithril/src/lib.rs
@@ -377,16 +377,25 @@ pub fn first_missing_immutable_chunk(immutable_dir: &Path) -> Result<u64, io::Er
     }
 }
 
-pub fn chunk_for_slot(network: NetworkName, slot: u64) -> u64 {
+pub fn chunk_for_slot(network: NetworkName, slot: u64) -> anyhow::Result<u64> {
     // Immutable chunks span one Byron epoch, i.e. 10 * k slots: 21600 on
     // mainnet and preprod (k = 2160), 4320 on preview (k = 432).
-    let global_parameters: &GlobalParameters = network.into();
-    let slots_per_chunk = 10 * global_parameters.consensus_security_param as u64;
-    slot / slots_per_chunk
+    let global_parameters: &GlobalParameters = network
+        .as_global_parameters()
+        .ok_or_else(|| anyhow::anyhow!("GlobalParameters not know for network name `{}`", network))?;
+    let slots_per_chunk = 10 * global_parameters.consensus_security_param;
+    Ok(slot / slots_per_chunk)
 }
 
-pub fn from_chunk_for_resume_point(network: NetworkName, latest_chunk: Option<u64>, resume_point: Point) -> u64 {
-    latest_chunk.unwrap_or_else(|| chunk_for_slot(network, resume_point.slot_or_default().into()).saturating_sub(1))
+pub fn from_chunk_for_resume_point(
+    network: NetworkName,
+    latest_chunk: Option<u64>,
+    resume_point: Point,
+) -> anyhow::Result<u64> {
+    if let Some(latest) = latest_chunk {
+        return Ok(latest);
+    }
+    Ok(chunk_for_slot(network, resume_point.slot_or_default().into())?.saturating_sub(1))
 }
 
 #[cfg(test)]

--- a/crates/amaru/src/bin/amaru/cmd/snapshot/create/mod.rs
+++ b/crates/amaru/src/bin/amaru/cmd/snapshot/create/mod.rs
@@ -315,7 +315,7 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let from_chunk = first_missing_immutable_chunk(&cardano_node_db.join("immutable"))?;
-    let required_chunk = targets.last().map(|t| chunk_for_slot(t.slot)).unwrap_or(0);
+    let required_chunk = targets.last().map(|t| chunk_for_slot(network, t.slot.into())).unwrap_or(0);
     if from_chunk > required_chunk {
         info!(from_chunk, required_chunk, target_dir = %cardano_node_db.display(), "local cardano-db already covers all target slots; skipping Mithril download");
     } else {

--- a/crates/amaru/src/bin/amaru/cmd/snapshot/create/mod.rs
+++ b/crates/amaru/src/bin/amaru/cmd/snapshot/create/mod.rs
@@ -315,7 +315,7 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let from_chunk = first_missing_immutable_chunk(&cardano_node_db.join("immutable"))?;
-    let required_chunk = targets.last().map(|t| chunk_for_slot(network, t.slot.into())).unwrap_or(0);
+    let required_chunk = targets.last().and_then(|t| chunk_for_slot(network, t.slot.into()).ok()).unwrap_or(0);
     if from_chunk > required_chunk {
         info!(from_chunk, required_chunk, target_dir = %cardano_node_db.display(), "local cardano-db already covers all target slots; skipping Mithril download");
     } else {

--- a/crates/amaru/src/bin/ledger/cmd/mithril.rs
+++ b/crates/amaru/src/bin/ledger/cmd/mithril.rs
@@ -76,7 +76,7 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     let resume_point = resume_point_for_archives(&existing_archives);
 
     let latest_chunk = get_latest_chunk(&immutable_dir)?;
-    let from_chunk = from_chunk_for_resume_point(latest_chunk, resume_point);
+    let from_chunk = from_chunk_for_resume_point(network, latest_chunk, resume_point);
 
     info!(
         tip=%tip, resume_point=%resume_point, from_chunk=%from_chunk,

--- a/crates/amaru/src/bin/ledger/cmd/mithril.rs
+++ b/crates/amaru/src/bin/ledger/cmd/mithril.rs
@@ -76,7 +76,7 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     let resume_point = resume_point_for_archives(&existing_archives);
 
     let latest_chunk = get_latest_chunk(&immutable_dir)?;
-    let from_chunk = from_chunk_for_resume_point(network, latest_chunk, resume_point);
+    let from_chunk = from_chunk_for_resume_point(network, latest_chunk, resume_point)?;
 
     info!(
         tip=%tip, resume_point=%resume_point, from_chunk=%from_chunk,

--- a/docs/PUBLISHING_SNAPSHOTS.md
+++ b/docs/PUBLISHING_SNAPSHOTS.md
@@ -1,0 +1,112 @@
+# Publishing bootstrap snapshots
+
+Amaru nodes bootstrap from three consecutive epoch snapshots. They are stored
+in a public R2 bucket and listed in
+`crates/amaru/config/bootstrap/<network>/snapshots.json`. See
+[BOOTSTRAP.md](./BOOTSTRAP.md) for how snapshots are built.
+
+## How to publish
+
+1. Go to Actions → "Publish Bootstrap Snapshots" → "Run workflow".
+2. Pick a network. Leave `epoch` empty to use the last three completed
+   epochs, or set the first epoch of the set you want.
+3. Optionally set `cardano_node_version` to a specific cardano-node release
+   tag (default: `11.0.1`). Must be a published release tag, not a commit hash.
+4. The run opens a pull request that updates `snapshots.json`. Review and
+   merge it.
+
+The PR is opened with `GITHUB_TOKEN`. This needs a one-time setting:
+Settings → Actions → General → Workflow permissions → enable "Allow GitHub
+Actions to create and approve pull requests".
+
+`GITHUB_TOKEN` cannot trigger `pull_request` workflows, so the workflow
+starts CI on the branch itself. To re-run CI, close and reopen the PR.
+
+## What the workflow does
+
+For each selected network:
+
+1. `amaru create-snapshots`: downloads chain data from Mithril, replays it
+   with `db-analyser` and packs three epoch snapshots into tar.gz archives.
+2. `scripts/publish-bootstrap-snapshots`: uploads the archives, checks they
+   can be downloaded publicly and updates `snapshots.json`.
+3. Runs `amaru bootstrap` in a temporary directory using the new
+   `snapshots.json`. This tests the same path end users take. Skip it with
+   `skip_verification`.
+4. Opens the pull request.
+
+Chain data stays on the runner between runs, so only the first run is slow.
+Running the workflow again for the same epoch is safe: nothing is uploaded
+twice and no PR is opened if nothing changed.
+
+If a run fails with "db-analyser did not create snapshot directory", the
+latest epoch is not yet available from Mithril. This can happen shortly
+after an epoch boundary, mostly on preview. Try again a few hours later.
+
+## Runner setup
+
+The workflow needs a self-hosted runner with the labels `self-hosted` and
+`snapshots`.
+
+- Linux or macOS, x86_64 or arm64.
+- Disk: about 50 GB per testnet, 500 GB for mainnet.
+- On `$PATH`: `rustup`, `aws`, `jq`, `curl`, `gh`, `git`.
+- `db-analyser` is always downloaded fresh from the cardano-node release
+  specified by `cardano_node_version`.
+
+If the runner runs as a service, make sure those tools are on the service's
+`PATH` (the runner reads a `.path` file from its directory).
+
+Work files are kept in `$HOME/amaru-snapshots/<network>/`, or in
+`SNAPSHOTS_CACHE_DIR` when set:
+
+- `dist/`: chain data and ledger snapshots. Keep it; it makes runs fast.
+- `snapshots/`: the generated archives. Old ones can be deleted once
+  published.
+
+### Secrets and variables
+
+| Name | Kind | Purpose |
+|------|------|---------|
+| `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` | secret | R2 credentials with write access to the bucket |
+| `S3_ENDPOINT` | secret | R2 S3 endpoint |
+| `SNAPSHOTS_BUCKET_NAME` | secret | Bucket to upload to |
+| `SNAPSHOTS_CACHE_DIR` | variable, optional | Cache directory on the runner |
+| `SNAPSHOTS_PUBLIC_URL_BASE` | variable, optional | Public URL of the bucket; defaults to the base of the URLs already in `snapshots.json` |
+
+### Security
+
+Amaru is a public repository, so lock the runner down:
+
+- Put it in a runner group limited to this repository.
+- Keep this workflow manual-only. Never add `pull_request` triggers to
+  workflows that use the `snapshots` label.
+- Require approval for workflow runs from outside collaborators.
+
+## Testing in a fork
+
+1. Push the branch and get the workflow file onto the fork's default branch.
+2. Create a bucket with public read access and set the secrets above.
+3. Set `SNAPSHOTS_PUBLIC_URL_BASE` to your bucket's public URL. Without it
+   the script checks the upstream URLs instead and skips your uploads.
+4. Enable the PR permission setting mentioned above.
+5. Register a runner with the `snapshots` label.
+6. Run the workflow for `preview`, the smallest network.
+
+## Running it by hand
+
+The same steps work on any machine that meets the requirements above:
+
+```shell
+cargo run --release --bin amaru -- create-snapshots --network preprod -f
+
+AWS_ACCESS_KEY_ID=... \
+AWS_SECRET_ACCESS_KEY=... \
+AWS_DEFAULT_REGION=auto \
+BUCKET_NAME=... \
+ENDPOINT=... \
+AMARU_NETWORK=preprod \
+bash ./scripts/publish-bootstrap-snapshots
+```
+
+Then commit the `snapshots.json` change and open a PR.

--- a/scripts/publish-bootstrap-snapshots
+++ b/scripts/publish-bootstrap-snapshots
@@ -25,13 +25,16 @@ require_env() {
 }
 
 if [ -z "$epoch" ]; then
-  latest_epoch="$(find "$metadata_dir" -maxdepth 1 -name '*.json' | sed 's|.*/||; s|\.json$||' | grep -E '^[0-9]+$' | sort -n | tail -1)"
-  if [ -z "$latest_epoch" ]; then
+  # The metadata directory holds one file per epoch and a snapshot set spans
+  # three consecutive epochs, so the start of the latest set is the
+  # third-highest epoch.
+  start_epoch="$(find "$metadata_dir" -maxdepth 1 -name '*.json' | sed 's|.*/||; s|\.json$||' | grep -E '^[0-9]+$' | sort -n | tail -3 | head -1)"
+  if [ -z "$start_epoch" ]; then
     echo "Error: no epoch metadata files found in '$metadata_dir'; pass an epoch as the first argument." >&2
     exit 1
   fi
-  epoch="$latest_epoch"
-  echo "No epoch specified; using latest available epoch: $epoch"
+  epoch="$start_epoch"
+  echo "No epoch specified; using start epoch of the latest snapshot set: $epoch"
 fi
 
 require_command aws
@@ -65,6 +68,15 @@ manifest_public_url_base() {
 
 candidate_public_url_bases() {
   local manifest_base
+
+  if [ -n "${PUBLIC_URL_BASE:-}" ]; then
+    if [[ ! "$PUBLIC_URL_BASE" =~ ^https?:// ]]; then
+      echo "Error: PUBLIC_URL_BASE must be a valid http(s) URL, got '$PUBLIC_URL_BASE'." >&2
+      exit 1
+    fi
+    printf '%s\n' "${PUBLIC_URL_BASE%/}"
+    return 0
+  fi
 
   manifest_base="$(manifest_public_url_base || true)"
   if [ -z "$manifest_base" ]; then


### PR DESCRIPTION
Adds a manually dispatched workflow that creates the three-epoch bootstrap snapshot set, uploads it to R2, verifies it by running a full amaru bootstrap against the published archives, and opens a PR updating snapshots.json.

Fixes https://github.com/pragma-org/amaru/issues/872

<img width="365" height="449" alt="Screenshot 2026-06-11 at 15 03 52" src="https://github.com/user-attachments/assets/da623592-9dcd-4d9c-941c-91f40410ca68" />

Before merging, one-time setup needed in this repo:

 - Setting up [secret variables](https://github.com/mmahut/amaru/blob/mmahut/snaps/docs/PUBLISHING_SNAPSHOTS.md#secrets-and-variables) for the Github actions
  - Settings → Actions → General → enable "Allow GitHub Actions to create and approve pull requests"
  - A [self-hosted runner with the snapshots label](https://github.com/mmahut/amaru/blob/mmahut/snaps/docs/PUBLISHING_SNAPSHOTS.md#runner-setup)
  
As a demo, this has ran on my fork:

- The Github [action run itself](https://github.com/mmahut/amaru/actions/runs/27345520522)
- The [PR it has opened](https://github.com/mmahut/amaru/pull/2)

Also:

- Fixed chunk_for_slot to derive the immutable chunk size from the network's security parameter instead of the hardcoded mainnet value (21600 slots), which made create-snapshots skip needed Mithril downloads on preview (4320 slots per chunk).
- Fixed the publish script's auto-epoch selection to use the third-latest epoch metadata file, given the latest one is the end of a snapshot set, not its start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GitHub Actions workflow to generate, optionally smoke-test, verify, and publish bootstrap snapshot archives to R2/S3 with manual epoch selection and automatic PR creation when `snapshots.json` changes.
* **Improvements**
  * Snapshot chunking/resume calculations are now network-aware for consistent immutable chunk mapping.
  * Snapshot publishing now selects a 3-epoch boundary from available epoch metadata.
  * Public download links support `PUBLIC_URL_BASE` override with URL validation.
* **Documentation**
  * Added an end-to-end guide for publishing bootstrap snapshots, including required runner setup and manual execution steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->