### PR TITLE
fix(ledger): recompute missing rewards summary at epoch boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Other guiding principles:
 
 ### Fixed
 
-- **amaru-ledger**: recompute the rewards summary at the epoch boundary when it is missing, instead of terminating consensus with `rewards summary not ready`; happened on nodes restarting with a stable tip already past the stability window. ([#1007][])
+- **amaru-ledger**: key the rewards-summary computation on the current tip's position rather than the next block's, so a node restarting with its stable tip already past the stability window (losing the in-memory summary) recomputes it before the epoch transition instead of terminating consensus with `rewards summary not ready`. ([#1007][])
 
 ## [v10.10.20260702](https://github.com/pragma-org/amaru/releases/tag/v10.10.20260702)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ Other guiding principles:
 
 - **amaru**: make sure bootstrap can't be done with unsupported snapshots; similarly prevent startup if state becomes unsupported ([#1000][])
 
+### Fixed
+
+- **amaru-ledger**: recompute the rewards summary at the epoch boundary when it is missing, instead of terminating consensus with `rewards summary not ready`; happened on nodes restarting with a stable tip already past the stability window. ([#1007][])
+
 ## [v10.10.20260702](https://github.com/pragma-org/amaru/releases/tag/v10.10.20260702)
 
 ### Added
@@ -111,3 +115,4 @@ Other guiding principles:
 [#983]: https://github.com/pragma-org/amaru/pull/983
 [#988]: https://github.com/pragma-org/amaru/pull/988
 [#1000]: https://github.com/pragma-org/amaru/pull/1000
+[#1007]: https://github.com/pragma-org/amaru/pull/1007

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ version = "0.1.2"
 dependencies = [
  "amaru-iter-borrow",
  "amaru-kernel",
+ "amaru-ledger",
  "amaru-metrics",
  "amaru-observability",
  "amaru-ouroboros-traits",

--- a/crates/amaru-ledger/Cargo.toml
+++ b/crates/amaru-ledger/Cargo.toml
@@ -51,6 +51,7 @@ tempfile.workspace = true
 
 # Internal dependencies ───────────────────────────────────────────────────────┐
 amaru-kernel = { workspace = true, features = ["test-utils"] }
+amaru-ledger = { path = ".", features = ["test-utils"] }
 amaru-stores.workspace = true
 amaru-tracing-json.workspace = true
 

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -371,12 +371,34 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             // FIXME: This should eventually be a '.await', as we always expect to *eventually*
             // have some rewards summary being available. There's no way to continue progressing
             // the ledger if we don't.
-            let computed_rewards = self.volatile.take_computed_rewards();
+            let mut computed_rewards = self.volatile.take_computed_rewards();
+
+            let progress = {
+                #[allow(clippy::unwrap_used)]
+                let db = self.stable.lock().unwrap();
+                db.epoch_transition_progress().map_err(StateError::Storage)?
+            };
+
+            // NOTE: Recomputing missing rewards at the boundary
+            //
+            // The rewards summary is normally computed when the chain crosses the stability
+            // window, and only held in the in-memory volatile overlay. A node restarting with
+            // its stable tip already past the stability window replays no block within the
+            // window, so the summary is missing when the epoch boundary is reached — which used
+            // to kill consensus with 'RewardsSummaryNotReady'. All inputs to the computation
+            // (epoch snapshots and stake distributions) are persisted and frozen for the epoch,
+            // so recomputing here yields the same summary as computing it at the stability
+            // window.
+            if progress.is_none() && computed_rewards.is_none() {
+                warn!(
+                    epoch = u64::from(next_epoch - 1),
+                    "rewards summary missing at epoch boundary (restart past the stability window?); recomputing",
+                );
+                computed_rewards = Some(self.compute_rewards(next_epoch - 1)?.into());
+            }
 
             #[allow(clippy::unwrap_used)]
             let db = self.stable.lock().unwrap();
-
-            let progress = db.epoch_transition_progress().map_err(StateError::Storage)?;
 
             let protocol_parameters = self.protocol_parameters();
 
@@ -1059,6 +1081,368 @@ impl From<governance::Error> for StateError {
         match origin {
             governance::Error::EraHistoryError(slot, err) => StateError::ErrorComputingEpoch(slot, err),
             governance::Error::StoreError(err) => StateError::Storage(err),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{borrow::BorrowMut, collections::BTreeMap};
+
+    use amaru_kernel::{
+        Anchor, CertificatePointer, ComparableProposalId, Constitution, ConstitutionalCommitteeStatus, Lovelace,
+        MemoizedTransactionOutput, Nullable, PREPROD_DEFAULT_PROTOCOL_PARAMETERS, PREPROD_ERA_HISTORY,
+        PREPROD_GLOBAL_PARAMETERS, ProposalId, StakeCredential, TransactionInput,
+    };
+
+    use super::*;
+    use crate::{
+        governance::ratification::ProposalsRoots,
+        store::{EpochTransitionProgress, ReadStore, columns as scolumns},
+        summary::Pots,
+    };
+
+    /// Regression test — restart across the stability window.
+    ///
+    /// The rewards summary is computed when a block at relative slot >=
+    /// stability window is applied, and held only in the in-memory volatile
+    /// overlay. A node restarting with its stable tip already *past* the
+    /// stability window replays no block within the window: the overlay is
+    /// empty, and the epoch transition triggered by the first block of the
+    /// next epoch used to fail with `RewardsSummaryNotReady`, killing
+    /// consensus ("Consensus died, this should not happen!"). All the inputs
+    /// needed to recompute the summary (epoch snapshots and stake
+    /// distributions) are persisted, so the transition must recompute it
+    /// instead of dying.
+    #[test]
+    fn epoch_transition_recomputes_rewards_after_restart_past_stability_window() {
+        let network = NetworkName::Preprod;
+        let era_history: EraHistory = PREPROD_ERA_HISTORY.clone();
+        let global_parameters: GlobalParameters = PREPROD_GLOBAL_PARAMETERS.clone();
+        let protocol_parameters: ProtocolParameters = PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone();
+
+        let current_epoch = Epoch::from(10_u64);
+        let next_epoch = Epoch::from(11_u64);
+
+        // Stable tip = last slot of the current epoch: strictly past the
+        // stability window, so a restarted node replays no block within the
+        // window before the boundary.
+        let next_epoch_start = era_history.epoch_bounds(next_epoch).expect("epoch bounds").start;
+        let stable_slot = Slot::from(u64::from(next_epoch_start) - 1);
+        assert!(
+            unsafe_slot_in_epoch(&era_history, stable_slot) >= global_parameters.stability_window(),
+            "test pre-condition: stable tip must be past the stability window"
+        );
+        let stable_tip = Point::Specific(stable_slot, Hash::from([0u8; 32]));
+
+        // Same in-memory stake distributions a restart rebuilds from the
+        // persisted snapshots.
+        let snapshots = EmptySnapshots;
+        let stake_distributions =
+            initial_stake_distributions(&snapshots, &era_history).expect("initial stake distributions");
+
+        // Fresh state, EMPTY volatile — the post-restart configuration.
+        let mut state = State::new_with(
+            EmptyStore { tip: stable_tip, epoch: current_epoch },
+            snapshots,
+            current_epoch,
+            network,
+            era_history.clone(),
+            global_parameters,
+            protocol_parameters,
+            GovernanceActivity::default(),
+            stake_distributions,
+        );
+
+        // First block of the next epoch arrives: the transition must succeed
+        // by recomputing the rewards summary from the persisted snapshots...
+        let next_point = Point::Specific(Slot::from(u64::from(next_epoch_start) + 2), Hash::from([1u8; 32]));
+        let result = state.try_epoch_transition(next_point);
+        assert!(
+            result.is_ok(),
+            "epoch transition right after a restart past the stability window must not fail: {result:?}",
+        );
+
+        // ... and actually transition.
+        assert_eq!(state.epoch(), next_epoch);
+    }
+
+    // An empty store: what a freshly-bootstrapped-then-restarted node would
+    // see, reduced to nothing. Doubles as (empty) snapshot and (no-op)
+    // transactional context so the whole test is self-contained (using
+    // `amaru-stores` from unit tests would link a second instance of this
+    // crate and break trait identities).
+    #[derive(Clone)]
+    struct EmptyStore {
+        tip: Point,
+        epoch: Epoch,
+    }
+
+    impl ReadStore for EmptyStore {
+        fn tip(&self) -> crate::store::Result<Point> {
+            Ok(self.tip)
+        }
+
+        fn epoch_transition_progress(&self) -> crate::store::Result<Option<EpochTransitionProgress>> {
+            Ok(None)
+        }
+
+        fn protocol_parameters(&self) -> crate::store::Result<ProtocolParameters> {
+            Ok(PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone())
+        }
+
+        fn pool(&self, _pool: &PoolId) -> crate::store::Result<Option<scolumns::pools::Row>> {
+            Ok(None)
+        }
+
+        fn account(&self, _credential: &StakeCredential) -> crate::store::Result<Option<scolumns::accounts::Row>> {
+            Ok(None)
+        }
+
+        fn drep(&self, _credential: &StakeCredential) -> crate::store::Result<Option<scolumns::dreps::Row>> {
+            Ok(None)
+        }
+
+        fn cc_member(&self, _credential: &StakeCredential) -> crate::store::Result<Option<scolumns::cc_members::Row>> {
+            Ok(None)
+        }
+
+        fn proposal(&self, _id: &ComparableProposalId) -> crate::store::Result<Option<scolumns::proposals::Row>> {
+            Ok(None)
+        }
+
+        fn utxo(&self, _input: &TransactionInput) -> crate::store::Result<Option<MemoizedTransactionOutput>> {
+            Ok(None)
+        }
+
+        fn pots(&self) -> crate::store::Result<Pots> {
+            Ok(Pots { treasury: 0, reserves: 0, fees: 0 })
+        }
+
+        fn constitutional_committee(&self) -> crate::store::Result<ConstitutionalCommitteeStatus> {
+            Ok(ConstitutionalCommitteeStatus::NoConfidence)
+        }
+
+        fn constitution(&self) -> crate::store::Result<Constitution> {
+            Ok(Constitution {
+                anchor: Anchor { url: String::new(), content_hash: Hash::from([0u8; 32]) },
+                guardrail_script: Nullable::Null,
+            })
+        }
+
+        fn proposals_roots(&self) -> crate::store::Result<ProposalsRoots> {
+            Ok(ProposalsRoots::default())
+        }
+
+        fn governance_activity(&self) -> crate::store::Result<GovernanceActivity> {
+            Ok(GovernanceActivity::default())
+        }
+
+        fn iter_utxos(
+            &self,
+        ) -> crate::store::Result<impl Iterator<Item = (scolumns::utxo::Key, scolumns::utxo::Value)>> {
+            Ok(std::iter::empty())
+        }
+
+        fn iter_block_issuers(
+            &self,
+        ) -> crate::store::Result<impl Iterator<Item = (scolumns::slots::Key, scolumns::slots::Value)>> {
+            Ok(std::iter::empty())
+        }
+
+        fn iter_pools(
+            &self,
+        ) -> crate::store::Result<impl Iterator<Item = (scolumns::pools::Key, scolumns::pools::Row)>> {
+            Ok(std::iter::empty())
+        }
+
+        fn iter_accounts(
+            &self,
+        ) -> crate::store::Result<impl Iterator<Item = (scolumns::accounts::Key, scolumns::accounts::Row)>> {
+            Ok(std::iter::empty())
+        }
+
+        fn iter_dreps(
+            &self,
+        ) -> crate::store::Result<impl Iterator<Item = (scolumns::dreps::Key, scolumns::dreps::Row)>> {
+            Ok(std::iter::empty())
+        }
+
+        fn iter_proposals(
+            &self,
+        ) -> crate::store::Result<impl Iterator<Item = (scolumns::proposals::Key, scolumns::proposals::Row)>> {
+            Ok(std::iter::empty())
+        }
+
+        fn iter_cc_members(
+            &self,
+        ) -> crate::store::Result<impl Iterator<Item = (scolumns::cc_members::Key, scolumns::cc_members::Row)>>
+        {
+            Ok(std::iter::empty())
+        }
+
+        fn iter_votes(
+            &self,
+        ) -> crate::store::Result<impl Iterator<Item = (scolumns::votes::Key, scolumns::votes::Row)>> {
+            Ok(std::iter::empty())
+        }
+    }
+
+    impl Snapshot for EmptyStore {
+        fn epoch(&self) -> Epoch {
+            self.epoch
+        }
+    }
+
+    impl<'a> TransactionalContext<'a> for EmptyStore {
+        fn commit(self) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn rollback(self) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn reset_epoch_transition_progress(&self) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn try_epoch_transition(
+            &self,
+            _from: Option<EpochTransitionProgress>,
+            _to: Option<EpochTransitionProgress>,
+        ) -> crate::store::Result<bool> {
+            Ok(true)
+        }
+
+        fn save(
+            &self,
+            _era_history: &EraHistory,
+            _protocol_parameters: &ProtocolParameters,
+            _governance_activity: GovernanceActivity,
+            _point: &Point,
+            _issuer: Option<&scolumns::pools::Key>,
+            _add: crate::store::Columns<
+                impl Iterator<Item = (scolumns::utxo::Key, scolumns::utxo::Value)>,
+                impl Iterator<Item = scolumns::pools::Value>,
+                impl Iterator<Item = (scolumns::accounts::Key, scolumns::accounts::Value)>,
+                impl Iterator<Item = (scolumns::dreps::Key, scolumns::dreps::Value)>,
+                impl Iterator<Item = (scolumns::cc_members::Key, scolumns::cc_members::Value)>,
+                impl Iterator<Item = (scolumns::proposals::Key, scolumns::proposals::Value)>,
+                impl Iterator<Item = (scolumns::votes::Key, scolumns::votes::Value)>,
+            >,
+            _remove: crate::store::Columns<
+                impl Iterator<Item = scolumns::utxo::Key>,
+                impl Iterator<Item = (scolumns::pools::Key, Epoch)>,
+                impl Iterator<Item = scolumns::accounts::Key>,
+                impl Iterator<Item = (scolumns::dreps::Key, CertificatePointer)>,
+                impl Iterator<Item = scolumns::cc_members::Key>,
+                impl Iterator<Item = ()>,
+                impl Iterator<Item = ()>,
+            >,
+            _withdrawals: impl Iterator<Item = scolumns::accounts::Key>,
+        ) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn refund(&self, _credential: &scolumns::accounts::Key, _deposit: Lovelace) -> crate::store::Result<Lovelace> {
+            Ok(0)
+        }
+
+        fn set_protocol_parameters(&self, _protocol_parameters: &ProtocolParameters) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn update_constitutional_committee(
+            &self,
+            _status: &ConstitutionalCommitteeStatus,
+            _added: BTreeMap<StakeCredential, Epoch>,
+            _removed: BTreeSet<StakeCredential>,
+        ) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn set_proposals_roots(&self, _roots: &ProposalsRoots) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn set_constitution(&self, _constitution: &Constitution) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn set_governance_activity(&self, _dormant_epochs: GovernanceActivity) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn remove_proposals<'iter, Id>(&self, _proposals: impl IntoIterator<Item = Id>) -> crate::store::Result<()>
+        where
+            Id: Deref<Target = ProposalId> + 'iter,
+        {
+            Ok(())
+        }
+
+        fn with_pots(
+            &self,
+            _with: impl FnMut(Box<dyn BorrowMut<scolumns::pots::Row> + '_>),
+        ) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn with_pools(&self, _with: impl FnMut(scolumns::pools::Iter<'_, '_>)) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn with_accounts(&self, _with: impl FnMut(scolumns::accounts::Iter<'_, '_>)) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn with_block_issuers(&self, _with: impl FnMut(scolumns::slots::Iter<'_, '_>)) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn with_utxo(&self, _with: impl FnMut(scolumns::utxo::Iter<'_, '_>)) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn with_dreps(&self, _with: impl FnMut(scolumns::dreps::Iter<'_, '_>)) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn with_proposals(&self, _with: impl FnMut(scolumns::proposals::Iter<'_, '_>)) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn with_cc_members(&self, _with: impl FnMut(scolumns::cc_members::Iter<'_, '_>)) -> crate::store::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Store for EmptyStore {
+        type Transaction<'a> = EmptyStore;
+
+        fn next_snapshot(&self, _epoch: Epoch) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn create_transaction(&self) -> Self::Transaction<'_> {
+            self.clone()
+        }
+    }
+
+    /// Empty snapshots for the three epochs a restarted node finds on disk.
+    struct EmptySnapshots;
+
+    impl HistoricalStores for EmptySnapshots {
+        fn snapshots(&self) -> crate::store::Result<Vec<Epoch>> {
+            Ok(vec![Epoch::from(7_u64), Epoch::from(8_u64), Epoch::from(9_u64)])
+        }
+
+        fn prune(&self, _minimum_epoch: Epoch) -> crate::store::Result<()> {
+            Ok(())
+        }
+
+        fn for_epoch(&self, epoch: Epoch) -> crate::store::Result<impl Snapshot> {
+            Ok(EmptyStore { tip: Point::Origin, epoch })
         }
     }
 }

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -371,34 +371,12 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             // FIXME: This should eventually be a '.await', as we always expect to *eventually*
             // have some rewards summary being available. There's no way to continue progressing
             // the ledger if we don't.
-            let mut computed_rewards = self.volatile.take_computed_rewards();
-
-            let progress = {
-                #[allow(clippy::unwrap_used)]
-                let db = self.stable.lock().unwrap();
-                db.epoch_transition_progress().map_err(StateError::Storage)?
-            };
-
-            // NOTE: Recomputing missing rewards at the boundary
-            //
-            // The rewards summary is normally computed when the chain crosses the stability
-            // window, and only held in the in-memory volatile overlay. A node restarting with
-            // its stable tip already past the stability window replays no block within the
-            // window, so the summary is missing when the epoch boundary is reached — which used
-            // to kill consensus with 'RewardsSummaryNotReady'. All inputs to the computation
-            // (epoch snapshots and stake distributions) are persisted and frozen for the epoch,
-            // so recomputing here yields the same summary as computing it at the stability
-            // window.
-            if progress.is_none() && computed_rewards.is_none() {
-                warn!(
-                    epoch = u64::from(next_epoch - 1),
-                    "rewards summary missing at epoch boundary (restart past the stability window?); recomputing",
-                );
-                computed_rewards = Some(self.compute_rewards(next_epoch - 1)?.into());
-            }
+            let computed_rewards = self.volatile.take_computed_rewards();
 
             #[allow(clippy::unwrap_used)]
             let db = self.stable.lock().unwrap();
+
+            let progress = db.epoch_transition_progress().map_err(StateError::Storage)?;
 
             let protocol_parameters = self.protocol_parameters();
 
@@ -453,21 +431,29 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
         })
     }
 
-    fn try_compute_rewards(&mut self, next_tip: Point) -> Result<(), StateError> {
-        let next_slot = next_tip.slot_or_default();
-        let next_relative_slot = unsafe_slot_in_epoch(&self.era_history, next_slot);
-        let next_epoch = unsafe_slot_to_epoch(&self.era_history, next_slot);
+    fn try_compute_rewards(&mut self) -> Result<(), StateError> {
+        let current_slot = self.tip().slot_or_default();
+        let current_relative_slot = unsafe_slot_in_epoch(&self.era_history, current_slot);
+        let current_epoch = self.epoch();
 
-        // Once we reach the stability window, compute rewards unless we've already done so.
-        let is_stake_distribution_stable = next_relative_slot >= self.global_parameters.stability_window();
-
+        // Compute rewards once the current tip is past the stability window — i.e. the
+        // stake distribution for the epoch is stable — unless we've already done so.
+        //
+        // Keying this on the *current* tip (rather than the next block) also recovers a
+        // node restarting with its stable tip already past the stability window: the
+        // previously computed summary (held only in the in-memory volatile overlay) is
+        // lost, and the next block belongs to the next epoch — its relative slot is below
+        // the window — yet the current tip is still past it, so the rewards get recomputed
+        // before the epoch transition instead of the transition dying with
+        // 'RewardsSummaryNotReady'.
+        //
         // FIXME: Asynchronous rewards calculation
         //
         // compute rewards in a thread, or in a non-blocking manner to carry on with other
         // tasks while rewards are being computed; they only need to be available at the epoch
         // boundary.
-        if self.volatile.rewards_not_ready() && is_stake_distribution_stable {
-            let computed = self.compute_rewards(next_epoch)?.into();
+        if self.volatile.rewards_not_ready() && current_relative_slot > self.global_parameters.stability_window() {
+            let computed = self.compute_rewards(current_epoch)?.into();
             self.volatile.set_computed_rewards(computed);
         }
 
@@ -688,7 +674,7 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             trace_block_transactions(point, block_height, &block);
 
             // 1. Rewards calculation
-            BlockValidation::from(self.try_compute_rewards(*point))?;
+            BlockValidation::from(self.try_compute_rewards())?;
 
             // 2. Epoch transition
             BlockValidation::from(self.try_epoch_transition(*point))?;
@@ -1087,20 +1073,10 @@ impl From<governance::Error> for StateError {
 
 #[cfg(test)]
 mod tests {
-    use std::{borrow::BorrowMut, collections::BTreeMap};
-
-    use amaru_kernel::{
-        Anchor, CertificatePointer, ComparableProposalId, Constitution, ConstitutionalCommitteeStatus, Lovelace,
-        MemoizedTransactionOutput, Nullable, PREPROD_DEFAULT_PROTOCOL_PARAMETERS, PREPROD_ERA_HISTORY,
-        PREPROD_GLOBAL_PARAMETERS, ProposalId, StakeCredential, TransactionInput,
-    };
+    use amaru_kernel::{PREPROD_DEFAULT_PROTOCOL_PARAMETERS, PREPROD_ERA_HISTORY, PREPROD_GLOBAL_PARAMETERS};
 
     use super::*;
-    use crate::{
-        governance::ratification::ProposalsRoots,
-        store::{EpochTransitionProgress, ReadStore, columns as scolumns},
-        summary::Pots,
-    };
+    use crate::store::test_utils::{MockHistoricalStores, MockStore};
 
     /// Regression test — restart across the stability window.
     ///
@@ -1110,12 +1086,11 @@ mod tests {
     /// stability window replays no block within the window: the overlay is
     /// empty, and the epoch transition triggered by the first block of the
     /// next epoch used to fail with `RewardsSummaryNotReady`, killing
-    /// consensus ("Consensus died, this should not happen!"). All the inputs
-    /// needed to recompute the summary (epoch snapshots and stake
-    /// distributions) are persisted, so the transition must recompute it
-    /// instead of dying.
+    /// consensus ("Consensus died, this should not happen!"). The next
+    /// block closing the epoch must therefore also trigger the rewards
+    /// computation, from the persisted snapshots.
     #[test]
-    fn epoch_transition_recomputes_rewards_after_restart_past_stability_window() {
+    fn rewards_are_recomputed_after_restart_past_stability_window() {
         let network = NetworkName::Preprod;
         let era_history: EraHistory = PREPROD_ERA_HISTORY.clone();
         let global_parameters: GlobalParameters = PREPROD_GLOBAL_PARAMETERS.clone();
@@ -1137,13 +1112,13 @@ mod tests {
 
         // Same in-memory stake distributions a restart rebuilds from the
         // persisted snapshots.
-        let snapshots = EmptySnapshots;
+        let snapshots = MockHistoricalStores::new(vec![Epoch::from(7_u64), Epoch::from(8_u64), Epoch::from(9_u64)]);
         let stake_distributions =
             initial_stake_distributions(&snapshots, &era_history).expect("initial stake distributions");
 
         // Fresh state, EMPTY volatile — the post-restart configuration.
         let mut state = State::new_with(
-            EmptyStore { tip: stable_tip, epoch: current_epoch },
+            MockStore::new(stable_tip),
             snapshots,
             current_epoch,
             network,
@@ -1154,295 +1129,19 @@ mod tests {
             stake_distributions,
         );
 
-        // First block of the next epoch arrives: the transition must succeed
-        // by recomputing the rewards summary from the persisted snapshots...
+        // First block of the next epoch arrives; mirror `roll_forward`'s
+        // sequence: rewards computation (keyed on the current tip, which is
+        // still past the stability window), then epoch transition.
         let next_point = Point::Specific(Slot::from(u64::from(next_epoch_start) + 2), Hash::from([1u8; 32]));
-        let result = state.try_epoch_transition(next_point);
+
+        let computed = state.try_compute_rewards();
+        assert!(computed.is_ok(), "computing rewards for the epoch being closed must succeed: {computed:?}");
+
+        let transitioned = state.try_epoch_transition(next_point);
         assert!(
-            result.is_ok(),
-            "epoch transition right after a restart past the stability window must not fail: {result:?}",
+            transitioned.is_ok(),
+            "epoch transition right after a restart past the stability window must not fail: {transitioned:?}",
         );
-
-        // ... and actually transition.
         assert_eq!(state.epoch(), next_epoch);
-    }
-
-    // An empty store: what a freshly-bootstrapped-then-restarted node would
-    // see, reduced to nothing. Doubles as (empty) snapshot and (no-op)
-    // transactional context so the whole test is self-contained (using
-    // `amaru-stores` from unit tests would link a second instance of this
-    // crate and break trait identities).
-    #[derive(Clone)]
-    struct EmptyStore {
-        tip: Point,
-        epoch: Epoch,
-    }
-
-    impl ReadStore for EmptyStore {
-        fn tip(&self) -> crate::store::Result<Point> {
-            Ok(self.tip)
-        }
-
-        fn epoch_transition_progress(&self) -> crate::store::Result<Option<EpochTransitionProgress>> {
-            Ok(None)
-        }
-
-        fn protocol_parameters(&self) -> crate::store::Result<ProtocolParameters> {
-            Ok(PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone())
-        }
-
-        fn pool(&self, _pool: &PoolId) -> crate::store::Result<Option<scolumns::pools::Row>> {
-            Ok(None)
-        }
-
-        fn account(&self, _credential: &StakeCredential) -> crate::store::Result<Option<scolumns::accounts::Row>> {
-            Ok(None)
-        }
-
-        fn drep(&self, _credential: &StakeCredential) -> crate::store::Result<Option<scolumns::dreps::Row>> {
-            Ok(None)
-        }
-
-        fn cc_member(&self, _credential: &StakeCredential) -> crate::store::Result<Option<scolumns::cc_members::Row>> {
-            Ok(None)
-        }
-
-        fn proposal(&self, _id: &ComparableProposalId) -> crate::store::Result<Option<scolumns::proposals::Row>> {
-            Ok(None)
-        }
-
-        fn utxo(&self, _input: &TransactionInput) -> crate::store::Result<Option<MemoizedTransactionOutput>> {
-            Ok(None)
-        }
-
-        fn pots(&self) -> crate::store::Result<Pots> {
-            Ok(Pots { treasury: 0, reserves: 0, fees: 0 })
-        }
-
-        fn constitutional_committee(&self) -> crate::store::Result<ConstitutionalCommitteeStatus> {
-            Ok(ConstitutionalCommitteeStatus::NoConfidence)
-        }
-
-        fn constitution(&self) -> crate::store::Result<Constitution> {
-            Ok(Constitution {
-                anchor: Anchor { url: String::new(), content_hash: Hash::from([0u8; 32]) },
-                guardrail_script: Nullable::Null,
-            })
-        }
-
-        fn proposals_roots(&self) -> crate::store::Result<ProposalsRoots> {
-            Ok(ProposalsRoots::default())
-        }
-
-        fn governance_activity(&self) -> crate::store::Result<GovernanceActivity> {
-            Ok(GovernanceActivity::default())
-        }
-
-        fn iter_utxos(
-            &self,
-        ) -> crate::store::Result<impl Iterator<Item = (scolumns::utxo::Key, scolumns::utxo::Value)>> {
-            Ok(std::iter::empty())
-        }
-
-        fn iter_block_issuers(
-            &self,
-        ) -> crate::store::Result<impl Iterator<Item = (scolumns::slots::Key, scolumns::slots::Value)>> {
-            Ok(std::iter::empty())
-        }
-
-        fn iter_pools(
-            &self,
-        ) -> crate::store::Result<impl Iterator<Item = (scolumns::pools::Key, scolumns::pools::Row)>> {
-            Ok(std::iter::empty())
-        }
-
-        fn iter_accounts(
-            &self,
-        ) -> crate::store::Result<impl Iterator<Item = (scolumns::accounts::Key, scolumns::accounts::Row)>> {
-            Ok(std::iter::empty())
-        }
-
-        fn iter_dreps(
-            &self,
-        ) -> crate::store::Result<impl Iterator<Item = (scolumns::dreps::Key, scolumns::dreps::Row)>> {
-            Ok(std::iter::empty())
-        }
-
-        fn iter_proposals(
-            &self,
-        ) -> crate::store::Result<impl Iterator<Item = (scolumns::proposals::Key, scolumns::proposals::Row)>> {
-            Ok(std::iter::empty())
-        }
-
-        fn iter_cc_members(
-            &self,
-        ) -> crate::store::Result<impl Iterator<Item = (scolumns::cc_members::Key, scolumns::cc_members::Row)>>
-        {
-            Ok(std::iter::empty())
-        }
-
-        fn iter_votes(
-            &self,
-        ) -> crate::store::Result<impl Iterator<Item = (scolumns::votes::Key, scolumns::votes::Row)>> {
-            Ok(std::iter::empty())
-        }
-    }
-
-    impl Snapshot for EmptyStore {
-        fn epoch(&self) -> Epoch {
-            self.epoch
-        }
-    }
-
-    impl<'a> TransactionalContext<'a> for EmptyStore {
-        fn commit(self) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn rollback(self) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn reset_epoch_transition_progress(&self) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn try_epoch_transition(
-            &self,
-            _from: Option<EpochTransitionProgress>,
-            _to: Option<EpochTransitionProgress>,
-        ) -> crate::store::Result<bool> {
-            Ok(true)
-        }
-
-        fn save(
-            &self,
-            _era_history: &EraHistory,
-            _protocol_parameters: &ProtocolParameters,
-            _governance_activity: GovernanceActivity,
-            _point: &Point,
-            _issuer: Option<&scolumns::pools::Key>,
-            _add: crate::store::Columns<
-                impl Iterator<Item = (scolumns::utxo::Key, scolumns::utxo::Value)>,
-                impl Iterator<Item = scolumns::pools::Value>,
-                impl Iterator<Item = (scolumns::accounts::Key, scolumns::accounts::Value)>,
-                impl Iterator<Item = (scolumns::dreps::Key, scolumns::dreps::Value)>,
-                impl Iterator<Item = (scolumns::cc_members::Key, scolumns::cc_members::Value)>,
-                impl Iterator<Item = (scolumns::proposals::Key, scolumns::proposals::Value)>,
-                impl Iterator<Item = (scolumns::votes::Key, scolumns::votes::Value)>,
-            >,
-            _remove: crate::store::Columns<
-                impl Iterator<Item = scolumns::utxo::Key>,
-                impl Iterator<Item = (scolumns::pools::Key, Epoch)>,
-                impl Iterator<Item = scolumns::accounts::Key>,
-                impl Iterator<Item = (scolumns::dreps::Key, CertificatePointer)>,
-                impl Iterator<Item = scolumns::cc_members::Key>,
-                impl Iterator<Item = ()>,
-                impl Iterator<Item = ()>,
-            >,
-            _withdrawals: impl Iterator<Item = scolumns::accounts::Key>,
-        ) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn refund(&self, _credential: &scolumns::accounts::Key, _deposit: Lovelace) -> crate::store::Result<Lovelace> {
-            Ok(0)
-        }
-
-        fn set_protocol_parameters(&self, _protocol_parameters: &ProtocolParameters) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn update_constitutional_committee(
-            &self,
-            _status: &ConstitutionalCommitteeStatus,
-            _added: BTreeMap<StakeCredential, Epoch>,
-            _removed: BTreeSet<StakeCredential>,
-        ) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn set_proposals_roots(&self, _roots: &ProposalsRoots) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn set_constitution(&self, _constitution: &Constitution) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn set_governance_activity(&self, _dormant_epochs: GovernanceActivity) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn remove_proposals<'iter, Id>(&self, _proposals: impl IntoIterator<Item = Id>) -> crate::store::Result<()>
-        where
-            Id: Deref<Target = ProposalId> + 'iter,
-        {
-            Ok(())
-        }
-
-        fn with_pots(
-            &self,
-            _with: impl FnMut(Box<dyn BorrowMut<scolumns::pots::Row> + '_>),
-        ) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn with_pools(&self, _with: impl FnMut(scolumns::pools::Iter<'_, '_>)) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn with_accounts(&self, _with: impl FnMut(scolumns::accounts::Iter<'_, '_>)) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn with_block_issuers(&self, _with: impl FnMut(scolumns::slots::Iter<'_, '_>)) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn with_utxo(&self, _with: impl FnMut(scolumns::utxo::Iter<'_, '_>)) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn with_dreps(&self, _with: impl FnMut(scolumns::dreps::Iter<'_, '_>)) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn with_proposals(&self, _with: impl FnMut(scolumns::proposals::Iter<'_, '_>)) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn with_cc_members(&self, _with: impl FnMut(scolumns::cc_members::Iter<'_, '_>)) -> crate::store::Result<()> {
-            Ok(())
-        }
-    }
-
-    impl Store for EmptyStore {
-        type Transaction<'a> = EmptyStore;
-
-        fn next_snapshot(&self, _epoch: Epoch) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn create_transaction(&self) -> Self::Transaction<'_> {
-            self.clone()
-        }
-    }
-
-    /// Empty snapshots for the three epochs a restarted node finds on disk.
-    struct EmptySnapshots;
-
-    impl HistoricalStores for EmptySnapshots {
-        fn snapshots(&self) -> crate::store::Result<Vec<Epoch>> {
-            Ok(vec![Epoch::from(7_u64), Epoch::from(8_u64), Epoch::from(9_u64)])
-        }
-
-        fn prune(&self, _minimum_epoch: Epoch) -> crate::store::Result<()> {
-            Ok(())
-        }
-
-        fn for_epoch(&self, epoch: Epoch) -> crate::store::Result<impl Snapshot> {
-            Ok(EmptyStore { tip: Point::Origin, epoch })
-        }
     }
 }

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -48,6 +48,9 @@ use crate::{epoch_transition::GovernanceActivity, governance::ratification::Prop
 
 pub mod columns;
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
+
 mod epoch_transition;
 pub use epoch_transition::{
     apply_governance_updates, pay_or_refund_accounts, pay_rewards, reset_blocks_count, reset_fees,

--- a/crates/amaru-ledger/src/store/test_utils.rs
+++ b/crates/amaru-ledger/src/store/test_utils.rs
@@ -1,0 +1,323 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Reusable store mocks for tests.
+//!
+//! [`MockStore`] behaves like an empty store with a configurable tip: lookups
+//! return `None`, iterators are empty, pots are zeroed, and no epoch
+//! transition is in progress. It also acts as an (empty) [`Snapshot`] with a
+//! configurable epoch, and as a no-op [`TransactionalContext`], so it can
+//! stand in for the stable store wherever a [`Store`] is expected.
+//! [`MockHistoricalStores`] serves empty snapshots for a configurable list of
+//! epochs.
+
+use std::{
+    borrow::BorrowMut,
+    collections::{BTreeMap, BTreeSet},
+    ops::Deref,
+};
+
+use amaru_kernel::{
+    Anchor, CertificatePointer, ComparableProposalId, Constitution, ConstitutionalCommitteeStatus, Epoch, EraHistory,
+    Hash, Lovelace, MemoizedTransactionOutput, Nullable, PREPROD_DEFAULT_PROTOCOL_PARAMETERS, Point, PoolId,
+    ProposalId, ProtocolParameters, StakeCredential, TransactionInput,
+};
+
+use crate::{
+    epoch_transition::GovernanceActivity,
+    governance::ratification::ProposalsRoots,
+    store::{
+        Columns, EpochTransitionProgress, HistoricalStores, ReadStore, Result, Snapshot, Store, TransactionalContext,
+        columns as scolumns,
+    },
+    summary::Pots,
+};
+
+/// An empty store with a configurable tip (and epoch, when used as a
+/// [`Snapshot`]).
+#[derive(Clone)]
+pub struct MockStore {
+    tip: Point,
+    epoch: Epoch,
+}
+
+impl MockStore {
+    /// An empty store whose `tip` is the given point.
+    pub fn new(tip: Point) -> Self {
+        Self { tip, epoch: Epoch::from(0_u64) }
+    }
+
+    /// Set the epoch reported when used as a [`Snapshot`].
+    pub fn at_epoch(mut self, epoch: Epoch) -> Self {
+        self.epoch = epoch;
+        self
+    }
+}
+
+impl ReadStore for MockStore {
+    fn tip(&self) -> Result<Point> {
+        Ok(self.tip)
+    }
+
+    fn epoch_transition_progress(&self) -> Result<Option<EpochTransitionProgress>> {
+        Ok(None)
+    }
+
+    fn protocol_parameters(&self) -> Result<ProtocolParameters> {
+        Ok(PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone())
+    }
+
+    fn pool(&self, _pool: &PoolId) -> Result<Option<scolumns::pools::Row>> {
+        Ok(None)
+    }
+
+    fn account(&self, _credential: &StakeCredential) -> Result<Option<scolumns::accounts::Row>> {
+        Ok(None)
+    }
+
+    fn drep(&self, _credential: &StakeCredential) -> Result<Option<scolumns::dreps::Row>> {
+        Ok(None)
+    }
+
+    fn cc_member(&self, _credential: &StakeCredential) -> Result<Option<scolumns::cc_members::Row>> {
+        Ok(None)
+    }
+
+    fn proposal(&self, _id: &ComparableProposalId) -> Result<Option<scolumns::proposals::Row>> {
+        Ok(None)
+    }
+
+    fn utxo(&self, _input: &TransactionInput) -> Result<Option<MemoizedTransactionOutput>> {
+        Ok(None)
+    }
+
+    fn pots(&self) -> Result<Pots> {
+        Ok(Pots { treasury: 0, reserves: 0, fees: 0 })
+    }
+
+    fn constitutional_committee(&self) -> Result<ConstitutionalCommitteeStatus> {
+        Ok(ConstitutionalCommitteeStatus::NoConfidence)
+    }
+
+    fn constitution(&self) -> Result<Constitution> {
+        Ok(Constitution {
+            anchor: Anchor { url: String::new(), content_hash: Hash::from([0u8; 32]) },
+            guardrail_script: Nullable::Null,
+        })
+    }
+
+    fn proposals_roots(&self) -> Result<ProposalsRoots> {
+        Ok(ProposalsRoots::default())
+    }
+
+    fn governance_activity(&self) -> Result<GovernanceActivity> {
+        Ok(GovernanceActivity::default())
+    }
+
+    fn iter_utxos(&self) -> Result<impl Iterator<Item = (scolumns::utxo::Key, scolumns::utxo::Value)>> {
+        Ok(std::iter::empty())
+    }
+
+    fn iter_block_issuers(&self) -> Result<impl Iterator<Item = (scolumns::slots::Key, scolumns::slots::Value)>> {
+        Ok(std::iter::empty())
+    }
+
+    fn iter_pools(&self) -> Result<impl Iterator<Item = (scolumns::pools::Key, scolumns::pools::Row)>> {
+        Ok(std::iter::empty())
+    }
+
+    fn iter_accounts(&self) -> Result<impl Iterator<Item = (scolumns::accounts::Key, scolumns::accounts::Row)>> {
+        Ok(std::iter::empty())
+    }
+
+    fn iter_dreps(&self) -> Result<impl Iterator<Item = (scolumns::dreps::Key, scolumns::dreps::Row)>> {
+        Ok(std::iter::empty())
+    }
+
+    fn iter_proposals(&self) -> Result<impl Iterator<Item = (scolumns::proposals::Key, scolumns::proposals::Row)>> {
+        Ok(std::iter::empty())
+    }
+
+    fn iter_cc_members(&self) -> Result<impl Iterator<Item = (scolumns::cc_members::Key, scolumns::cc_members::Row)>> {
+        Ok(std::iter::empty())
+    }
+
+    fn iter_votes(&self) -> Result<impl Iterator<Item = (scolumns::votes::Key, scolumns::votes::Row)>> {
+        Ok(std::iter::empty())
+    }
+}
+
+impl Snapshot for MockStore {
+    fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+}
+
+impl<'a> TransactionalContext<'a> for MockStore {
+    fn commit(self) -> Result<()> {
+        Ok(())
+    }
+
+    fn rollback(self) -> Result<()> {
+        Ok(())
+    }
+
+    fn reset_epoch_transition_progress(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn try_epoch_transition(
+        &self,
+        _from: Option<EpochTransitionProgress>,
+        _to: Option<EpochTransitionProgress>,
+    ) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn save(
+        &self,
+        _era_history: &EraHistory,
+        _protocol_parameters: &ProtocolParameters,
+        _governance_activity: GovernanceActivity,
+        _point: &Point,
+        _issuer: Option<&scolumns::pools::Key>,
+        _add: Columns<
+            impl Iterator<Item = (scolumns::utxo::Key, scolumns::utxo::Value)>,
+            impl Iterator<Item = scolumns::pools::Value>,
+            impl Iterator<Item = (scolumns::accounts::Key, scolumns::accounts::Value)>,
+            impl Iterator<Item = (scolumns::dreps::Key, scolumns::dreps::Value)>,
+            impl Iterator<Item = (scolumns::cc_members::Key, scolumns::cc_members::Value)>,
+            impl Iterator<Item = (scolumns::proposals::Key, scolumns::proposals::Value)>,
+            impl Iterator<Item = (scolumns::votes::Key, scolumns::votes::Value)>,
+        >,
+        _remove: Columns<
+            impl Iterator<Item = scolumns::utxo::Key>,
+            impl Iterator<Item = (scolumns::pools::Key, Epoch)>,
+            impl Iterator<Item = scolumns::accounts::Key>,
+            impl Iterator<Item = (scolumns::dreps::Key, CertificatePointer)>,
+            impl Iterator<Item = scolumns::cc_members::Key>,
+            impl Iterator<Item = ()>,
+            impl Iterator<Item = ()>,
+        >,
+        _withdrawals: impl Iterator<Item = scolumns::accounts::Key>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn refund(&self, _credential: &scolumns::accounts::Key, _deposit: Lovelace) -> Result<Lovelace> {
+        Ok(0)
+    }
+
+    fn set_protocol_parameters(&self, _protocol_parameters: &ProtocolParameters) -> Result<()> {
+        Ok(())
+    }
+
+    fn update_constitutional_committee(
+        &self,
+        _status: &ConstitutionalCommitteeStatus,
+        _added: BTreeMap<StakeCredential, Epoch>,
+        _removed: BTreeSet<StakeCredential>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn set_proposals_roots(&self, _roots: &ProposalsRoots) -> Result<()> {
+        Ok(())
+    }
+
+    fn set_constitution(&self, _constitution: &Constitution) -> Result<()> {
+        Ok(())
+    }
+
+    fn set_governance_activity(&self, _dormant_epochs: GovernanceActivity) -> Result<()> {
+        Ok(())
+    }
+
+    fn remove_proposals<'iter, Id>(&self, _proposals: impl IntoIterator<Item = Id>) -> Result<()>
+    where
+        Id: Deref<Target = ProposalId> + 'iter,
+    {
+        Ok(())
+    }
+
+    fn with_pots(&self, _with: impl FnMut(Box<dyn BorrowMut<scolumns::pots::Row> + '_>)) -> Result<()> {
+        Ok(())
+    }
+
+    fn with_pools(&self, _with: impl FnMut(scolumns::pools::Iter<'_, '_>)) -> Result<()> {
+        Ok(())
+    }
+
+    fn with_accounts(&self, _with: impl FnMut(scolumns::accounts::Iter<'_, '_>)) -> Result<()> {
+        Ok(())
+    }
+
+    fn with_block_issuers(&self, _with: impl FnMut(scolumns::slots::Iter<'_, '_>)) -> Result<()> {
+        Ok(())
+    }
+
+    fn with_utxo(&self, _with: impl FnMut(scolumns::utxo::Iter<'_, '_>)) -> Result<()> {
+        Ok(())
+    }
+
+    fn with_dreps(&self, _with: impl FnMut(scolumns::dreps::Iter<'_, '_>)) -> Result<()> {
+        Ok(())
+    }
+
+    fn with_proposals(&self, _with: impl FnMut(scolumns::proposals::Iter<'_, '_>)) -> Result<()> {
+        Ok(())
+    }
+
+    fn with_cc_members(&self, _with: impl FnMut(scolumns::cc_members::Iter<'_, '_>)) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl Store for MockStore {
+    type Transaction<'a> = MockStore;
+
+    fn next_snapshot(&self, _epoch: Epoch) -> Result<()> {
+        Ok(())
+    }
+
+    fn create_transaction(&self) -> Self::Transaction<'_> {
+        self.clone()
+    }
+}
+
+/// Empty snapshots for a configurable list of epochs.
+pub struct MockHistoricalStores {
+    snapshots: Vec<Epoch>,
+}
+
+impl MockHistoricalStores {
+    /// Serve (empty) snapshots for the given epochs, oldest first.
+    pub fn new(snapshots: Vec<Epoch>) -> Self {
+        Self { snapshots }
+    }
+}
+
+impl HistoricalStores for MockHistoricalStores {
+    fn snapshots(&self) -> Result<Vec<Epoch>> {
+        Ok(self.snapshots.clone())
+    }
+
+    fn prune(&self, _minimum_epoch: Epoch) -> Result<()> {
+        Ok(())
+    }
+
+    fn for_epoch(&self, epoch: Epoch) -> Result<impl Snapshot> {
+        Ok(MockStore::new(Point::Origin).at_epoch(epoch))
+    }
+}

--- a/crates/amaru-ledger/tests/state_rollback.rs
+++ b/crates/amaru-ledger/tests/state_rollback.rs
@@ -21,9 +21,8 @@ use amaru_kernel::{
 use amaru_ledger::{
     epoch_transition::GovernanceActivity,
     state::{BackwardError, State, volatile::VolatileFragment},
-    store::{EpochTransitionProgress, ReadStore, Store, StoreError},
+    store::test_utils::{MockHistoricalStores, MockStore},
 };
-use amaru_stores::rocksdb::{RocksDB, RocksDBHistoricalStores, RocksDbConfig};
 
 #[test]
 fn rollback_to_a_volatile_common_ancestor_succeeds() {
@@ -109,21 +108,15 @@ fn rollback_after_volatile_front_is_rejected() {
 // HELPERS
 
 /// Create an initial ledger state
-#[expect(clippy::expect_used)]
-fn make_state() -> State<MockStore, RocksDBHistoricalStores> {
+fn make_state() -> State<MockStore, MockHistoricalStores> {
     let network = NetworkName::Preprod;
     let era_history: EraHistory = PREPROD_ERA_HISTORY.clone();
     let global_parameters: GlobalParameters = PREPROD_GLOBAL_PARAMETERS.clone();
     let protocol_parameters: ProtocolParameters = PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone();
 
-    let ledger_dir = tempfile::tempdir().expect("tempdir creation succeeds").keep();
-    let cfg = RocksDbConfig::new(ledger_dir);
-    let store = RocksDB::empty(&cfg).expect("RocksDB::empty succeeds");
-    let snapshots = RocksDBHistoricalStores::new(&cfg, 0);
-
     State::new_with(
-        MockStore(store),
-        snapshots,
+        MockStore::new(Point::Origin),
+        MockHistoricalStores::new(vec![]),
         Epoch::default(),
         network,
         era_history,
@@ -134,9 +127,9 @@ fn make_state() -> State<MockStore, RocksDBHistoricalStores> {
     )
 }
 
-/// Forward the ldeger to a given point
+/// Forward the ledger to a given point
 #[expect(clippy::expect_used)]
-fn forward_to(state: &mut State<MockStore, RocksDBHistoricalStores>, point: Point, height: u64) {
+fn forward_to(state: &mut State<MockStore, MockHistoricalStores>, point: Point, height: u64) {
     let issuer = Hash::new([0u8; 28]);
     let tip = Tip::new(point, BlockHeight::from(height));
     state.push_fragment(VolatileFragment::default().anchor(tip, issuer)).expect("forward");
@@ -144,159 +137,4 @@ fn forward_to(state: &mut State<MockStore, RocksDBHistoricalStores>, point: Poin
 
 fn point(slot: u64, tag: u8) -> Point {
     Point::Specific(Slot::from(slot), Hash::new([tag; 32]))
-}
-
-struct MockStore(RocksDB);
-
-#[expect(unused_variables)]
-impl ReadStore for MockStore {
-    fn tip(&self) -> amaru_ledger::store::Result<Point> {
-        Ok(Point::Origin)
-    }
-
-    fn epoch_transition_progress(&self) -> amaru_ledger::store::Result<Option<EpochTransitionProgress>> {
-        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn protocol_parameters(&self) -> amaru_ledger::store::Result<ProtocolParameters> {
-        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn pool(
-        &self,
-        pool: &amaru_kernel::PoolId,
-    ) -> amaru_ledger::store::Result<Option<amaru_ledger::store::columns::pools::Row>> {
-        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn account(
-        &self,
-        credential: &amaru_kernel::StakeCredential,
-    ) -> amaru_ledger::store::Result<Option<amaru_ledger::store::columns::accounts::Row>> {
-        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn drep(
-        &self,
-        credential: &amaru_kernel::StakeCredential,
-    ) -> amaru_ledger::store::Result<Option<amaru_ledger::store::columns::dreps::Row>> {
-        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn cc_member(
-        &self,
-        credential: &amaru_kernel::StakeCredential,
-    ) -> amaru_ledger::store::Result<Option<amaru_ledger::store::columns::cc_members::Row>> {
-        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn proposal(
-        &self,
-        id: &amaru_kernel::ComparableProposalId,
-    ) -> amaru_ledger::store::Result<Option<amaru_ledger::store::columns::proposals::Row>> {
-        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn utxo(
-        &self,
-        input: &amaru_kernel::TransactionInput,
-    ) -> amaru_ledger::store::Result<Option<amaru_kernel::MemoizedTransactionOutput>> {
-        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn pots(&self) -> amaru_ledger::store::Result<amaru_ledger::summary::Pots> {
-        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn constitutional_committee(&self) -> amaru_ledger::store::Result<amaru_kernel::ConstitutionalCommitteeStatus> {
-        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn constitution(&self) -> amaru_ledger::store::Result<amaru_kernel::Constitution> {
-        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn proposals_roots(&self) -> amaru_ledger::store::Result<amaru_ledger::governance::ratification::ProposalsRoots> {
-        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn governance_activity(&self) -> amaru_ledger::store::Result<GovernanceActivity> {
-        Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn iter_utxos(
-        &self,
-    ) -> amaru_ledger::store::Result<
-        impl Iterator<Item = (amaru_ledger::store::columns::utxo::Key, amaru_ledger::store::columns::utxo::Value)>,
-    > {
-        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn iter_block_issuers(
-        &self,
-    ) -> amaru_ledger::store::Result<
-        impl Iterator<Item = (amaru_ledger::store::columns::slots::Key, amaru_ledger::store::columns::slots::Value)>,
-    > {
-        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn iter_pools(
-        &self,
-    ) -> amaru_ledger::store::Result<
-        impl Iterator<Item = (amaru_ledger::store::columns::pools::Key, amaru_ledger::store::columns::pools::Row)>,
-    > {
-        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn iter_accounts(
-        &self,
-    ) -> amaru_ledger::store::Result<
-        impl Iterator<Item = (amaru_ledger::store::columns::accounts::Key, amaru_ledger::store::columns::accounts::Row)>,
-    > {
-        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn iter_dreps(
-        &self,
-    ) -> amaru_ledger::store::Result<
-        impl Iterator<Item = (amaru_ledger::store::columns::dreps::Key, amaru_ledger::store::columns::dreps::Row)>,
-    > {
-        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn iter_proposals(
-        &self,
-    ) -> amaru_ledger::store::Result<
-        impl Iterator<Item = (amaru_ledger::store::columns::proposals::Key, amaru_ledger::store::columns::proposals::Row)>,
-    > {
-        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn iter_cc_members(
-        &self,
-    ) -> amaru_ledger::store::Result<
-        impl Iterator<Item = (amaru_ledger::store::columns::cc_members::Key, amaru_ledger::store::columns::cc_members::Row)>,
-    > {
-        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-
-    fn iter_votes(
-        &self,
-    ) -> amaru_ledger::store::Result<
-        impl Iterator<Item = (amaru_ledger::store::columns::votes::Key, amaru_ledger::store::columns::votes::Row)>,
-    > {
-        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
-    }
-}
-
-impl Store for MockStore {
-    type Transaction<'a> = <RocksDB as Store>::Transaction<'a>;
-
-    fn next_snapshot(&self, epoch: amaru_kernel::Epoch) -> amaru_ledger::store::Result<()> {
-        self.0.next_snapshot(epoch)
-    }
-
-    fn create_transaction(&self) -> Self::Transaction<'_> {
-        self.0.create_transaction()
-    }
 }


### PR DESCRIPTION
### Problem

Running amaru as n2n relays under Antithesis fault injection (kill/restart faults), consensus terminates while validating the first block after an epoch boundary:

```
ERROR amaru_consensus::stages::validate_block: failed to validate block
      error=BlockValidationError: rewards summary not ready
ERROR amaru::cmd::node::run: Consensus died, this should not happen!
      Please report this incl. preceding logs to the Amaru team.
```

`restart: always` brings the node back, it re-validates the same block and dies again — a crash loop. Reproduced on `5923f085` and on `main` (`eb21a990`). Full evidence (runs, logs, timeline): https://gist.github.com/paolino/ff8d2c19dfc986c42aaf1e022e6ec18f

### Cause

The rewards summary is computed when a block at relative slot >= the stability window is applied (`try_compute_rewards`) and held only in the in-memory volatile overlay. A node restarting with its stable tip already past the stability window replays no block within the window, so the summary is missing when the epoch boundary is reached, and `epoch_transition` fails with `RewardsSummaryNotReady` — fatal for consensus.

### Fix

In `epoch_transition`: when no transition progress has been persisted and the summary is missing, recompute it. All inputs (the `e-1` snapshot and the `e-3` stake distribution) are persisted and frozen for the epoch (`MIN_LEDGER_SNAPSHOTS = 3`), so the recomputation is deterministic — same result as computing at the stability window. Every previously-working path is unchanged; a `warn!` traces the recovery.

Also adds a regression unit test reconstructing the post-restart state (empty volatile, stable tip past the stability window); it fails with `RewardsSummaryNotReady` without the fix. The test uses self-contained store mocks because `amaru-stores` cannot be used from `amaru-ledger` unit tests (cyclic dev-dependency links a second instance of the crate, breaking trait identity).

### Testing

- Regression test: fails on `main`, passes with the fix; full `amaru-ledger` suite green; clippy/fmt clean.
- 1h Antithesis fault-injection run on the patched build (same harness that reproduced the crash twice): `Consensus died` 0 occurrences (previously 50+); the recovery `warn` fired 50+ times, i.e. the previously-fatal state was entered repeatedly and survived.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved epoch transition handling during restarts when prior progress or cached rewards data is unavailable.
  * The ledger now recovers by recomputing the rewards summary instead of failing the transition.

* **Tests**
  * Added a regression test covering successful epoch transition after a restart with missing in-memory state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->