### PR TITLE
chore: always test e2e snapshots

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -126,7 +126,6 @@ jobs:
 
   snapshots:
     name: Compare ledger epoch snapshots
-    if: ${{ !github.event.pull_request.draft }}
     uses: ./.github/workflows/template-ledger-epoch-snapshots.yml
     with:
       use_fixed_epoch: true


### PR DESCRIPTION
Make sure when creating a PR, snapshots tests are always run. Even for draft PR.
Currently users are sometimes forced to put a draft PR just to have those tests run, leading to miscommunication regarding the PR state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Continuous integration now runs the snapshot comparison check for all pull requests, including draft pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->