### PR TITLE
fix: make sure that tips are removed from the select_chain map in case of a fork

### DIFF
--- a/crates/amaru-consensus/src/stages/select_chain/mod.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/mod.rs
@@ -64,7 +64,8 @@ use crate::effects::FindBestCandidate;
 /// - **BlockValidationResult(point: Tip, valid: bool)**:
 ///   - Terminates (error) if header not present in store.
 ///   - Persists the validity result via `set_block_valid` (terminates on store error).
-///   - If `valid`: for every pending chain, drains the prefix up through the now-validated hash (advances all branches).
+///   - If `valid`: for every pending chain, drains the prefix up through the now-validated hash (advances all branches),
+///     then drops any branch that is now fully validated, except the current `best_tip` (kept so it can still be extended).
 ///   - If `!valid`: prunes every `tips` entry whose first (unvalidated) element is this hash; `removed` count logged at warn if >0.
 ///     If the current `best_tip` is no longer present in `tips` (i.e., its branch was pruned): logs "best tip candidate invalidated",
 ///     calls `eff.external(FindBestCandidate)`, and on success (non-origin): loads the new header + parent point,
@@ -209,10 +210,15 @@ impl SelectChain {
 
         if valid {
             let h = tip.hash();
-            self.tips.values_mut().for_each(|v| {
-                if let Some(idx) = v.iter().position(|hash| hash == &h) {
-                    v.drain(0..=idx);
+            // Advance every pending chain past the now-validated block, then drop any branch
+            // that is now fully validated.
+            // The current best tip is always retained so it can still be extended.
+            let best = self.best_tip.as_ref().map(|header| header.hash());
+            self.tips.retain(|tip_hash, chain| {
+                if let Some(idx) = chain.iter().position(|hash| hash == &h) {
+                    chain.drain(0..=idx);
                 }
+                !chain.is_empty() || best.as_ref() == Some(tip_hash)
             });
             return;
         }

--- a/crates/amaru-consensus/src/stages/select_chain/tests.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/tests.rs
@@ -364,6 +364,38 @@ fn test_block_validation_result_valid() {
 }
 
 #[test]
+fn test_block_validation_result_valid_prunes_fully_validated_chains() {
+    let mut prep = test_prep();
+    prep.state.best_tip = Some(prep.headers.h3.clone());
+    prep.state.tips = BTreeMap::from_iter([
+        (prep.headers.h3.hash(), vec![prep.headers.h2.hash(), prep.headers.h3.hash()]),
+        (prep.headers.h2a.hash(), vec![prep.headers.h2a.hash()]),
+    ]);
+    prep.store_headers(&prep.headers.all());
+    let tip = prep.headers.h2a.tip();
+    let msg = SelectChainMsg::BlockValidationResult(tip, true);
+
+    // Validating h2a empties the fork's chain; since it is not the current best tip,
+    // the now-dead entry is removed
+    let expected = SelectChain {
+        tips: BTreeMap::from_iter([(prep.headers.h3.hash(), vec![prep.headers.h2.hash(), prep.headers.h3.hash()])]),
+        ..prep.state.clone()
+    };
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    assert_trace(
+        &running,
+        &[
+            te_state("sc-1", &prep.state),
+            te_input("sc-1", &msg),
+            te_has_header("sc-1", tip.hash()),
+            te_set_block_valid("sc-1", tip.hash(), true),
+            te_state("sc-1", &expected),
+        ],
+    );
+    logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
 fn test_block_validation_result_invalid_best_tip_invalidated() {
     let mut prep = test_prep();
     prep.state.best_tip = Some(prep.headers.h3.clone());


### PR DESCRIPTION
We don't completely clean-up the `select_chain` stage in case of a fork.

Skip-Changelog