### PR TITLE
allow null-length era params (for custom testnets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Other guiding principles:
 - **amaru-kernel**: `ConsensusParameters` and `GlobalParameters` now live in their own modules instead of being paired with `ProtocolParameters`. Still exported at the top-level. ([#886][])
 - **amaru-kernel**: remove `From` instances between `NetworkName` and `GlobalParameters`, `ProtocolParameters` and `EraHistory` in favor of faillible `as_
 - **pure-stage**: rename to `amaru-pure-stage` ([#954][])
+- **amaru-kernel**: allow null-length era params, so custom testnets can skip leading eras (encoded as empty eras with identical start/end bounds and a zero epoch size). ([#959][])
 
 ### Removed
 
@@ -69,3 +70,4 @@ Other guiding principles:
 [#942]: https://github.com/pragma-org/amaru/pull/942
 [#953]: https://github.com/pragma-org/amaru/pull/953
 [#954]: https://github.com/pragma-org/amaru/pull/954
+[#959]: https://github.com/pragma-org/amaru/pull/959

--- a/crates/amaru-kernel/src/cardano/era_history.rs
+++ b/crates/amaru-kernel/src/cardano/era_history.rs
@@ -456,6 +456,7 @@ impl EraHistory {
         if eras.is_empty() {
             panic!("EraHistory cannot be empty");
         }
+
         // TODO ensures only last era ends with Option
         EraHistory { stability_window, eras: eras.to_vec() }
     }
@@ -839,6 +840,46 @@ mod tests {
                 },
             ],
         }
+    }
+
+    #[test]
+    fn slot_to_epoch_with_null_eras_prefix() {
+        let eras = EraHistory::new(
+            &[
+                {
+                    let start = EraBound { time: Duration::from_secs(0), slot: Slot::new(0), epoch: Epoch::new(0) };
+                    let end = EraBound { time: Duration::from_secs(0), slot: Slot::new(0), epoch: Epoch::new(0) };
+                    let params = EraParams::from_bounds(&start, &end, EraName::Byron).unwrap();
+                    EraSummary { start, end: Some(end), params }
+                },
+                {
+                    let start = EraBound { time: Duration::from_secs(0), slot: Slot::new(0), epoch: Epoch::new(0) };
+                    let end = EraBound { time: Duration::from_secs(0), slot: Slot::new(0), epoch: Epoch::new(0) };
+                    let params = EraParams::from_bounds(&start, &end, EraName::Shelley).unwrap();
+                    EraSummary { start, end: Some(end), params }
+                },
+                {
+                    let start = EraBound { time: Duration::from_secs(0), slot: Slot::new(0), epoch: Epoch::new(0) };
+                    let params = default_params();
+                    EraSummary { start, end: None, params }
+                },
+            ],
+            Slot::new(25920),
+        );
+
+        let s0 = Slot::new(0);
+        let s1 = Slot::new(1);
+        let s2 = Slot::new(86400);
+
+        let e0 = Epoch::new(0);
+        let e1 = Epoch::new(1);
+
+        assert_eq!(eras.slot_to_epoch(s0, s0), Ok(e0), "slot=0; epoch=0");
+        assert_eq!(eras.slot_to_epoch_unchecked_horizon(s0), Ok(e0), "slot=0; epoch=0; unchecked");
+        assert_eq!(eras.slot_to_epoch(s1, s1), Ok(e0), "slot=1; epoch=0");
+        assert_eq!(eras.slot_to_epoch_unchecked_horizon(s1), Ok(e0), "slot=1; epoch=0; unchecked");
+        assert_eq!(eras.slot_to_epoch(s2, s2), Ok(e1), "slot=86400; epoch=1");
+        assert_eq!(eras.slot_to_epoch_unchecked_horizon(s2), Ok(e1), "slot=86400; epoch=1l unchecked");
     }
 
     #[test]

--- a/crates/amaru-kernel/src/cardano/era_params.rs
+++ b/crates/amaru-kernel/src/cardano/era_params.rs
@@ -38,6 +38,10 @@ impl EraParams {
 
     pub fn from_bounds(start: &EraBound, end: &EraBound, era_name: EraName) -> Option<Self> {
         if end.slot <= start.slot || end.epoch <= start.epoch {
+            if end.slot == start.slot && end.epoch == start.epoch {
+                return Some(Self { epoch_size_slots: 0, slot_length: Duration::from_secs(1), era_name });
+            }
+
             return None;
         }
 

--- a/crates/amaru-kernel/src/cardano/era_summary.rs
+++ b/crates/amaru-kernel/src/cardano/era_summary.rs
@@ -26,10 +26,21 @@ pub struct EraSummary {
 }
 
 impl EraSummary {
+    /// Check whether an era is empty; which may occurs for custom testnets where the first
+    /// eras are typically skipped. By conventio, those eras have an epoch size of 0 and the start
+    /// and end slots are the same.
+    fn is_empty(&self) -> bool {
+        self.end.as_ref().is_some_and(|end| &self.start == end)
+    }
+
     /// Checks whether the current `EraSummary` ends after the given slot; In case
     /// where the EraSummary doesn't have any upper bound, then we check whether the
     /// point is within a foreseeable horizon.
     pub fn contains_slot(&self, slot: &Slot, tip: &Slot, stability_window: &Slot) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+
         &self.end.as_ref().map(|end| end.slot).unwrap_or_else(|| self.calculate_end_bound(tip, stability_window).slot)
             >= slot
     }
@@ -37,6 +48,10 @@ impl EraSummary {
     /// Like contains_slot, but doesn't enforce anything about the upper bound. So when there's no
     /// upper bound, the slot is simply always considered within the era.
     pub fn contains_slot_unchecked_horizon(&self, slot: &Slot) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+
         self.end.as_ref().map(|end| &end.slot >= slot).unwrap_or(true)
     }
 

--- a/crates/amaru-kernel/src/cardano/era_summary.rs
+++ b/crates/amaru-kernel/src/cardano/era_summary.rs
@@ -27,7 +27,7 @@ pub struct EraSummary {
 
 impl EraSummary {
     /// Check whether an era is empty; which may occurs for custom testnets where the first
-    /// eras are typically skipped. By conventio, those eras have an epoch size of 0 and the start
+    /// eras are typically skipped. By convention, those eras have an epoch size of 0 and the start
     /// and end slots are the same.
     fn is_empty(&self) -> bool {
         self.end.as_ref().is_some_and(|end| &self.start == end)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for null-length era parameters when an era’s start and end bounds are identical (including zero epoch size).
  * Updated era containment checks so “empty” eras correctly report that they contain no slots/epochs, while preserving behavior when the end bound is unset.
* **Tests**
  * Added unit coverage for slot-to-epoch conversion when era history starts with null/zeroed bounds.
* **Documentation**
  * Updated the unreleased changelog to reflect null-length era support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->