### PR TITLE
Make DiffBind::Append Infallible

### DIFF
--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -43,9 +43,7 @@ use crate::{
     rules::block::BlockValidation,
     state::{
         overlay::StateOverlay,
-        volatile::{
-            AnchoredVolatileFragment, StoreUpdate, VolatileDB, VolatileFragment, VolatileView, VolatileViewError,
-        },
+        volatile::{AnchoredVolatileFragment, StoreUpdate, VolatileDB, VolatileFragment, VolatileView},
     },
     store::{HistoricalStores, Snapshot, Store, StoreError, TransactionalContext},
     summary::{
@@ -377,8 +375,7 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             // last k blocks for a single epoch. Or carry some kind of type-level guard that
             // the this is called within an acceptable context (i.e. the volatile
             // pre-conditions have been checked).
-            let mut volatile_view = VolatileView::new(next_epoch - 1, protocol_parameters, &self.volatile, &*db)
-                .map_err(StateError::FailedToCreateVolatileView)?;
+            let mut volatile_view = VolatileView::new(next_epoch - 1, protocol_parameters, &self.volatile, &*db);
 
             let (treasury, effective_rewards) = if progress.is_none() {
                 let effective_rewards = epoch_transition::end_epoch(
@@ -1097,9 +1094,6 @@ pub enum StateError {
 
     #[error("expected effective rewards to apply but found something else")]
     NoEffectiveRewards,
-
-    #[error("inconsistent or invalid volatile states; failed to create an aggregated volatile view")]
-    FailedToCreateVolatileView(#[source] VolatileViewError),
 
     #[error("failed to compute epoch from slot {0:?}: {1}")]
     ErrorComputingEpoch(Slot, EraHistoryError),

--- a/crates/amaru-ledger/src/state/diff_bind.rs
+++ b/crates/amaru-ledger/src/state/diff_bind.rs
@@ -110,19 +110,6 @@ pub enum RegisterError<K> {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum MergeError<K> {
-    #[error("key is already registered")]
-    AlreadyRegistered(K),
-}
-
-impl<K: ToOwned<Owned = K>> MergeError<&K> {
-    pub fn to_owned(self) -> MergeError<K> {
-        let Self::AlreadyRegistered(k) = self;
-        MergeError::AlreadyRegistered(k.to_owned())
-    }
-}
-
-#[derive(thiserror::Error, Debug)]
 pub enum BindError<K> {
     #[error("key is already unregistered")]
     AlreadyUnregistered(K),
@@ -137,16 +124,19 @@ impl<K: Ord, L, R, V> DiffBind<K, L, R, V> {
     }
 
     /// Merge two states together, assuming that the other is a more recent update.
-    pub fn append(&mut self, most_recent: Self) -> Result<&mut Self, MergeError<K>> {
+    ///
+    /// Importantly, this composes two already-validated `DiffBind`s, it does not re-validate them.
+    /// This composes two already-validated diffs; it does not re-validate them.
+    ///
+    /// In particular, a `value: Some(...)` in `most_recent` denotes a re-registration of the key;
+    /// it fully supersedes any prior registration or bindings accumulated for that key.
+    /// This could happen when a single block deregisters and re-registers a credential.
+    pub fn append(&mut self, most_recent: Self) -> &mut Self {
         for key in most_recent.unregistered {
             self.unregister(key);
         }
 
         for (key, bind) in most_recent.registered {
-            if self.registered.contains_key(&key) && bind.value.is_some() {
-                return Err(MergeError::AlreadyRegistered(key));
-            }
-
             self.unregistered.remove(&key);
 
             match self.registered.entry(key) {
@@ -155,18 +145,22 @@ impl<K: Ord, L, R, V> DiffBind<K, L, R, V> {
                 }
 
                 Entry::Occupied(mut e) => {
-                    if !matches!(&bind.left, &Resettable::Unchanged) {
-                        e.get_mut().left = bind.left;
-                    }
+                    if bind.value.is_some() {
+                        *e.get_mut() = bind;
+                    } else {
+                        if !matches!(&bind.left, &Resettable::Unchanged) {
+                            e.get_mut().left = bind.left;
+                        }
 
-                    if !matches!(&bind.right, &Resettable::Unchanged) {
-                        e.get_mut().right = bind.right;
+                        if !matches!(&bind.right, &Resettable::Unchanged) {
+                            e.get_mut().right = bind.right;
+                        }
                     }
                 }
             };
         }
 
-        Ok(self)
+        self
     }
 
     pub fn register(&mut self, key: K, value: V, left: Option<L>, right: Option<R>) -> Result<(), RegisterError<K>> {
@@ -382,6 +376,45 @@ mod tests {
         assert_eq!(
             Some(&Bind { left: Resettable::Unchanged::<()>, right: Resettable::Set("right"), value: None::<()> }),
             diff_bind.registered.get(&1)
+        );
+    }
+
+    #[test]
+    fn append_reregistration_supersedes_prior_binding() {
+        // Accumulated window state: key 1 was only re-bound (e.g. a pure vote delegation), not
+        // registered within the window: { left: Unchanged, right: Set, value: None }.
+        let mut current = DiffBind::default();
+        current.bind_right(1, Some("abstain")).unwrap();
+
+        // A later fragment deregisters then re-registers key 1 within a single block, which
+        // collapses to a plain registration: { left: Reset, right: Reset, value: Some }.
+        let mut next = DiffBind::default();
+        next.register(1, "deposit", None::<&str>, None).unwrap();
+
+        current.append(next);
+
+        assert!(current.unregistered.is_empty());
+        assert_eq!(
+            Some(&Bind { left: Resettable::Reset, right: Resettable::Reset, value: Some("deposit") }),
+            current.registered.get(&1)
+        );
+    }
+
+    #[test]
+    fn append_binding_update_preserves_existing_registration() {
+        let mut current = DiffBind::default();
+        current.register(1, "deposit", None::<&str>, None::<&str>).unwrap();
+
+        // A later fragment only re-binds the right: the existing deposit and
+        // the untouched left must be preserved.
+        let mut next = DiffBind::default();
+        next.bind_right(1, Some("abstain")).unwrap();
+
+        current.append(next);
+
+        assert_eq!(
+            Some(&Bind { left: Resettable::Reset, right: Resettable::Set("abstain"), value: Some("deposit") }),
+            current.registered.get(&1)
         );
     }
 }

--- a/crates/amaru-ledger/src/state/volatile.rs
+++ b/crates/amaru-ledger/src/state/volatile.rs
@@ -19,4 +19,4 @@ mod fragment;
 pub use fragment::{AnchoredVolatileFragment, StoreUpdate, VolatileFragment};
 
 mod view;
-pub use view::{VolatileView, VolatileViewError};
+pub use view::VolatileView;

--- a/crates/amaru-ledger/src/state/volatile/view.rs
+++ b/crates/amaru-ledger/src/state/volatile/view.rs
@@ -18,18 +18,13 @@ use std::{
 };
 
 use amaru_kernel::{
-    CertificatePointer, ComparableProposalId, DRep, Epoch, Lovelace, PoolId, PoolParams, Proposal, ProposalPointer,
-    ProtocolParameters, StakeCredential, Tip,
+    CertificatePointer, ComparableProposalId, Epoch, PoolId, PoolParams, Proposal, ProposalPointer, ProtocolParameters,
+    StakeCredential,
 };
 
 use crate::{
     governance::ratification::ProposalsRootsRc,
-    state::{
-        AnchoredVolatileFragment, VolatileDB,
-        diff_bind::{DiffBind, MergeError},
-        diff_epoch_reg::DiffEpochReg,
-        volatile::fragment::add_proposals,
-    },
+    state::{VolatileDB, diff_bind::DiffBind, diff_epoch_reg::DiffEpochReg, volatile::fragment::add_proposals},
     store::{
         ReadStore, StoreError,
         columns::{pools::Row as Pool, *},
@@ -68,15 +63,13 @@ impl<'volatile, 'db, DB: ReadStore> VolatileView<'volatile, 'db, DB> {
         protocol_parameters: &ProtocolParameters,
         volatile: &'volatile VolatileDB,
         stable: &'db DB,
-    ) -> Result<VolatileView<'volatile, 'db, DB>, VolatileViewError> {
+    ) -> VolatileView<'volatile, 'db, DB> {
         let mut pools = DiffEpochReg::default();
         let mut proposals = BTreeMap::new();
         let mut accounts = DiffBind::default();
 
         for anchored in volatile.iter() {
-            if let Err(merge_error) = accounts.append(anchored.fragment.accounts.into_borrowed()) {
-                return Err(VolatileViewError::accounts_merge_error(anchored, merge_error, accounts));
-            }
+            accounts.append(anchored.fragment.accounts.into_borrowed());
 
             pools.append(anchored.fragment.pools.into_borrowed());
 
@@ -90,14 +83,14 @@ impl<'volatile, 'db, DB: ReadStore> VolatileView<'volatile, 'db, DB> {
             unregistered: accounts.unregistered,
         };
 
-        Ok(Self {
+        Self {
             epoch,
             proposal_lifetime: protocol_parameters.gov_action_lifetime,
             db: stable,
             accounts: Some(accounts),
             pools: Some(pools),
             proposals,
-        })
+        }
     }
 
     /// Provides an iterator for pools on top of the stable store, but adding any pending updates
@@ -160,46 +153,4 @@ impl<'volatile, 'db, DB: ReadStore> VolatileView<'volatile, 'db, DB> {
 struct AccountVolatileView<'volatile> {
     registered: BTreeSet<&'volatile StakeCredential>,
     unregistered: BTreeSet<&'volatile StakeCredential>,
-}
-
-// ------------------------------------------------------------------------------- VolatileViewError
-
-#[derive(Debug, thiserror::Error)]
-pub enum VolatileViewError {
-    #[error(
-        "unable to construct volatile view: invariant violation ({:?}) when processing \
-        accounts at anchor {:?}:\nnext_accounts: {:#?}\ncurrent_accounts: {:#?}",
-         .merge_error,
-         .anchor,
-         .next_accounts,
-         .current_accounts,
-    )]
-    AccountsMergeError {
-        anchor: Box<(Tip, PoolId)>,
-        merge_error: MergeError<StakeCredential>,
-        next_accounts:
-            Box<DiffBind<StakeCredential, (PoolId, CertificatePointer), (DRep, CertificatePointer), Lovelace>>,
-        current_accounts:
-            Box<DiffBind<StakeCredential, (PoolId, CertificatePointer), (DRep, CertificatePointer), Lovelace>>,
-    },
-}
-
-impl VolatileViewError {
-    pub fn accounts_merge_error(
-        anchored: &AnchoredVolatileFragment,
-        merge_error: MergeError<&StakeCredential>,
-        current_accounts: DiffBind<
-            &StakeCredential,
-            &(PoolId, CertificatePointer),
-            &(DRep, CertificatePointer),
-            &Lovelace,
-        >,
-    ) -> Self {
-        Self::AccountsMergeError {
-            merge_error: merge_error.to_owned(),
-            anchor: Box::new(anchored.anchor),
-            next_accounts: Box::new(anchored.fragment.accounts.clone()),
-            current_accounts: Box::new(current_accounts.to_owned()),
-        }
-    }
 }


### PR DESCRIPTION
On preview, the epoch transition from 1098 -> 1099 currently crashes, with the following error (first reported by @Cerkoryn on [Discord](https://discord.com/channels/1202416088776712253/1514660741490278460/1514747308041044030)):
```
2026-06-11T21:37:27.917392Z ERROR amaru_consensus::stages::validate_block: failed to validate block error=BlockValidationError: inconsistent or invalid volatile states; failed to create an aggregated volatile view point=94953610.bc237c0372978edb4de333a43ab35f53739051c22ca4563f28694b7e27080128
2026-06-11T21:37:27.917397Z  WARN pure_stage::tokio: stage `validate_block-7` terminated
2026-06-11T21:37:27.917452Z ERROR amaru::cmd::run: Consensus died, this should not happen! Please report this incl. preceding logs to the Amaru team.
```

That error is due to transaction`c4f6162a3dd4f1136952b7a46f5b76d92c904d1a7702f317eda8af21223ac33f` in which a user deregisters a stake credential and then immediately re-registers it. This caused a `MergeError::AlreadyRegistered` when constructing the `VolatileView`.

Validation in `DiffBind` happens during construction, and `append` is only ever going to be merging two already valid `DiffBind`s, so we do not need this extra check. This generally simplifies our logic as well.

Future work here should look at how we can simplify `DiffBind` and whether or not it's still needed, following the 2-sequence volatile DB changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ledger state stability by making volatile view creation non-failing and streamlining volatile state transitions.
  * Updated state binding merging so re-registration cleanly supersedes prior bindings, and subsequent updates preserve existing registration state.

* **Tests**
  * Added unit tests covering re-registration precedence and preservation of registration state during binding updates.

* **Chores**
  * Removed and stopped exporting obsolete public error types related to volatile view creation and merge-time registration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->