### PR TITLE
Test MaxTxSizeUTxO

### DIFF
--- a/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
@@ -352,6 +352,7 @@ mod tests {
     #[test_case(fixture!("fail/BabbageNonDisjointRefInputs/0"); "input appears as both spent and reference")]
     #[test_case(fixture!("fail/WrongNetworkInTxBody/0"); "body network_id disagrees with fixture network")]
     #[test_case(fixture!("pass/tx-size-at-limit"); "transaction size exactly at maxTransactionSize")]
+    #[test_case(fixture!("fail/tx-size-just-above-limit"); "transaction size just above maxTransactionSize")]
     #[test_case(fixture!("fail/MaxTxSizeUTxO/0"); "transaction larger than maxTransactionSize")]
     #[test_case(fixture!("fail/OutsideValidityIntervalUTxO/0"); "current slot before invalid_before")]
     #[test_case(fixture!("fail/OutsideForecast/0"); "upper validity bound past forecast horizon with redeemer")]

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
@@ -351,6 +351,7 @@ mod tests {
     #[test_case(fixture!("pass/native-script-input"); "native script-locked input")]
     #[test_case(fixture!("fail/BabbageNonDisjointRefInputs/0"); "input appears as both spent and reference")]
     #[test_case(fixture!("fail/WrongNetworkInTxBody/0"); "body network_id disagrees with fixture network")]
+    #[test_case(fixture!("pass/tx-size-at-limit"); "transaction size exactly at maxTransactionSize")]
     #[test_case(fixture!("fail/MaxTxSizeUTxO/0"); "transaction larger than maxTransactionSize")]
     #[test_case(fixture!("fail/OutsideValidityIntervalUTxO/0"); "current slot before invalid_before")]
     #[test_case(fixture!("fail/OutsideForecast/0"); "upper validity bound past forecast horizon with redeemer")]

--- a/crates/amaru-ledger/tests/data/phase-one/fail/tx-size-just-above-limit.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/tx-size-just-above-limit.json
@@ -1,0 +1,33 @@
+{
+  "title": "tx-size-just-above-limit",
+  "description": "simple-transfer with maxTransactionSize set to exactly one byte less than the (computed) tx size.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v9.json",
+    "$override": {
+      "maxTransactionSize": 199
+    }
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00",
+        "output": "a200581d6091de07fed8a2b52a92686dd68bb2b8d443d6d42089cf508259774675011a004c4b40"
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a400d9010281825820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa000181a200581d60c3f9920656fdbfe2842e2c5671e0a2b0c1c84c497d42879de5376d7b011a00493e00021a00030d400f00a100d9010281825820b2f2453e32288dd3c90d532e997d0e5992a633ff66365e2b852606037ae8fc7b5840ec12c03465ef6693a9d862e1ba44969bfc38b7761ae5e2527524a1478bb152a5ba44707fae37f7d33f550888035111e4dca051d9441ee973ec9f1da7d90fbe0ff5f6",
+  "expected": {
+    "predicate": "MaxTxSizeUTxO"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/pass/tx-size-at-limit.json
+++ b/crates/amaru-ledger/tests/data/phase-one/pass/tx-size-at-limit.json
@@ -1,0 +1,31 @@
+{
+  "title": "tx-size-at-limit",
+  "description": "simple-transfer with maxTransactionSize set to exactly the tx size.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v9.json",
+    "$override": {
+      "maxTransactionSize": 200
+    }
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00",
+        "output": "a200581d6091de07fed8a2b52a92686dd68bb2b8d443d6d42089cf508259774675011a004c4b40"
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a400d9010281825820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa000181a200581d60c3f9920656fdbfe2842e2c5671e0a2b0c1c84c497d42879de5376d7b011a00493e00021a00030d400f00a100d9010281825820b2f2453e32288dd3c90d532e997d0e5992a633ff66365e2b852606037ae8fc7b5840ec12c03465ef6693a9d862e1ba44969bfc38b7761ae5e2527524a1478bb152a5ba44707fae37f7d33f550888035111e4dca051d9441ee973ec9f1da7d90fbe0ff5f6",
+  "expected": "Pass"
+}


### PR DESCRIPTION
While `MaxTxSizeUTxO` has already been implemented, this PR provides an extra fixture to enforce the boundary behavior (tx size can be equal to the max size). 


Closes: #893
Skip-changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction size handling so conformance checks now match ledger fee calculation when testing standalone transactions.
  * Added support for transactions that are exactly at the configured maximum size.

* **Tests**
  * Added a new pass fixture covering a transaction at the size limit.
  * Improved test size calculations for transaction fixtures to better reflect the encoded format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->