### PR TITLE
fix: command-line --help not being properly rendered.

### DIFF
--- a/crates/amaru/src/bin/amaru/cli.rs
+++ b/crates/amaru/src/bin/amaru/cli.rs
@@ -115,6 +115,6 @@ pub(crate) fn command(version: &'static str) -> clap::Command {
 }
 
 pub(crate) fn parse(version: &'static str) -> Result<Cli, clap::Error> {
-    let matches = command(version).try_get_matches()?;
+    let matches = command(version).get_matches();
     <Cli as FromArgMatches>::from_arg_matches(&matches)
 }


### PR DESCRIPTION
Shouldn't have listened to the rabbit on this one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal error-handling behavior for CLI argument parsing to use built-in failure management instead of early returns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->