### PR TITLE
doc: update the tracing EDR and its relationship with the observability EDR

### DIFF
--- a/engineering-decision-records/007-observability.md
+++ b/engineering-decision-records/007-observability.md
@@ -7,19 +7,13 @@ status: accepted
 
 ## Context
 
-This decision record documents a general organization for how the Amaru node will collect and report critical
-operational metrics, logs, and tracing data.
+This decision record documents a general organization for how the Amaru node will collect and report critical operational metrics, logs, and tracing data.
 
-A key component of operating any computing system at scale is observability: tracking what happened, how often something
-happened, how long it took, how many resources something is consuming, and where potential issues or bottlenecks might
-be found.
+A key component of operating any computing system at scale is observability: tracking what happened, how often something happened, how long it took, how many resources something is consuming, and where potential issues or bottlenecks might be found.
 
-Thus, we would like Amaru to track and report these traces and metrics. We would also like to use industry standards so
-that users of the Amaru node can swap out their own visualization and aggregation infrastructure as needed.
+Thus, we would like Amaru to track and report these traces and metrics. We would also like to use industry standards so that users of the Amaru node can swap out their own visualization and aggregation infrastructure as needed.
 
-We would like the codebase to organize the metrics it tracks in a simple, consistent and modular way, such that each
-module or crate can own a subset of the metrics, while at the same time being consistent and discoverable through
-reading the code.
+We would like the codebase to organize the metrics it tracks in a simple, consistent and modular way, such that each module or crate can own a subset of the metrics, while at the same time being consistent and discoverable through reading the code.
 
 ## Decision
 
@@ -27,9 +21,7 @@ reading the code.
 
 - By default, the application provides human-readable information on stderr in a pretty format (possibly TUI).
 
-- Additionally, the application will
-  embrace [observability](https://peter.bourgon.org/blog/2017/02/21/metrics-tracing-and-logging.html) and provide logs,
-  traces, spans and metrics using Rust's [tracing](https://docs.rs/tracing/latest/tracing/index.html) ecosystem.
+- Additionally, the application will embrace [observability](https://peter.bourgon.org/blog/2017/02/21/metrics-tracing-and-logging.html) and provide logs, traces, spans and metrics using Rust's [tracing](https://docs.rs/tracing/latest/tracing/index.html) ecosystem.
 
 - All traces and spans can be made available on stdout in a structured format (JSON).
 
@@ -38,11 +30,9 @@ reading the code.
         - [Jaeger](https://www.jaegertracing.io/)
         - [Grafana](https://grafana.com/) and [Tempo](https://grafana.com/oss/tempo/)
 
-    - We will use the [opentelemetry-rust](https://github.com/open-telemetry/opentelemetry-rust) crate to collect and
-      report traces and metrics.
+    - We will use the [opentelemetry-rust](https://github.com/open-telemetry/opentelemetry-rust) crate to collect and report traces and metrics.
 
-    - We will make judicious use of [Spans](https://opentelemetry.io/docs/concepts/observability-primer/#spans) to
-      expose the structured nature of the workload the Amaru node performs.
+    - We will make judicious use of [Spans](https://opentelemetry.io/docs/concepts/observability-primer/#spans) to expose the structured nature of the workload the Amaru node performs.
 
 - We define the frontier between logs and traces by following a simple rule:
     - Any event at the DEBUG level or above is considered a log
@@ -50,13 +40,11 @@ reading the code.
 
 ### Tracing Schemas
 
-To ensure consistency and enable compile-time validation of tracing instrumentation, we use a schema-based approach
-implemented in the `amaru-observability` crate.
+To ensure consistency and enable compile-time validation of tracing instrumentation, we use a schema-based approach implemented in the `amaru-observability` crate.
 
 #### Schema Definition
 
-Schemas are defined using the `define_schemas!` macro in a central location (`amaru-observability/src/schemas.rs`).
-They are organized hierarchically with five levels of nesting:
+Schemas are defined using the `define_schemas!` macro in a central location (`amaru-observability/src/schemas.rs`). They are organized hierarchically with five levels of nesting:
 
 - The first two levels define the target of a span, for example `amaru::consensus` or `amaru::ledger`.
 - The next three levels define the name of the span, for example `header.evolve_nonce` or `block.apply` (
@@ -73,15 +61,15 @@ define_schemas! {
                 VALIDATE {
                     required issuer_key: String
                 }
-            }            
+            }
         }
-        ledger {           
+        ledger {
             block {
                 APPLY {
                     required point_slot: u64
                     optional error: String
-                }              
-            }               
+                }
+            }
         }
     }
 }
@@ -94,27 +82,17 @@ Each schema declares:
 
 ##### Tags
 
-In addition to fields, a `tags: <name>, ...` entry assigns functional tags to schemas, classifying spans by the kind of
-work they perform (`setup`, `cpu`, `db`, `io`, etc., see [EDR-026](./026-tracing-span-design.md) for the list of tags).
+In addition to fields, a `tags: <name>, ...` entry assigns functional tags to schemas, classifying spans by the kind of work they perform (`setup`, `cpu`, `db`, `io`, etc., see [EDR-026](./026-tracing-span-design.md) for the list of tags).
 
-Tags can be declared at the module level, in which case they are inherited by all the schemas nested below that module,
-or inside a specific schema, in which case they override the module-level declaration. Each tag is automatically
-recorded on the corresponding spans as a boolean attribute named `amaru.tag.<name>`. 
+Tags can be declared at the module level, in which case they are inherited by all the schemas nested below that module, or inside a specific schema, in which case they override the module-level declaration. Each tag is automatically recorded on the corresponding spans as a boolean attribute named `amaru.tag.<name>`.
 
-Since tags are regular span attributes, they can be used to select spans regardless of their target and name with 
-an `EnvFilter` directive: for example `AMARU_LOG='[{amaru.tag.cpu=true}]=trace'` enables all the spans tagged with `cpu`.
+Since tags are regular span attributes, they can be used to select spans regardless of their target and name with an `EnvFilter` directive: for example `AMARU_LOG='[{amaru.tag.cpu=true}]=trace'` enables all the spans tagged with `cpu`.
 
 #### Explicit Span Construction
 
-Amaru now prefers explicit span creation over function-wide instrumentation wrappers. New schema-based tracing should
-use `debug_span!`
-or `info_span!` to create a span at the point where the work actually begins, then either enter that span or attach it
-to a future with `.instrument(...)`.
+Amaru now prefers explicit span creation over function-wide instrumentation wrappers. New schema-based tracing should use `debug_span!` or `info_span!` to create a span at the point where the work actually begins, then either enter that span or attach it to a future with `.instrument(...)`.
 
-Note that even though the schema compilation generates full names like
-`amaru_observability::amaru::consensus::state::header::EVOLVE_NONCE`,
-the `info_span!/debug_span!/trace_span!` macros only requires the second target name and the span name, e.g.
-`consensus::state::header::EVOLVE_NONCE`.
+Note that even though the schema compilation generates full names like `amaru_observability::amaru::consensus::state::header::EVOLVE_NONCE`, the `info_span!/debug_span!/trace_span!` macros only requires the second target name and the span name, e.g. `consensus::state::header::EVOLVE_NONCE`.
 
 ```rust
 fn evolve_nonce(&self, hash: String) -> Result<Nonce, ConsensusError> {
@@ -141,8 +119,7 @@ At compile time, `debug_span!` validates:
 - Required fields are supplied when the span is created
 - Field names and types match the schema declaration
 
-This explicit style is preferred because it makes span boundaries visible in the code and works naturally with partial
-scopes and async pipelines.
+This explicit style is preferred because it makes span boundaries visible in the code and works naturally with partial scopes and async pipelines.
 
 #### Span Augmentation
 
@@ -161,55 +138,36 @@ fn apply_block(block: &Block, point_slot: u64) {
 }
 ```
 
-This macro is a lightweight way to add context to the current span without creating a new one. The schema constant
-anchors the recording and documents which schema these fields belong to.
+This macro is a lightweight way to add context to the current span without creating a new one. The schema constant anchors the recording and documents which schema these fields belong to.
 
 #### Benefits
 
 - **Compile-time safety**: Typos or type mismatches in field names cause compilation errors
 - **Consistency**: All spans follow the same instrumentation pattern
 - **Discoverability**: All schemas are defined in a central, documented location
-- **Flexibility**: Functions can have additional parameters beyond schema fields, and spans can cover exactly the
-  synchronous or asynchronous scope that matters
+- **Flexibility**: Functions can have additional parameters beyond schema fields, and spans can cover exactly the synchronous or asynchronous scope that matters
 
 ### Metrics
 
-Each top-level module or crate will (optionally) define its own Metrics module, which exposes a `{CrateName}Metrics`
-struct, with a `new(..)` method and deriving `Clone`. At the time of this decision record, this would be the Amaru
-binary, Consensus, the Ledger, and the Sync module.
+Each top-level module or crate will (optionally) define its own Metrics module, which exposes a `{CrateName}Metrics` struct, with a `new(..)` method and deriving `Clone`. At the time of this decision record, this would be the Amaru binary, Consensus, the Ledger, and the Sync module.
 
-Each module or crate will, if applicable, accept an argument of type `{CrateName}Metrics` during initialization, and
-store an owned instance of this struct.
+Each module or crate will, if applicable, accept an argument of type `{CrateName}Metrics` during initialization, and store an owned instance of this struct.
 
-Each metrics struct will expose a number of
-top-level [Counters, Gauges, or Histograms](https://docs.rs/opentelemetry/latest/opentelemetry/metrics/index.html)
-relevant to its workload, and in the course of performing its work, will update these accordingly. The `new(..)` method
-will accept an [
-`SdkMeterProvider`](https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/metrics/struct.SdkMeterProvider.html) and
-initialize relevant objects with names, descriptions, and units as appropriate.
+Each metrics struct will expose a number of top-level [Counters, Gauges, or Histograms](https://docs.rs/opentelemetry/latest/opentelemetry/metrics/index.html) relevant to its workload, and in the course of performing its work, will update these accordingly. The `new(..)` method will accept an [`SdkMeterProvider`](https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/metrics/struct.SdkMeterProvider.html) and initialize relevant objects with names, descriptions, and units as appropriate.
 
-- [Counters](https://opentelemetry.io/docs/specs/otel/metrics/api/#counter) are used to count discrete or measurable
-  events or quantities that can be accumulated over time, such as number of blocks processed, number of bytes read, etc.
-- [Gauges](https://opentelemetry.io/docs/specs/otel/metrics/api/#gauge) are used to track measurements that only make
-  sense at a point in time, and shouldn't be added, such as current Memory or CPU usage, temperature, etc.
-- [Histograms](https://opentelemetry.io/docs/specs/otel/metrics/api/#histogram) are used to track values where the
-  statistical distributions are important, such as response latencies, where you want to query the 90th percentile, etc.
+- [Counters](https://opentelemetry.io/docs/specs/otel/metrics/api/#counter) are used to count discrete or measurable events or quantities that can be accumulated over time, such as number of blocks processed, number of bytes read, etc.
+- [Gauges](https://opentelemetry.io/docs/specs/otel/metrics/api/#gauge) are used to track measurements that only make sense at a point in time, and shouldn't be added, such as current Memory or CPU usage, temperature, etc.
+- [Histograms](https://opentelemetry.io/docs/specs/otel/metrics/api/#histogram) are used to track values where the statistical distributions are important, such as response latencies, where you want to query the 90th percentile, etc.
 
-Such metrics should follow
-the [Open Telemetry Metrics Semantics conventions](https://opentelemetry.io/docs/specs/semconv/general/metrics/).
+Such metrics should follow the [Open Telemetry Metrics Semantics conventions](https://opentelemetry.io/docs/specs/semconv/general/metrics/).
 
-The Amaru binary itself will contain a `metrics` module that stores and constructs instances of all other metrics types.
-It will be responsible for constructing and orchestrating all modules and crates. It will also track common system and
-process metrics, such as CPU and memory usage.
+The Amaru binary itself will contain a `metrics` module that stores and constructs instances of all other metrics types. It will be responsible for constructing and orchestrating all modules and crates. It will also track common system and process metrics, such as CPU and memory usage.
 
 ## Consequences
 
-- Each component of the Amaru node can fully own its own metrics. At the same time, someone wishing to document or
-  explore the metrics supported by the Amaru node has a single entrypoint to begin their exploration.
+- Each component of the Amaru node can fully own its own metrics. At the same time, someone wishing to document or explore the metrics supported by the Amaru node has a single entrypoint to begin their exploration.
 
-- Users of the Amaru node can track, aggregate, and alert on the health of the node based on multiple system or
-  component specific metrics. They might notice, for example, that CPU usage hits 100% at epoch boundaries, resulting in
-  missing slot leader checks, which indicates that the machine they are running the node on is underprovisioned.
+- Users of the Amaru node can track, aggregate, and alert on the health of the node based on multiple system or component specific metrics. They might notice, for example, that CPU usage hits 100% at epoch boundaries, resulting in missing slot leader checks, which indicates that the machine they are running the node on is underprovisioned.
 
 ## References
 

--- a/engineering-decision-records/007-observability.md
+++ b/engineering-decision-records/007-observability.md
@@ -59,33 +59,29 @@ Schemas are defined using the `define_schemas!` macro in a central location (`am
 They are organized hierarchically with five levels of nesting:
 
 - The first two levels define the target of a span, for example `amaru::consensus` or `amaru::ledger`.
-- The next three levels define the name of the span, for example `state.header.evolve_nonce` or `state.block.apply` (
+- The next three levels define the name of the span, for example `header.evolve_nonce` or `block.apply` (
   see [EDR-026](./026-tracing-span-design.md) for more details).
 
 ```rust
 define_schemas! {
     amaru {
         consensus {
-            state {
-                header {
-                    EVOLVE_NONCE {
-                        required hash: String
-                    }
-                    VALIDATE {
-                        required issuer_key: String
-                    }
-                }            
-            }     
+            header {
+                EVOLVE_NONCE {
+                    required hash: String
+                }
+                VALIDATE {
+                    required issuer_key: String
+                }
+            }            
         }
-        ledger {
-            state {
-                block {
-                    APPLY {
-                        required point_slot: u64
-                        optional error: String
-                    }              
-                }   
-            }
+        ledger {           
+            block {
+                APPLY {
+                    required point_slot: u64
+                    optional error: String
+                }              
+            }               
         }
     }
 }
@@ -95,6 +91,18 @@ Each schema declares:
 
 - **Required fields**: Must be supplied when creating the span, with matching types
 - **Optional fields**: Supplementary context that can be recorded later
+
+##### Tags
+
+In addition to fields, a `tags: <name>, ...` entry assigns functional tags to schemas, classifying spans by the kind of
+work they perform (`setup`, `cpu`, `db`, `io`, etc., see [EDR-026](./026-tracing-span-design.md) for the list of tags).
+
+Tags can be declared at the module level, in which case they are inherited by all the schemas nested below that module,
+or inside a specific schema, in which case they override the module-level declaration. Each tag is automatically
+recorded on the corresponding spans as a boolean attribute named `amaru.tag.<name>`. 
+
+Since tags are regular span attributes, they can be used to select spans regardless of their target and name with 
+an `EnvFilter` directive: for example `AMARU_LOG='[{amaru.tag.cpu=true}]=trace'` enables all the spans tagged with `cpu`.
 
 #### Explicit Span Construction
 
@@ -121,7 +129,7 @@ For async work, the same schema-validated span can be attached directly to the f
 
 ```rust
 async move {
-apply_block(block).await
+    apply_block(block).await
 }
 .instrument(debug_span!(ledger::state::block::APPLY, point_slot = point_slot))
 .await;

--- a/engineering-decision-records/007-observability.md
+++ b/engineering-decision-records/007-observability.md
@@ -7,13 +7,19 @@ status: accepted
 
 ## Context
 
-This decision record documents a general organization for how the Amaru node will collect and report critical operational metrics, logs, and tracing data.
+This decision record documents a general organization for how the Amaru node will collect and report critical
+operational metrics, logs, and tracing data.
 
-A key component of operating any computing system at scale is observability: tracking what happened, how often something happened, how long it took, how many resources something is consuming, and where potential issues or bottlenecks might be found.
+A key component of operating any computing system at scale is observability: tracking what happened, how often something
+happened, how long it took, how many resources something is consuming, and where potential issues or bottlenecks might
+be found.
 
-Thus, we would like Amaru to track and report these traces and metrics. We would also like to use industry standards so that users of the Amaru node can swap out their own visualization and aggregation infrastructure as needed.
+Thus, we would like Amaru to track and report these traces and metrics. We would also like to use industry standards so
+that users of the Amaru node can swap out their own visualization and aggregation infrastructure as needed.
 
-We would like the codebase to organize the metrics it tracks in a simple, consistent and modular way, such that each module or crate can own a subset of the metrics, while at the same time being consistent and discoverable through reading the code.
+We would like the codebase to organize the metrics it tracks in a simple, consistent and modular way, such that each
+module or crate can own a subset of the metrics, while at the same time being consistent and discoverable through
+reading the code.
 
 ## Decision
 
@@ -21,48 +27,64 @@ We would like the codebase to organize the metrics it tracks in a simple, consis
 
 - By default, the application provides human-readable information on stderr in a pretty format (possibly TUI).
 
-- Additionally, the application will embrace [observability](https://peter.bourgon.org/blog/2017/02/21/metrics-tracing-and-logging.html) and provide logs, traces, spans and metrics using Rust's [tracing](https://docs.rs/tracing/latest/tracing/index.html) ecosystem.
+- Additionally, the application will
+  embrace [observability](https://peter.bourgon.org/blog/2017/02/21/metrics-tracing-and-logging.html) and provide logs,
+  traces, spans and metrics using Rust's [tracing](https://docs.rs/tracing/latest/tracing/index.html) ecosystem.
 
 - All traces and spans can be made available on stdout in a structured format (JSON).
 
 - All traces, spans and metrics can be made available via the OpenTelemetry Protocol (OTLP) on the default OTLP ports.
-  - To ease its consumption, we provide at least two example setups for collecting and monitoring this telemetry:
-    - [Jaeger](https://www.jaegertracing.io/)
-    - [Grafana](https://grafana.com/) and [Tempo](https://grafana.com/oss/tempo/)
+    - To ease its consumption, we provide at least two example setups for collecting and monitoring this telemetry:
+        - [Jaeger](https://www.jaegertracing.io/)
+        - [Grafana](https://grafana.com/) and [Tempo](https://grafana.com/oss/tempo/)
 
-  - We will use the [opentelemetry-rust](https://github.com/open-telemetry/opentelemetry-rust) crate to collect and report traces and metrics.
+    - We will use the [opentelemetry-rust](https://github.com/open-telemetry/opentelemetry-rust) crate to collect and
+      report traces and metrics.
 
-  - We will make judicious use of [Spans](https://opentelemetry.io/docs/concepts/observability-primer/#spans) to expose the structured nature of the workload the Amaru node performs.
+    - We will make judicious use of [Spans](https://opentelemetry.io/docs/concepts/observability-primer/#spans) to
+      expose the structured nature of the workload the Amaru node performs.
 
 - We define the frontier between logs and traces by following a simple rule:
-  - Any event at the DEBUG level or above is considered a log
-  - Any event at the TRACE level is considered a trace
+    - Any event at the DEBUG level or above is considered a log
+    - Any event at the TRACE level is considered a trace
 
 ### Tracing Schemas
 
-To ensure consistency and enable compile-time validation of tracing instrumentation, we use a schema-based approach implemented in the `amaru-observability` crate.
+To ensure consistency and enable compile-time validation of tracing instrumentation, we use a schema-based approach
+implemented in the `amaru-observability` crate.
 
 #### Schema Definition
 
-Schemas are defined using the `define_schemas!` macro in a central location (`amaru-observability/src/schemas.rs`). They are organized hierarchically matching the crate/module structure:
+Schemas are defined using the `define_schemas!` macro in a central location (`amaru-observability/src/schemas.rs`).
+They are organized hierarchically with five levels of nesting:
+
+- The first two levels define the target of a span, for example `amaru::consensus` or `amaru::ledger`.
+- The next three levels define the name of the span, for example `state.header.evolve_nonce` or `state.block.apply` (
+  see [EDR-026](./026-tracing-span-design.md) for more details).
 
 ```rust
 define_schemas! {
-    consensus {
-        validate_header {
-            EVOLVE_NONCE {
-                required hash: String
-            }
-            VALIDATE {
-                required issuer_key: String
-            }
+    amaru {
+        consensus {
+            state {
+                header {
+                    EVOLVE_NONCE {
+                        required hash: String
+                    }
+                    VALIDATE {
+                        required issuer_key: String
+                    }
+                }            
+            }     
         }
-    }
-    ledger {
-        state {
-            APPLY_BLOCK {
-                required point_slot: u64
-                optional error: String
+        ledger {
+            state {
+                block {
+                    APPLY {
+                        required point_slot: u64
+                        optional error: String
+                    }              
+                }   
             }
         }
     }
@@ -70,16 +92,25 @@ define_schemas! {
 ```
 
 Each schema declares:
+
 - **Required fields**: Must be supplied when creating the span, with matching types
 - **Optional fields**: Supplementary context that can be recorded later
 
 #### Explicit Span Construction
 
-Amaru now prefers explicit span creation over function-wide instrumentation wrappers. New schema-based tracing should use `trace_span!` to create a span at the point where the work actually begins, then either enter that span or attach it to a future with `.instrument(...)`.
+Amaru now prefers explicit span creation over function-wide instrumentation wrappers. New schema-based tracing should
+use `debug_span!`
+or `info_span!` to create a span at the point where the work actually begins, then either enter that span or attach it
+to a future with `.instrument(...)`.
+
+Note that even though the schema compilation generates full names like
+`amaru_observability::amaru::consensus::state::header::EVOLVE_NONCE`,
+the `info_span!/debug_span!/trace_span!` macros only requires the second target name and the span name, e.g.
+`consensus::state::header::EVOLVE_NONCE`.
 
 ```rust
 fn evolve_nonce(&self, hash: String) -> Result<Nonce, ConsensusError> {
-    let span = trace_span!(consensus::validate_header::EVOLVE_NONCE, hash = &hash);
+    let span = debug_span!(consensus::state::header::EVOLVE_NONCE, hash = &hash);
     let _guard = span.enter();
 
     // function body
@@ -90,18 +121,20 @@ For async work, the same schema-validated span can be attached directly to the f
 
 ```rust
 async move {
-    apply_block(block).await
+apply_block(block).await
 }
-.instrument(trace_span!(ledger::state::APPLY_BLOCK, point_slot = point_slot))
+.instrument(debug_span!(ledger::state::block::APPLY, point_slot = point_slot))
 .await;
 ```
 
-At compile time, `trace_span!` validates:
+At compile time, `debug_span!` validates:
+
 - The schema exists at the specified path
 - Required fields are supplied when the span is created
 - Field names and types match the schema declaration
 
-This explicit style is preferred because it makes span boundaries visible in the code and works naturally with partial scopes and async pipelines.
+This explicit style is preferred because it makes span boundaries visible in the code and works naturally with partial
+scopes and async pipelines.
 
 #### Span Augmentation
 
@@ -109,47 +142,66 @@ The `trace_record!` macro records fields to the current span with a schema ancho
 
 ```rust
 fn apply_block(block: &Block, point_slot: u64) {
-    let span = trace_span!(ledger::state::APPLY_BLOCK, point_slot = point_slot);
+    let span = debug_span!(ledger::state::block::APPLY, point_slot = point_slot);
     let _guard = span.enter();
 
     trace_record!(
-        ledger::state::APPLY_BLOCK,
+        ledger::state::block::APPLY,
         block_size = block.size(),
         tx_count = block.transactions.len()
     );
 }
 ```
 
-This macro is a lightweight way to add context to the current span without creating a new one. The schema constant anchors the recording and documents which schema these fields belong to.
+This macro is a lightweight way to add context to the current span without creating a new one. The schema constant
+anchors the recording and documents which schema these fields belong to.
 
 #### Benefits
 
 - **Compile-time safety**: Typos or type mismatches in field names cause compilation errors
 - **Consistency**: All spans follow the same instrumentation pattern
 - **Discoverability**: All schemas are defined in a central, documented location
-- **Flexibility**: Functions can have additional parameters beyond schema fields, and spans can cover exactly the synchronous or asynchronous scope that matters
+- **Flexibility**: Functions can have additional parameters beyond schema fields, and spans can cover exactly the
+  synchronous or asynchronous scope that matters
 
 ### Metrics
 
-Each top-level module or crate will (optionally) define its own Metrics module, which exposes a `{CrateName}Metrics` struct, with a `new(..)` method and deriving `Clone`. At the time of this decision record, this would be the Amaru binary, Consensus, the Ledger, and the Sync module.
+Each top-level module or crate will (optionally) define its own Metrics module, which exposes a `{CrateName}Metrics`
+struct, with a `new(..)` method and deriving `Clone`. At the time of this decision record, this would be the Amaru
+binary, Consensus, the Ledger, and the Sync module.
 
-Each module or crate will, if applicable, accept an argument of type `{CrateName}Metrics` during initialization, and store an owned instance of this struct.
+Each module or crate will, if applicable, accept an argument of type `{CrateName}Metrics` during initialization, and
+store an owned instance of this struct.
 
-Each metrics struct will expose a number of top-level [Counters, Gauges, or Histograms](https://docs.rs/opentelemetry/latest/opentelemetry/metrics/index.html) relevant to its workload, and in the course of performing its work, will update these accordingly. The `new(..)` method will accept an [`SdkMeterProvider`](https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/metrics/struct.SdkMeterProvider.html) and initialize relevant objects with names, descriptions, and units as appropriate.
+Each metrics struct will expose a number of
+top-level [Counters, Gauges, or Histograms](https://docs.rs/opentelemetry/latest/opentelemetry/metrics/index.html)
+relevant to its workload, and in the course of performing its work, will update these accordingly. The `new(..)` method
+will accept an [
+`SdkMeterProvider`](https://docs.rs/opentelemetry_sdk/latest/opentelemetry_sdk/metrics/struct.SdkMeterProvider.html) and
+initialize relevant objects with names, descriptions, and units as appropriate.
 
-- [Counters](https://opentelemetry.io/docs/specs/otel/metrics/api/#counter) are used to count discrete or measurable events or quantities that can be accumulated over time, such as number of blocks processed, number of bytes read, etc.
-- [Gauges](https://opentelemetry.io/docs/specs/otel/metrics/api/#gauge) are used to track measurements that only make sense at a point in time, and shouldn't be added, such as current Memory or CPU usage, temperature, etc.
-- [Histograms](https://opentelemetry.io/docs/specs/otel/metrics/api/#histogram) are used to track values where the statistical distributions are important, such as response latencies, where you want to query the 90th percentile, etc.
+- [Counters](https://opentelemetry.io/docs/specs/otel/metrics/api/#counter) are used to count discrete or measurable
+  events or quantities that can be accumulated over time, such as number of blocks processed, number of bytes read, etc.
+- [Gauges](https://opentelemetry.io/docs/specs/otel/metrics/api/#gauge) are used to track measurements that only make
+  sense at a point in time, and shouldn't be added, such as current Memory or CPU usage, temperature, etc.
+- [Histograms](https://opentelemetry.io/docs/specs/otel/metrics/api/#histogram) are used to track values where the
+  statistical distributions are important, such as response latencies, where you want to query the 90th percentile, etc.
 
-Such metrics should follow the [Open Telemetry Metrics Semantics conventions](https://opentelemetry.io/docs/specs/semconv/general/metrics/).
+Such metrics should follow
+the [Open Telemetry Metrics Semantics conventions](https://opentelemetry.io/docs/specs/semconv/general/metrics/).
 
-The Amaru binary itself will contain a `metrics` module that stores and constructs instances of all other metrics types. It will be responsible for constructing and orchestrating all modules and crates. It will also track common system and process metrics, such as CPU and memory usage.
+The Amaru binary itself will contain a `metrics` module that stores and constructs instances of all other metrics types.
+It will be responsible for constructing and orchestrating all modules and crates. It will also track common system and
+process metrics, such as CPU and memory usage.
 
 ## Consequences
 
-- Each component of the Amaru node can fully own its own metrics. At the same time, someone wishing to document or explore the metrics supported by the Amaru node has a single entrypoint to begin their exploration.
+- Each component of the Amaru node can fully own its own metrics. At the same time, someone wishing to document or
+  explore the metrics supported by the Amaru node has a single entrypoint to begin their exploration.
 
-- Users of the Amaru node can track, aggregate, and alert on the health of the node based on multiple system or component specific metrics. They might notice, for example, that CPU usage hits 100% at epoch boundaries, resulting in missing slot leader checks, which indicates that the machine they are running the node on is underprovisioned.
+- Users of the Amaru node can track, aggregate, and alert on the health of the node based on multiple system or
+  component specific metrics. They might notice, for example, that CPU usage hits 100% at epoch boundaries, resulting in
+  missing slot leader checks, which indicates that the machine they are running the node on is underprovisioned.
 
 ## References
 

--- a/engineering-decision-records/007-observability.md
+++ b/engineering-decision-records/007-observability.md
@@ -44,10 +44,10 @@ To ensure consistency and enable compile-time validation of tracing instrumentat
 
 #### Schema Definition
 
-Schemas are defined using the `define_schemas!` macro in a central location (`amaru-observability/src/schemas.rs`). They are organized hierarchically with five levels of nesting:
+Schemas are defined using the `define_schemas!` macro in a central location (`amaru-observability/src/schemas.rs`). They are organized hierarchically:
 
 - The first two levels define the target of a span, for example `amaru::consensus` or `amaru::ledger`.
-- The next three levels define the name of the span, for example `header.evolve_nonce` or `block.apply` (
+- The other levels (two or three in practice) define the name of the span, for example `header.evolve_nonce` or `block.apply` (
   see [EDR-026](./026-tracing-span-design.md) for more details).
 
 ```rust
@@ -88,15 +88,20 @@ Tags can be declared at the module level, in which case they are inherited by al
 
 Since tags are regular span attributes, they can be used to select spans regardless of their target and name with an `EnvFilter` directive: for example `AMARU_LOG='[{amaru.tag.cpu=true}]=trace'` enables all the spans tagged with `cpu`.
 
+Several tags can be combined:
+
+- To select the spans carrying _either_ tag (OR), use one directive per tag: `AMARU_LOG='[{amaru.tag.db=true}]=trace,[{amaru.tag.io=true}]=trace'` enables all the spans tagged with `db` plus all the spans tagged with `io`, because each directive is evaluated independently.
+- To select only the spans carrying _all_ the tags (AND), list the tags inside a single directive: `AMARU_LOG='[{amaru.tag.cpu=true,amaru.tag.db=true}]=trace'` only enables the spans tagged with both `cpu` and `db`.
+
 #### Explicit Span Construction
 
 Amaru now prefers explicit span creation over function-wide instrumentation wrappers. New schema-based tracing should use `debug_span!` or `info_span!` to create a span at the point where the work actually begins, then either enter that span or attach it to a future with `.instrument(...)`.
 
-Note that even though the schema compilation generates full names like `amaru_observability::amaru::consensus::state::header::EVOLVE_NONCE`, the `info_span!/debug_span!/trace_span!` macros only requires the second target name and the span name, e.g. `consensus::state::header::EVOLVE_NONCE`.
+Note that even though the schema compilation generates full names like `amaru_observability::amaru::consensus::header::EVOLVE_NONCE`, the `info_span!/debug_span!/trace_span!` macros only requires the second target name and the span name, e.g. `consensus::header::EVOLVE_NONCE`.
 
 ```rust
 fn evolve_nonce(&self, hash: String) -> Result<Nonce, ConsensusError> {
-    let span = debug_span!(consensus::state::header::EVOLVE_NONCE, hash = &hash);
+    let span = debug_span!(consensus::header::EVOLVE_NONCE, hash = &hash);
     let _guard = span.enter();
 
     // function body
@@ -109,7 +114,7 @@ For async work, the same schema-validated span can be attached directly to the f
 async move {
     apply_block(block).await
 }
-.instrument(debug_span!(ledger::state::block::APPLY, point_slot = point_slot))
+.instrument(debug_span!(ledger::block::APPLY, point_slot = point_slot))
 .await;
 ```
 
@@ -127,11 +132,11 @@ The `trace_record!` macro records fields to the current span with a schema ancho
 
 ```rust
 fn apply_block(block: &Block, point_slot: u64) {
-    let span = debug_span!(ledger::state::block::APPLY, point_slot = point_slot);
+    let span = debug_span!(ledger::block::APPLY, point_slot = point_slot);
     let _guard = span.enter();
 
     trace_record!(
-        ledger::state::block::APPLY,
+        ledger::block::APPLY,
         block_size = block.size(),
         tx_count = block.transactions.len()
     );
@@ -149,7 +154,7 @@ This macro is a lightweight way to add context to the current span without creat
 
 ### Metrics
 
-Each top-level module or crate will (optionally) define its own Metrics module, which exposes a `{CrateName}Metrics` struct, with a `new(..)` method and deriving `Clone`. At the time of this decision record, this would be the Amaru binary, Consensus, the Ledger, and the Sync module.
+Each top-level module or crate will (optionally) define its own Metrics module, which exposes a `{CrateName}Metrics` struct, with a `new(..)` method and deriving `Clone`. At the time of this decision record, this would be the Ledger module.
 
 Each module or crate will, if applicable, accept an argument of type `{CrateName}Metrics` during initialization, and store an owned instance of this struct.
 

--- a/engineering-decision-records/026-tracing-span-design.md
+++ b/engineering-decision-records/026-tracing-span-design.md
@@ -7,8 +7,10 @@ status: accepted
 
 ## Context
 
-EDRs [007 (Observability)][edr-observability] and [015 (nView metrics)][edr-metrics] define our general approach to observability and some guidance regarding metrics to enable infrastructure reuse between node implementations.
-This EDR defines the guaranteed tracing spans exported for Cardano network health monitoring as well as the approach towards adding spans specific to Amaru maintenance and development and their initial setup.
+EDRs [007 (Observability)][edr-observability] and [015 (nView metrics)][edr-metrics] define our general approach to
+observability and some guidance regarding metrics to enable infrastructure reuse between node implementations.
+This EDR defines the guaranteed tracing spans exported for Cardano network health monitoring as well as the approach
+towards adding spans specific to Amaru maintenance and development and their initial setup.
 
 ## Decision
 
@@ -18,116 +20,179 @@ This section is structured by the kind of traces under consideration:
 - handling transactions in the _mempool_
 - _peer management_ activities
 
-Each of these areas contains parts that are intended for node operators as well as implementation details relevant for Amaru developers.
-It is important that the node admin can enable any desired trace to aid in debugging issues that may be observed in production.
+Each of these areas contains parts that are intended for node operators as well as implementation details relevant for
+Amaru developers.
+It is important that the node admin can enable any desired trace to aid in debugging issues that may be observed in
+production.
 
-All traces are classified first by a TARGET and within that target by a NAME (which is not to be confused with the span’s message).
-The target gives a rough categorization and allows selecting traces pertaining to one of the major Amaru components (precise granularity to be decided case by case).
+All spans are classified first by a TARGET and within that target by a NAME.
+The target gives a rough categorization and allows selecting traces pertaining to one of the major Amaru components (
+precise granularity to be decided case by case).
 
-The name uniquely identifies the source location within a given target **(see discussion below)** and is composed from multiple components separated by dots.
+The name uniquely identifies the source location within a given target **(see discussion below)** and is composed from
+multiple components separated by dots.
 
 1. a category for describing the type of work being done:
 
-   - `setup` for starting up a component or subsystem
-   - `check` for validating inputs, peer behaviour, authorization, integrity, etc.
-   - `state` for computing or updating internal state
-   - `db` for structured storage operations
-   - `io` for all other file / storage / network operations
-   - `cli` for all operations related to the command-line interface or terminal user interface
-   - `perf` for dedicated performance measurements
+    - `setup` for starting up a component or subsystem
+    - `check` for validating inputs, peer behaviour, authorization, integrity, etc.
+    - `state` for computing or updating internal state
+    - `db` for structured storage operations
+    - `io` for all other file / storage / network operations
+    - `cli` for all operations related to the command-line interface or terminal user interface
+    - `perf` for dedicated performance measurements
 
 2. a function, logical unit, data item, or similar
 3. an operation (if applicable) described as a verb
 
 > **IMPORTANT NOTICE ON `tracing` LEVELS**
 >
-> The `tracing` infrastructure we use to emit OpenTelemetry spans is built around log levels `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`.
-> Log messages (including spans) from `INFO` upwards are printed to `stderr` by default and are part of the CLI / TUI design; these must not occur with high frequency and be relevant to a human observer.
-> `TRACE` level is only intended for debug builds when actually debugging a specific code module, it is not considered viable to switch on all `TRACE` logging, and it is not considered viable to switch on ANY `TRACE` logging during normal operation; `TRACE` level is removed from release binaries by compile-time options.
+> The `tracing` infrastructure we use to emit OpenTelemetry spans is built around log levels `TRACE`, `DEBUG`, `INFO`,
+`WARN`, `ERROR`.
+> Log messages (including spans) from `INFO` upwards are printed to `stderr` by default and are part of the CLI / TUI
+> design; these must not occur with high frequency and be relevant to a human observer.
+> `TRACE` level is only intended for debug builds when actually debugging a specific code module, it is not considered
+> viable to switch on all `TRACE` logging, and it is not considered viable to switch on ANY `TRACE` logging during
+> normal
+> operation; `TRACE` level is removed from release binaries by compile-time options.
 >
-> **For these reasons all nominally emitted trace spans intended for production use MUST be emitted at `DEBUG` level!**
+> **For these reasons all nominally emitted trace spans intended for production use MUST be emitted at `DEBUG` or
+the `INFO` levels!**
 >
-> Since OpenTelemetry treats logs (i.e. tracing events a.k.a. log messages) as individually important, all debug logging that may occur at high rate MUST be emitted at `TRACE` level.
+> Since OpenTelemetry treats logs (i.e. tracing events a.k.a. log messages) as individually important, all debug logging
+> that may occur at high rate MUST be emitted at `TRACE` level.
+
+### Impact on EDR 007 (Observability)
+
+[EDR-007 on observability][edr-observability] defines the general approach to observability and the use of
+OpenTelemetry. It prescribes the use of a schema to specify spans attributes and their types with namespacing to avoid
+collisions.
+
+The current EDR restricts the definition of the schema to five levels of nesting, where the first two levels are used to
+define the target of a span and the next 3 levels to define the name of the span.
+
+Here are two examples. During consensus, we receive an upstream message informing the node of a new block header and we
+need to evolve the nonce associated with the current header. In that case the fully qualified name of the span in the
+schema is:
+
+```rust
+amaru::consensus::state::header::evolve_nonce
+```
+
+In this example, the target is `amaru::consensus` and the name is `state.header.evolve_nonce`.
+Similarly for the ledger, we can find a schema entry like:
+
+```rust
+amaru::ledger::state::validation_context::create
+```
+
+In this case, the target is `amaru::ledger` and the name is `state.validation_context.create`.
+
+We also mandate that the span names are unique, even across targets, to avoid having two spans called
+`state.block.validate` both in `amaru::consensus` and in `amaru::ledger`.
+
+Note: we might increase the number of levels in the schema in the future, to allow for more precise target names.
+For example with `amaru::ledger::script`.
 
 ### Blockchain
 
 The unit of processing for the chain is one block, which is logically also the unit for tracing.
-We therefore generate a trace ID for each header received from upstream and associate the header hash with that trace ID as an OpenTelemetry property.
-The trace ID can already be generated by the per-connection multiplexer when seeing inbound chainsync messages: traces that pertain to messages other than `chainsync::Message::RollForward` will not be tagged with the header hash property.
+We therefore generate a trace ID for each header received from upstream and associate the header hash with that trace ID
+as a span attribute (`header_hash`).
+The trace ID can already be generated by the per-connection multiplexer when seeing inbound chainsync messages: traces
+that pertain to messages other than `chainsync`'s `RollForward` message will not be tagged with the header hash
+property.
 
-Each tracing span pertaining to header or block processing shall be associated with the trace ID for that header hash; this implies that this trace ID is transported through the consensus stages and via the external effects into stores and ledger.
+Each span pertaining to header or block processing shall be associated with the trace ID for that header hash;
+this implies that this trace ID is transported through the consensus stages and via the external effects into stores and
+ledger.
 
 #### Cardano Health Monitoring
 
-> **TARGET:** `amaru::CHAIN_DIFFUSION`
+> **TARGET:** `amaru::network`
 >
-> Even though the below spans are constructed in different consensus stages, this purpose justifies the overarching target selection.
+> Even though the below spans are constructed in different consensus stages, this purpose justifies the overarching
+> target selection.
 
-One result of the Node Diversity Workshop in Porto (June 2–3, 2026) was a reaffirmation of the statement that core network health monitoring relies on recording four processing points:
+One result of the Node Diversity Workshop in Porto (June 2–3, 2026) was a reaffirmation of the statement that core
+network health monitoring relies on recording four processing points:
 
 1. first reception of a header from some upstream peer
 2. first request to fetch the block sent to an upstream peer
 3. first reception of the block from some upstream peer
 4. local adoption of the block
 
-We support this by opening a span with NAME `perf.e2e.forward` upon successful decoding of the header in `track_peers` and closing that span in `select_chain`, either upon seeing that the header is not on the best chain candidate or upon receiving the block validation result (which is slightly after adopting the block but typically before communicating the new tip to downstream peers);
-this records points 1 and 4.
+We support this by opening a span with NAME `perf.header.forward` upon successful decoding of the header in the
+`track_peers` stage and closing that span in the `select_chain` stage, either upon seeing that the header is not on the
+best chain candidate or upon receiving the block validation result (which is slightly after adopting the block but
+typically before communicating the new tip to downstream peers). This records points 1 and 4.
 
-Points 2 and 3 are recorded by opening a span with NAME `perf.rb.fetch` in `fetch_blocks` when requesting a range containing that block and closing that range when the block has been received.
+Points 2 and 3 are recorded by opening a span with NAME `perf.blocks.fetch` in `fetch_blocks` when requesting a range
+containing that block and closing that range when the block has been received.
 
 Switching to a different fork will then open a span with NAME `perf.fork.switch` for all blocks on the target fork.
 
 #### Consensus
 
-> **TARGET:** `amaru::consensus::*`
+> **TARGET:** `amaru::consensus`
 
-This category is only relevant when developing, improving, or debugging Amaru itself.
-Each consensus stage invocation opens and closes a span whose TARGET matches the stage name (in the code, not the `pure-stage` identifier) with the NAME `state.msg.process`.
-Further spans for tracking the execution time of individual processing steps are created where this is deemed helpful.
+The span names for this target don't have to follow the names of the stages in the consensus pipeline,
+but rather reflect the logical processing steps that are performed on a header or block.
 
-External `pure-stage` effect handling is extended such that the calling stage’s tracing span is set as the context when executing the effect logic.
-This will tie for example all store or ledger spans to their parent span from the consensus stage that triggered the effect.
+External `pure-stage` effect handling is extended such that the calling stage’s span is set as the context when
+executing the effect logic. This will tie for example all store or ledger spans to their parent span from the consensus
+span that triggered the effect.
 
-Messages sent to the `peer_selection` stage stemming from adversarial peer behaviour are associated with the related header’s trace ID.
+Messages sent to the `peer_selection` stage stemming from adversarial peer behaviour must be associated with the related
+header’s trace ID.
 
-The waiting time of a header in `select_chain` before being eligible for fetching blocks during catch-up (due to the back-pressure decoupling twixt `select_chain` and `fetch_blocks`) is made explicitly visible in the traces by opening and closing a span with NAME `perf.header_sync.wait` accordingly.
+The waiting time of a header in `select_chain` before being eligible for fetching blocks during catch-up (due to the
+back-pressure decoupling twixt `select_chain` and `fetch_blocks`) must be made explicitly visible in the traces by
+opening and closing a span with NAME `perf.header.block_fetch_wait` accordingly.
 
 #### Ledger
 
-> **TARGET:** `amaru::LEDGER`
+> **TARGET:** `amaru::ledger`
 
 All ledger operations (validating headers and blocks, performing reward calculations, etc.) are traced in this category.
-Those activities that are related to a specific block will automatically be associated with the right tracing context via the parent propagation added to `pure-stage` effect handlers.
-Activities spawned from such invocations that are not related to that block or header (like asynchronous rewards calculations) are NOT associated with the calling trace context and instead create new trace IDs.
+Those activities that are related to a specific block will automatically be associated with the right tracing context
+via the parent propagation added to `pure-stage` effect handlers.
+Activities spawned from such invocations that are not related to that block or header (like asynchronous rewards
+calculations) are NOT associated with the calling trace context and instead create new trace IDs.
 
 ### Mempool
 
-> **TARGET:** `amaru::MEMPOOL`
+> **TARGET:** `amaru::mempool`
 
 Each received transaction gives rise to a trace ID associated with the transaction hash as a property.
 The spans recorded are:
 
-- NAME `state.txn.submit`: is opened upon local reception of the transaction and closed when inserted in the mempool or rejected
-- NAME `state.txn.receive`: is opened upon N2N reception of the transaction and closed when inserted in the mempool or rejected
-- NAME `state.txn.forward`: is opened when an upstream peer is requesting transactions and this transaction’s ID is sent; it is closed when the transaction has been sent to the peer
+- NAME `state.transaction.submit`: is opened upon local reception of the transaction and closed when inserted in the
+  mempool or
+  rejected
+- NAME `state.transaction.receive`: is opened upon N2N reception of the transaction and closed when inserted in the
+  mempool or
+  rejected
+- NAME `state.transaction.forward`: is opened when an upstream peer is requesting transactions and this transaction’s ID
+  is
+  sent; it is closed when the transaction has been sent to the peer
 
-### Peer Management
+### Protocols
 
-> **TARGET:** `amaru::PEER`
+> **TARGET:** `amaru::protocols`
 
-This category covers all peer management operations like connecting, disconnecting, mini-protocol state changes, etc.
-It is important to note that OpenTelemetry traces are not meant to be long-running while peers are long-lived entities.
-We therefore do not associate a single trace ID with each peer but rather generate a new trace ID per peer management activity.
+This target groups spans that are related to the implementation of specific protocols, like `chainsync`, `txsubmission`,
+`keepalive` etc...
 
-The precise design of spans and their names will be done at a later time.
+### Network
 
-## Consequences
+> **TARGET:** `amaru::network`
 
-## Discussion Points
-
-- shall we make the span name globally unique, enforce that in the schema, and select the target automatically based on the name?
+This target is reserved for spans that are related to the network layer, regardless of the protocol being used.
+It is typically used for tracking the lifecycle of network connections.
 
 ## References
 
 [edr-observability]: ./007-observability.md
+
 [edr-metrics]: ./015-recording-cardano-metrics.md

--- a/engineering-decision-records/026-tracing-span-design.md
+++ b/engineering-decision-records/026-tracing-span-design.md
@@ -30,20 +30,10 @@ The target gives a rough categorization and allows selecting traces pertaining t
 precise granularity to be decided case by case).
 
 The name uniquely identifies the source location within a given target **(see discussion below)** and is composed from
-multiple components separated by dots.
+multiple components separated by dots. For example
 
-1. a category for describing the type of work being done:
-
-    - `setup` for starting up a component or subsystem
-    - `check` for validating inputs, peer behaviour, authorization, integrity, etc.
-    - `state` for computing or updating internal state
-    - `db` for structured storage operations
-    - `io` for all other file / storage / network operations
-    - `cli` for all operations related to the command-line interface or terminal user interface
-    - `perf` for dedicated performance measurements
-
-2. a function, logical unit, data item, or similar
-3. an operation (if applicable) described as a verb
+1. a function, logical unit, data item, or similar
+2. an operation (if applicable) described as a verb
 
 > **IMPORTANT NOTICE ON `tracing` LEVELS**
 >
@@ -68,31 +58,37 @@ the `INFO` levels!**
 OpenTelemetry. It prescribes the use of a schema to specify spans attributes and their types with namespacing to avoid
 collisions.
 
-The current EDR restricts the definition of the schema to five levels of nesting, where the first two levels are used to
-define the target of a span and the next 3 levels to define the name of the span.
+In the current EDR the first two levels are used to define the target of a span and the next levels to define the name of the span.
 
 Here are two examples. During consensus, we receive an upstream message informing the node of a new block header and we
 need to evolve the nonce associated with the current header. In that case the fully qualified name of the span in the
 schema is:
 
 ```rust
-amaru::consensus::state::header::evolve_nonce
+amaru::consensus::header::evolve_nonce
 ```
 
-In this example, the target is `amaru::consensus` and the name is `state.header.evolve_nonce`.
+In this example, the target is `amaru::consensus` and the name is `header.evolve_nonce`.
 Similarly for the ledger, we can find a schema entry like:
 
 ```rust
-amaru::ledger::state::validation_context::create
+amaru::ledger::validation_context::create
 ```
 
-In this case, the target is `amaru::ledger` and the name is `state.validation_context.create`.
+In this case, the target is `amaru::ledger` and the name is `validation_context.create`.
 
 We also mandate that the span names are unique, even across targets, to avoid having two spans called
-`state.block.validate` both in `amaru::consensus` and in `amaru::ledger`.
+`block.validate` both in `amaru::consensus` and in `amaru::ledger`.
 
-Note: we might increase the number of levels in the schema in the future, to allow for more precise target names.
-For example with `amaru::ledger::script`.
+In addition to the target and name of a span, the schema can define a number of tags, that translate to boolean span
+attributes. This can be used to classify spans across target and span names. For example:
+
+    - `setup` for starting up a component or subsystem
+    - `check` for validating inputs, peer behaviour, authorization, integrity, etc.
+    - `cpu` for computing or updating internal state
+    - `db` for structured storage operations
+    - `io` for all other file / storage / network operations
+    - `cli` for all operations related to the command-line interface or terminal user interface
 
 ### Blockchain
 

--- a/engineering-decision-records/026-tracing-span-design.md
+++ b/engineering-decision-records/026-tracing-span-design.md
@@ -7,10 +7,8 @@ status: accepted
 
 ## Context
 
-EDRs [007 (Observability)][edr-observability] and [015 (nView metrics)][edr-metrics] define our general approach to
-observability and some guidance regarding metrics to enable infrastructure reuse between node implementations.
-This EDR defines the guaranteed tracing spans exported for Cardano network health monitoring as well as the approach
-towards adding spans specific to Amaru maintenance and development and their initial setup.
+EDRs [007 (Observability)][edr-observability] and [015 (nView metrics)][edr-metrics] define our general approach to observability and some guidance regarding metrics to enable infrastructure reuse between node implementations.
+This EDR defines the guaranteed tracing spans exported for Cardano network health monitoring as well as the approach towards adding spans specific to Amaru maintenance and development and their initial setup.
 
 ## Decision
 
@@ -20,37 +18,26 @@ This section is structured by the kind of traces under consideration:
 - handling transactions in the _mempool_
 - _peer management_ activities
 
-Each of these areas contains parts that are intended for node operators as well as implementation details relevant for
-Amaru developers.
-It is important that the node admin can enable any desired trace to aid in debugging issues that may be observed in
-production.
+Each of these areas contains parts that are intended for node operators as well as implementation details relevant for Amaru developers.
+It is important that the node admin can enable any desired trace to aid in debugging issues that may be observed in production.
 
 All spans are classified first by a TARGET and within that target by a NAME.
-The target gives a rough categorization and allows selecting traces pertaining to one of the major Amaru components (
-precise granularity to be decided case by case).
+The target gives a rough categorization and allows selecting traces pertaining to one of the major Amaru components (precise granularity to be decided case by case).
 
-The name uniquely identifies the source location within a given target **(see discussion below)** and is composed from
-multiple components separated by dots. For example
+The name uniquely identifies the source location within a given target **(see discussion below)** and is composed from multiple components separated by dots. For example
 
 1. a function, logical unit, data item, or similar
 2. an operation (if applicable) described as a verb
 
 > **IMPORTANT NOTICE ON `tracing` LEVELS**
 >
-> The `tracing` infrastructure we use to emit OpenTelemetry spans is built around log levels `TRACE`, `DEBUG`, `INFO`,
-`WARN`, `ERROR`.
-> Log messages (including spans) from `INFO` upwards are printed to `stderr` by default and are part of the CLI / TUI
-> design; these must not occur with high frequency and be relevant to a human observer.
-> `TRACE` level is only intended for debug builds when actually debugging a specific code module, it is not considered
-> viable to switch on all `TRACE` logging, and it is not considered viable to switch on ANY `TRACE` logging during
-> normal
-> operation; `TRACE` level is removed from release binaries by compile-time options.
+> The `tracing` infrastructure we use to emit OpenTelemetry spans is built around log levels `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`.
+> Log messages (including spans) from `INFO` upwards are printed to `stderr` by default and are part of the CLI / TUI design; these must not occur with high frequency and be relevant to a human observer.
+> `TRACE` level is only intended for debug builds when actually debugging a specific code module, it is not considered viable to switch on all `TRACE` logging, and it is not considered viable to switch on ANY `TRACE` logging during normal operation; `TRACE` level is removed from release binaries by compile-time options.
 >
-> **For these reasons all nominally emitted trace spans intended for production use MUST be emitted at `DEBUG` or
-the `INFO` levels!**
+> **For these reasons all nominally emitted trace spans intended for production use MUST be emitted at `DEBUG` or the `INFO` levels!**
 >
-> Since OpenTelemetry treats logs (i.e. tracing events a.k.a. log messages) as individually important, all debug logging
-> that may occur at high rate MUST be emitted at `TRACE` level.
+> Since OpenTelemetry treats logs (i.e. tracing events a.k.a. log messages) as individually important, all debug logging that may occur at high rate MUST be emitted at `TRACE` level.
 
 ### Impact on EDR 007 (Observability)
 
@@ -93,38 +80,27 @@ attributes. This can be used to classify spans across target and span names. For
 ### Blockchain
 
 The unit of processing for the chain is one block, which is logically also the unit for tracing.
-We therefore generate a trace ID for each header received from upstream and associate the header hash with that trace ID
-as a span attribute (`header_hash`).
-The trace ID can already be generated by the per-connection multiplexer when seeing inbound chainsync messages: traces
-that pertain to messages other than `chainsync`'s `RollForward` message will not be tagged with the header hash
-property.
+We therefore generate a trace ID for each header received from upstream and associate the header hash with that trace ID as a span attribute (`header_hash`).
+The trace ID can already be generated by the per-connection multiplexer when seeing inbound chainsync messages: traces that pertain to messages other than `chainsync`'s `RollForward` message will not be tagged with the header hash property.
 
-Each span pertaining to header or block processing shall be associated with the trace ID for that header hash;
-this implies that this trace ID is transported through the consensus stages and via the external effects into stores and
-ledger.
+Each span pertaining to header or block processing shall be associated with the trace ID for that header hash; this implies that this trace ID is transported through the consensus stages and via the external effects into stores and ledger.
 
 #### Cardano Health Monitoring
 
 > **TARGET:** `amaru::network`
 >
-> Even though the below spans are constructed in different consensus stages, this purpose justifies the overarching
-> target selection.
+> Even though the below spans are constructed in different consensus stages, this purpose justifies the overarching target selection.
 
-One result of the Node Diversity Workshop in Porto (June 2–3, 2026) was a reaffirmation of the statement that core
-network health monitoring relies on recording four processing points:
+One result of the Node Diversity Workshop in Porto (June 2–3, 2026) was a reaffirmation of the statement that core network health monitoring relies on recording four processing points:
 
 1. first reception of a header from some upstream peer
 2. first request to fetch the block sent to an upstream peer
 3. first reception of the block from some upstream peer
 4. local adoption of the block
 
-We support this by opening a span with NAME `perf.header.forward` upon successful decoding of the header in the
-`track_peers` stage and closing that span in the `select_chain` stage, either upon seeing that the header is not on the
-best chain candidate or upon receiving the block validation result (which is slightly after adopting the block but
-typically before communicating the new tip to downstream peers). This records points 1 and 4.
+We support this by opening a span with NAME `perf.header.forward` upon successful decoding of the header in the `track_peers` stage and closing that span in the `select_chain` stage, either upon seeing that the header is not on the best chain candidate or upon receiving the block validation result (which is slightly after adopting the block but typically before communicating the new tip to downstream peers). This records points 1 and 4.
 
-Points 2 and 3 are recorded by opening a span with NAME `perf.blocks.fetch` in `fetch_blocks` when requesting a range
-containing that block and closing that range when the block has been received.
+Points 2 and 3 are recorded by opening a span with NAME `perf.blocks.fetch` in `fetch_blocks` when requesting a range containing that block and closing that range when the block has been received.
 
 Switching to a different fork will then open a span with NAME `perf.fork.switch` for all blocks on the target fork.
 
@@ -132,60 +108,42 @@ Switching to a different fork will then open a span with NAME `perf.fork.switch`
 
 > **TARGET:** `amaru::consensus`
 
-The span names for this target don't have to follow the names of the stages in the consensus pipeline,
-but rather reflect the logical processing steps that are performed on a header or block.
+The span names for this target don't have to follow the names of the stages in the consensus pipeline, but rather reflect the logical processing steps that are performed on a header or block.
 
-External `pure-stage` effect handling is extended such that the calling stage’s span is set as the context when
-executing the effect logic. This will tie for example all store or ledger spans to their parent span from the consensus
-span that triggered the effect.
+External `pure-stage` effect handling is extended such that the calling stage’s span is set as the context when executing the effect logic. This will tie for example all store or ledger spans to their parent span from the consensus span that triggered the effect.
 
-Messages sent to the `peer_selection` stage stemming from adversarial peer behaviour must be associated with the related
-header’s trace ID.
+Messages sent to the `peer_selection` stage stemming from adversarial peer behaviour must be associated with the related header’s trace ID.
 
-The waiting time of a header in `select_chain` before being eligible for fetching blocks during catch-up (due to the
-back-pressure decoupling twixt `select_chain` and `fetch_blocks`) must be made explicitly visible in the traces by
-opening and closing a span with NAME `perf.header.block_fetch_wait` accordingly.
+The waiting time of a header in `select_chain` before being eligible for fetching blocks during catch-up (due to the back-pressure decoupling twixt `select_chain` and `fetch_blocks`) must be made explicitly visible in the traces by opening and closing a span with NAME `perf.header.block_fetch_wait` accordingly.
 
 #### Ledger
 
 > **TARGET:** `amaru::ledger`
 
-All ledger operations (validating headers and blocks, performing reward calculations, etc.) are traced in this category.
-Those activities that are related to a specific block will automatically be associated with the right tracing context
-via the parent propagation added to `pure-stage` effect handlers.
-Activities spawned from such invocations that are not related to that block or header (like asynchronous rewards
-calculations) are NOT associated with the calling trace context and instead create new trace IDs.
+All ledger operations (validating headers and blocks, performing reward calculations, etc.) are traced in this category. Those activities that are related to a specific block will automatically be associated with the right tracing context via the parent propagation added to `pure-stage` effect handlers.
+Activities spawned from such invocations that are not related to that block or header (like asynchronous rewards calculations) are NOT associated with the calling trace context and instead create new trace IDs.
 
 ### Mempool
 
 > **TARGET:** `amaru::mempool`
 
-Each received transaction gives rise to a trace ID associated with the transaction hash as a property.
-The spans recorded are:
+Each received transaction gives rise to a trace ID associated with the transaction hash as a property. The spans recorded are:
 
-- NAME `state.transaction.submit`: is opened upon local reception of the transaction and closed when inserted in the
-  mempool or
-  rejected
-- NAME `state.transaction.receive`: is opened upon N2N reception of the transaction and closed when inserted in the
-  mempool or
-  rejected
-- NAME `state.transaction.forward`: is opened when an upstream peer is requesting transactions and this transaction’s ID
-  is
-  sent; it is closed when the transaction has been sent to the peer
+- NAME `state.transaction.submit`: is opened upon local reception of the transaction and closed when inserted in the mempool or rejected
+- NAME `state.transaction.receive`: is opened upon N2N reception of the transaction and closed when inserted in the mempool or rejected
+- NAME `state.transaction.forward`: is opened when an upstream peer is requesting transactions and this transaction’s ID is sent; it is closed when the transaction has been sent to the peer
 
 ### Protocols
 
 > **TARGET:** `amaru::protocols`
 
-This target groups spans that are related to the implementation of specific protocols, like `chainsync`, `txsubmission`,
-`keepalive` etc...
+This target groups spans that are related to the implementation of specific protocols, like `chainsync`, `txsubmission`, `keepalive` etc...
 
 ### Network
 
 > **TARGET:** `amaru::network`
 
-This target is reserved for spans that are related to the network layer, regardless of the protocol being used.
-It is typically used for tracking the lifecycle of network connections.
+This target is reserved for spans that are related to the network layer, regardless of the protocol being used. It is typically used for tracking the lifecycle of network connections.
 
 ## References
 


### PR DESCRIPTION
This PR updates the EDRs for tracing spans, EDR-26, and observability, EDR-07.

There are some formatting changes due to my IDE (line breaks) but the most relevant changes are:

 - The recommended use of `debug_span!` and `info_span!` for creating spans with a macro.
 - The description of the relation between spans schema definition and the creation of the target + name of a span.
 - Some adjustments for the target names (in particular, there's only `amaru::consensus` and no mention of stage names for that target.
 - I changed some previous span names to follow a bit more a pattern like `state.object.action` (in any case, I think that EDR-26 just shows guidelines for targets and span names, it doesn't have to reflect the exact situation IMO).
 
 The [tracing spans PR](https://github.com/pragma-org/amaru/pull/996) is an application of those 2 modified EDRs.

skip-changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated observability guidance with a standardized, hierarchical tracing schema, including revised span construction/instrumentation examples for both synchronous and asynchronous code.
  * Refined tracing span naming conventions and logging-level expectations, clarifying uniqueness across targets and improved schema-based classification via tags.
  * Expanded tracing guidance across network, consensus, ledger, mempool, and protocol activity, including header trace-ID/attribute handling and updated performance-span naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->