### PR TITLE
Update mainnet snapshot manifest

### DIFF
--- a/crates/amaru/config/bootstrap/mainnet/snapshots.json
+++ b/crates/amaru/config/bootstrap/mainnet/snapshots.json
@@ -1,19 +1,35 @@
 [
   {
-    "epoch": 507,
-    "point": "134092758.670ca68c3de580f8469677754a725e86ca72a7be381d3108569f0704a5fca327",
-    "url": "https://pub-b844360df4774bb092a2bb2043b888e5.r2.dev/134092758.670ca68c3de580f8469677754a725e86ca72a7be381d3108569f0704a5fca327.tar.gz"
+    "epoch": 600,
+    "point": "174268750.80b13f6d5e260f8081a0c6dee5f235d10f6cbea9097c00289c40f5eaabb8c58b",
+    "url": "https://pub-b844360df4774bb092a2bb2043b888e5.r2.dev/174268750.80b13f6d5e260f8081a0c6dee5f235d10f6cbea9097c00289c40f5eaabb8c58b.tar.gz",
+    "parent_point": {
+      "Specific": [
+        174268735,
+        "b1eef900da0a737f9d1ca41e1ec0d77628e9efdaf39217573175f28be4a2e4a7"
+      ]
+    }
   },
   {
-    "epoch": 508,
-    "point": "134524753.29011cc1320d03b3da0121236dc66e6bc391feef4bb1d506a7fb20e769d6a494",
-    "url": "https://pub-b844360df4774bb092a2bb2043b888e5.r2.dev/134524753.29011cc1320d03b3da0121236dc66e6bc391feef4bb1d506a7fb20e769d6a494.tar.gz",
-    "parent_point": "134524751.93d554d67c46749f45fba3a091857a9c489ad3ed1d2c7b32b587ab290bec51f5"
+    "epoch": 601,
+    "point": "174700763.db945630bc5a9609deb9b837b642f92a95ba4c339cc64aa32bc324c305170bf9",
+    "url": "https://pub-b844360df4774bb092a2bb2043b888e5.r2.dev/174700763.db945630bc5a9609deb9b837b642f92a95ba4c339cc64aa32bc324c305170bf9.tar.gz",
+    "parent_point": {
+      "Specific": [
+        174700757,
+        "a64b75d59b1e99447b956972d8e726060aacbf260c7d9a0587011f8273cad0ca"
+      ]
+    }
   },
   {
-    "epoch": 509,
-    "point": "134956789.6558deef007ba372a414466e49214368c17c1f8428093193fc187d1c4587053c",
-    "url": "https://pub-b844360df4774bb092a2bb2043b888e5.r2.dev/134956789.6558deef007ba372a414466e49214368c17c1f8428093193fc187d1c4587053c.tar.gz",
-    "parent_point": "134956761.13cb4a62597e36fad2dba4e00974ec5ac29c3824d96b2ceb4ce056271cd4f8da"
+    "epoch": 602,
+    "point": "175132798.6f9b6e18c110f24e7697d32603027e41c8b110d96765f91f5411dcaa42e8ee2c",
+    "url": "https://pub-b844360df4774bb092a2bb2043b888e5.r2.dev/175132798.6f9b6e18c110f24e7697d32603027e41c8b110d96765f91f5411dcaa42e8ee2c.tar.gz",
+    "parent_point": {
+      "Specific": [
+        175132792,
+        "32977d42a622b258de7893d5440d75887a3cc8a75648503d261ae3d4dc347337"
+      ]
+    }
   }
 ]

--- a/crates/amaru/src/bin/amaru/cmd/snapshot/create/mod.rs
+++ b/crates/amaru/src/bin/amaru/cmd/snapshot/create/mod.rs
@@ -298,6 +298,10 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         remove_target_outputs(&snapshot_output_dir, &targets)?;
     }
 
+    for target in &targets {
+        write_epoch_metadata(&metadata_dir, target)?;
+    }
+
     let existing_snapshots = existing_snapshot_paths(&snapshot_output_dir, &targets);
     let existing_archives = existing_archive_paths(&snapshot_output_dir, &targets);
     if !existing_snapshots.is_empty() || !existing_archives.is_empty() {
@@ -308,10 +312,6 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
             .collect::<Vec<_>>()
             .join(", ");
         return Err(format!("refusing to overwrite existing snapshot outputs: {existing_outputs}").into());
-    }
-
-    for target in &targets {
-        write_epoch_metadata(&metadata_dir, target)?;
     }
 
     let from_chunk = first_missing_immutable_chunk(&cardano_node_db.join("immutable"))?;

--- a/crates/amaru/src/bin/amaru/cmd/snapshot/create/mod.rs
+++ b/crates/amaru/src/bin/amaru/cmd/snapshot/create/mod.rs
@@ -29,7 +29,7 @@ use amaru_mithril::{
 use anyhow::anyhow;
 use clap::{ArgAction, Parser};
 use num::{CheckedAdd, CheckedSub};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use tracing::info;
 
 mod archive;
@@ -46,6 +46,13 @@ use db_analyser::{ensure_db_analyser_binary, exact_snapshot_dir, run_db_analyser
 use koios::{fetch_current_epoch, fetch_last_block_for_epoch};
 
 const PACKAGED_HEADERS_FILE_NAME: &str = "bootstrap.headers.json";
+
+fn serialize_point_to_string<S: Serializer>(point: &Option<Point>, s: S) -> Result<S::Ok, S::Error> {
+    match point {
+        Some(p) => s.serialize_some(&p.to_string()),
+        None => s.serialize_none(),
+    }
+}
 
 #[derive(Debug, Parser)]
 pub struct Args {
@@ -170,7 +177,7 @@ struct EpochTarget {
     epoch: Epoch,
     slot: Slot,
     hash: HeaderHash,
-    #[serde(default, skip_serializing_if = "Option::is_none", alias = "header_parent")]
+    #[serde(default, skip_serializing_if = "Option::is_none", serialize_with = "serialize_point_to_string")]
     parent_point: Option<Point>,
     #[serde(default)]
     archive_path: Option<String>,
@@ -644,7 +651,7 @@ fn read_secondary_offsets(secondary_path: &Path) -> Result<Vec<u64>, Box<dyn std
 mod tests {
     use std::{fs, path::Path};
 
-    use amaru_kernel::{Epoch, NetworkName, Slot, hash};
+    use amaru_kernel::{Epoch, NetworkName, Point, Slot, hash};
     use tempfile::TempDir;
 
     use super::{
@@ -855,5 +862,26 @@ mod tests {
         write_snapshot_archive(&snapshot_dir, &archive_path).unwrap();
 
         assert!(archive_path.is_file());
+    }
+
+    #[test]
+    fn epoch_target_serializes_parent_point_as_string() {
+        let target = EpochTarget {
+            epoch: Epoch::from(164),
+            slot: Slot::from(69_638_382),
+            hash: hash!("5da6ba37a4a07df015c4ea92c880e3600d7f098b97e73816f8df04bbb5fad3b7"),
+            parent_point: Some(
+                Point::try_from("69638365.4ec0f5a78431fdcc594eab7db91aff7dfd91c13cc93e9fbfe70cd15a86fadfb2").unwrap(),
+            ),
+            archive_path: Some("/path/to/archive.tar.gz".to_string()),
+            snapshot_path: Some("/path/to/snapshot".to_string()),
+        };
+
+        let json = serde_json::to_value(&target).unwrap();
+
+        assert_eq!(
+            json.get("parent_point").and_then(|v| v.as_str()),
+            Some("69638365.4ec0f5a78431fdcc594eab7db91aff7dfd91c13cc93e9fbfe70cd15a86fadfb2")
+        );
     }
 }


### PR DESCRIPTION
Skip-Changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the mainnet bootstrap snapshot list with newer snapshot entries, replacing older epochs with more recent ones.
* **Bug Fixes**
  * Snapshot creation now records epoch metadata earlier in the process, so metadata can be preserved even if later output checks stop the run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->