### PR TITLE
fix(amaru): improve ledger lock startup error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Other guiding principles:
 ### Fixed
 
 - **amaru**: fix `--help` being displayed as a debug Rust value instead of properly formatted. ([#953][])
+- **amaru**: report ledger RocksDB lock contention with dedicated startup guidance. ([#769][])
 - **amaru**: resolve era history from snapshots instead of inferring them from network (required for custom testnets). ([#886][])
 - **amaru-ouroboros**: default to `0` as leader relative stake when the leader has no stake (instad of crashing due to a division by zero) ([#886][])
 - **amaru-ouroboros**: skip leader-schedule check if active_slot_coeff is greater than or equal to 1 (degenerate case) ([#886][])
@@ -71,6 +72,7 @@ Other guiding principles:
 
 
 [#778]: https://github.com/pragma-org/amaru/issues/778
+[#769]: https://github.com/pragma-org/amaru/issues/769
 [#886]: https://github.com/pragma-org/amaru/pull/886
 [#942]: https://github.com/pragma-org/amaru/pull/942
 [#953]: https://github.com/pragma-org/amaru/pull/953

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ Other guiding principles:
 
 - **amaru-kernel**: allow null-length era params, so custom testnets can skip leading eras (encoded as empty eras with identical start/end bounds and a zero epoch size). ([#959][])
 
+### Fixed
+
+- **amaru-ledger**: report ledger RocksDB lock contention with dedicated startup guidance. ([#769][])
+
 ## [v10.10.20260618](https://github.com/pragma-org/amaru/releases/tag/v10.10.20260618)
 
 ### Added
@@ -62,7 +66,6 @@ Other guiding principles:
 ### Fixed
 
 - **amaru**: fix `--help` being displayed as a debug Rust value instead of properly formatted. ([#953][])
-- **amaru**: report ledger RocksDB lock contention with dedicated startup guidance. ([#769][])
 - **amaru**: resolve era history from snapshots instead of inferring them from network (required for custom testnets). ([#886][])
 - **amaru-ouroboros**: default to `0` as leader relative stake when the leader has no stake (instad of crashing due to a division by zero) ([#886][])
 - **amaru-ouroboros**: skip leader-schedule check if active_slot_coeff is greater than or equal to 1 (degenerate case) ([#886][])
@@ -71,8 +74,8 @@ Other guiding principles:
 ## [v10.10.20260611](https://github.com/pragma-org/amaru/releases/tag/v10.10.20260611)
 
 
-[#778]: https://github.com/pragma-org/amaru/issues/778
 [#769]: https://github.com/pragma-org/amaru/issues/769
+[#778]: https://github.com/pragma-org/amaru/issues/778
 [#886]: https://github.com/pragma-org/amaru/pull/886
 [#942]: https://github.com/pragma-org/amaru/pull/942
 [#953]: https://github.com/pragma-org/amaru/pull/953

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
  "amaru-ledger",
  "amaru-observability",
  "amaru-ouroboros-traits",
+ "anyhow",
  "hex",
  "proptest",
  "rand 0.9.2",

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -62,6 +62,8 @@ pub enum OpenErrorKind {
         #[source]
         source: io::Error,
     },
+    #[error("RocksDB database '{file}' is locked: {message}")]
+    Locked { file: String, message: String },
     #[error("no ledger stable snapshot found; at least two are expected")]
     NoStableSnapshot,
 }
@@ -99,6 +101,10 @@ impl StoreError {
 impl OpenErrorKind {
     pub fn io_with_file<P: AsRef<Path>>(file: P, error: io::Error) -> Self {
         Self::IO { file: file.as_ref().display().to_string(), source: error }
+    }
+
+    pub fn locked<P: AsRef<Path>>(file: P, message: impl Into<String>) -> Self {
+        Self::Locked { file: file.as_ref().display().to_string(), message: message.into() }
     }
 }
 

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -56,13 +56,13 @@ pub use epoch_transition::{
 #[derive(Debug, Error)]
 #[error(transparent)]
 pub enum OpenErrorKind {
-    #[error("IO error with file '{file}': {source}")]
+    #[error("IO error with file '{file}'")]
     IO {
         file: PathBuf,
         #[source]
         source: io::Error,
     },
-    #[error("Ledger store at '{file}' is locked: {source}")]
+    #[error("Ledger store at '{file}' is locked")]
     Locked {
         file: PathBuf,
         #[source]
@@ -89,7 +89,17 @@ pub enum StoreError {
     #[error("error sending work unit through output port")]
     Send,
 
-    #[error("error opening the store: {0}")]
+    #[error(
+        "{}",
+        if .0.is_locked() {
+            "Failed to connect to the ledger store because it is is locked. Another Amaru \
+            process may still be using it, or a stale LOCK file may remain after an \
+            unclean shutdown. Stop any process using the ledger database before retrying; \
+            only remove the LOCK file after confirming no process is using it."
+        } else {
+            "Failed to create ledger. Did you bootstrap your node?"
+        }
+    )]
     Open(#[source] OpenErrorKind),
 
     #[error("error retrieving {0}: {1}")]
@@ -109,6 +119,10 @@ impl OpenErrorKind {
 
     pub fn locked<P: AsRef<Path>>(file: P, source: anyhow::Error) -> Self {
         Self::Locked { file: file.as_ref().to_path_buf(), source }
+    }
+
+    pub fn is_locked(&self) -> bool {
+        matches!(self, Self::Locked { .. })
     }
 }
 
@@ -476,5 +490,28 @@ impl<U, P, A, D, C, PP, V> Columns<U, P, A, D, C, PP, V> {
             proposals: std::iter::empty(),
             votes: std::iter::empty(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::anyhow;
+
+    use super::*;
+
+    #[test]
+    fn better_context_on_open_locked() {
+        let error = StoreError::Open(OpenErrorKind::locked(PathBuf::from("db/live"), anyhow!("lock held")));
+        let message = format!("{error:#}");
+        assert!(message.contains("Failed to connect to the ledger store because it is is locked"));
+        assert!(!message.contains("Did you bootstrap your node?"));
+    }
+
+    #[test]
+    fn suggest_bootstrap_on_open_error() {
+        let error = StoreError::Open(OpenErrorKind::io_with_file(PathBuf::from("db/live"), io::Error::other("foo")));
+        let message = format!("{error:#}");
+        assert!(!message.contains("Failed to connect to the ledger store because it is is locked"));
+        assert!(message.contains("Did you bootstrap your node?"));
     }
 }

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -17,7 +17,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fmt, io, iter,
     ops::Deref,
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use amaru_kernel::ProposalId;
@@ -58,12 +58,16 @@ pub use epoch_transition::{
 pub enum OpenErrorKind {
     #[error("IO error with file '{file}': {source}")]
     IO {
-        file: String,
+        file: PathBuf,
         #[source]
         source: io::Error,
     },
-    #[error("RocksDB database '{file}' is locked: {message}")]
-    Locked { file: String, message: String },
+    #[error("Ledger store at '{file}' is locked: {source}")]
+    Locked {
+        file: PathBuf,
+        #[source]
+        source: anyhow::Error,
+    },
     #[error("no ledger stable snapshot found; at least two are expected")]
     NoStableSnapshot,
 }
@@ -99,12 +103,12 @@ impl StoreError {
 }
 
 impl OpenErrorKind {
-    pub fn io_with_file<P: AsRef<Path>>(file: P, error: io::Error) -> Self {
-        Self::IO { file: file.as_ref().display().to_string(), source: error }
+    pub fn io_with_file<P: AsRef<Path>>(file: P, source: io::Error) -> Self {
+        Self::IO { file: file.as_ref().to_path_buf(), source }
     }
 
-    pub fn locked<P: AsRef<Path>>(file: P, message: impl Into<String>) -> Self {
-        Self::Locked { file: file.as_ref().display().to_string(), message: message.into() }
+    pub fn locked<P: AsRef<Path>>(file: P, source: anyhow::Error) -> Self {
+        Self::Locked { file: file.as_ref().to_path_buf(), source }
     }
 }
 

--- a/crates/amaru-stores/Cargo.toml
+++ b/crates/amaru-stores/Cargo.toml
@@ -17,10 +17,11 @@ categories.workspace = true
 
 [dependencies]
 # External dependencies ───────────────────────────────────────────────────────┐
+anyhow.workspace = true
 hex.workspace = true
+rand = { workspace = true, optional = true }
 rocksdb = { workspace = true, optional = true }
 tracing.workspace = true
-rand = { workspace = true, optional = true }
 
 # Internal dependencies ───────────────────────────────────────────────────────┐
 amaru-kernel.workspace = true

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -37,6 +37,7 @@ use amaru_ledger::{
     summary::Pots,
 };
 use amaru_observability::{info_span, trace_record, trace_span};
+use anyhow::anyhow;
 use rocksdb::{
     DB, DBAccess, DBIteratorWithThreadMode, DBPinnableSlice, Direction, Env, IteratorMode, ReadOptions, Transaction,
 };
@@ -214,9 +215,8 @@ impl RocksDB {
 }
 
 fn map_rocksdb_open_error(path: &Path, error: rocksdb::Error) -> StoreError {
-    let message = error.to_string();
-    if is_rocksdb_lock_error(&message) {
-        StoreError::Open(OpenErrorKind::locked(path, message))
+    if is_rocksdb_lock_error(error.as_ref()) {
+        StoreError::Open(OpenErrorKind::locked(path, anyhow!(error)))
     } else {
         StoreError::Internal(error.into())
     }

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -190,25 +190,41 @@ impl RocksDB {
     pub fn new(config: &RocksDbConfig) -> Result<Self, StoreError> {
         let dir = config.dir.clone();
         assert_sufficient_snapshots(&dir)?;
+        let live_dir = dir.join(DIR_LIVE_DB);
         let mut opts = set_default_opts(config.into());
         opts.create_if_missing(true);
-        OptimisticTransactionDB::open(&opts, dir.join(DIR_LIVE_DB))
+        OptimisticTransactionDB::open(&opts, &live_dir)
             .map(|db| Self { dir, incremental_save: false, db, ongoing_transaction: OngoingTransaction::new() })
-            .map_err(|err| StoreError::Internal(err.into()))
+            .map_err(|err| map_rocksdb_open_error(&live_dir, err))
     }
 
     pub fn empty(config: &RocksDbConfig) -> Result<RocksDB, StoreError> {
         let dir = config.dir.clone();
+        let live_dir = dir.join(DIR_LIVE_DB);
         let mut opts = set_default_opts(config.into());
         opts.create_if_missing(true);
-        OptimisticTransactionDB::open(&opts, dir.join(DIR_LIVE_DB))
+        OptimisticTransactionDB::open(&opts, &live_dir)
             .map(|db| Self { dir, incremental_save: true, db, ongoing_transaction: OngoingTransaction::new() })
-            .map_err(|err| StoreError::Internal(err.into()))
+            .map_err(|err| map_rocksdb_open_error(&live_dir, err))
     }
 
     fn transaction_ended(&self) {
         self.ongoing_transaction.set(false);
     }
+}
+
+fn map_rocksdb_open_error(path: &Path, error: rocksdb::Error) -> StoreError {
+    let message = error.to_string();
+    if is_rocksdb_lock_error(&message) {
+        StoreError::Open(OpenErrorKind::locked(path, message))
+    } else {
+        StoreError::Internal(error.into())
+    }
+}
+
+fn is_rocksdb_lock_error(message: &str) -> bool {
+    let lowercase = message.to_ascii_lowercase();
+    lowercase.contains("lock") && (message.contains("/LOCK") || message.contains("\\LOCK"))
 }
 
 // RocksDBReadOnly
@@ -224,10 +240,11 @@ impl ReadOnlyRocksDB {
     pub fn new(config: &RocksDbConfig) -> Result<Self, StoreError> {
         let dir = config.dir.clone();
         assert_sufficient_snapshots(&dir)?;
+        let live_dir = dir.join(DIR_LIVE_DB);
         let opts = set_default_opts(config.into());
-        rocksdb::DB::open_for_read_only(&opts, dir.join(DIR_LIVE_DB), false)
+        rocksdb::DB::open_for_read_only(&opts, &live_dir, false)
             .map(|db| ReadOnlyRocksDB { db })
-            .map_err(|err| StoreError::Internal(err.into()))
+            .map_err(|err| map_rocksdb_open_error(&live_dir, err))
     }
 }
 
@@ -300,9 +317,10 @@ pub struct RocksDBHistoricalStores {
 impl RocksDBHistoricalStores {
     pub fn for_epoch_with(config: &RocksDbConfig, epoch: Epoch) -> Result<RocksDBSnapshot, StoreError> {
         let base_dir = config.dir.clone();
+        let snapshot_dir = base_dir.join(PathBuf::from(format!("{epoch}")));
         let opts = set_default_opts(config.into());
-        OptimisticTransactionDB::open(&opts, base_dir.join(PathBuf::from(format!("{epoch}"))))
-            .map_err(|err| StoreError::Internal(err.into()))
+        OptimisticTransactionDB::open(&opts, &snapshot_dir)
+            .map_err(|err| map_rocksdb_open_error(&snapshot_dir, err))
             .map(|db| RocksDBSnapshot { epoch, db })
     }
 
@@ -996,7 +1014,7 @@ fn with_prefix_iterator<
 #[cfg(test)]
 mod tests {
     use amaru_kernel::PREPROD_ERA_HISTORY;
-    use amaru_ledger::store::{Store, StoreError};
+    use amaru_ledger::store::{OpenErrorKind, Store, StoreError};
     use proptest::test_runner::TestRunner;
     use tempfile::TempDir;
 
@@ -1036,6 +1054,16 @@ mod tests {
 
         let ro_db = ReadOnlyRocksDB::new(&RocksDbConfig::new(dir.path().into())).inspect_err(|e| eprintln!("{e:#?}"));
         assert!(matches!(ro_db, Ok(..)));
+    }
+
+    #[test]
+    fn open_locked_writer_returns_locked_error() {
+        let dir = TempDir::new().unwrap();
+        let _db = RocksDB::empty(&RocksDbConfig::new(dir.path().into())).expect("first writer opens");
+
+        let result = RocksDB::empty(&RocksDbConfig::new(dir.path().into()));
+
+        assert!(matches!(result, Err(StoreError::Open(OpenErrorKind::Locked { .. }))));
     }
 
     #[test]

--- a/crates/amaru/src/stages/build_node.rs
+++ b/crates/amaru/src/stages/build_node.rs
@@ -22,6 +22,7 @@ use amaru_consensus::{
     validate_header::ValidateHeader,
 };
 use amaru_kernel::{ConsensusParameters, EraHistory, GlobalParameters, ORIGIN_HASH, Point, Transaction};
+use amaru_ledger::store::{OpenErrorKind, StoreError as LedgerStoreError};
 use amaru_mempool::{InMemoryMempool, MempoolConfig};
 use amaru_metrics::METRICS_METER_NAME;
 use amaru_network::connection::TokioConnections;
@@ -36,7 +37,7 @@ use amaru_pure_stage::{
     trace_buffer::TraceBuffer,
 };
 use amaru_stores::rocksdb::consensus::RocksDBStore;
-use anyhow::{Context, anyhow};
+use anyhow::anyhow;
 use opentelemetry::metrics::MeterProvider;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use parking_lot::Mutex;
@@ -107,8 +108,7 @@ pub fn build_node(
     let era_history = &config.era_history;
 
     // Make the ledger and get its tip
-    let ledger = Ledger::new(config, era_history.clone(), global_parameters.clone())
-        .context("Failed to create ledger. Have you bootstrapped your node?")?;
+    let ledger = Ledger::new(config, era_history.clone(), global_parameters.clone()).map_err(ledger_creation_error)?;
 
     let ledger_tip = ledger.get_tip();
     tracing::info!(
@@ -149,6 +149,26 @@ pub fn build_node(
         .map_err(|e| anyhow!(format!("{e:?}")))?;
 
     Ok(node_stages)
+}
+
+fn ledger_creation_error(error: anyhow::Error) -> anyhow::Error {
+    if is_ledger_store_locked(&error) {
+        error.context(
+            "Failed to create ledger because its RocksDB database is locked. Another Amaru process may still be \
+             using it, or a stale LOCK file may remain after an unclean shutdown. Stop any process using the ledger \
+             database before retrying; only remove the LOCK file after confirming no process is using it.",
+        )
+    } else {
+        error.context("Failed to create ledger. Have you bootstrapped your node?")
+    }
+}
+
+fn is_ledger_store_locked(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<LedgerStoreError>()
+            .is_some_and(|store_error| matches!(store_error, LedgerStoreError::Open(OpenErrorKind::Locked { .. })))
+    })
 }
 
 /// Register the resources required by the external effects invoked by the stages in the stage graph.
@@ -211,4 +231,34 @@ fn make_validate_header(
         Arc::new(ConsensusParameters::new(global_parameters.clone(), era_history, Default::default()));
 
     ValidateHeader::new(consensus_parameters, chain_store, stake_distribution)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ledger_lock_error_uses_dedicated_context() {
+        let error = anyhow::Error::new(LedgerStoreError::Open(OpenErrorKind::locked("db/live", "lock held")));
+
+        assert!(is_ledger_store_locked(&error));
+
+        let error = ledger_creation_error(error);
+        let message = format!("{error:#}");
+
+        assert!(message.contains("RocksDB database is locked"));
+        assert!(!message.contains("Have you bootstrapped your node?"));
+    }
+
+    #[test]
+    fn other_ledger_errors_keep_bootstrap_context() {
+        let error = anyhow!("ledger failed");
+
+        assert!(!is_ledger_store_locked(&error));
+
+        let error = ledger_creation_error(error);
+        let message = format!("{error:#}");
+
+        assert!(message.contains("Have you bootstrapped your node?"));
+    }
 }

--- a/crates/amaru/src/stages/build_node.rs
+++ b/crates/amaru/src/stages/build_node.rs
@@ -22,7 +22,6 @@ use amaru_consensus::{
     validate_header::ValidateHeader,
 };
 use amaru_kernel::{ConsensusParameters, EraHistory, GlobalParameters, ORIGIN_HASH, Point, Transaction};
-use amaru_ledger::store::{OpenErrorKind, StoreError as LedgerStoreError};
 use amaru_mempool::{InMemoryMempool, MempoolConfig};
 use amaru_metrics::METRICS_METER_NAME;
 use amaru_network::connection::TokioConnections;
@@ -108,7 +107,7 @@ pub fn build_node(
     let era_history = &config.era_history;
 
     // Make the ledger and get its tip
-    let ledger = Ledger::new(config, era_history.clone(), global_parameters.clone()).map_err(ledger_creation_error)?;
+    let ledger = Ledger::new(config, era_history.clone(), global_parameters.clone())?;
 
     let ledger_tip = ledger.get_tip();
     tracing::info!(
@@ -149,26 +148,6 @@ pub fn build_node(
         .map_err(|e| anyhow!(format!("{e:?}")))?;
 
     Ok(node_stages)
-}
-
-fn ledger_creation_error(error: anyhow::Error) -> anyhow::Error {
-    if is_ledger_store_locked(&error) {
-        error.context(
-            "Failed to create ledger because its RocksDB database is locked. Another Amaru process may still be \
-             using it, or a stale LOCK file may remain after an unclean shutdown. Stop any process using the ledger \
-             database before retrying; only remove the LOCK file after confirming no process is using it.",
-        )
-    } else {
-        error.context("Failed to create ledger. Have you bootstrapped your node?")
-    }
-}
-
-fn is_ledger_store_locked(error: &anyhow::Error) -> bool {
-    error.chain().any(|cause| {
-        cause
-            .downcast_ref::<LedgerStoreError>()
-            .is_some_and(|store_error| matches!(store_error, LedgerStoreError::Open(OpenErrorKind::Locked { .. })))
-    })
 }
 
 /// Register the resources required by the external effects invoked by the stages in the stage graph.
@@ -231,34 +210,4 @@ fn make_validate_header(
         Arc::new(ConsensusParameters::new(global_parameters.clone(), era_history, Default::default()));
 
     ValidateHeader::new(consensus_parameters, chain_store, stake_distribution)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn ledger_lock_error_uses_dedicated_context() {
-        let error = anyhow::Error::new(LedgerStoreError::Open(OpenErrorKind::locked("db/live", "lock held")));
-
-        assert!(is_ledger_store_locked(&error));
-
-        let error = ledger_creation_error(error);
-        let message = format!("{error:#}");
-
-        assert!(message.contains("RocksDB database is locked"));
-        assert!(!message.contains("Have you bootstrapped your node?"));
-    }
-
-    #[test]
-    fn other_ledger_errors_keep_bootstrap_context() {
-        let error = anyhow!("ledger failed");
-
-        assert!(!is_ledger_store_locked(&error));
-
-        let error = ledger_creation_error(error);
-        let message = format!("{error:#}");
-
-        assert!(message.contains("Have you bootstrapped your node?"));
-    }
 }

--- a/crates/amaru/src/stages/ledger.rs
+++ b/crates/amaru/src/stages/ledger.rs
@@ -41,6 +41,7 @@ impl Ledger {
             era_history,
             global_parameters,
         )?;
+
         Ok(Ledger(ledger))
     }
 


### PR DESCRIPTION
Fixes #769

## Summary
- classify ledger RocksDB LOCK failures as a dedicated open error
- replace the generic bootstrap hint with lock-file startup guidance
- add regression coverage and a changelog entry

## Testing
- cargo fmt --all -- --check
- cargo test -p amaru-stores open_locked_writer_returns_locked_error
- cargo test -p amaru ledger_
- git diff --check upstream/main..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for RocksDB lock contention with a dedicated “RocksDB database is locked” message and clearer node startup guidance.
  * Second concurrent writer open attempts now surface a specific locked error instead of a generic failure.

* **Documentation**
  * Updated release notes/changelog with guidance for reporting and troubleshooting ledger RocksDB lock contention (including the related issue reference).

* **Tests**
  * Added unit test coverage to verify locked-RocksDB error behavior and message correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->