### PR TITLE
Stake distribution fixes

### DIFF
--- a/.github/actions/bootstrap-db/action.yml
+++ b/.github/actions/bootstrap-db/action.yml
@@ -12,7 +12,7 @@ inputs:
   cache-version:
     description: Cache key version
     required: false
-    default: "v13"
+    default: "v14"
 
 runs:
   using: composite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,13 +37,37 @@ Other guiding principles:
 
 ## v10.10.20260709 _[unreleased; planned for 2026-07-09]_
 
+### Added
+
+- **amaru-ledger**: keep treasury donations as first-class ledger state, so protocol pots and derived summaries retain the corresponding accounting information. ([#1010][])
+
 ### Changed
 
 - **amaru**: make sure bootstrap can't be done with unsupported snapshots; similarly prevent startup if state becomes unsupported. ([#1000][])
 
 - **amaru**: more robust procedure and tooling to produce stake-distribution epoch snapshots for conformance testing and comparison with the haskell node. ([#985][])
 
-- **amaru**: fix snapshot import of pool with no metadata. ([#1013][])
+- **amaru**: fix snapshot import of pools with no metadata. ([#1013][])
+
+- **amaru**: stake-distribution conformance tests now auto-detect which local epochs are available in `ledger.<network>.db` and run those by default, while leaving uncovered fixtures visible as ignored tests. ([#1010][])
+
+- **amaru-ledger**: load the initial in-memory stake distributions in parallel at startup, to reduce restore time when opening the node from existing snapshots. ([#1010][])
+
+### Fixed
+
+- **amaru**: align the cardano-node reference snapshots in the haskell-node-extractor with the post-rewards epoch state, so treasury, reserves, accounts, and voting stake match what Amaru snapshots at epoch end. ([#1010][])
+
+- **amaru-consensus**: be more conservative when fetching ahead from peers during long low-density periods, to avoid requesting headers whose stake distribution is not ready yet. ([#1010][])
+
+- **amaru-ledger**: make epoch transitions and rewards calculations more resilient around restarts, interrupted transitions, and weak chain-growth periods near epoch boundaries. ([#1010][])
+
+- **amaru-ledger**: preserve delegators across DRep re-registration, while still ignoring stale DRep delegations that pre-date the current registration. ([#1010][])
+
+- **amaru-ledger**: fix epoch-boundary stake-distribution accounting by remembering recently pruned proposals and counting just-ratified treasury withdrawals in DRep voting stake. ([#1010][])
+
+- **amaru-ledger**: stop treating governance proposals as expired one epoch too early when rebuilding the proposal forest for ratification. ([#1010][])
+
+- **amaru-ledger**: fix pool registration shadowing retirements when done in the last k blocks of an epoch. ([#1010][])
 
 ## [v10.10.20260702](https://github.com/pragma-org/amaru/releases/tag/v10.10.20260702)
 
@@ -99,7 +123,6 @@ Other guiding principles:
 
 ## [v10.10.20260611](https://github.com/pragma-org/amaru/releases/tag/v10.10.20260611)
 
-
 [#769]: https://github.com/pragma-org/amaru/issues/769
 [#778]: https://github.com/pragma-org/amaru/issues/778
 [#886]: https://github.com/pragma-org/amaru/pull/886
@@ -116,4 +139,5 @@ Other guiding principles:
 [#985]: https://github.com/pragma-org/amaru/pull/985
 [#988]: https://github.com/pragma-org/amaru/pull/988
 [#1000]: https://github.com/pragma-org/amaru/pull/1000
+[#1010]: https://github.com/pragma-org/amaru/pull/1010
 [#1013]: https://github.com/pragma-org/amaru/pull/1013

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ dependencies = [
  "num",
  "once_cell",
  "proptest",
+ "rayon",
  "serde",
  "tempfile",
  "test-case",

--- a/Makefile
+++ b/Makefile
@@ -205,10 +205,6 @@ ledger-conformance-known-failures: ## &test Update the set of 'known conformance
 	cargo test -p amaru-ledger --test evaluate_ledger_states -- --test-threads=1; \
 	mv "$$AMARU_UPDATE_LEDGER_CONFORMANCE_SNAPSHOT_PATH" "./crates/amaru-ledger/tests/data/rules-conformance.failures.toml"
 
-generate-test-snapshots: ## &test Generate test snapshots for test-e2e
-	@npm --prefix conformance-tests run generate-all -- "$(AMARU_NETWORK)"
-	@./scripts/generate-snapshot-test-cases
-
 regenerate-cbor-fixtures: ## &test Regenerate cuddle/antigen CBOR fixtures (requires GHC + cabal)
 	@./scripts/regenerate-cbor-fixtures
 

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -415,7 +415,44 @@ impl TrackPeers {
                     }
                 };
 
-                let min_ledger_height = header.block_height() - self.consensus_security_parameter;
+                // FIXME: Handle missing stake distributions by deferring request next instead of this
+                //
+                // Here, we have to artificially lower the forecast window we want because of a
+                // period on the network (November 2025) where the chain coped with a long fork
+                // (thousands of blocks) that actually violated a few of the chain growth
+                // properties.
+                //
+                // For example on Preview, the epoch 1123 has only seen 251 blocks; which is far
+                // less than `k=432` blocks on Preview. So we had a scenario where a window of more
+                // than `3*k/f` slots have seen less than `k` blocks. This happened because of a bug
+                // which partitioned the chain into two; until the initially-loosing-chain was
+                // adopted by majority (by fixing the bug and having the majority of the stake
+                // endorsing that fork).
+                //
+                // The consequences of this makes the following check too optimistic when using `k`;
+                // because we end up trying to validate headers that are too far and for which we
+                // don't yet have a stake distribution ready in the ledger.
+                //
+                // The temporary fix for now is to simply avoid looking too far ahead, while we're
+                // working on the proper fix which would consist in handling the missing stake
+                // distributions from the ledger as an event that *can* happen, and that should
+                // simply cause the header validation to be postponed (to until the stake
+                // distribution is available).
+                //
+                // How much is too far ahead? On Preview (where the problem is the most visible),
+                // the stake distribution required for 1124 will be calculated after about ~80
+                // blocks in the epoch 1123. So that means, we cannot go more than 171 blocks. So we
+                // use `k / 3 = 144` which is well below, and still a function of `k`, so that on
+                // Mainnet or PreProd, we can still fetch a fair amount of blocks ahead of us and
+                // not impact synchronization too much.
+                //
+                // /!\ IMPORTANT /!\
+                // To fix this properly, we not only need to handle the error from here; but we also
+                // need to ensure that the ledger produces stake distributions at least once per
+                // epoch. Currently, in the extreme scenario where no blocks would be produced for
+                // the last 2/3rd of an epoch, the ledger would not have produced a stake
+                // distribution and arrive at an epoch boundary with a big problem.
+                let min_ledger_height = header.block_height() - self.consensus_security_parameter / 3;
                 if min_ledger_height > self.ledger_applied_block_height
                     && let now = eff.clock().await
                     && (now.saturating_since(self.ledger_last_checked_at) > Duration::from_secs(5)

--- a/crates/amaru-kernel/src/cardano.rs
+++ b/crates/amaru-kernel/src/cardano.rs
@@ -47,6 +47,7 @@ pub mod ex_units_prices;
 pub mod governance_action;
 pub mod hash;
 pub mod language_view;
+pub mod ratification_status;
 pub mod script_integrity_data;
 // TODO: BlockHeader vs Header
 //

--- a/crates/amaru-kernel/src/cardano/ratification_status.rs
+++ b/crates/amaru-kernel/src/cardano/ratification_status.rs
@@ -1,0 +1,45 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::cbor;
+
+/// A self-documenting boolean
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RatificationStatus {
+    Ratified,
+    NotRatified,
+}
+
+impl<C> cbor::Encode<C> for RatificationStatus {
+    fn encode<W: cbor::encode::Write>(
+        &self,
+        e: &mut cbor::Encoder<W>,
+        ctx: &mut C,
+    ) -> Result<(), cbor::encode::Error<W::Error>> {
+        e.encode_with(
+            match self {
+                Self::Ratified => true,
+                Self::NotRatified => false,
+            },
+            ctx,
+        )?;
+        Ok(())
+    }
+}
+
+impl<'b, C> cbor::Decode<'b, C> for RatificationStatus {
+    fn decode(d: &mut cbor::Decoder<'b>, ctx: &mut C) -> Result<Self, cbor::decode::Error> {
+        Ok(if bool::decode(d, ctx)? { Self::Ratified } else { Self::NotRatified })
+    }
+}

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -114,6 +114,7 @@ pub use cardano::{
     },
     protocol_parameters_update::{ProtocolParamUpdate, display_protocol_parameters_update},
     protocol_version::{self, PROTOCOL_VERSION_10, ProtocolVersion, ProtocolVersionTooOld},
+    ratification_status::{self, RatificationStatus},
     rational_number::{self, RationalNumber},
     raw_block::RawBlock,
     redeemer::Redeemer,

--- a/crates/amaru-ledger/Cargo.toml
+++ b/crates/amaru-ledger/Cargo.toml
@@ -27,6 +27,7 @@ async-trait.workspace = true
 hex.workspace = true
 num.workspace = true
 proptest = { workspace = true, optional = true }
+rayon.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -35,7 +35,10 @@ use crate::{
     epoch_transition::GovernanceActivity,
     governance::ratification::ProposalsRoots,
     state::{diff_bind::Resettable, diff_epoch_reg::DiffEpochReg},
-    store::{self, Store, StoreError, TransactionalContext, columns::proposals},
+    store::{
+        self, Store, StoreError, TransactionalContext,
+        columns::{pots::Row as Pots, proposals},
+    },
 };
 
 const BATCH_SIZE: usize = 1000;
@@ -230,7 +233,7 @@ pub fn import_initial_snapshot(
     decoder.skip()?;
 
     // Epoch State / Ledger State / UTxO State / utxosDonation
-    decoder.skip()?;
+    let donations = decoder.with_decoder(|d| Ok(d.u64()?))?;
 
     // Epoch State / Snapshots
     decoder.with_decoder(|d| {
@@ -283,9 +286,12 @@ pub fn import_initial_snapshot(
 
     import_pots(
         db,
-        (treasury + delta_treasury) as u64 + unclaimed_rewards,
-        (reserves - delta_reserves) as u64,
-        (fees - delta_fees) as u64,
+        Pots {
+            treasury: (treasury + delta_treasury) as u64 + unclaimed_rewards,
+            reserves: (reserves - delta_reserves) as u64,
+            fees: (fees - delta_fees) as u64,
+            donations,
+        },
     )?;
 
     // NOTE(INITIAL_BOOTSTRAP):
@@ -581,16 +587,14 @@ fn import_stake_pools(
     Ok(transaction.commit()?)
 }
 
-fn import_pots(db: &impl Store, treasury: u64, reserves: u64, fees: u64) -> Result<(), Box<dyn std::error::Error>> {
+fn import_pots(db: &impl Store, pots: Pots) -> Result<(), Box<dyn std::error::Error>> {
     let transaction = db.create_transaction();
     transaction.with_pots(|mut row| {
-        let pots = row.borrow_mut();
-        pots.treasury = treasury;
-        pots.reserves = reserves;
-        pots.fees = fees;
+        *row.borrow_mut() = pots;
     })?;
     transaction.commit()?;
-    info!(treasury, reserves, fees, "pots");
+    let Pots { treasury, reserves, fees, donations } = pots;
+    info!(treasury, reserves, fees, donations, "pots");
     Ok(())
 }
 

--- a/crates/amaru-ledger/src/context.rs
+++ b/crates/amaru-ledger/src/context.rs
@@ -149,6 +149,7 @@ impl<S: fmt::Debug> From<diff_bind::BindError<S>> for UpdateError<S> {
 /// An interface for interacting with the protocol pots.
 pub trait PotsSlice {
     fn add_fees(&mut self, fees: Lovelace);
+    fn add_donation(&mut self, donation: Lovelace);
 }
 
 // UTxO

--- a/crates/amaru-ledger/src/context/assert.rs
+++ b/crates/amaru-ledger/src/context/assert.rs
@@ -144,6 +144,10 @@ impl PotsSlice for AssertValidationContext {
         let _span = trace_span!(amaru_observability::amaru::ledger::context::ADD_FEES, fee = fee);
         let _guard = _span.enter();
     }
+
+    fn add_donation(&mut self, _donation: Lovelace) {
+        unimplemented!()
+    }
 }
 
 impl UtxoSlice for AssertValidationContext {

--- a/crates/amaru-ledger/src/context/default/validation.rs
+++ b/crates/amaru-ledger/src/context/default/validation.rs
@@ -97,6 +97,10 @@ impl PotsSlice for DefaultValidationContext {
     fn add_fees(&mut self, fees: Lovelace) {
         self.state.fees += fees;
     }
+
+    fn add_donation(&mut self, donation: Lovelace) {
+        self.state.donations += donation;
+    }
 }
 
 impl UtxoSlice for DefaultValidationContext {

--- a/crates/amaru-ledger/src/epoch_transition/pools_updates.rs
+++ b/crates/amaru-ledger/src/epoch_transition/pools_updates.rs
@@ -205,8 +205,9 @@ impl PoolsEpochTransitionUpdates {
         assert_eq!(
             last,
             Some(&(None, epoch)),
-            "invariant violation: most recent retirement is not last certificate: {:?}",
-            last,
+            "invariant violation: most recent retirement (epoch={epoch}) is not the last certificate;\npool={}\ncertificates={:#?}",
+            pool.id(),
+            pool.future_params,
         );
     }
 }

--- a/crates/amaru-ledger/src/epoch_transition/pools_updates.rs
+++ b/crates/amaru-ledger/src/epoch_transition/pools_updates.rs
@@ -88,8 +88,7 @@ impl PoolsEpochTransitionUpdates {
     /// Only check if a pool would be retiring, without taking ownership or modifying the original
     /// object.
     pub fn is_retiring(epoch: Epoch, pool: &Pool) -> bool {
-        let (_, retirement, needs_update) = fold_future_params(&pool.future_params, epoch);
-        needs_update && retirement.is_some_and(|retirement_epoch| retirement_epoch <= epoch)
+        fold_future_params(&pool.future_params, epoch).1.is_some()
     }
 
     /// Check whether a pool needs any sort of updates at the beginning of an epoch
@@ -109,62 +108,65 @@ impl PoolsEpochTransitionUpdates {
     /// a. Any re-registration that comes after a retirement cancels that retirement.
     /// b. Any retirement that come after a retirement cancels that previous retirement.
     pub fn tick_pool(&mut self, epoch: Epoch, mut pool: Pool) {
-        let (update, retirement, needs_update) = fold_future_params(&pool.future_params, epoch);
+        let (update, retirement) = fold_future_params(&pool.future_params, epoch);
 
-        if needs_update {
-            // If the most recent retirement is effective as per the current epoch, we simply drop the
-            // entry. Note that, any re-registration happening after that retirement would cancel it,
-            // which is taken care of in the fold above (returning 'None').
-            if let Some(retirement_epoch) = retirement
-                && retirement_epoch <= epoch
-            {
-                return self.retire_pool(epoch, pool);
-            }
+        // If the most recent retirement is effective as per the current epoch, we simply drop the
+        // entry. Note that, any re-registration happening after that retirement would cancel it,
+        // which is taken care of in the fold above (returning 'None').
+        if retirement.is_some() {
+            return self.retire_pool(epoch, pool);
+        }
 
-            let pool_id = pool.id();
+        let pool_id = pool.id();
 
-            if let Some(new_params) = update {
-                // NOTE: hidden exhaustiveness check
-                //
-                // The following statement is destructuring and not using a wildcard spread `..`
-                // *on purpose*. This lets the compiler warns us in case we add new fields to
-                // PoolParams.
-                let PoolParams { id: _, vrf, pledge, cost, margin, reward_account, owners, relays, metadata } =
-                    new_params;
+        let has_updated = if let Some(new_params) = update {
+            // NOTE: hidden exhaustiveness check
+            //
+            // The following statement is destructuring and not using a wildcard spread `..`
+            // *on purpose*. This lets the compiler warns us in case we add new fields to
+            // PoolParams.
+            let PoolParams { id: _, vrf, pledge, cost, margin, reward_account, owners, relays, metadata } = new_params;
 
-                let current_params = &mut pool.current_params;
+            let current_params = &mut pool.current_params;
 
-                // NOTE: /!\ IMPORTANT /!\ DO NOT INLINE
-                //
-                // It is tempting to inline all the identifier in the log event below. But don't.
-                // This would make the mutation conditioned to the trace severity level. We do need
-                // to update the pool parameters irrespective of the severity!
-                let vrf = set(&mut current_params.vrf, vrf, Hash::to_string);
-                let pledge = set(&mut current_params.pledge, pledge, Lovelace::to_string);
-                let cost = set(&mut current_params.cost, cost, Lovelace::to_string);
-                let margin = set(&mut current_params.margin, margin, rational_number::fmt);
-                let reward_account = set(&mut current_params.reward_account, reward_account, RewardAccount::to_string);
-                let owners = set(&mut current_params.owners, owners, |s| hash::fmt(s.deref()));
-                let relays = set(&mut current_params.relays, relays, |r| relay::fmt(r));
-                let metadata = set(&mut current_params.metadata, metadata, pool_metadata::fmt);
+            // NOTE: /!\ IMPORTANT /!\ DO NOT INLINE
+            //
+            // It is tempting to inline all the identifier in the log event below. But don't.
+            // This would make the mutation conditioned to the trace severity level. We do need
+            // to update the pool parameters irrespective of the severity!
+            let vrf = set(&mut current_params.vrf, vrf, Hash::to_string);
+            let pledge = set(&mut current_params.pledge, pledge, Lovelace::to_string);
+            let cost = set(&mut current_params.cost, cost, Lovelace::to_string);
+            let margin = set(&mut current_params.margin, margin, rational_number::fmt);
+            let reward_account = set(&mut current_params.reward_account, reward_account, RewardAccount::to_string);
+            let owners = set(&mut current_params.owners, owners, |s| hash::fmt(s.deref()));
+            let relays = set(&mut current_params.relays, relays, |r| relay::fmt(r));
+            let metadata = set(&mut current_params.metadata, metadata, pool_metadata::fmt);
 
-                debug!(
-                    name: "pool.update",
-                    id = %pool_id,
-                    vrf,
-                    pledge,
-                    cost,
-                    margin,
-                    reward_account,
-                    owners,
-                    relays,
-                    metadata,
-                );
-            }
+            debug!(
+                name: "pool.update",
+                id = %pool_id,
+                vrf,
+                pledge,
+                cost,
+                margin,
+                reward_account,
+                owners,
+                relays,
+                metadata,
+            );
 
-            // Regardless, always prune future params from those that are now-obsolete.
-            pool.future_params.retain(|(_, effective_in)| effective_in > &epoch);
+            true
+        } else {
+            false
+        };
 
+        // Regardless, always prune future params from those that are now-obsolete.
+        let future_params_old_len = pool.future_params.len();
+        pool.future_params.retain(|(_, effective_in)| effective_in > &epoch);
+        let has_pruned_params = pool.future_params.len() < future_params_old_len;
+
+        if has_updated || has_pruned_params {
             self.updated.insert(pool_id, pool);
         }
     }
@@ -216,24 +218,21 @@ impl PoolsEpochTransitionUpdates {
 ///
 /// The function returns any new params becoming active in the 'current_epoch', and the retirement
 /// status of the pool. Note that the pool can both have new parameters AND a retirement scheduled
-/// at a later epoch.
-///
-/// The boolean indicates whether any of the future params are now-obsolete as per the
-/// 'current_epoch'.
+/// at a later epoch; so the return parameters are not necessarily a replacement of the existing
+/// ones.
 pub fn fold_future_params(
     future_params: &[(Option<PoolParams>, Epoch)],
     current_epoch: Epoch,
-) -> (Option<&PoolParams>, Option<Epoch>, bool) {
-    future_params.iter().fold((None, None, false), |(update, retirement, needs_update), (params, epoch)| {
+) -> (Option<&PoolParams>, Option<Epoch>) {
+    future_params.iter().fold((None, None), |(update, _retirement), (params, epoch)| {
         match params {
-            // Pool has a parameter update that should now be applied.
-            Some(params) if epoch <= &current_epoch => (Some(params), None, true),
-            // Pool has a parameter update for another future epoch.
-            Some(..) => (update, retirement, needs_update),
-            // Pool is retiring *now*
-            None if epoch <= &current_epoch => (None, Some(*epoch), true),
-            // Pool is retiring later.
-            None => (update, Some(*epoch), needs_update),
+            // Pool has a parameter update that should now be applied; overwrite any prior update
+            // and cancels any immediate retirement.
+            Some(params) => (Some(params), None),
+            // Pool is retiring *now*, cancels any pool update.
+            None if epoch <= &current_epoch => (None, Some(*epoch)),
+            // Pool is retiring later, though updates may still be present.
+            None => (update, None),
         }
     })
 }
@@ -252,7 +251,7 @@ fn set<A: Eq + Clone>(source: &mut A, new: &A, to_string: impl FnOnce(&A) -> Str
 
 #[cfg(test)]
 mod tests {
-    use amaru_kernel::{Epoch, PoolParams, any_certificate_pointer, any_pool_params};
+    use amaru_kernel::{Epoch, PoolId, PoolParams, any_certificate_pointer, any_pool_params};
     use proptest::{collection::vec, prelude::*};
 
     use super::PoolsEpochTransitionUpdates;
@@ -260,15 +259,18 @@ mod tests {
 
     // Generate a sequence of plausible updates, where each item in the vector correspond to an
     // epoch's update. So a caller is expected to tick a base Pool between each application.
-    pub fn any_row_seq_updates() -> impl Strategy<Value = Vec<Vec<(Option<PoolParams>, Epoch)>>> {
-        vec(Just(()), 0..10).prop_flat_map(|cols| {
+    pub fn any_row_seq_updates(id: PoolId) -> impl Strategy<Value = Vec<Vec<(Option<PoolParams>, Epoch)>>> {
+        vec(Just(()), 0..10).prop_flat_map(move |cols| {
             cols.iter()
                 .enumerate()
                 .map(|(epoch, _)| {
                     let future_params = || {
                         prop_oneof![
                             (1..3u64).prop_map(move |offset| (None, Epoch::from(epoch as u64) + offset)),
-                            any_pool_params().prop_map(move |params| (Some(params), Epoch::from(epoch as u64 + 1)))
+                            any_pool_params().prop_map(move |params| (
+                                Some(PoolParams { id, ..params }),
+                                Epoch::from(epoch as u64 + 1)
+                            ))
                         ]
                     };
                     vec(future_params(), 0..3)
@@ -280,48 +282,33 @@ mod tests {
     #[derive(Debug)]
     struct Model {
         current: Option<PoolParams>,
-        future: Option<PoolParams>,
-        retiring: Option<Epoch>,
+        future: Vec<(Option<PoolParams>, Epoch)>,
     }
 
     impl Model {
         fn new(initial_params: PoolParams) -> Self {
-            Self { current: Some(initial_params), future: None, retiring: None }
-        }
-
-        // Apply model's changes at the epoch boundary
-        fn begin_epoch(&mut self, epoch: Epoch) {
-            if let Some(retirement) = self.retiring
-                && retirement <= epoch
-            {
-                self.current = None;
-            }
-
-            if let Some(future) = self.future.take() {
-                self.current = Some(future);
-            }
+            Self { current: Some(initial_params), future: Vec::new() }
         }
 
         // Process all updates through our simpler model
         fn tick(&mut self, epoch: Epoch, updates: &[(Option<PoolParams>, Epoch)]) {
-            self.begin_epoch(epoch);
+            self.future =
+                self.future.iter().chain(updates).fold(Vec::new(), |mut future, (update, retirement_epoch)| {
+                    match update {
+                        None => {
+                            if retirement_epoch <= &epoch {
+                                self.current = None;
+                            } else {
+                                future.push((None, *retirement_epoch));
+                            }
+                        }
+                        Some(params) => {
+                            self.current = Some(params.clone());
+                        }
+                    }
 
-            for (update, retirement_epoch) in updates {
-                match update {
-                    None if self.current.is_none() => {}
-                    None => {
-                        self.retiring = Some(*retirement_epoch);
-                    }
-                    Some(params) if self.current.is_none() => {
-                        self.retiring = None;
-                        self.current = Some(params.clone());
-                    }
-                    Some(params) => {
-                        self.retiring = None;
-                        self.future = Some(params.clone());
-                    }
-                }
-            }
+                    future
+                });
         }
     }
 
@@ -329,8 +316,9 @@ mod tests {
         #[test]
         fn prop_tick_pool(
             registered_at in any_certificate_pointer(u64::MAX),
-            initial_params in any_pool_params(),
-            sequence in any_row_seq_updates(),
+            (initial_params, sequence) in any_pool_params().prop_flat_map(|params| {
+                any_row_seq_updates(params.id).prop_map(move |seq| (params.clone(), seq))
+            })
         ) {
             let mut model = Model::new(initial_params.clone());
             let mut pool_opt = Some(Pool::new(registered_at, initial_params));

--- a/crates/amaru-ledger/src/epoch_transition/ratification.rs
+++ b/crates/amaru-ledger/src/epoch_transition/ratification.rs
@@ -12,14 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt,
-    rc::Rc,
-};
+use std::{collections::BTreeMap, fmt, rc::Rc};
 
 use amaru_kernel::{
-    AsHash, StakeCredentialKind, cost_models, drep_voting_thresholds, ex_units, ex_units_prices,
+    AsHash, RatificationStatus, StakeCredentialKind, cost_models, drep_voting_thresholds, ex_units, ex_units_prices,
     pool_voting_thresholds, protocol_version,
 };
 use amaru_kernel::{
@@ -62,7 +58,7 @@ pub struct GovernanceUpdates {
 
     /// Proposals that have been ratified, have expired or have been pruned due to another
     /// conflicting proposal being dropped.
-    pub pruned_proposals: BTreeSet<ComparableProposalId>,
+    pub pruned_proposals: BTreeMap<ComparableProposalId, RatificationStatus>,
 
     /// Payouts done to accounts; either because of a deposit refunds or because of a treasury
     /// withdrawal.
@@ -182,12 +178,12 @@ impl GovernanceUpdates {
             let mut payouts_str = String::new();
             for (id, proposal) in proposals_metadata.into_iter() {
                 let expired = ctx.epoch == proposal.valid_until;
-                let ratified_or_evicted = ctx.pruned_proposals.contains(&id);
+                let ratified_or_evicted = ctx.pruned_proposals.contains_key(&id);
 
                 debug!(name: "ratification.proposals", proposal_id = %id, expired, ratified_or_evicted);
 
                 if expired || ratified_or_evicted {
-                    ctx.pruned_proposals.insert(id); // For expired proposals
+                    ctx.pruned_proposals.insert(id, RatificationStatus::NotRatified); // For expired proposals
                     let return_account = proposal.return_account;
                     let deposit = proposal.deposit;
                     payouts
@@ -230,10 +226,10 @@ impl GovernanceUpdates {
             // proposal ids, so that the next 'unwrap_or_clone' should in practice results in a
             // clean transfer of ownership without clone.
             let mut pruned_proposals_str = String::new();
-            let pruned_proposals: BTreeSet<ComparableProposalId> = ctx
+            let pruned_proposals: BTreeMap<ComparableProposalId, RatificationStatus> = ctx
                 .pruned_proposals
                 .into_iter()
-                .map(|id| {
+                .map(|(id, status)| {
                     let id = Rc::unwrap_or_clone(id);
 
                     if pruned_proposals_str.is_empty() {
@@ -242,7 +238,7 @@ impl GovernanceUpdates {
                         pruned_proposals_str += &format!(", {id}");
                     }
 
-                    id
+                    (id, status)
                 })
                 .collect();
 

--- a/crates/amaru-ledger/src/governance/ratification.rs
+++ b/crates/amaru-ledger/src/governance/ratification.rs
@@ -136,11 +136,6 @@ impl<'distr> RatificationContext<'distr> {
             span.record("votes", votes_count);
 
             Ok(RatificationContext {
-                // Ratification happens with one epoch of delay, and at the next epoch transition. So,
-                // if we ratify votes that happened in epoch `e`, the ratification is done during the
-                // transition from `e + 1` to `e + 2`; but it is done "as if" it was happening at the
-                // beginning of epoch `e + 1`. So, the epoch we consider for DRep mandates and proposal
-                // expiry is the one from after the snapshot.
                 epoch,
                 treasury,
                 stake_distribution,

--- a/crates/amaru-ledger/src/governance/ratification.rs
+++ b/crates/amaru-ledger/src/governance/ratification.rs
@@ -236,7 +236,7 @@ impl<'distr> RatificationContext<'distr> {
 
             Span::current().record(
                 "pruned_relatives",
-                now_obsolete.iter().map(|id| id.to_compact_string()).collect::<Vec<_>>().join(", "),
+                now_obsolete.keys().map(|id| id.to_compact_string()).collect::<Vec<_>>().join(", "),
             );
 
             self.pruned_proposals.append(&mut now_obsolete);

--- a/crates/amaru-ledger/src/governance/ratification.rs
+++ b/crates/amaru-ledger/src/governance/ratification.rs
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    rc::Rc,
-};
+use std::{collections::BTreeMap, rc::Rc};
 
 use amaru_kernel::{
     Ballot, ComparableProposalId, Constitution, ConstitutionalCommitteeStatus, DRep, Epoch, EraHistory, Lovelace,
-    PoolId, ProtocolParameters, StakeCredential, Vote, Voter,
+    PoolId, ProtocolParameters, RatificationStatus, StakeCredential, Vote, Voter,
 };
 use amaru_observability::info_span;
 use num::Zero;
@@ -64,7 +61,7 @@ pub struct RatificationContext<'distr> {
     pub protocol_parameters: ProtocolParameters,
 
     /// All proposals that have been pruned due to ratification or conflict.
-    pub pruned_proposals: BTreeSet<Rc<ComparableProposalId>>,
+    pub pruned_proposals: BTreeMap<Rc<ComparableProposalId>, RatificationStatus>,
 
     /// Enacted withdrawals during this round of ratification.
     pub withdrawals: BTreeMap<StakeCredential, Lovelace>,
@@ -148,7 +145,7 @@ impl<'distr> RatificationContext<'distr> {
                 treasury,
                 stake_distribution,
                 protocol_parameters,
-                pruned_proposals: BTreeSet::new(),
+                pruned_proposals: BTreeMap::new(),
                 withdrawals: BTreeMap::new(),
                 constitutional_committee,
                 constitutional_committee_update: None,

--- a/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
+++ b/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
@@ -21,8 +21,8 @@ use std::{
 
 use amaru_kernel::{
     ComparableProposalId, Constitution, Epoch, EraHistory, GovernanceAction, Lovelace, Nullable, ProposalId,
-    ProposalPointer, ProtocolParamUpdate, ProtocolParameters, ProtocolVersion, display_protocol_parameters_update,
-    expect_stake_credential,
+    ProposalPointer, ProtocolParamUpdate, ProtocolParameters, ProtocolVersion, RatificationStatus,
+    display_protocol_parameters_update, expect_stake_credential,
 };
 use tracing::debug;
 
@@ -256,9 +256,9 @@ impl ProposalsForest {
         id: Rc<ComparableProposalId>,
         proposal: &ProposalEnum,
         compass: &mut ProposalsForestCompass,
-    ) -> Result<BTreeSet<Rc<ComparableProposalId>>, ProposalsEnactError<ComparableProposalId>> {
+    ) -> Result<BTreeMap<Rc<ComparableProposalId>, RatificationStatus>, ProposalsEnactError<ComparableProposalId>> {
         // Promote to new root & remember delaying cases
-        let (id, mut pruned) = match proposal {
+        let (id, pruned) = match proposal {
             ProposalEnum::HardFork(..) => {
                 self.is_interrupted = true;
                 self.hard_fork.enact(id)
@@ -290,13 +290,16 @@ impl ProposalsForest {
             }
         }?;
 
-        pruned.insert(id);
+        let mut pruned: BTreeMap<Rc<ComparableProposalId>, RatificationStatus> =
+            pruned.into_iter().map(|id| (id, RatificationStatus::NotRatified)).collect();
+
+        pruned.insert(id, RatificationStatus::Ratified);
 
         // Clean up the lookup table.
-        self.proposals.retain(|pid, _| !pruned.contains(pid.as_ref()));
+        self.proposals.retain(|pid, _| !pruned.contains_key(pid.as_ref()));
 
         // Clean up sequence, while preserving its order.
-        self.sequence.retain(|sid| !pruned.contains(sid.as_ref()));
+        self.sequence.retain(|sid| !pruned.contains_key(sid.as_ref()));
 
         // Force replacement of the compass; since any previous one is now obsolete.
         *compass = self.new_compass();
@@ -1060,7 +1063,7 @@ mod tests {
                 while let Some((id, _)) = compass.next(&forest, &PROTOCOL_PARAMETERS) {
                     yielded_another = true;
                     prop_assert!(
-                        !pruned.contains(&id),
+                        !pruned.contains_key(&id),
                         "compass yielded a pruned proposal!",
                     );
                 }

--- a/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
+++ b/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
@@ -112,9 +112,9 @@ impl ProposalsForest {
         proposals.drain(..).try_fold::<_, _, Result<_, ProposalsInsertError<_>>>(&mut self, |forest, (id, row)| {
             // There shouldn't be any expired proposals left at this point.
             assert!(
-                row.valid_until + 1 >= current_epoch,
-                "proposal {id:?} is expired (ratification epoch = {current_epoch}) but was \
-                        drained into the forest: {row:?}",
+                row.valid_until >= current_epoch,
+                "proposal {id:?} is valid until epoch={}, but was found when ratifying data for epoch={current_epoch}: {row:?}",
+                row.valid_until,
             );
 
             forest.insert(era_history, id, row.proposed_in, row.governance_action)?;

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
@@ -241,6 +241,10 @@ where
 
     // At last, consume inputs
     let consumed_inputs = if is_valid {
+        if let Some(donation) = transaction_body.donation {
+            context.add_donation(u64::from(donation));
+        }
+
         transaction_body.inputs.to_vec()
     } else {
         transaction_body.collateral.map(|x| x.to_vec()).unwrap_or_default()

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -278,21 +278,6 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
         let immutable_slot = now_stable.anchor.0.slot();
         let immutable_epoch = unsafe_slot_to_epoch(&self.era_history, immutable_slot);
 
-        // TODO: Flush ledger overlay sooner.
-        //
-        // This is flushing the overlay at the last moment; just before we need to apply a
-        // now-stable block from the new epoch. In principle, that block has been sitting in the
-        // volatile db for a while.
-        //
-        // Hence, we know in advanced that the overlay must be applied. In fact, there can be
-        // between 1s and multiple minutes before the next block. So we could get a head start and
-        // start flushing right away; instead of awaiting for the next block to arrive.
-        if self.volatile.is_epoch_transition_stable() {
-            let db = self.stable.lock().unwrap();
-            self.volatile.apply_transition(&*db)?;
-            self.snapshots.prune(self.volatile.epoch() - MIN_LEDGER_SNAPSHOTS)?;
-        }
-
         trace_span!(amaru_observability::amaru::ledger::state::APPLY_BLOCK, point_slot = u64::from(immutable_slot)).in_scope(
             || {
                 let protocol_parameters = self.protocol_parameters_for(immutable_epoch).unwrap_or_else(|| unreachable! {
@@ -356,6 +341,28 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             if old_protocol_version != new_protocol_version {
                 info!(from = old_protocol_version.0, to = new_protocol_version.0, "protocol.upgrade")
             }
+        }
+
+        // TODO: Flush ledger overlay sooner.
+        //
+        // This is flushing the overlay at the last moment; just before we need to apply a
+        // now-stable block from the new epoch. In principle, that block has been sitting in the
+        // volatile db for a while.
+        //
+        // Hence, we know in advanced that the overlay must be applied. In fact, there can be
+        // between 1s and multiple minutes before the next block. So we could get a head start and
+        // start flushing right away; instead of awaiting for the next block to arrive.
+        //
+        // However, we have to be careful about restarts. There are scenarios where we must
+        // transition and flush immediately, before we even record the next block to disk. So
+        // here is the safest moment to perform this operation. We may additionally attempt to
+        // do it just after flushing a block to the db (should it be the last block of a
+        // previous epoch).
+        if self.volatile.is_epoch_transition_stable() {
+            #[allow(clippy::unwrap_used)]
+            let db = self.stable.lock().unwrap();
+            self.volatile.apply_transition(&*db)?;
+            self.snapshots.prune(self.volatile.epoch() - MIN_LEDGER_SNAPSHOTS)?;
         }
 
         Ok(())

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -287,7 +287,7 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
                 });
 
                 // Persist changes for this block
-                let StoreUpdate { point: stable_point, issuer: stable_issuer, fees, add, remove, withdrawals } =
+                let StoreUpdate { point: stable_point, issuer: stable_issuer, fees, donations, add, remove, withdrawals } =
                     now_stable.into_store_update(immutable_epoch, protocol_parameters);
 
                 self.stable.lock().unwrap()
@@ -308,7 +308,9 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
                         )?;
 
                         batch.with_pots(|mut row| {
-                            row.borrow_mut().fees += fees;
+                            let row = row.borrow_mut();
+                            row.fees += fees;
+                            row.donations += donations;
                         })?;
 
                         batch.reset_epoch_transition_progress()?;

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -400,7 +400,7 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             // last k blocks for a single epoch. Or carry some kind of type-level guard that
             // the this is called within an acceptable context (i.e. the volatile
             // pre-conditions have been checked).
-            let mut volatile_view = VolatileView::new(next_epoch - 1, protocol_parameters, &self.volatile, &*db);
+            let mut volatile_view = VolatileView::new(&self.volatile, &*db);
 
             let (treasury, effective_rewards) = if progress.is_none() {
                 let effective_rewards = epoch_transition::end_epoch(

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -901,19 +901,7 @@ where
 
     [Some(latest_epoch), epoch_for_leader_schedule, epoch_for_rewards]
         .into_iter()
-        .enumerate()
-        .filter_map(|(ix, epoch)| {
-            if let Some(epoch) = epoch {
-                Some(snapshots.for_epoch(epoch))
-            } else {
-                warn!(
-                    "ignoring initial stake distribution for epoch 'e - {}', where e = {}; not available",
-                    2 - ix,
-                    latest_epoch
-                );
-                None
-            }
-        })
+        .filter_map(|epoch| epoch.map(|e| snapshots.for_epoch(e)))
         .collect::<Result<Vec<_>, _>>()?
         .into_par_iter()
         .map(|snapshot| compute_stake_distribution(&snapshot, era_history))

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -24,6 +24,7 @@ use std::{
 use amaru_kernel::{
     Block, Epoch, EraHistory, EraHistoryError, GlobalParameters, HasTransactionId, Hash, Hasher, NetworkName, Point,
     PoolId, ProtocolParameters, Slot, Tip, Transaction, TransactionId, TransactionPointer, protocol_version, to_cbor,
+    utils::string::display_collection,
 };
 use amaru_metrics::ledger::LedgerMetrics;
 use amaru_observability::{info_span, trace_span};
@@ -151,7 +152,7 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
     }
 }
 
-impl<S: Store, HS: HistoricalStores> State<S, HS> {
+impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
     pub fn new(
         stable: S,
         snapshots: HS,
@@ -238,6 +239,10 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
 
     pub fn global_parameters(&self) -> &GlobalParameters {
         &self.global_parameters
+    }
+
+    pub fn most_recent_snapshot(&self) -> Epoch {
+        self.volatile.most_recent_snapshot(&self.snapshots)
     }
 
     /// Inspect the tip of this ledger state. This corresponds to the point of the latest block
@@ -328,9 +333,7 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
     /// corresponds to a block in a different (next) epoch, in which case, we must first transition
     /// into the new epoch before the block can be validated.
     fn try_epoch_transition(&mut self, next_tip: Point) -> Result<(), StateError> {
-        let current_tip = self.tip();
-
-        let current_epoch = unsafe_slot_to_epoch(&self.era_history, current_tip.slot_or_default());
+        let current_epoch = unsafe_slot_to_epoch(&self.era_history, self.tip().slot_or_default());
         let next_epoch = unsafe_slot_to_epoch(&self.era_history, next_tip.slot_or_default());
 
         if next_epoch > current_epoch {
@@ -345,28 +348,6 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             }
         }
 
-        // TODO: Flush ledger overlay sooner.
-        //
-        // This is flushing the overlay at the last moment; just before we need to apply a
-        // now-stable block from the new epoch. In principle, that block has been sitting in the
-        // volatile db for a while.
-        //
-        // Hence, we know in advanced that the overlay must be applied. In fact, there can be
-        // between 1s and multiple minutes before the next block. So we could get a head start and
-        // start flushing right away; instead of awaiting for the next block to arrive.
-        //
-        // However, we have to be careful about restarts. There are scenarios where we must
-        // transition and flush immediately, before we even record the next block to disk. So
-        // here is the safest moment to perform this operation. We may additionally attempt to
-        // do it just after flushing a block to the db (should it be the last block of a
-        // previous epoch).
-        if self.volatile.is_epoch_transition_stable() {
-            #[allow(clippy::unwrap_used)]
-            let db = self.stable.lock().unwrap();
-            self.volatile.apply_transition(&*db)?;
-            self.snapshots.prune(self.volatile.epoch() - MIN_LEDGER_SNAPSHOTS)?;
-        }
-
         Ok(())
     }
 
@@ -377,17 +358,33 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             into = u64::from(next_epoch)
         )
         .in_scope(|| {
-            // FIXME: This should eventually be a '.await', as we always expect to *eventually*
-            // have some rewards summary being available. There's no way to continue progressing
-            // the ledger if we don't.
             let computed_rewards = self.volatile.take_computed_rewards();
 
             #[allow(clippy::unwrap_used)]
             let db = self.stable.lock().unwrap();
 
-            let progress = db.epoch_transition_progress().map_err(StateError::Storage)?;
+            let progress = db.epoch_transition_progress()?;
 
-            let protocol_parameters = self.protocol_parameters();
+            match progress {
+                Some(resuming_from) => {
+                    Span::current().record("resuming_from", resuming_from.to_string());
+                }
+                // NOTE: Skipping epoch transition
+                //
+                // It is possible to interrupt Amaru just after the epoch transition was flushed
+                // to disk. The consequence of that is: the tip of the immutable db is still in the
+                // previous epoch which will cause the next block we see to trigger an epoch transition.
+                //
+                // However, the epoch transition had already happened and was even persisted to disk
+                // already! So we must not redo it. This strange behaviour occurs because we do not
+                // persist the volatile; so on restart, we rewind `k` blocks in the past, for which we
+                // may or may not need to perform the transition again (depending where we interrupted).
+                None if self.most_recent_snapshot() == next_epoch - 1 => {
+                    Span::current().record("skipped", true);
+                    return Ok(());
+                }
+                None => (),
+            }
 
             // NOTE: Crossing states during epoch transition
             //
@@ -402,7 +399,22 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             // pre-conditions have been checked).
             let mut volatile_view = VolatileView::new(&self.volatile, &*db);
 
+            // NOTE: No rewards during epoch transition?
+            //
+            // It is fine in some situation to compute an epoch transition and yet have no rewards.
+            // This happens if Amaru is interrupted *while it is flushing* an epoch transition to
+            // disk.
+            //
+            // This happens artificially every time someone bootstraps; because the bootstrapping
+            // process behaves as if we had interrupted the transition just after taking the
+            // snapshot. So we must proceed with computing the beginning of an epoch (ratification,
+            // pool updates, etc...) but not the end (rewards).
             let (treasury, effective_rewards) = if progress.is_none() {
+                // FIXME: asynchronous rewards calculations
+                //
+                // This should eventually be a '.await', as we always expect to *eventually*
+                // have some rewards summary being available. There's no way to continue progressing
+                // the ledger if we don't.
                 let effective_rewards = epoch_transition::end_epoch(
                     &mut volatile_view,
                     computed_rewards.ok_or(StateError::RewardsSummaryNotReady)?,
@@ -412,6 +424,8 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             } else {
                 (db.pots()?.treasury, None)
             };
+
+            let protocol_parameters = self.protocol_parameters();
 
             let ratification_context = RatificationContext::new(
                 // Ratification happens with one epoch of delay, and at the next epoch transition. So,
@@ -446,55 +460,70 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
         })
     }
 
-    fn try_compute_rewards(&mut self, next_tip: Point) -> Result<(), StateError> {
-        let next_slot = next_tip.slot_or_default();
-        let next_relative_slot = unsafe_slot_in_epoch(&self.era_history, next_slot);
-        let next_epoch = unsafe_slot_to_epoch(&self.era_history, next_slot);
-
-        // Once we reach the stability window, compute rewards unless we've already done so.
-        let is_stake_distribution_stable = next_relative_slot >= self.global_parameters.stability_window();
+    fn try_compute_rewards(&mut self) -> Result<(), StateError> {
+        let tip = self.tip().slot_or_default();
+        let current_epoch = unsafe_slot_to_epoch(&self.era_history, tip);
+        let is_previous_epoch_stable =
+            self.era_history.slot_in_epoch(tip, tip).unwrap_or_default() >= self.global_parameters().stability_window();
 
         // FIXME: Asynchronous rewards calculation
         //
         // compute rewards in a thread, or in a non-blocking manner to carry on with other
         // tasks while rewards are being computed; they only need to be available at the epoch
         // boundary.
-        if self.volatile.rewards_not_ready() && is_stake_distribution_stable {
-            let computed = self.compute_rewards(next_epoch)?.into();
-            self.volatile.set_computed_rewards(computed);
+        if self.volatile.rewards_not_ready()
+            && self.most_recent_snapshot() == current_epoch - 1
+            && is_previous_epoch_stable
+        {
+            let rewards = self.compute_rewards(current_epoch)?;
+            self.volatile.set_computed_rewards(rewards);
         }
 
         Ok(())
     }
 
     #[expect(clippy::unwrap_used)]
-    fn compute_rewards(&mut self, current_epoch: Epoch) -> Result<RewardsSummary, StateError> {
-        info_span!(amaru_observability::amaru::ledger::state::COMPUTE_REWARDS, current_epoch = u64::from(current_epoch))
-            .in_scope(|| {
-                let mut stake_distributions = self.stake_distributions.lock().unwrap();
-                let stake_distribution =
-                    stake_distributions.pop_back().ok_or(StateError::StakeDistributionNotAvailableForRewards)?;
+    fn compute_rewards(&mut self, for_epoch: Epoch) -> Result<RewardsSummary, StateError> {
+        let span =
+            info_span!(amaru_observability::amaru::ledger::state::COMPUTE_REWARDS, for_epoch = u64::from(for_epoch));
 
-                assert_eq!(stake_distribution.epoch, current_epoch - 3, "unexpected stake distribution for epoch");
+        // NOTE: Explicit span guard handling
+        //
+        // We resort to manually entering and leaving the span here to avoid measuring the
+        // 'compute_stake_distribution' as part of the 'compute_rewards' but instead, have each in
+        // a separate span.
+        //
+        // The reason they happen in the same function here is because they both modify the
+        // shared 'stake_distributions' that lives behind a mutex. So to avoid holding the mutext
+        // for too long, we resort to that trick.
+        let span_guard = span.enter();
 
-                Span::current().record("stake_distribution_epoch", u64::from(stake_distribution.epoch));
+        let mut stake_distributions = self.stake_distributions.lock().unwrap();
+        let stake_distribution =
+            stake_distributions.pop_back().ok_or(StateError::StakeDistributionNotAvailableForRewards)?;
 
-                let snapshot = self.snapshots.for_epoch(current_epoch - 1)?;
+        assert_eq!(stake_distribution.epoch + 3, for_epoch, "unexpected stake distribution for epoch");
 
-                let rewards_summary = RewardsSummary::new(
-                    &snapshot,
-                    stake_distribution,
-                    &self.global_parameters,
-                    self.protocol_parameters(),
-                )
+        span.record("using_stake_distribution_from", u64::from(stake_distribution.epoch));
+
+        let snapshot = self.snapshots.for_epoch(for_epoch - 1)?;
+
+        let rewards_summary =
+            RewardsSummary::new(&snapshot, stake_distribution, &self.global_parameters, self.protocol_parameters())
                 .map_err(StateError::Storage)?;
 
-                if stake_distributions.front().map(|distr| distr.epoch < snapshot.epoch()).unwrap_or(true) {
-                    stake_distributions.push_front(compute_stake_distribution(&snapshot, &self.era_history)?);
-                }
+        drop(span_guard);
 
-                Ok(rewards_summary)
-            })
+        if stake_distributions.front().map(|distr| distr.epoch < snapshot.epoch()).unwrap_or(true) {
+            stake_distributions.push_front(compute_stake_distribution(&snapshot, &self.era_history)?);
+            info!(
+                name: "state::stake_distribution::rotate",
+                target: "amaru::ledger::state::stake_distribution::rotate",
+                stake_distributions = display_collection(stake_distributions.iter().map(|distr| distr.epoch)),
+            )
+        }
+
+        Ok(rewards_summary)
     }
 
     /// Push a next state into the ledger volatile storage. Once the volatile is full (i.e. filled
@@ -527,6 +556,45 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
 
             Ok(now_stable)
         })
+    }
+
+    #[allow(clippy::unwrap_used)]
+    fn apply_transition(&mut self) -> Result<(), StateError> {
+        if self.volatile.is_epoch_transition_stable(self.era_history(), self.global_parameters()) {
+            if let Some((len, epoch_tail)) = self.volatile.epoch_tail() {
+                // NOTE: Forcing snapshot after 3*k/f slots
+                //
+                // In a healthy chain that honors the Chain Growth property, we should never reach
+                // this line; because we would have seen `k` blocks before that point and there
+                // should be no trailing epoch tail in the volatile. However, Cardano does not
+                // necessarily honors Chain Growth; and we can detect this as such.
+                //
+                // Yet, we must produce a new snapshot in order to produce a new stake distribution
+                // to keep validating upcoming block headers.
+                warn!(
+                    name: "amaru::ledger::chain_growth::violation",
+                    unstable_tail_length = len,
+                    "chain growth violation: less than k={k} blocks seen in a window of \
+                    3*k/f={stability_window} slots; if this occurs during historical sync, it may \
+                    not be a big problem. However If this occurs at the tip, it can be more \
+                    serious. We will not be able to rollback through still-unstable blocks that \
+                    must now be persisted to disk.",
+                    k = self.global_parameters().consensus_security_param,
+                    stability_window = self.global_parameters().stability_window(),
+                );
+
+                for anchored_fragment in epoch_tail {
+                    self.apply_block(anchored_fragment)?;
+                }
+            }
+
+            let db = self.stable.lock().unwrap();
+
+            self.volatile.apply_transition(&*db)?;
+            self.snapshots.prune(self.volatile.epoch() - MIN_LEDGER_SNAPSHOTS)?;
+        }
+
+        Ok(())
     }
 
     /// View a stake distribution for a given epoch. Note that this *locks* the stake distribution
@@ -646,7 +714,7 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
     ///
     /// 3. **Validation Context**
     ///
-    ///    Create a validation context from the current stable ledger state + overlay if any
+    ///    Create a validation context from the current stable ledger state + epoch transition if any
     ///
     /// 4. **Ledger rules execution**
     ///
@@ -657,18 +725,17 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
     ///
     ///    Anchor those updates and push them into the volatile store.
     ///
-    /// 6. **Flush overlay**
+    /// 6. **Apply now-stable block**
+    ///
+    ///    Finally, we can store the new now-stable block to the stable store.
+    ///
+    /// 7. **Flush epoch transition**
     ///
     ///    In normal operations (i.e. once the ledger is done warming up), pushing a new state to
     ///    the volatile automatically yields a new now-stable state that is recorded to disk.
     ///
-    ///    Before attempting to record a block from a new epoch to disk, any pending overlay must
-    ///    be fully flushed and a snapshot taken.
-    ///
-    /// 7. **Apply now-stable block**
-    ///
-    ///    Finally, we can store the new now-stable block to the stable store.
-    ///
+    ///    Before attempting to record the next block from a new epoch to disk, any pending epoch
+    ///    transition must be fully flushed and a snapshot taken.
     pub fn roll_forward(
         &mut self,
         point: &Point,
@@ -681,7 +748,7 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             trace_block_transactions(point, block_height, &block);
 
             // 1. Rewards calculation
-            BlockValidation::from(self.try_compute_rewards(*point))?;
+            BlockValidation::from(self.try_compute_rewards())?;
 
             // 2. Epoch transition
             BlockValidation::from(self.try_epoch_transition(*point))?;
@@ -709,9 +776,12 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             let tip = Tip::new(*point, block_height.into());
             let fragment = VolatileFragment::from(context).anchor(tip, issuer);
             if let Some(now_stable) = BlockValidation::from(self.push_fragment(fragment))? {
-                // 6-7. Flush overlay & Apply now-stable block
+                // 6. Apply now-stable block
                 BlockValidation::from(self.apply_block(now_stable))?;
             }
+
+            // 7. Flush the epoch transition
+            BlockValidation::from(self.apply_transition())?;
 
             BlockValidation::Valid(metrics)
         })
@@ -821,7 +891,7 @@ pub fn initial_stake_distributions<HS>(
     era_history: &EraHistory,
 ) -> Result<VecDeque<StakeDistribution>, StoreError>
 where
-    HS: HistoricalStores + Send + Sync,
+    HS: HistoricalStores + Send,
 {
     use rayon::prelude::*;
 
@@ -857,7 +927,7 @@ pub fn compute_stake_distribution(
 ) -> Result<StakeDistribution, StateError> {
     info_span!(
         amaru_observability::amaru::ledger::state::COMPUTE_STAKE_DISTRIBUTION,
-        epoch = u64::from(snapshot.epoch())
+        epoch = u64::from(snapshot.epoch()),
     )
     .in_scope(|| {
         StakeDistribution::new(snapshot, GovernanceSummary::new(snapshot, era_history)?).map_err(StateError::Storage)
@@ -960,13 +1030,6 @@ fn unsafe_slot_to_epoch(era_history: &EraHistory, slot: Slot) -> Epoch {
     era_history
         .slot_to_epoch_unchecked_horizon(slot)
         .unwrap_or_else(|e| unreachable!("impossible; failed to compute epoch from tip ({slot:?}): {e:?}"))
-}
-
-// See [`unsafe_slot_to_epoch`]
-fn unsafe_slot_in_epoch(era_history: &EraHistory, slot: Slot) -> Slot {
-    era_history
-        .slot_in_epoch(slot, slot)
-        .unwrap_or_else(|e| unreachable!("impossible; failed to compute relative slot from tip ({slot:?}): {e:?}"))
 }
 
 // Errors

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -414,6 +414,12 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
             };
 
             let ratification_context = RatificationContext::new(
+                // Ratification happens with one epoch of delay, and at the next epoch transition. So,
+                // if we ratify votes that happened in epoch `e`, the ratification is done during the
+                // transition from `e + 1` to `e + 2`;
+                //
+                // Here, we have `next_epoch = e + 2`. And so, we have to pull the data and stake
+                // distribution from at `next_epoch - 2`.
                 self.snapshots.for_epoch(next_epoch - 2)?,
                 self.stake_distribution(next_epoch - 2)?,
                 protocol_parameters.clone(),

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -816,32 +816,39 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
 //
 // Note that the most recent snapshot we have is necessarily `e`, since `e + 1` designates
 // the ongoing epoch, not yet finished (and so, not available as snapshot).
-pub fn initial_stake_distributions(
-    snapshots: &impl HistoricalStores,
+pub fn initial_stake_distributions<HS>(
+    snapshots: &HS,
     era_history: &EraHistory,
-) -> Result<VecDeque<StakeDistribution>, StoreError> {
-    let mut stake_distributions = VecDeque::new();
+) -> Result<VecDeque<StakeDistribution>, StoreError>
+where
+    HS: HistoricalStores + Send + Sync,
+{
+    use rayon::prelude::*;
 
     let latest_epoch = snapshots.most_recent_snapshot();
     let epoch_for_leader_schedule = latest_epoch.checked_sub(Epoch::ONE);
     let epoch_for_rewards = latest_epoch.checked_sub(Epoch::TWO);
 
-    for (ix, epoch) in [epoch_for_rewards, epoch_for_leader_schedule, Some(latest_epoch)].into_iter().enumerate() {
-        if let Some(epoch) = epoch {
-            let snapshot = snapshots.for_epoch(epoch)?;
-            stake_distributions.push_front(
-                compute_stake_distribution(&snapshot, era_history).map_err(|err| StoreError::Internal(err.into()))?,
-            );
-        } else {
-            warn!(
-                "ignoring initial stake distribution for epoch 'e - {}', where e = {}; not available",
-                2 - ix,
-                latest_epoch
-            );
-        }
-    }
-
-    Ok(stake_distributions)
+    [Some(latest_epoch), epoch_for_leader_schedule, epoch_for_rewards]
+        .into_iter()
+        .enumerate()
+        .filter_map(|(ix, epoch)| {
+            if let Some(epoch) = epoch {
+                Some(snapshots.for_epoch(epoch))
+            } else {
+                warn!(
+                    "ignoring initial stake distribution for epoch 'e - {}', where e = {}; not available",
+                    2 - ix,
+                    latest_epoch
+                );
+                None
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_par_iter()
+        .map(|snapshot| compute_stake_distribution(&snapshot, era_history))
+        .collect::<Result<VecDeque<_>, _>>()
+        .map_err(|err| StoreError::Internal(err.into()))
 }
 
 pub fn compute_stake_distribution(

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -462,18 +462,18 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
     }
 
     #[expect(clippy::unwrap_used)]
-    fn compute_rewards(&mut self, epoch: Epoch) -> Result<RewardsSummary, StateError> {
-        info_span!(amaru_observability::amaru::ledger::state::COMPUTE_REWARDS, current_epoch = u64::from(epoch))
+    fn compute_rewards(&mut self, current_epoch: Epoch) -> Result<RewardsSummary, StateError> {
+        info_span!(amaru_observability::amaru::ledger::state::COMPUTE_REWARDS, current_epoch = u64::from(current_epoch))
             .in_scope(|| {
                 let mut stake_distributions = self.stake_distributions.lock().unwrap();
                 let stake_distribution =
                     stake_distributions.pop_back().ok_or(StateError::StakeDistributionNotAvailableForRewards)?;
 
-                assert_eq!(stake_distribution.epoch, epoch - 3, "unexpected stake distribution for epoch");
+                assert_eq!(stake_distribution.epoch, current_epoch - 3, "unexpected stake distribution for epoch");
 
                 Span::current().record("stake_distribution_epoch", u64::from(stake_distribution.epoch));
 
-                let snapshot = self.snapshots.for_epoch(epoch - 1)?;
+                let snapshot = self.snapshots.for_epoch(current_epoch - 1)?;
 
                 let rewards_summary = RewardsSummary::new(
                     &snapshot,

--- a/crates/amaru-ledger/src/state/diff_epoch_reg.rs
+++ b/crates/amaru-ledger/src/state/diff_epoch_reg.rs
@@ -147,15 +147,15 @@ impl<K: Ord + Copy, V> DiffEpochReg<K, V> {
     /// Both states MUST belong to the same epoch. This isn't suitable for combining states across
     /// epoch boundaries.
     pub fn append(&mut self, most_recent: Self) {
-        for (k, v) in most_recent.unregistered {
-            self.unregister(k, v)
-        }
-
         for (k, v) in most_recent.registered {
             self.register(k, v.0.0);
             if let Some(re_registration) = v.0.1 {
                 self.register(k, re_registration);
             }
+        }
+
+        for (k, v) in most_recent.unregistered {
+            self.unregister(k, v)
         }
     }
 
@@ -164,15 +164,15 @@ impl<K: Ord + Copy, V> DiffEpochReg<K, V> {
     where
         V: Clone,
     {
-        for (k, v) in &most_recent.unregistered {
-            self.unregister(*k, *v)
-        }
-
         for (k, v) in &most_recent.registered {
             self.register(*k, v.0.0.clone());
             if let Some(re_registration) = v.0.1.as_ref() {
                 self.register(*k, re_registration.clone());
             }
+        }
+
+        for (k, v) in &most_recent.unregistered {
+            self.unregister(*k, *v)
         }
     }
 }

--- a/crates/amaru-ledger/src/state/volatile.rs
+++ b/crates/amaru-ledger/src/state/volatile.rs
@@ -69,6 +69,7 @@ pub trait VolatileSequence {
     fn has_point(&self, point: &Point) -> bool;
 
     fn iter(&self) -> impl Iterator<Item = &Self::Item>;
+    fn into_iter(self) -> impl Iterator<Item = Self::Item>;
 
     fn pop_front(&mut self) -> Option<Self::Item>;
     fn push_back(&mut self, item: Self::Item);

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -938,7 +938,7 @@ mod tests {
         GovernanceUpdates {
             roots: ProposalsRoots::default(),
             protocol_parameters: PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone(),
-            pruned_proposals: BTreeSet::new(),
+            pruned_proposals: BTreeMap::new(),
             payouts: BTreeMap::new(),
             is_dormant_epoch: false,
             constitutional_committee: committee,

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -15,8 +15,9 @@
 use std::mem;
 
 use amaru_kernel::{
-    ComparableProposalId, Epoch, Lovelace, MemoizedTransactionOutput, PREPROD_DEFAULT_PROTOCOL_PARAMETERS, Point,
-    PoolId, ProtocolParameters, StakeCredential, TermLimit, TransactionInput,
+    ComparableProposalId, Epoch, EraHistory, GlobalParameters, Lovelace, MemoizedTransactionOutput,
+    PREPROD_DEFAULT_PROTOCOL_PARAMETERS, Point, PoolId, ProtocolParameters, StakeCredential, TermLimit,
+    TransactionInput,
 };
 
 use crate::{
@@ -31,7 +32,7 @@ use crate::{
             overlay::StateOverlay,
         },
     },
-    store::Store,
+    store::{HistoricalStores, Store},
 };
 
 pub struct VolatileDB {
@@ -195,6 +196,10 @@ impl VolatileSequence for VolatileDB {
         self.draining.iter().chain(self.current.iter())
     }
 
+    fn into_iter(self) -> impl Iterator<Item = Self::Item> {
+        self.draining.into_iter().chain(self.current.into_iter())
+    }
+
     fn pop_front(&mut self) -> Option<Self::Item> {
         self.draining.pop_front().or_else(|| self.current.pop_front())
     }
@@ -288,6 +293,12 @@ impl VolatileDB {
         self.overlay.epoch()
     }
 
+    /// Get the most recent taken, by peaking at the files on disk or looking an in-memory cached
+    /// value if available.
+    pub fn most_recent_snapshot<HS: HistoricalStores>(&self, snapshots: &HS) -> Epoch {
+        self.overlay.most_recent_snapshot(snapshots)
+    }
+
     /// The protocol parameters carried by an in-flight epoch transition, if any.
     pub fn protocol_parameters(&self) -> &ProtocolParameters {
         self.overlay.pending_protocol_parameters().unwrap_or(&self.protocol_parameters)
@@ -354,8 +365,28 @@ impl VolatileDB {
     }
 
     /// Stash the freshly computed rewards summary, to be applied at the next epoch boundary.
-    pub fn set_computed_rewards(&mut self, rewards: Rewards<Computed>) {
-        *self.overlay.rewards_mut() = RewardsState::Computed(rewards);
+    pub fn set_computed_rewards(&mut self, rewards: impl Into<Rewards<Computed>>) {
+        *self.overlay.rewards_mut() = RewardsState::Computed(rewards.into());
+    }
+
+    /// Ensure that the 'draining' sequence is empty before we cross an epoch boundary. Note that
+    /// this is a bandaid on the fact that the Haskell node (and thus Amaru) does not honour the
+    /// Chain Growth property; so we can have situations where an epoch may contain less than `k`
+    /// blocks overall which isn't enough time for the volatile db to fully drain the draining
+    /// sequence. Yet, it must be empty and on-disk for the transition to happen.
+    ///
+    /// This means that momentarily, we are unable to rollback as far as we should. While this may
+    /// seem like a big thing, it is *probably* less serious: if we end up in a situation where we
+    /// have less than `k` blocks in an epoch, it probably means that there has been a problem with
+    /// the chain and the network partitioned for some time, with one partition initially having
+    /// less than the majority and eventually switched to it. That means, we have *already rolled
+    /// back* over a long-range.
+    pub fn epoch_tail(&mut self) -> Option<(usize, impl Iterator<Item = AnchoredVolatileFragment> + use<>)> {
+        if !self.draining.is_empty() {
+            Some((self.draining.len(), std::mem::take(&mut self.draining).into_iter()))
+        } else {
+            None
+        }
     }
 
     pub fn transition(
@@ -387,8 +418,13 @@ impl VolatileDB {
     }
 
     /// Whether an epoch transition has been computed but not yet flushed to the stable store.
-    pub fn is_epoch_transition_stable(&self) -> bool {
-        self.draining.is_empty() && !self.overlay.is_empty()
+    pub fn is_epoch_transition_stable(&self, era_history: &EraHistory, global_parameters: &GlobalParameters) -> bool {
+        !self.overlay.is_empty()
+            && self.draining.view_front().is_none_or(|_| {
+                let absolute_slot = self.current.view_back().map(|fragment| fragment.slot()).unwrap_or_default();
+                let relative_slot = era_history.slot_in_epoch(absolute_slot, absolute_slot).unwrap_or_default();
+                relative_slot >= global_parameters.stability_window()
+            })
     }
 
     /// Flush the pending epoch transition to the stable store. Returns the freshly-enacted

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -159,7 +159,7 @@ impl VolatileState for VolatileDB {
     fn resolve_proposal(&self, id: &ComparableProposalId) -> Self::Proposal {
         if let Existence::Exists(proposal) = self.current.resolve_proposal(id) {
             Existence::Exists(proposal)
-        } else if self.overlay.is_proposal_pruned(id) {
+        } else if self.overlay.has_pruned_proposal(id) {
             Existence::Gone
         } else {
             self.draining.resolve_proposal(id)

--- a/crates/amaru-ledger/src/state/volatile/fragment.rs
+++ b/crates/amaru-ledger/src/state/volatile/fragment.rs
@@ -100,6 +100,7 @@ pub struct VolatileFragment {
     pub proposals: BTreeMap<ComparableProposalId, Arc<(Proposal, ProposalPointer)>>,
     pub votes: DiffSet<BallotId, Ballot>,
     pub fees: Lovelace,
+    pub donations: Lovelace,
 }
 
 impl VolatileFragment {
@@ -198,6 +199,7 @@ impl VolatileFragment {
             withdrawals,
             proposals,
             fees,
+            donations,
             accounts: _,
             committee: _,
             dreps: _,
@@ -218,6 +220,7 @@ impl VolatileFragment {
         }
 
         self.fees -= *fees;
+        self.donations -= *donations;
     }
 
     /// Fold `more_recent` into this fragment, treating it as applied *after* `self`.
@@ -230,6 +233,7 @@ impl VolatileFragment {
             withdrawals,
             proposals,
             fees,
+            donations,
             accounts,
             dreps,
             dreps_deregistrations,
@@ -246,6 +250,7 @@ impl VolatileFragment {
         self.dreps_deregistrations.extend(dreps_deregistrations.iter().map(|(k, v)| (k.clone(), *v)));
         self.committee.extend(committee);
         self.fees += *fees;
+        self.donations += *donations;
     }
 }
 
@@ -312,6 +317,7 @@ impl AnchoredVolatileFragment {
                     proposals,
                     votes,
                     fees,
+                    donations,
                 },
             anchor: (tip, issuer),
         } = self;
@@ -320,6 +326,7 @@ impl AnchoredVolatileFragment {
             point: tip.point(),
             issuer,
             fees,
+            donations,
             withdrawals: withdrawals.into_iter(),
             add: store::Columns {
                 utxo: utxo.produced.into_iter().map(|(input, output)| (input, Arc::unwrap_or_clone(output))),
@@ -365,6 +372,7 @@ pub struct StoreUpdate<W, A, R> {
     pub point: Point,
     pub issuer: PoolId,
     pub fees: Lovelace,
+    pub donations: Lovelace,
     pub withdrawals: W,
     pub add: A,
     pub remove: R,

--- a/crates/amaru-ledger/src/state/volatile/overlay.rs
+++ b/crates/amaru-ledger/src/state/volatile/overlay.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::mem;
+use std::{collections::BTreeSet, mem};
 
 use amaru_kernel::{ComparableProposalId, Epoch, Lovelace, PoolId, ProtocolParameters, StakeCredential, TermLimit};
 use amaru_observability::info_span;
@@ -30,7 +30,8 @@ use crate::{
     },
     store::{
         EpochTransitionProgress, Store, TransactionalContext, apply_governance_updates, pay_or_refund_accounts,
-        pay_rewards, reset_blocks_count, reset_fees_and_donations, update_or_retire_pools,
+        pay_rewards, reset_blocks_count, reset_fees_and_donations, reset_recently_pruned_proposals,
+        update_or_retire_pools,
     },
 };
 
@@ -125,6 +126,7 @@ impl StateOverlay {
                 if should_end_epoch {
                     if let RewardsState::Effective(effective_rewards) = mem::take(&mut self.rewards) {
                         pay_rewards(batch, effective_rewards)?;
+                        reset_recently_pruned_proposals(batch, self.pruned_proposals())?;
                     } else {
                         return Err(StateError::NoEffectiveRewards);
                     }
@@ -258,8 +260,14 @@ impl StateOverlay {
 
     /// Whether the proposal is pruned by the pending boundary transition (ratified, expired, or
     /// dropped). Like pool reaping, this short-circuits before the stale stable entry.
-    pub fn is_proposal_pruned(&self, id: &ComparableProposalId) -> bool {
-        self.governance_updates.as_ref().is_some_and(|updates| updates.pruned_proposals.contains(id))
+    pub fn has_pruned_proposal(&self, proposal: &ComparableProposalId) -> bool {
+        self.governance_updates.as_ref().is_some_and(|updates| updates.pruned_proposals.contains(proposal))
+    }
+
+    /// The set of all pruned proposals from the epoch boundary (because they expired, were
+    /// ratified, or evicted due to another ratification).
+    pub fn pruned_proposals(&self) -> BTreeSet<&ComparableProposalId> {
+        self.governance_updates.as_ref().map(|updates| updates.pruned_proposals.iter().collect()).unwrap_or_default()
     }
 
     /// The pending governance roots from the boundary transition, if any.

--- a/crates/amaru-ledger/src/state/volatile/overlay.rs
+++ b/crates/amaru-ledger/src/state/volatile/overlay.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeMap, mem};
+use std::{cell::RefCell, collections::BTreeMap, mem};
 
 use amaru_kernel::{
     ComparableProposalId, Epoch, Lovelace, PoolId, ProtocolParameters, RatificationStatus, StakeCredential, TermLimit,
@@ -31,9 +31,9 @@ use crate::{
         volatile::{CommitteeMemberBind, Existence},
     },
     store::{
-        EpochTransitionProgress, Store, TransactionalContext, apply_governance_updates, pay_or_refund_accounts,
-        pay_rewards, reset_blocks_count, reset_fees_and_donations, reset_recently_pruned_proposals,
-        update_or_retire_pools,
+        EpochTransitionProgress, HistoricalStores, Store, TransactionalContext, apply_governance_updates,
+        pay_or_refund_accounts, pay_rewards, reset_blocks_count, reset_fees_and_donations,
+        reset_recently_pruned_proposals, update_or_retire_pools,
     },
 };
 
@@ -48,6 +48,9 @@ use crate::{
 pub struct StateOverlay {
     /// The last known epoch; or said differently, the epoch for which this overlay is valid.
     epoch: Epoch,
+
+    /// The most recent snapshot taken, kept in memory to avoid repeated I/O.
+    most_recent_snapshot: RefCell<Option<Epoch>>,
 
     /// The computed rewards summary to be applied on the next epoch boundary. This is computed
     /// once in the epoch, and held until the end where it is reset.
@@ -73,7 +76,25 @@ pub struct StateOverlay {
 impl StateOverlay {
     /// Construct a new default/empty overlay for the given epoch.
     pub fn new(epoch: Epoch) -> Self {
-        Self { epoch, rewards: RewardsState::NotReady, pools_updates: None, governance_updates: None }
+        Self {
+            epoch,
+            most_recent_snapshot: RefCell::new(None),
+            rewards: RewardsState::NotReady,
+            pools_updates: None,
+            governance_updates: None,
+        }
+    }
+
+    /// Get the most recent taken, by peaking at the files on disk or looking an in-memory cached
+    /// value if available.
+    pub fn most_recent_snapshot<HS: HistoricalStores>(&self, snapshots: &HS) -> Epoch {
+        if let Some(epoch) = *self.most_recent_snapshot.borrow() {
+            epoch
+        } else {
+            let epoch = snapshots.most_recent_snapshot();
+            self.most_recent_snapshot.replace(Some(epoch));
+            epoch
+        }
     }
 
     /// Rollback an existing overlay, throwing away the epoch transition calculations.
@@ -147,6 +168,7 @@ impl StateOverlay {
 
                 if should_snapshot {
                     db.next_snapshot(self.epoch - 1)?;
+                    self.most_recent_snapshot.replace(Some(self.epoch - 1));
                 }
 
                 Ok(())
@@ -154,7 +176,7 @@ impl StateOverlay {
 
             // -------------------------------------------------------------------------- Start of epoch
             db.with_transaction::<_, StateError>(|batch| {
-                let should_begin_epoch = batch.try_epoch_transition(Some(SnapshotTaken), Some(EpochStarted))?;
+                let should_begin_epoch = batch.try_epoch_transition(Some(SnapshotTaken), None)?;
 
                 Span::current().record("should_begin_epoch", should_begin_epoch);
 

--- a/crates/amaru-ledger/src/state/volatile/overlay.rs
+++ b/crates/amaru-ledger/src/state/volatile/overlay.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     store::{
         EpochTransitionProgress, Store, TransactionalContext, apply_governance_updates, pay_or_refund_accounts,
-        pay_rewards, reset_blocks_count, reset_fees, update_or_retire_pools,
+        pay_rewards, reset_blocks_count, reset_fees_and_donations, update_or_retire_pools,
     },
 };
 
@@ -157,7 +157,7 @@ impl StateOverlay {
                 let updated = if should_begin_epoch {
                     reset_blocks_count(batch)?;
 
-                    reset_fees(batch)?;
+                    reset_fees_and_donations(batch)?;
 
                     if let Some(mut pools_updates) = mem::take(&mut self.pools_updates) {
                         update_or_retire_pools(batch, pools_updates.take_updated(), pools_updates.take_retired())?;

--- a/crates/amaru-ledger/src/state/volatile/overlay.rs
+++ b/crates/amaru-ledger/src/state/volatile/overlay.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeSet, mem};
+use std::{collections::BTreeMap, mem};
 
-use amaru_kernel::{ComparableProposalId, Epoch, Lovelace, PoolId, ProtocolParameters, StakeCredential, TermLimit};
+use amaru_kernel::{
+    ComparableProposalId, Epoch, Lovelace, PoolId, ProtocolParameters, RatificationStatus, StakeCredential, TermLimit,
+};
 use amaru_observability::info_span;
 use tracing::{Span, debug};
 
@@ -260,14 +262,17 @@ impl StateOverlay {
 
     /// Whether the proposal is pruned by the pending boundary transition (ratified, expired, or
     /// dropped). Like pool reaping, this short-circuits before the stale stable entry.
-    pub fn has_pruned_proposal(&self, proposal: &ComparableProposalId) -> bool {
-        self.governance_updates.as_ref().is_some_and(|updates| updates.pruned_proposals.contains(proposal))
+    pub fn has_pruned_proposal(&self, id: &ComparableProposalId) -> bool {
+        self.governance_updates.as_ref().is_some_and(|updates| updates.pruned_proposals.contains_key(id))
     }
 
     /// The set of all pruned proposals from the epoch boundary (because they expired, were
     /// ratified, or evicted due to another ratification).
-    pub fn pruned_proposals(&self) -> BTreeSet<&ComparableProposalId> {
-        self.governance_updates.as_ref().map(|updates| updates.pruned_proposals.iter().collect()).unwrap_or_default()
+    pub fn pruned_proposals(&self) -> BTreeMap<&ComparableProposalId, RatificationStatus> {
+        self.governance_updates
+            .as_ref()
+            .map(|updates| updates.pruned_proposals.iter().map(|(k, v)| (k, *v)).collect())
+            .unwrap_or_default()
     }
 
     /// The pending governance roots from the boundary transition, if any.

--- a/crates/amaru-ledger/src/state/volatile/series.rs
+++ b/crates/amaru-ledger/src/state/volatile/series.rs
@@ -141,6 +141,10 @@ impl VolatileSequence for VolatileSeries {
         self.sequence.iter()
     }
 
+    fn into_iter(self) -> impl Iterator<Item = Self::Item> {
+        self.sequence.into_iter()
+    }
+
     fn pop_front(&mut self) -> Option<Self::Item> {
         let popped = self.sequence.pop_front()?;
         if self.forced_recompute_in == 0 {

--- a/crates/amaru-ledger/src/state/volatile/view.rs
+++ b/crates/amaru-ledger/src/state/volatile/view.rs
@@ -19,8 +19,7 @@ use std::{
 };
 
 use amaru_kernel::{
-    CertificatePointer, ComparableProposalId, Epoch, PoolId, PoolParams, Proposal, ProposalPointer, ProtocolParameters,
-    StakeCredential,
+    CertificatePointer, ComparableProposalId, Epoch, PoolId, PoolParams, Proposal, ProposalPointer, StakeCredential,
 };
 
 use crate::{
@@ -58,18 +57,7 @@ impl<'volatile, 'db, DB: ReadStore> VolatileView<'volatile, 'db, DB> {
     /// Obtain a view of the database, which acts as a proxy 'ReadStore' augmented with the latest
     /// volatile updates, if any. This is used in context where one needs the true latest view of
     /// the ledger; for example at the epoch boundary.
-    pub fn new(
-        // TODO: Derive epoch instead of taking extra arg
-        //
-        // Currently passing this argument for simplicity, but that's a door open to
-        // inconsistencies. In principle we should be able to derive the epoch from either the
-        // stable db or self; since there can be only epoch in the context where this function is
-        // called. It's even an invariant violation if not...
-        epoch: Epoch,
-        protocol_parameters: &ProtocolParameters,
-        volatile: &'volatile VolatileDB,
-        stable: &'db DB,
-    ) -> VolatileView<'volatile, 'db, DB> {
+    pub fn new(volatile: &'volatile VolatileDB, stable: &'db DB) -> VolatileView<'volatile, 'db, DB> {
         let mut pools = DiffEpochReg::default();
         let mut proposals = BTreeMap::new();
         let mut accounts = DiffBind::default();
@@ -90,8 +78,8 @@ impl<'volatile, 'db, DB: ReadStore> VolatileView<'volatile, 'db, DB> {
         };
 
         Self {
-            epoch,
-            proposal_lifetime: protocol_parameters.gov_action_lifetime,
+            epoch: volatile.epoch(),
+            proposal_lifetime: volatile.protocol_parameters().gov_action_lifetime,
             db: stable,
             accounts: Some(accounts),
             pools: Some(pools),

--- a/crates/amaru-ledger/src/state/volatile/view/iter_pools.rs
+++ b/crates/amaru-ledger/src/state/volatile/view/iter_pools.rs
@@ -115,9 +115,366 @@ impl<'volatile, DBIter: Iterator<Item = (PoolId, Pool)>> Iterator for IterPools<
                 pool.future_params = vec![(Some(re_registration.0.clone()), self.epoch + 1)]
             }
 
+            // Pool has announced its retirement.
+            if let Some(retirement_epoch) = self.retirements.remove(&pool_id) {
+                pool.future_params.append(&mut vec![(None, retirement_epoch)])
+            }
+
             return Some((pool_id, pool));
         }
 
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        sync::LazyLock,
+    };
+
+    use amaru_kernel::{any_certificate_pointer, any_pool_params};
+    use proptest::{
+        strategy::{Strategy, ValueTree},
+        test_runner::{Config, RngSeed, TestRunner},
+    };
+    use test_case::test_case;
+
+    use super::*;
+    use crate::epoch_transition::PoolsEpochTransitionUpdates;
+
+    const MAX_POOLS: u8 = 3;
+
+    static STABLE: LazyLock<BTreeMap<u8, (PoolId, Pool)>> = LazyLock::new(|| {
+        let row = |ix| {
+            let (current_params, registered_at) = mock_pool(ix);
+            let future_params = Vec::new();
+            (mock_pool_id(ix), Pool { registered_at, current_params, future_params })
+        };
+
+        (0..MAX_POOLS).map(|ix| (ix, row(ix))).collect()
+    });
+
+    static VOLATILE: LazyLock<BTreeMap<u8, (PoolParams, CertificatePointer)>> = LazyLock::new(|| {
+        (0..MAX_POOLS)
+            .map(|ix| {
+                let (pool_params, registered_at) = mock_pool(u8::MAX - ix);
+                (ix, (PoolParams { id: mock_pool_id(ix), ..pool_params }, registered_at))
+            })
+            .collect()
+    });
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum Event {
+        Registration,
+        LateRetirement,
+        ImminentRetirement,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct EndOfEpochView<'a> {
+        stable: &'a [(u8, &'a [Event])],
+        volatile: &'a [(u8, Event)],
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct NextEpochExpectations<'a> {
+        updated: &'a [(u8, Pool)],
+        retired: &'a [u8],
+        seen: &'a [u8],
+    }
+
+    impl From<EndOfEpochView<'_>> for IterPools<'static, std::vec::IntoIter<(PoolId, Pool)>> {
+        fn from(test: EndOfEpochView<'_>) -> Self {
+            let epoch = Epoch::new(100);
+
+            Self::new(
+                epoch,
+                test.stable
+                    .iter()
+                    .map(|(ix, row)| {
+                        let (current_params, registered_at) = mock_pool(*ix);
+                        let future_params = row
+                            .iter()
+                            .map(|event| match event {
+                                Event::Registration => (Some(mock_pool_params(*ix)), epoch + 1),
+                                Event::LateRetirement => (None, epoch + 10),
+                                Event::ImminentRetirement => (None, epoch + 1),
+                            })
+                            .collect();
+                        (mock_pool_id(*ix), Pool { registered_at, current_params, future_params })
+                    })
+                    .collect::<Vec<(PoolId, Pool)>>()
+                    .into_iter(),
+                &mut test.volatile.iter().fold(DiffEpochReg::default(), |mut diff_epoch_reg, (ix, event)| {
+                    let pool_id = mock_pool_id(*ix);
+
+                    match event {
+                        Event::Registration => {
+                            diff_epoch_reg.register(pool_id, (*VOLATILE).get(ix).unwrap());
+                        }
+                        Event::LateRetirement => {
+                            diff_epoch_reg.unregister(pool_id, epoch + 10);
+                        }
+                        Event::ImminentRetirement => {
+                            diff_epoch_reg.unregister(pool_id, epoch + 1);
+                        }
+                    }
+
+                    diff_epoch_reg
+                }),
+            )
+        }
+    }
+
+    fn mock_pool_id(ix: u8) -> PoolId {
+        let mut pool_id = [0; 28];
+        pool_id[27] = ix;
+        PoolId::from(pool_id)
+    }
+
+    fn mock_pool(ix: u8) -> (PoolParams, CertificatePointer) {
+        let registered_at = sample(ix, any_certificate_pointer(u64::MAX));
+        let pool_params = PoolParams { id: mock_pool_id(ix), ..mock_pool_params(ix) };
+        (pool_params, registered_at)
+    }
+
+    fn mock_pool_params(ix: u8) -> PoolParams {
+        PoolParams { id: mock_pool_id(ix), ..sample(ix, any_pool_params()) }
+    }
+
+    fn stable(ix: u8) -> Pool {
+        (*STABLE).get(&ix).unwrap().1.clone()
+    }
+
+    fn volatile(ix: u8) -> Pool {
+        let (current_params, registered_at) = (*VOLATILE).get(&ix).cloned().unwrap();
+        Pool { current_params, registered_at, future_params: Vec::new() }
+    }
+
+    fn sample<T>(seed: u8, strategy: impl Strategy<Value = T>) -> T {
+        let config = Config { failure_persistence: None, rng_seed: RngSeed::Fixed(seed as u64), ..Default::default() };
+        strategy
+            .new_tree(&mut TestRunner::new(config))
+            .unwrap_or_else(|e| panic!("unable to generate arbitrary data: {e}"))
+            .current()
+    }
+
+    #[test_case(
+        EndOfEpochView {
+            stable: &[(0, &[]), (1, &[])],
+            volatile: &[]
+        },
+        NextEpochExpectations {
+            seen: &[0, 1],
+            updated: &[],
+            retired: &[],
+        };
+        "no volatile, no updates, no retirements"
+    )]
+    #[test_case(
+        EndOfEpochView {
+            stable: &[],
+            volatile: &[(0, Event::Registration)]
+        },
+        NextEpochExpectations {
+            seen: &[0],
+            updated: &[],
+            retired: &[],
+        };
+        "no stable, one volatile registration"
+    )]
+    #[test_case(
+        EndOfEpochView {
+            stable: &[(0, &[])],
+            volatile: &[(0, Event::Registration)]
+        },
+        NextEpochExpectations {
+            seen: &[0],
+            updated: &[(0, Pool { current_params: volatile(0).current_params, ..stable(0) })],
+            retired: &[]
+        };
+        "existing stable, one volatile update"
+    )]
+    #[test_case(
+        EndOfEpochView {
+            stable: &[(0, &[Event::Registration])],
+            volatile: &[]
+        },
+        NextEpochExpectations {
+            seen: &[0],
+            updated: &[(0, stable(0))],
+            retired: &[]
+        };
+        "existing stable, one stable update"
+    )]
+    #[test_case(
+        EndOfEpochView {
+            stable: &[(0, &[Event::Registration])],
+            volatile: &[(0, Event::Registration)]
+        },
+        NextEpochExpectations {
+            seen: &[0],
+            // Volatile wins
+            updated: &[(0, Pool { current_params: volatile(0).current_params, ..stable(0) })],
+            retired: &[]
+        };
+        "existing stable, one stable update, one volatile update"
+    )]
+    #[test_case(
+        EndOfEpochView {
+            stable: &[(0, &[])],
+            volatile: &[(0, Event::ImminentRetirement)]
+        },
+        NextEpochExpectations {
+            seen: &[0],
+            updated: &[],
+            retired: &[0]
+        };
+        "existing stable, imminent retirement in volatile"
+    )]
+    #[test_case(
+        EndOfEpochView {
+            stable: &[(0, &[])],
+            volatile: &[(0, Event::LateRetirement)]
+        },
+        NextEpochExpectations {
+            seen: &[0],
+            // No update at the epoch boundary, the retirement certificate will eventually be
+            // inserted but not as a result of crossing the epoch boundary. By the time we
+            // flush the update to the store, it will already be there, so there's no need to
+            // re-insert it or clean up the future parameters.
+            updated: &[],
+            retired: &[]
+        };
+        "existing stable, late retirement in volatile"
+    )]
+    #[test_case(
+        EndOfEpochView {
+            stable: &[(0, &[Event::Registration])],
+            volatile: &[(0, Event::LateRetirement)]
+        },
+        NextEpochExpectations {
+            seen: &[0],
+            // Unlike the previous case, we have to clean-up the re-registration from the future
+            // parameters and yet, preserve the late retirement as well. There's no diff strategy on
+            // pool updates, we just replace the pool object entirely; and must therefore include
+            // the late retirement.
+            updated: &[(0, Pool { future_params: vec![(None, Epoch::from(110))], ..stable(0) })],
+            retired: &[]
+        };
+        "update in stable, late retirement in volatile"
+    )]
+    #[test_case(
+        EndOfEpochView {
+            stable: &[(0, &[Event::Registration])],
+            volatile: &[(0, Event::ImminentRetirement)]
+        },
+        NextEpochExpectations {
+            seen: &[0],
+            updated: &[],
+            retired: &[0]
+        };
+        "update in stable, imminent retirement in volatile"
+    )]
+    #[test_case(
+        EndOfEpochView {
+            stable: &[(0, &[Event::ImminentRetirement])],
+            volatile: &[(0, Event::Registration)]
+        },
+        NextEpochExpectations {
+            seen: &[0],
+            updated: &[(0, Pool { current_params: volatile(0).current_params, ..stable(0) })],
+            retired: &[]
+        };
+        "imminent retirement in stable, update in volatile"
+    )]
+    #[test_case(
+        EndOfEpochView {
+            stable: &[(0, &[Event::ImminentRetirement])],
+            volatile: &[(0, Event::LateRetirement)]
+        },
+        NextEpochExpectations {
+            seen: &[0],
+            updated: &[(0, Pool { future_params: vec![(None, Epoch::from(110))], ..stable(0) })],
+            retired: &[]
+        };
+        "imminent retirement in stable, late retirement in volatile"
+    )]
+    #[test_case(
+        EndOfEpochView {
+            stable: &[],
+            volatile: &[(0, Event::Registration), (0, Event::ImminentRetirement)]
+        },
+        NextEpochExpectations {
+            seen: &[0],
+            updated: &[],
+            retired: &[0]
+        };
+        "registration in volatile, imminent retirement in volatile"
+    )]
+    #[test_case(
+        EndOfEpochView {
+            stable: &[],
+            volatile: &[(0, Event::Registration), (0, Event::LateRetirement)]
+        },
+        NextEpochExpectations {
+            seen: &[0],
+            updated: &[],
+            retired: &[]
+        };
+        "registration in volatile, late retirement in volatile"
+    )]
+    #[test_case(
+        EndOfEpochView {
+            stable: &[],
+            volatile: &[(0, Event::Registration), (0, Event::Registration)]
+        },
+        NextEpochExpectations {
+            seen: &[0],
+            updated: &[(0, volatile(0))],
+            retired: &[]
+        };
+        "registration in volatile, re-registration in volatile"
+    )]
+    #[test_case(
+        EndOfEpochView {
+            stable: &[(0, &[])],
+            volatile: &[(0, Event::Registration), (0, Event::Registration)]
+        },
+        NextEpochExpectations {
+            seen: &[0],
+            updated: &[(0, Pool { current_params: volatile(0).current_params, ..stable(0) })],
+            retired: &[]
+        };
+        "existing stable, registration in volatile, re-registration in volatile"
+    )]
+    fn iter_pools_scenarios(test: EndOfEpochView<'_>, expectations: NextEpochExpectations<'_>) {
+        let iterator = IterPools::from(test);
+        let epoch = iterator.epoch;
+
+        let mut seen = BTreeSet::new();
+        let transition = PoolsEpochTransitionUpdates::new(
+            iterator.map(|(ix, pool)| {
+                seen.insert(ix);
+                (ix, pool)
+            }),
+            epoch + 1,
+        );
+
+        assert_eq!(expectations.seen.iter().copied().map(mock_pool_id).collect::<BTreeSet<_>>(), seen, "seen mismatch");
+
+        let retired = transition.retired();
+        for ix in expectations.retired {
+            assert!(retired.contains(&mock_pool_id(*ix)), "missing retired");
+        }
+        assert_eq!(expectations.retired.len(), retired.len(), "retired mismatch");
+
+        let updated = transition.updated();
+        for (ix, pool) in expectations.updated {
+            assert_eq!(Some(pool), updated.get(&mock_pool_id(*ix)), "updated mismatch")
+        }
+        assert_eq!(expectations.updated.len(), updated.len(), "updated mismatch");
     }
 }

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -141,8 +141,6 @@ pub enum EpochTransitionProgress {
     EpochEnded,
     #[n(1)]
     SnapshotTaken,
-    #[n(2)]
-    EpochStarted,
 }
 
 impl fmt::Display for EpochTransitionProgress {
@@ -153,7 +151,6 @@ impl fmt::Display for EpochTransitionProgress {
             match self {
                 Self::EpochEnded => "Epoch Ended",
                 Self::SnapshotTaken => "Snapshot Taken",
-                Self::EpochStarted => "Epoch Started",
             }
         )
     }

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -327,7 +327,7 @@ pub trait HistoricalStores {
     }
 
     /// Access a `Snapshot` for a specific `Epoch`
-    fn for_epoch(&self, epoch: Epoch) -> Result<impl Snapshot>;
+    fn for_epoch(&self, epoch: Epoch) -> Result<impl Snapshot + Send>;
 }
 
 // TransactionalContext

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -95,7 +95,7 @@ pub enum StoreError {
     #[error(
         "{}",
         if .0.is_locked() {
-            "Failed to connect to the ledger store because it is is locked. Another Amaru \
+            "Failed to connect to the ledger store because it is locked. Another Amaru \
             process may still be using it, or a stale LOCK file may remain after an \
             unclean shutdown. Stop any process using the ledger database before retrying; \
             only remove the LOCK file after confirming no process is using it."
@@ -514,7 +514,7 @@ mod tests {
     fn better_context_on_open_locked() {
         let error = StoreError::Open(OpenErrorKind::locked(PathBuf::from("db/live"), anyhow!("lock held")));
         let message = format!("{error:#}");
-        assert!(message.contains("Failed to connect to the ledger store because it is is locked"));
+        assert!(message.contains("Failed to connect to the ledger store because it is locked"));
         assert!(!message.contains("Did you bootstrap your node?"));
     }
 
@@ -522,7 +522,7 @@ mod tests {
     fn suggest_bootstrap_on_open_error() {
         let error = StoreError::Open(OpenErrorKind::io_with_file(PathBuf::from("db/live"), io::Error::other("foo")));
         let message = format!("{error:#}");
-        assert!(!message.contains("Failed to connect to the ledger store because it is is locked"));
+        assert!(!message.contains("Failed to connect to the ledger store because it is locked"));
         assert!(message.contains("Did you bootstrap your node?"));
     }
 }

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -53,7 +53,7 @@ pub mod columns;
 mod epoch_transition;
 pub use epoch_transition::{
     apply_governance_updates, pay_or_refund_accounts, pay_rewards, reset_blocks_count, reset_fees_and_donations,
-    update_constitutional_committee, update_or_retire_pools,
+    reset_recently_pruned_proposals, update_constitutional_committee, update_or_retire_pools,
 };
 
 #[derive(Debug, Error)]
@@ -281,6 +281,9 @@ pub trait ReadStore {
     /// Get details about all proposals
     fn iter_proposals(&self) -> Result<impl Iterator<Item = (proposals::Key, proposals::Row)>>;
 
+    /// Get proposals that were *just* pruned at last epoch boundary. The list changes every epoch.
+    fn iter_recently_pruned_proposals(&self) -> Result<impl Iterator<Item = ComparableProposalId>>;
+
     /// Iterate over constitutional committee members.
     fn iter_cc_members(&self) -> Result<impl Iterator<Item = (cc_members::Key, cc_members::Row)>>;
 
@@ -404,6 +407,12 @@ pub trait TransactionalContext<'a>: ReadStore {
 
     /// Track the current governance activity.
     fn set_governance_activity(&self, dormant_epochs: GovernanceActivity) -> Result<()>;
+
+    /// Record the recently (i.e. last epoch boundary) pruned proposals
+    fn set_recently_pruned_proposals<'iter>(
+        &self,
+        proposals: impl IntoIterator<Item = &'iter ComparableProposalId>,
+    ) -> Result<()>;
 
     /// Remove a list of proposals from the database. This is done when enacting proposals that
     /// cause other proposals to become obsolete.

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -20,7 +20,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use amaru_kernel::ProposalId;
 use amaru_kernel::{
     CertificatePointer,
     ComparableProposalId,
@@ -41,6 +40,7 @@ use amaru_kernel::{
     // for 'minicbor' in scope, and not an alias of any sort...
     cbor as minicbor,
 };
+use amaru_kernel::{ProposalId, RatificationStatus};
 use columns::*;
 use thiserror::Error;
 
@@ -282,7 +282,9 @@ pub trait ReadStore {
     fn iter_proposals(&self) -> Result<impl Iterator<Item = (proposals::Key, proposals::Row)>>;
 
     /// Get proposals that were *just* pruned at last epoch boundary. The list changes every epoch.
-    fn iter_recently_pruned_proposals(&self) -> Result<impl Iterator<Item = ComparableProposalId>>;
+    fn iter_recently_pruned_proposals(
+        &self,
+    ) -> Result<impl Iterator<Item = (recently_pruned_proposals::Key, recently_pruned_proposals::Value)>>;
 
     /// Iterate over constitutional committee members.
     fn iter_cc_members(&self) -> Result<impl Iterator<Item = (cc_members::Key, cc_members::Row)>>;
@@ -411,12 +413,12 @@ pub trait TransactionalContext<'a>: ReadStore {
     /// Record the recently (i.e. last epoch boundary) pruned proposals
     fn set_recently_pruned_proposals<'iter>(
         &self,
-        proposals: impl IntoIterator<Item = &'iter ComparableProposalId>,
+        proposals: impl IntoIterator<Item = (&'iter ComparableProposalId, RatificationStatus)>,
     ) -> Result<()>;
 
     /// Remove a list of proposals from the database. This is done when enacting proposals that
     /// cause other proposals to become obsolete.
-    fn remove_proposals<'iter, Id>(&self, proposals: impl IntoIterator<Item = Id>) -> Result<()>
+    fn remove_proposals<'iter, Id>(&self, proposals: impl Iterator<Item = &'iter Id>) -> Result<()>
     where
         Id: Deref<Target = ProposalId> + 'iter;
 

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -44,13 +44,15 @@ use amaru_kernel::{
 use columns::*;
 use thiserror::Error;
 
-use crate::{epoch_transition::GovernanceActivity, governance::ratification::ProposalsRoots, summary::Pots};
+use crate::{
+    epoch_transition::GovernanceActivity, governance::ratification::ProposalsRoots, store::columns::pots::Row as Pots,
+};
 
 pub mod columns;
 
 mod epoch_transition;
 pub use epoch_transition::{
-    apply_governance_updates, pay_or_refund_accounts, pay_rewards, reset_blocks_count, reset_fees,
+    apply_governance_updates, pay_or_refund_accounts, pay_rewards, reset_blocks_count, reset_fees_and_donations,
     update_constitutional_committee, update_or_retire_pools,
 };
 

--- a/crates/amaru-ledger/src/store/columns/mod.rs
+++ b/crates/amaru-ledger/src/store/columns/mod.rs
@@ -20,6 +20,7 @@ pub mod dreps;
 pub mod pools;
 pub mod pots;
 pub mod proposals;
+pub mod recently_pruned_proposals;
 pub mod slots;
 pub mod utxo;
 pub mod votes;

--- a/crates/amaru-ledger/src/store/columns/pots.rs
+++ b/crates/amaru-ledger/src/store/columns/pots.rs
@@ -15,17 +15,12 @@
 /// This modules captures protocol-wide value pots such as treasury and reserves accounts.
 use amaru_kernel::{Lovelace, cbor};
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Row {
     pub treasury: Lovelace,
     pub reserves: Lovelace,
     pub fees: Lovelace,
-}
-
-impl Row {
-    pub fn new(treasury: Lovelace, reserves: Lovelace, fees: Lovelace) -> Self {
-        Self { treasury, reserves, fees }
-    }
+    pub donations: Lovelace,
 }
 
 impl<C> cbor::encode::Encode<C> for Row {
@@ -34,10 +29,11 @@ impl<C> cbor::encode::Encode<C> for Row {
         e: &mut cbor::Encoder<W>,
         ctx: &mut C,
     ) -> Result<(), cbor::encode::Error<W::Error>> {
-        e.array(3)?;
+        e.array(4)?;
         e.encode_with(self.treasury, ctx)?;
         e.encode_with(self.reserves, ctx)?;
         e.encode_with(self.fees, ctx)?;
+        e.encode_with(self.donations, ctx)?;
         Ok(())
     }
 }
@@ -48,7 +44,8 @@ impl<'a, C> cbor::decode::Decode<'a, C> for Row {
         let treasury = d.decode_with(ctx)?;
         let reserves = d.decode_with(ctx)?;
         let fees = d.decode_with(ctx)?;
-        Ok(Row::new(treasury, reserves, fees))
+        let donations = d.decode_with(ctx)?;
+        Ok(Self { treasury, reserves, fees, donations })
     }
 }
 
@@ -64,11 +61,13 @@ mod tests {
             treasury in any::<Lovelace>(),
             reserves in any::<Lovelace>(),
             fees in any::<Lovelace>(),
+            donations in any::<Lovelace>(),
         ) -> Row {
             Row {
                 treasury,
                 reserves,
                 fees,
+                donations,
             }
         }
     }

--- a/crates/amaru-ledger/src/store/columns/recently_pruned_proposals.rs
+++ b/crates/amaru-ledger/src/store/columns/recently_pruned_proposals.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 PRAGMA
+// Copyright 2026 PRAGMA
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod accounts;
-pub mod cc_members;
-pub mod dreps;
-pub mod pools;
-pub mod pots;
-pub mod proposals;
-pub mod recently_pruned_proposals;
-pub mod slots;
-pub mod utxo;
-pub mod votes;
+use amaru_kernel::ComparableProposalId;
+
+pub type Key = ComparableProposalId;
+pub type Value = ();

--- a/crates/amaru-ledger/src/store/columns/recently_pruned_proposals.rs
+++ b/crates/amaru-ledger/src/store/columns/recently_pruned_proposals.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::ComparableProposalId;
+use amaru_kernel::{ComparableProposalId, RatificationStatus};
 
 pub type Key = ComparableProposalId;
-pub type Value = ();
+pub type Value = RatificationStatus;

--- a/crates/amaru-ledger/src/store/epoch_transition.rs
+++ b/crates/amaru-ledger/src/store/epoch_transition.rs
@@ -94,10 +94,13 @@ pub fn pay_rewards<'store>(
 // ---------------------------------------------------------------------------------- Start of epoch
 // -------------------------------------------------------------------------------------------------
 
-pub fn reset_fees<'store>(db: &impl TransactionalContext<'store>) -> Result<(), StoreError> {
+pub fn reset_fees_and_donations<'store>(db: &impl TransactionalContext<'store>) -> Result<(), StoreError> {
     debug_span!(amaru_observability::amaru::ledger::epoch_transition::RESET_FEES).in_scope(|| {
         db.with_pots(|mut row| {
-            row.borrow_mut().fees = 0;
+            let row = row.borrow_mut();
+            row.fees = 0;
+            row.treasury += row.donations;
+            row.donations = 0;
         })
     })
 }

--- a/crates/amaru-ledger/src/store/epoch_transition.rs
+++ b/crates/amaru-ledger/src/store/epoch_transition.rs
@@ -18,8 +18,8 @@ use std::{
 };
 
 use amaru_kernel::{
-    AsHash, ConstitutionalCommitteeStatus, Lovelace, PoolId, ProtocolParameters, RationalNumber, StakeCredential,
-    StakeCredentialKind,
+    AsHash, ComparableProposalId, ConstitutionalCommitteeStatus, Lovelace, PoolId, ProtocolParameters, RationalNumber,
+    StakeCredential, StakeCredentialKind,
 };
 use amaru_observability::debug_span;
 use num::BigUint;
@@ -86,6 +86,18 @@ pub fn pay_rewards<'store>(
             Span::current().record("reserves_delta", (delta_reserves as i64).neg());
         })?;
 
+        Ok(())
+    })
+}
+
+/// Retain recently pruned proposals (ratified, expired or dropped due to other ratifying to
+/// expiring) for the epoch, to allow resolving voting stake distribution for the epoch correctly.
+pub fn reset_recently_pruned_proposals<'store>(
+    db: &impl TransactionalContext<'store>,
+    pruned_proposals: BTreeSet<&ComparableProposalId>,
+) -> Result<(), StoreError> {
+    debug_span!(amaru_observability::amaru::ledger::epoch_transition::RECORD_PRUNED_PROPOSALS).in_scope(|| {
+        db.set_recently_pruned_proposals(pruned_proposals)?;
         Ok(())
     })
 }

--- a/crates/amaru-ledger/src/store/epoch_transition.rs
+++ b/crates/amaru-ledger/src/store/epoch_transition.rs
@@ -18,8 +18,8 @@ use std::{
 };
 
 use amaru_kernel::{
-    AsHash, ComparableProposalId, ConstitutionalCommitteeStatus, Lovelace, PoolId, ProtocolParameters, RationalNumber,
-    StakeCredential, StakeCredentialKind,
+    AsHash, ComparableProposalId, ConstitutionalCommitteeStatus, Lovelace, PoolId, ProtocolParameters,
+    RatificationStatus, RationalNumber, StakeCredential, StakeCredentialKind,
 };
 use amaru_observability::debug_span;
 use num::BigUint;
@@ -94,7 +94,7 @@ pub fn pay_rewards<'store>(
 /// expiring) for the epoch, to allow resolving voting stake distribution for the epoch correctly.
 pub fn reset_recently_pruned_proposals<'store>(
     db: &impl TransactionalContext<'store>,
-    pruned_proposals: BTreeSet<&ComparableProposalId>,
+    pruned_proposals: BTreeMap<&ComparableProposalId, RatificationStatus>,
 ) -> Result<(), StoreError> {
     debug_span!(amaru_observability::amaru::ledger::epoch_transition::RECORD_PRUNED_PROPOSALS).in_scope(|| {
         db.set_recently_pruned_proposals(pruned_proposals)?;
@@ -241,7 +241,7 @@ pub fn apply_governance_updates<'store, 'iter>(
             db.set_governance_activity(governance_activity)?;
         }
 
-        db.remove_proposals(updates.pruned_proposals)?;
+        db.remove_proposals(updates.pruned_proposals.keys())?;
 
         Ok((updates.protocol_parameters, governance_activity))
     })

--- a/crates/amaru-ledger/src/summary/governance.rs
+++ b/crates/amaru-ledger/src/summary/governance.rs
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Deref,
+};
 
 use amaru_kernel::{
-    Anchor, CertificatePointer, ComparableProposalId, DRep, Epoch, EraHistory, EraHistoryError, Lovelace, Slot,
-    StakeCredential, TransactionPointer, anchor, expect_stake_credential,
+    Anchor, CertificatePointer, ComparableProposalId, DRep, Epoch, EraHistory, EraHistoryError, Lovelace,
+    RatificationStatus, Slot, StakeCredential, TransactionPointer, anchor, expect_stake_credential,
 };
 
 use crate::{
@@ -72,7 +75,8 @@ impl GovernanceSummary {
         let mut dreps_deposits: BTreeMap<StakeCredential, Lovelace> = BTreeMap::new();
         let mut pools_deposits: BTreeMap<StakeCredential, Lovelace> = BTreeMap::new();
 
-        let recently_pruned_proposals: BTreeSet<ComparableProposalId> = db.iter_recently_pruned_proposals()?.collect();
+        let recently_pruned_proposals: BTreeMap<ComparableProposalId, RatificationStatus> =
+            db.iter_recently_pruned_proposals()?.collect();
 
         db.iter_proposals()?.try_for_each(|(proposal_id, row)| -> Result<(), Error> {
             let proposed_in = era_history
@@ -86,6 +90,7 @@ impl GovernanceSummary {
             if current_epoch <= row.valid_until + 1 {
                 let stake_credential = expect_stake_credential(&row.proposal.reward_account);
                 let deposit: u64 = row.proposal.deposit;
+                let recently_pruned = recently_pruned_proposals.get(&proposal_id);
 
                 // NOTE: Pool voting stake distribution after proposal pruning
                 //
@@ -101,7 +106,7 @@ impl GovernanceSummary {
                 // Interestingly, this is only true for stake pools, not for DReps. The DReps voting
                 // stake correctly uses the stake distribution after the refunds / withdrawals have
                 // been processed; so this gap is only observed for stake pools.
-                if current_epoch <= row.valid_until && !recently_pruned_proposals.contains(&proposal_id) {
+                if current_epoch <= row.valid_until && recently_pruned.is_none() {
                     pools_deposits
                         .entry(stake_credential.clone())
                         .and_modify(|total| *total += deposit)
@@ -109,6 +114,38 @@ impl GovernanceSummary {
                 }
 
                 dreps_deposits.entry(stake_credential).and_modify(|total| *total += deposit).or_insert(deposit);
+
+                // NOTE: Ratified withdrawals immediately count towards DRep voting stake
+                //
+                // This really is a weird edge case but, the stake distribution to compute the DRep
+                // voting power is taken just after the deposits and withdrawals payouts. So a
+                // withdrawal that was just ratified could contribute towards the DRep stake
+                // distribution.
+                //
+                // What makes it weird (beyond the fact that it's using stuff happening in the
+                // future), is that the constitution mostly prevents this since it (currently)
+                // requires that target addresses are not delegated to a registered drep. So while
+                // this never happens *in practice*, it can happen in theory and is not even
+                // technically complicated. So we must get this right.
+                if let Some(RatificationStatus::Ratified) = recently_pruned {
+                    use amaru_kernel::GovernanceAction::*;
+                    match row.proposal.gov_action {
+                        TreasuryWithdrawals(withdrawals, _) => {
+                            for (bytes, withdrawal) in withdrawals.deref() {
+                                dreps_deposits
+                                    .entry(expect_stake_credential(bytes))
+                                    .and_modify(|total| *total += withdrawal)
+                                    .or_insert(*withdrawal);
+                            }
+                        }
+                        ParameterChange(..)
+                        | HardForkInitiation(..)
+                        | NoConfidence(..)
+                        | UpdateCommittee(..)
+                        | NewConstitution(..)
+                        | Information => (),
+                    }
+                }
             }
 
             Ok(())

--- a/crates/amaru-ledger/src/summary/governance.rs
+++ b/crates/amaru-ledger/src/summary/governance.rs
@@ -15,8 +15,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use amaru_kernel::{
-    Anchor, CertificatePointer, DRep, Epoch, EraHistory, EraHistoryError, Lovelace, Slot, StakeCredential,
-    TransactionPointer, anchor, expect_stake_credential,
+    Anchor, CertificatePointer, ComparableProposalId, DRep, Epoch, EraHistory, EraHistoryError, Lovelace, Slot,
+    StakeCredential, TransactionPointer, anchor, expect_stake_credential,
 };
 
 use crate::{
@@ -27,7 +27,8 @@ use crate::{
 #[derive(Debug)]
 pub struct GovernanceSummary {
     pub dreps: BTreeMap<DRep, DRepState>,
-    pub deposits: BTreeMap<StakeCredential, Vec<ProposalState>>,
+    pub dreps_deposits: BTreeMap<StakeCredential, Lovelace>,
+    pub pools_deposits: BTreeMap<StakeCredential, Lovelace>,
 }
 
 #[derive(Debug, serde::Serialize)]
@@ -65,28 +66,49 @@ impl GovernanceSummary {
     pub fn new(db: &impl Snapshot, era_history: &EraHistory) -> Result<Self, Error> {
         let current_epoch = db.epoch();
 
-        let mut proposals = BTreeSet::new();
-
-        let mut deposits = BTreeMap::new();
-
         let GovernanceActivity { consecutive_dormant_epochs } = db.governance_activity()?;
 
-        db.iter_proposals()?.try_for_each(|(_, row)| -> Result<(), Error> {
-            let epoch = era_history
+        let mut proposals = BTreeSet::new();
+        let mut dreps_deposits: BTreeMap<StakeCredential, Lovelace> = BTreeMap::new();
+        let mut pools_deposits: BTreeMap<StakeCredential, Lovelace> = BTreeMap::new();
+
+        let recently_pruned_proposals: BTreeSet<ComparableProposalId> = db.iter_recently_pruned_proposals()?.collect();
+
+        db.iter_proposals()?.try_for_each(|(proposal_id, row)| -> Result<(), Error> {
+            let proposed_in = era_history
                 .slot_to_epoch_unchecked_horizon(row.proposed_in.transaction.slot)
                 .map_err(|e| Error::EraHistoryError(row.proposed_in.transaction.slot, e))?;
 
-            proposals.insert((row.proposed_in.transaction, epoch));
+            proposals.insert((row.proposed_in.transaction, proposed_in));
 
             // Proposals are ratified with an epoch of delay always, so deposits count towards
-            // the voting stake of DRep for an extra epoch following the proposal expiry.
+            // the voting stake for an extra epoch following the proposal expiry.
             if current_epoch <= row.valid_until + 1 {
-                let proposal = || ProposalState { deposit: row.proposal.deposit, valid_until: row.valid_until };
+                let stake_credential = expect_stake_credential(&row.proposal.reward_account);
+                let deposit: u64 = row.proposal.deposit;
 
-                deposits
-                    .entry(expect_stake_credential(&row.proposal.reward_account))
-                    .and_modify(|proposals: &mut Vec<ProposalState>| proposals.push(proposal()))
-                    .or_insert_with(|| vec![proposal()]);
+                // NOTE: Pool voting stake distribution after proposal pruning
+                //
+                // The stake distribution used for computing pools voting power is taken before
+                // refunds or withdrawals are processed. Yet the stake distribution calculation
+                // begins after proposals have been ratified/pruned.
+                //
+                // This means that when proposals are pruned (due to ratification, expiry or a
+                // dependency thereof), the stake corresponding to the associated proposal's deposit
+                // or withdrawals momentarily stops contributing towards the pools voting stake; and
+                // magically re-appear in the next epoch.
+                //
+                // Interestingly, this is only true for stake pools, not for DReps. The DReps voting
+                // stake correctly uses the stake distribution after the refunds / withdrawals have
+                // been processed; so this gap is only observed for stake pools.
+                if current_epoch <= row.valid_until && !recently_pruned_proposals.contains(&proposal_id) {
+                    pools_deposits
+                        .entry(stake_credential.clone())
+                        .and_modify(|total| *total += deposit)
+                        .or_insert(deposit);
+                }
+
+                dreps_deposits.entry(stake_credential).and_modify(|total| *total += deposit).or_insert(deposit);
             }
 
             Ok(())
@@ -126,6 +148,6 @@ impl GovernanceSummary {
         dreps.insert(DRep::Abstain, default_protocol_drep());
         dreps.insert(DRep::NoConfidence, default_protocol_drep());
 
-        Ok(GovernanceSummary { dreps, deposits })
+        Ok(GovernanceSummary { dreps, dreps_deposits, pools_deposits })
     }
 }

--- a/crates/amaru-ledger/src/summary/mod.rs
+++ b/crates/amaru-ledger/src/summary/mod.rs
@@ -109,7 +109,3 @@ pub fn safe_ratio(numerator: u64, denominator: u64) -> SafeRatio {
 pub fn into_safe_ratio(ratio: &RationalNumber) -> SafeRatio {
     SafeRatio::new(BigUint::from(ratio.numerator), BigUint::from(ratio.denominator))
 }
-
-fn serialize_safe_ratio(r: &SafeRatio) -> String {
-    format!("{}/{}", r.numer(), r.denom())
-}

--- a/crates/amaru-ledger/src/summary/mod.rs
+++ b/crates/amaru-ledger/src/summary/mod.rs
@@ -14,17 +14,16 @@
 
 use std::ops::Deref;
 
-use amaru_kernel::pool_metadata;
+use ::serde::ser::SerializeStruct;
+use amaru_kernel::{
+    CertificatePointer, DRep, Lovelace, PoolId, PoolParams, RationalNumber, drep, pool_metadata, relay,
+};
+use num::{BigUint, rational::Ratio};
+
 pub mod governance;
 pub mod rewards;
 pub mod serde;
 pub mod stake_distribution;
-
-use ::serde::ser::SerializeStruct;
-use amaru_kernel::{CertificatePointer, DRep, Lovelace, PoolId, PoolParams, RationalNumber, drep, relay};
-use num::{BigUint, rational::Ratio};
-
-use crate::store::columns::*;
 
 // ---------------------------------------------------------------- AccountState
 
@@ -95,34 +94,6 @@ impl ::serde::Serialize for PoolState {
         s.serialize_field("voting_stake", &self.voting_stake)?;
         s.serialize_field("vrf_key_hash", &hex::encode(self.parameters.vrf))?;
 
-        s.end()
-    }
-}
-
-// ------------------------------------------------------------------------ Pots
-
-#[derive(Debug)]
-pub struct Pots {
-    /// Value, in Lovelace, of the treasury at a given epoch.
-    pub treasury: Lovelace,
-    /// Value, in Lovelace, of the reserves at a given epoch.
-    pub reserves: Lovelace,
-    /// Values, in Lovelace, generated from fees during an epoch.
-    pub fees: Lovelace,
-}
-
-impl From<&pots::Row> for Pots {
-    fn from(pots: &pots::Row) -> Pots {
-        Pots { treasury: pots.treasury, reserves: pots.reserves, fees: pots.fees }
-    }
-}
-
-impl ::serde::Serialize for Pots {
-    fn serialize<S: ::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut s = serializer.serialize_struct("Pots", 3)?;
-        s.serialize_field("treasury", &self.treasury)?;
-        s.serialize_field("reserves", &self.reserves)?;
-        s.serialize_field("fees", &self.fees)?;
         s.end()
     }
 }

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -412,7 +412,6 @@ impl RewardsSummary {
 
         info!(
             target: EVENT_TARGET,
-            epoch = %stake_distribution.epoch,
             %efficiency,
             %incentives,
             %treasury_tax,

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -122,10 +122,7 @@ use tracing::info;
 use crate::{
     epoch_transition::{Computed, PoolsEpochTransitionUpdates, Rewards},
     store::{Snapshot, StoreError, columns::pots::Row as Pots},
-    summary::{
-        AccountState, PoolState, SafeRatio, safe_ratio, serde::serialize_map, serialize_safe_ratio,
-        stake_distribution::StakeDistribution,
-    },
+    summary::{AccountState, PoolState, SafeRatio, safe_ratio, stake_distribution::StakeDistribution},
 };
 
 const EVENT_TARGET: &str = "amaru::ledger::state::rewards";
@@ -310,20 +307,10 @@ pub struct RewardsSummary {
     /// following epoch.
     epoch: Epoch,
 
-    /// The ratio of total blocks produced in the epoch, over the expected number of blocks
-    /// (determined by protocol parameters).
-    efficiency: SafeRatio,
-
     /// The amount of Ada taken out of the reserves as incentivies at this particular epoch
     /// (a.k.a ΔR1).
     /// It is so-to-speak, the monetary inflation of the network that fuels the incentives.
     incentives: Lovelace,
-
-    /// Total amount of rewards available before the treasury tax.
-    /// In particular, we have:
-    ///
-    ///   total_rewards = treasury_tax + available_rewards
-    total_rewards: Lovelace,
 
     /// Portion of the rewards going to the treasury (irrespective of unallocated pool rewards).
     treasury_tax: Lovelace,
@@ -338,26 +325,8 @@ pub struct RewardsSummary {
     /// Various protocol money pots pertaining to the epoch at the beginning of the rewards calculation.
     pots: Pots,
 
-    /// Per-pool rewards determined from their (apparent) performances, available rewards and
-    /// relative stake.
-    pools: BTreeMap<PoolId, PoolRewards>,
-
     /// Per-account rewards, determined from their relative stake and their delegatee.
     accounts: BTreeMap<StakeCredential, Lovelace>,
-}
-
-impl serde::Serialize for RewardsSummary {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut s = serializer.serialize_struct("RewardsSummary", 7)?;
-        s.serialize_field("epoch", &self.epoch)?;
-        s.serialize_field("efficiency", &serialize_safe_ratio(&self.efficiency))?;
-        s.serialize_field("incentives", &self.incentives)?;
-        s.serialize_field("total_rewards", &self.total_rewards)?;
-        s.serialize_field("treasury_tax", &self.treasury_tax)?;
-        s.serialize_field("available_rewards", &self.available_rewards)?;
-        serialize_map("pools", &mut s, &self.pools, |id| hex::encode(id))?;
-        s.end()
-    }
 }
 
 impl RewardsSummary {
@@ -458,14 +427,11 @@ impl RewardsSummary {
 
         Ok(RewardsSummary {
             epoch: stake_distribution.epoch,
-            efficiency,
             incentives,
-            total_rewards,
             treasury_tax,
             available_rewards,
             effective_rewards,
             pots,
-            pools,
             accounts,
         })
     }

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -121,9 +121,9 @@ use tracing::info;
 
 use crate::{
     epoch_transition::{Computed, PoolsEpochTransitionUpdates, Rewards},
-    store::{Snapshot, StoreError},
+    store::{Snapshot, StoreError, columns::pots::Row as Pots},
     summary::{
-        AccountState, PoolState, Pots, SafeRatio, safe_ratio, serde::serialize_map, serialize_safe_ratio,
+        AccountState, PoolState, SafeRatio, safe_ratio, serde::serialize_map, serialize_safe_ratio,
         stake_distribution::StakeDistribution,
     },
 };
@@ -348,14 +348,13 @@ pub struct RewardsSummary {
 
 impl serde::Serialize for RewardsSummary {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut s = serializer.serialize_struct("RewardsSummary", 8)?;
+        let mut s = serializer.serialize_struct("RewardsSummary", 7)?;
         s.serialize_field("epoch", &self.epoch)?;
         s.serialize_field("efficiency", &serialize_safe_ratio(&self.efficiency))?;
         s.serialize_field("incentives", &self.incentives)?;
         s.serialize_field("total_rewards", &self.total_rewards)?;
         s.serialize_field("treasury_tax", &self.treasury_tax)?;
         s.serialize_field("available_rewards", &self.available_rewards)?;
-        s.serialize_field("pots", &self.pots)?;
         serialize_map("pools", &mut s, &self.pools, |id| hex::encode(id))?;
         s.end()
     }

--- a/crates/amaru-ledger/src/summary/stake_distribution.rs
+++ b/crates/amaru-ledger/src/summary/stake_distribution.rs
@@ -20,9 +20,9 @@ use tracing::info;
 
 use crate::{
     epoch_transition::PoolsEpochTransitionUpdates,
-    store::{Snapshot, StoreError},
+    store::{Snapshot, StoreError, columns::pots::Row as Pots},
     summary::{
-        AccountState, PoolState, Pots,
+        AccountState, PoolState,
         governance::{DRepState, GovernanceSummary},
         safe_ratio,
         serde::serialize_map,

--- a/crates/amaru-ledger/src/summary/stake_distribution.rs
+++ b/crates/amaru-ledger/src/summary/stake_distribution.rs
@@ -83,7 +83,7 @@ impl StakeDistribution {
 
         let stake_pool_deposit = db.protocol_parameters()?.stake_pool_deposit;
 
-        let mut refunds: BTreeMap<StakeCredential, Lovelace> = BTreeMap::new();
+        let mut pools_deregistration_refunds: BTreeMap<StakeCredential, Lovelace> = BTreeMap::new();
 
         let mut pools = db
             .iter_pools()?
@@ -98,7 +98,7 @@ impl StakeDistribution {
                     // FIXME: Store the deposit with the pool, and ensures the same deposit
                     // it returned back.
                     let reward_account = expect_stake_credential(&row.current_params.reward_account);
-                    refunds
+                    pools_deregistration_refunds
                         .entry(reward_account)
                         .and_modify(|refund| *refund += stake_pool_deposit)
                         .or_insert(stake_pool_deposit);
@@ -163,19 +163,15 @@ impl StakeDistribution {
             if let Some(drep) = &account.drep
                 && let Some(st) = dreps.get_mut(drep)
             {
-                let refund = refunds.get(credential).copied().unwrap_or_default();
-                let proposal_deposits = dreps_deposits.get(credential).copied().unwrap_or_default();
+                let deregistration_refunds = pools_deregistration_refunds.get(credential).copied().unwrap_or_default();
+                let proposal_deposits_and_withdrawals = dreps_deposits.get(credential).copied().unwrap_or_default();
 
-                // FIXME: DRep voting stake should also include:
-                //
-                // - successful withdrawals ratified at the beginning of the ratification epoch.
-                let voting_stake = account.balance + proposal_deposits + refund;
+                // NOTE: 'proposal_deposits' also include just-ratified withdrawals, if any.
+                let voting_stake = account.balance + proposal_deposits_and_withdrawals + deregistration_refunds;
                 dreps_voting_stake += &voting_stake;
                 st.voting_stake += &voting_stake;
             }
 
-            // NOTE: Delegation to *active* pools
-            //
             // Only accounts delegated to active pools counts towards the active stake.
             if let Some(pool_id) = account.pool
                 && let Some(pool) = pools.get_mut(&pool_id)

--- a/crates/amaru-ledger/src/summary/stake_distribution.rs
+++ b/crates/amaru-ledger/src/summary/stake_distribution.rs
@@ -77,7 +77,7 @@ impl StakeDistribution {
     /// Invariant: The given store is expected to be a snapshot taken at the end of an epoch.
     pub fn new(
         db: &impl Snapshot,
-        GovernanceSummary { mut dreps, deposits }: GovernanceSummary,
+        GovernanceSummary { mut dreps, pools_deposits, dreps_deposits }: GovernanceSummary,
     ) -> Result<Self, StoreError> {
         let epoch = db.epoch();
 
@@ -159,53 +159,19 @@ impl StakeDistribution {
         let mut dreps_voting_stake: Lovelace = 0;
 
         for (credential, account) in accounts.iter() {
-            let (drep_deposits, pool_deposits) = deposits
-                .get(credential)
-                .map(|proposals| {
-                    proposals.iter().fold((0, 0), |(drep_deposits, pool_deposits), proposal| {
-                        (
-                            drep_deposits + proposal.deposit,
-                            // NOTE: Pool voting stake distribution
-                            //
-                            // The pool distribution used for computing voting power is
-                            // determined BEFORE refunds or withdrawal are processed.
-                            //
-                            // So unlike the DRep voting stake, which already includes those,
-                            // we mustn't include the deposit as part of the pool voting stake
-                            // for the epoch that immediately follows the expiry.
-                            //
-                            // Note that the refund is eventually credited in the following
-                            // epoch so the deposit is effectively missing from the pools'
-                            // voting stake for an entire epoch.
-                            if epoch <= proposal.valid_until {
-                                pool_deposits + proposal.deposit
-                            } else {
-                                pool_deposits
-                            },
-                        )
-                    })
-                })
-                .unwrap_or((0, 0));
-
             // Only accounts delegated to active dreps counts towards the voting stake.
             if let Some(drep) = &account.drep
                 && let Some(st) = dreps.get_mut(drep)
             {
                 let refund = refunds.get(credential).copied().unwrap_or_default();
+                let proposal_deposits = dreps_deposits.get(credential).copied().unwrap_or_default();
 
                 // FIXME: DRep voting stake should also include:
                 //
-                // - refunds coming from *ratified* proposals, not only expired ones.
-                // - successful withdrawals ratified at the beginning of the ratification
-                //   epoch.
-                //
-                // The problem being that we cannot easily compute those from the current
-                // snapshot, since it requires either:
-                //
-                // - To replay ratification altogether.
-                // - Data from the future (i.e. the next snapshot).
-                dreps_voting_stake += account.balance + drep_deposits + refund;
-                st.voting_stake += account.balance + drep_deposits + refund;
+                // - successful withdrawals ratified at the beginning of the ratification epoch.
+                let voting_stake = account.balance + proposal_deposits + refund;
+                dreps_voting_stake += &voting_stake;
+                st.voting_stake += &voting_stake;
             }
 
             // NOTE: Delegation to *active* pools
@@ -214,6 +180,8 @@ impl StakeDistribution {
             if let Some(pool_id) = account.pool
                 && let Some(pool) = pools.get_mut(&pool_id)
             {
+                let proposal_deposits = pools_deposits.get(credential).copied().unwrap_or_default();
+
                 // NOTE: Pool voting stake distribution
                 //
                 // Governance deposits do not count towards the pools' stake. They are
@@ -222,7 +190,7 @@ impl StakeDistribution {
                 active_stake += &stake;
                 pool.stake += &stake;
 
-                let voting_stake = stake + pool_deposits;
+                let voting_stake = stake + proposal_deposits;
                 pool.voting_stake += &voting_stake;
                 pools_voting_stake += &voting_stake;
             }

--- a/crates/amaru-ledger/src/summary/stake_distribution.rs
+++ b/crates/amaru-ledger/src/summary/stake_distribution.rs
@@ -131,9 +131,12 @@ impl StakeDistribution {
                             let PoolState { registered_at, .. } = pools.get(&pool)?;
                             if &since >= registered_at { Some(pool) } else { None }
                         }),
-                        drep: row.drep.and_then(|(drep, _)| match drep {
+                        drep: row.drep.and_then(|(drep, since)| match drep {
                             DRep::Abstain | DRep::NoConfidence => Some(drep),
-                            DRep::Key { .. } | DRep::Script { .. } => dreps.contains_key(&drep).then_some(drep),
+                            DRep::Key { .. } | DRep::Script { .. } => {
+                                let DRepState { registered_at, .. } = dreps.get(&drep)?;
+                                if &since >= registered_at { Some(drep) } else { None }
+                            }
                         }),
                     },
                 )

--- a/crates/amaru-ledger/tests/state_rollback.rs
+++ b/crates/amaru-ledger/tests/state_rollback.rs
@@ -204,7 +204,7 @@ impl ReadStore for MockStore {
         Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
     }
 
-    fn pots(&self) -> amaru_ledger::store::Result<amaru_ledger::summary::Pots> {
+    fn pots(&self) -> amaru_ledger::store::Result<amaru_ledger::store::columns::pots::Row> {
         Err(StoreError::Internal(anyhow::anyhow!("mock").into()))
     }
 

--- a/crates/amaru-ledger/tests/state_rollback.rs
+++ b/crates/amaru-ledger/tests/state_rollback.rs
@@ -272,6 +272,13 @@ impl ReadStore for MockStore {
         Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
     }
 
+    fn iter_recently_pruned_proposals(
+        &self,
+    ) -> amaru_ledger::store::Result<impl Iterator<Item = amaru_ledger::store::columns::recently_pruned_proposals::Key>>
+    {
+        Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
     fn iter_cc_members(
         &self,
     ) -> amaru_ledger::store::Result<

--- a/crates/amaru-ledger/tests/state_rollback.rs
+++ b/crates/amaru-ledger/tests/state_rollback.rs
@@ -274,8 +274,14 @@ impl ReadStore for MockStore {
 
     fn iter_recently_pruned_proposals(
         &self,
-    ) -> amaru_ledger::store::Result<impl Iterator<Item = amaru_ledger::store::columns::recently_pruned_proposals::Key>>
-    {
+    ) -> amaru_ledger::store::Result<
+        impl Iterator<
+            Item = (
+                amaru_ledger::store::columns::recently_pruned_proposals::Key,
+                amaru_ledger::store::columns::recently_pruned_proposals::Value,
+            ),
+        >,
+    > {
         Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
     }
 

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -159,8 +159,8 @@ define_schemas! {
 
             /// Compute rewards for epoch
             public COMPUTE_REWARDS {
-                required current_epoch: u64
-                optional stake_distribution_epoch: u64
+                required for_epoch: u64
+                optional using_stake_distribution_from: u64
             }
 
             /// Forward ledger state with new volatile state
@@ -180,6 +180,8 @@ define_schemas! {
             public EPOCH_TRANSITION {
                 required from: u64
                 required into: u64
+                optional skipped: bool,
+                optional resuming_from: String,
             }
 
             /// Perform end-of-epoch epoch boundary computations
@@ -415,6 +417,7 @@ define_schemas! {
             /// Prune old snapshots
             public PRUNE {
                 required functional_minimum: u64
+                required desired_minimum: u64
                 required db_system_name: String
                 required db_operation_name: String
             }

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -229,6 +229,10 @@ define_schemas! {
                 optional reserves_delta: i64
             }
 
+            /// Pruned proposals at an epoch boundary, recorded to facilitate future stake
+            /// distribution calculations.
+            public RECORD_PRUNED_PROPOSALS {}
+
             /// Pay withdrawals to accounts, or refund deposits
             public PAY_OR_REFUND_ACCOUNTS {
                 /// Total quantity of ADA paid, excluding treasury leftovers
@@ -559,6 +563,13 @@ define_schemas! {
 
                 /// Remove enacted or expired proposals
                 public PROPOSALS_REMOVE {
+                    required db_system_name: String
+                    required db_operation_name: String
+                    required db_collection_name: String
+                }
+
+                /// Inserting recently pruned proposals
+                public RECENTLY_PRUNED_PROPOSALS_REPLACE_ALL {
                     required db_system_name: String
                     required db_operation_name: String
                     required db_collection_name: String

--- a/crates/amaru-stores/src/lib.rs
+++ b/crates/amaru-stores/src/lib.rs
@@ -484,7 +484,7 @@ pub mod tests {
         let context = store.create_transaction();
 
         let from = None;
-        let to = Some(EpochTransitionProgress::EpochStarted);
+        let to = Some(EpochTransitionProgress::SnapshotTaken);
 
         let success = context.try_epoch_transition(from, to)?;
         assert!(success, "Expected epoch transition to succeed when previous state matches");

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/proposals.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/proposals.rs
@@ -69,7 +69,7 @@ pub fn add<DB>(db: &Transaction<'_, DB>, rows: impl Iterator<Item = (Key, Value)
 }
 
 /// Remove an expired or enacted proposal.
-pub fn remove<'iter, DB, K>(db: &Transaction<'_, DB>, rows: impl Iterator<Item = K>) -> Result<(), StoreError>
+pub fn remove<'iter, DB, K>(db: &Transaction<'_, DB>, rows: impl Iterator<Item = &'iter K>) -> Result<(), StoreError>
 where
     K: Deref<Target = ProposalId> + 'iter,
 {

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/proposals.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/proposals.rs
@@ -28,7 +28,7 @@ use rocksdb::{DBPinnableSlice, Transaction};
 use crate::rocksdb::common::{PREFIX_LEN, as_key, as_value};
 
 /// Name prefixed used for storing Proposals entries. UTF-8 encoding for "prop"
-pub const PREFIX: [u8; PREFIX_LEN] = [0x70, 0x72, 0x6F, 0x70];
+pub const PREFIX: [u8; PREFIX_LEN] = *b"prop";
 
 /// Retrieve a single governance proposal.
 pub fn get<'a>(

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/recently_pruned_proposals.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/recently_pruned_proposals.rs
@@ -1,0 +1,57 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub use amaru_ledger::store::{
+    StoreError,
+    columns::proposals::{Key, Value},
+};
+use amaru_observability::debug_span;
+use rocksdb::Transaction;
+
+use crate::rocksdb::{
+    as_value,
+    common::{PREFIX_LEN, as_key},
+    with_prefix_iterator,
+};
+
+/// Name prefixed used for storing recently pruned proposals entries.
+pub const PREFIX: [u8; PREFIX_LEN] = *b"prup";
+
+pub const COLLECTION_NAME: &str = "recently_pruned_proposals";
+
+/// Replace all recently pruned proposals with a new set.
+pub fn replace_all<'iter, DB>(
+    db: &Transaction<'_, DB>,
+    rows: impl IntoIterator<Item = &'iter Key>,
+) -> Result<(), StoreError> {
+    debug_span!(
+        amaru_observability::amaru::stores::ledger::columns::RECENTLY_PRUNED_PROPOSALS_REPLACE_ALL,
+        db_system_name = "rocksdb".to_string(),
+        db_operation_name = "put".to_string(),
+        db_collection_name = COLLECTION_NAME.to_string()
+    )
+    .in_scope(|| {
+        with_prefix_iterator::<Key, Value, DB>(db, PREFIX, COLLECTION_NAME, |iterator| {
+            for (_, mut row) in iterator {
+                *row.borrow_mut() = None;
+            }
+        })?;
+
+        for key in rows {
+            db.put(as_key(&PREFIX, key), as_value(())).map_err(|err| StoreError::Internal(err.into()))?;
+        }
+
+        Ok(())
+    })
+}

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/recently_pruned_proposals.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/recently_pruned_proposals.rs
@@ -14,7 +14,7 @@
 
 pub use amaru_ledger::store::{
     StoreError,
-    columns::proposals::{Key, Value},
+    columns::recently_pruned_proposals::{Key, Value},
 };
 use amaru_observability::debug_span;
 use rocksdb::Transaction;
@@ -33,7 +33,7 @@ pub const COLLECTION_NAME: &str = "recently_pruned_proposals";
 /// Replace all recently pruned proposals with a new set.
 pub fn replace_all<'iter, DB>(
     db: &Transaction<'_, DB>,
-    rows: impl IntoIterator<Item = &'iter Key>,
+    rows: impl IntoIterator<Item = (&'iter Key, Value)>,
 ) -> Result<(), StoreError> {
     debug_span!(
         amaru_observability::amaru::stores::ledger::columns::RECENTLY_PRUNED_PROPOSALS_REPLACE_ALL,
@@ -48,8 +48,8 @@ pub fn replace_all<'iter, DB>(
             }
         })?;
 
-        for key in rows {
-            db.put(as_key(&PREFIX, key), as_value(())).map_err(|err| StoreError::Internal(err.into()))?;
+        for (key, value) in rows {
+            db.put(as_key(&PREFIX, key), as_value(value)).map_err(|err| StoreError::Internal(err.into()))?;
         }
 
         Ok(())

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -24,7 +24,8 @@ use ::rocksdb::{self, OptimisticTransactionDB, Options, SliceTransform, checkpoi
 use amaru_iter_borrow::{self, IterBorrow, borrowable_proxy::BorrowableProxy};
 use amaru_kernel::{
     CertificatePointer, ComparableProposalId, Constitution, ConstitutionalCommitteeStatus, Epoch, EraHistory, Lovelace,
-    MemoizedTransactionOutput, Point, PoolId, ProposalId, ProtocolParameters, StakeCredential, TransactionInput, cbor,
+    MemoizedTransactionOutput, Point, PoolId, ProposalId, ProtocolParameters, RatificationStatus, StakeCredential,
+    TransactionInput, cbor,
 };
 use amaru_ledger::{
     epoch_transition::GovernanceActivity,
@@ -548,13 +549,13 @@ macro_rules! impl_ReadStore_body {
             fn iter_recently_pruned_proposals(
                 &self,
             ) -> Result<
-                impl Iterator<Item = scolumns::recently_pruned_proposals::Key>,
+                impl Iterator<Item = (scolumns::recently_pruned_proposals::Key, scolumns::recently_pruned_proposals::Value)>,
                 StoreError,
             > {
-                Ok(iter(
+                iter(
                     |mode, opts| self.db.iterator_opt(mode, opts),
                     recently_pruned_proposals::PREFIX,
-                )?.map(|(key, ())| key))
+                )
             }
 
             fn iter_cc_members(
@@ -718,16 +719,17 @@ impl TransactionalContext<'_> for RocksDBTransactionalContext<'_> {
             .map_err(|err| StoreError::Internal(err.into()))?;
         Ok(())
     }
+
     fn set_recently_pruned_proposals<'iter>(
         &self,
-        proposals: impl IntoIterator<Item = &'iter ComparableProposalId>,
+        proposals: impl IntoIterator<Item = (&'iter ComparableProposalId, RatificationStatus)>,
     ) -> Result<(), StoreError> {
         recently_pruned_proposals::replace_all(&self.db, proposals)
     }
 
     /// Remove a list of proposals from the database. This is done when enacting proposals that
     /// cause other proposals to become obsolete.
-    fn remove_proposals<'iter, Id>(&self, proposals: impl IntoIterator<Item = Id>) -> Result<(), StoreError>
+    fn remove_proposals<'iter, Id>(&self, proposals: impl IntoIterator<Item = &'iter Id>) -> Result<(), StoreError>
     where
         Id: Deref<Target = ProposalId> + 'iter,
     {

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -173,15 +173,10 @@ impl RocksDB {
     pub fn snapshots(dir: &Path) -> Result<Vec<Epoch>, StoreError> {
         let mut snapshots: Vec<Epoch> = Vec::new();
 
-        for entry in fs::read_dir(dir).map_err(|err| StoreError::Open(OpenErrorKind::io_with_file(dir, err)))?.by_ref()
-        {
-            let entry = entry.map_err(|err| StoreError::Open(OpenErrorKind::io_with_file(dir, err)))?;
-            if let Ok(epoch) = entry.file_name().to_str().unwrap_or_default().parse::<Epoch>() {
-                snapshots.push(epoch);
-            } else if entry.file_name() != DIR_LIVE_DB {
-                warn!(filename = entry.file_name().to_str().unwrap_or_default(), "new.unexpected_file");
-            }
-        }
+        with_snapshots(dir, |_, epoch| {
+            snapshots.push(epoch);
+            Ok(())
+        })?;
 
         snapshots.sort();
 
@@ -331,14 +326,16 @@ impl RocksDBHistoricalStores {
 
 impl HistoricalStores for RocksDBHistoricalStores {
     fn prune(&self, functional_minimum: Epoch) -> Result<(), StoreError> {
+        let desired_minimum = functional_minimum.saturating_sub(self.max_extra_ledger_snapshots);
+
         info_span!(
             amaru::stores::ledger::PRUNE,
             functional_minimum = u64::from(functional_minimum),
+            desired_minimum = u64::from(desired_minimum),
             db_system_name = "rocksdb".to_string(),
             db_operation_name = "delete".to_string()
         )
         .in_scope(|| {
-            let desired_minimum = functional_minimum.saturating_sub(self.max_extra_ledger_snapshots);
             with_snapshots(&self.config.dir, |path, epoch| {
                 if epoch < desired_minimum {
                     fs::remove_dir_all(&path)
@@ -351,17 +348,9 @@ impl HistoricalStores for RocksDBHistoricalStores {
     }
 
     fn snapshots(&self) -> Result<Vec<Epoch>, StoreError> {
-        let mut snapshots: Vec<Epoch> = Vec::new();
-
-        with_snapshots(&self.config.dir, |_, epoch| {
-            snapshots.push(epoch);
-            Ok(())
-        })?;
-
-        snapshots.sort();
-
-        Ok(snapshots)
+        RocksDB::snapshots(&self.config.dir)
     }
+
     fn for_epoch(&self, epoch: Epoch) -> Result<impl Snapshot, StoreError> {
         RocksDBHistoricalStores::for_epoch_with(&self.config, epoch)
     }

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -32,9 +32,8 @@ use amaru_ledger::{
     state::diff_bind::Resettable,
     store::{
         Columns, EpochTransitionProgress, HistoricalStores, OpenErrorKind, ReadStore, Snapshot, Store, StoreError,
-        TransactionalContext, columns as scolumns,
+        TransactionalContext, columns as scolumns, columns::pots::Row as Pots,
     },
-    summary::Pots,
 };
 use amaru_observability::{info_span, trace_record, trace_span};
 use anyhow::anyhow;
@@ -491,7 +490,7 @@ macro_rules! impl_ReadStore_body {
             }
 
             fn pots(&self) -> Result<Pots, StoreError> {
-                pots::get(|key| self.db.get_pinned(key)).map(|row| Pots::from(&row))
+                pots::get(|key| self.db.get_pinned(key))
             }
 
             fn iter_accounts(

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -545,6 +545,18 @@ macro_rules! impl_ReadStore_body {
                 )
             }
 
+            fn iter_recently_pruned_proposals(
+                &self,
+            ) -> Result<
+                impl Iterator<Item = scolumns::recently_pruned_proposals::Key>,
+                StoreError,
+            > {
+                Ok(iter(
+                    |mode, opts| self.db.iterator_opt(mode, opts),
+                    recently_pruned_proposals::PREFIX,
+                )?.map(|(key, ())| key))
+            }
+
             fn iter_cc_members(
                 &self,
             ) -> Result<
@@ -705,6 +717,12 @@ impl TransactionalContext<'_> for RocksDBTransactionalContext<'_> {
             .put(KEY_GOVERNANCE_ACTIVITY, as_value(governance_activity))
             .map_err(|err| StoreError::Internal(err.into()))?;
         Ok(())
+    }
+    fn set_recently_pruned_proposals<'iter>(
+        &self,
+        proposals: impl IntoIterator<Item = &'iter ComparableProposalId>,
+    ) -> Result<(), StoreError> {
+        recently_pruned_proposals::replace_all(&self.db, proposals)
     }
 
     /// Remove a list of proposals from the database. This is done when enacting proposals that

--- a/crates/amaru/build.rs
+++ b/crates/amaru/build.rs
@@ -57,17 +57,23 @@ fn write_stake_distribution_test_cases_file(network: &str) -> Result<(), Box<dyn
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
     let fixtures_root = manifest_dir.join("tests").join("stake-distributions");
     let network_dir = fixtures_root.join(network);
+    let ledger_dir = default_ledger_dir(&manifest_dir, network);
 
     println!("cargo:rerun-if-changed={}", fixtures_root.display());
     println!("cargo:rerun-if-changed={}", network_dir.display());
 
     let epochs = stake_distribution_epochs(&network_dir)?;
-    let contents = stake_distribution_test_cases_source(network, &epochs)?;
+    let available_epochs = available_ledger_snapshot_epochs(&manifest_dir, &ledger_dir)?;
+    let contents = stake_distribution_test_cases_source(network, &epochs, &available_epochs)?;
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
     write_if_changed(&out_dir.join("stake_distribution_test_cases.rs"), &contents)?;
 
     Ok(())
+}
+
+fn default_ledger_dir(manifest_dir: &Path, network: &str) -> PathBuf {
+    manifest_dir.join("../..").join(format!("ledger.{network}.db"))
 }
 
 fn stake_distribution_epochs(network_dir: &Path) -> Result<Vec<u64>, Box<dyn std::error::Error>> {
@@ -104,7 +110,47 @@ fn stake_distribution_epoch(path: &Path) -> Option<u64> {
     epoch.parse().ok()
 }
 
-fn stake_distribution_test_cases_source(network: &str, epochs: &[u64]) -> Result<String, Box<dyn std::error::Error>> {
+fn available_ledger_snapshot_epochs(
+    manifest_dir: &Path,
+    ledger_dir: &Path,
+) -> Result<BTreeSet<u64>, Box<dyn std::error::Error>> {
+    if !ledger_dir.is_dir() {
+        println!("cargo:rerun-if-changed={}", manifest_dir.join("../..").display());
+        return Ok(BTreeSet::new());
+    }
+
+    println!("cargo:rerun-if-changed={}", ledger_dir.display());
+
+    let mut epochs = BTreeSet::new();
+    for entry in fs::read_dir(ledger_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if !path.is_dir() {
+            continue;
+        }
+
+        if let Some(epoch) = ledger_snapshot_epoch(&path) {
+            epochs.insert(epoch);
+        }
+    }
+
+    Ok(epochs)
+}
+
+fn ledger_snapshot_epoch(path: &Path) -> Option<u64> {
+    path.file_name()?.to_str()?.parse().ok()
+}
+
+fn partition_fixture_epochs(epochs: &[u64], available_epochs: &BTreeSet<u64>) -> (Vec<u64>, Vec<u64>) {
+    epochs.iter().copied().partition(|epoch| available_epochs.contains(epoch))
+}
+
+fn stake_distribution_test_cases_source(
+    network: &str,
+    epochs: &[u64],
+    available_epochs: &BTreeSet<u64>,
+) -> Result<String, Box<dyn std::error::Error>> {
     if epochs.is_empty() {
         return Ok(format!(
             r#"// No stake distribution fixtures found for network={network}.
@@ -117,15 +163,58 @@ const _: fn(
     }
 
     let network_variant = network_name_to_rust_variant(network)?;
+    let (active_epochs, ignored_epochs) = partition_fixture_epochs(epochs, available_epochs);
+    let mut contents = String::new();
+
+    contents.push_str(&format!(
+        "// Generated from {} fixture epoch(s): {} active, {} ignored.\n",
+        epochs.len(),
+        active_epochs.len(),
+        ignored_epochs.len(),
+    ));
+
+    if !active_epochs.is_empty() {
+        contents.push_str(&render_stake_distribution_test_function(
+            network,
+            network_variant,
+            "compare",
+            &active_epochs,
+            false,
+        ));
+    }
+
+    if !ignored_epochs.is_empty() {
+        contents.push_str(&render_stake_distribution_test_function(
+            network,
+            network_variant,
+            "compare_missing_local_snapshot",
+            &ignored_epochs,
+            true,
+        ));
+    }
+
+    Ok(contents)
+}
+
+fn render_stake_distribution_test_function(
+    network: &str,
+    network_variant: &str,
+    prefix: &str,
+    epochs: &[u64],
+    ignored: bool,
+) -> String {
     let mut contents = String::new();
 
     for epoch in epochs {
         contents.push_str(&format!("#[test_case::test_case({epoch})]\n"));
     }
 
+    if ignored {
+        contents.push_str("#[ignore]\n");
+    }
+
     contents.push_str(&format!(
-        r#"#[ignore]
-pub fn compare_{network}_stake_distribution_with_haskell_node(epoch: u64) -> Result<(), Box<dyn std::error::Error>> {{
+        r#"pub fn {prefix}_{network}_stake_distribution_with_haskell_node(epoch: u64) -> Result<(), Box<dyn std::error::Error>> {{
     compare_stake_distribution_with_haskell_node(
         amaru_kernel::NetworkName::{network_variant},
         amaru_kernel::Epoch::from(epoch),
@@ -134,7 +223,7 @@ pub fn compare_{network}_stake_distribution_with_haskell_node(epoch: u64) -> Res
 "#
     ));
 
-    Ok(contents)
+    contents
 }
 
 fn network_name_to_rust_variant(network: &str) -> Result<&'static str, Box<dyn std::error::Error>> {

--- a/crates/amaru/build.rs
+++ b/crates/amaru/build.rs
@@ -59,11 +59,10 @@ fn write_stake_distribution_test_cases_file(network: &str) -> Result<(), Box<dyn
     let network_dir = fixtures_root.join(network);
     let ledger_dir = default_ledger_dir(&manifest_dir, network);
 
-    println!("cargo:rerun-if-changed={}", fixtures_root.display());
     println!("cargo:rerun-if-changed={}", network_dir.display());
 
     let epochs = stake_distribution_epochs(&network_dir)?;
-    let available_epochs = available_ledger_snapshot_epochs(&manifest_dir, &ledger_dir)?;
+    let available_epochs = available_ledger_snapshot_epochs(&ledger_dir)?;
     let contents = stake_distribution_test_cases_source(network, &epochs, &available_epochs)?;
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
@@ -92,7 +91,6 @@ fn stake_distribution_epochs(network_dir: &Path) -> Result<Vec<u64>, Box<dyn std
         }
 
         if let Some(epoch) = stake_distribution_epoch(&path) {
-            println!("cargo:rerun-if-changed={}", path.display());
             epochs.insert(epoch);
         }
     }
@@ -110,16 +108,12 @@ fn stake_distribution_epoch(path: &Path) -> Option<u64> {
     epoch.parse().ok()
 }
 
-fn available_ledger_snapshot_epochs(
-    manifest_dir: &Path,
-    ledger_dir: &Path,
-) -> Result<BTreeSet<u64>, Box<dyn std::error::Error>> {
+fn available_ledger_snapshot_epochs(ledger_dir: &Path) -> Result<BTreeSet<u64>, Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed={}", ledger_dir.display());
+
     if !ledger_dir.is_dir() {
-        println!("cargo:rerun-if-changed={}", manifest_dir.join("../..").display());
         return Ok(BTreeSet::new());
     }
-
-    println!("cargo:rerun-if-changed={}", ledger_dir.display());
 
     let mut epochs = BTreeSet::new();
     for entry in fs::read_dir(ledger_dir)? {

--- a/crates/amaru/src/cardano_node/tvar.rs
+++ b/crates/amaru/src/cardano_node/tvar.rs
@@ -85,7 +85,7 @@ fn read_state_snapshot(file: &mut std::fs::File) -> Result<Vec<u8>, Box<dyn std:
 fn default_utxo_size(network: NetworkName) -> usize {
     match network {
         NetworkName::Mainnet => 11_000_000,
-        NetworkName::Preview => 1_500_000,
+        NetworkName::Preview => 3_000_000,
         NetworkName::Preprod => 4_000_000,
         NetworkName::Testnet(..) => 1,
     }

--- a/crates/amaru/tests/stake-distributions/haskell-node-extractor/src/Query/StakeDistribution.hs
+++ b/crates/amaru/tests/stake-distributions/haskell-node-extractor/src/Query/StakeDistribution.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Query.StakeDistribution
     ( queryStakeDistribution
@@ -24,7 +26,7 @@ import Cardano.Ledger.BaseTypes
     , NonZero (unNonZero)
     )
 import Cardano.Ledger.Shelley.LedgerState
-    ( NewEpochState
+    ( NewEpochState (..)
     , applyRUpd
     , completeRupd
     , esLStateL
@@ -41,6 +43,7 @@ import Cardano.Ledger.State
         ( accountsMapL
         )
     , EraCertState (certDStateL)
+    , EraGov
     , EraStake (instantStakeCredentialsL)
     )
 import Data.Coin
@@ -79,7 +82,7 @@ queryStakeDistribution
     -> NewEpochState ConwayEra
     -> NewEpochState ConwayEra
     -> StakeDistribution
-queryStakeDistribution network epochNumber targetEpochState nextEpochState =
+queryStakeDistribution network epochNumber (withRewards -> targetEpochState) nextEpochState =
     StakeDistribution
         { epoch = epochNumber
         , treasury = JsonCoin treasury
@@ -117,28 +120,28 @@ queryStakeDistribution network epochNumber targetEpochState nextEpochState =
         queryDRepStakeDistr nextEpochState Set.empty
 
     accountSummaries =
-        Map.mapWithKey (mkAccountSummary instantStake dRepDelegatees) accountsMap
+        Map.mapWithKey
+            (mkAccountSummary instantStake dRepDelegatees)
+            (targetEpochState ^. nesEsL . esLStateL . lsCertStateL . certDStateL . accountsL . accountsMapL)
+      where
+        instantStake =
+            targetEpochState ^. instantStakeL . instantStakeCredentialsL
 
-    accountsMap =
-        epochStateForAccounts ^. esLStateL . lsCertStateL . certDStateL . accountsL . accountsMapL
+        dRepDelegatees =
+            Map.fromList
+                [ (credential, drep)
+                | (drep, delegators) <- Map.toAscList (queryDRepDelegations targetEpochState Set.empty)
+                , credential <- Set.toAscList delegators
+                ]
 
-    instantStake =
-        targetEpochState ^. instantStakeL . instantStakeCredentialsL
-
-    dRepDelegatees =
-        Map.fromList
-            [ (credential, drep)
-            | (drep, delegators) <- Map.toAscList (queryDRepDelegations targetEpochState Set.empty)
-            , credential <- Set.toAscList delegators
-            ]
-
-    epochStateForAccounts =
-        case nesRu targetEpochState of
-            SNothing ->
-                targetEpochState ^. nesEsL
-            SJust pulsingRewardUpdate ->
-                applyRUpd (completeRewardUpdate pulsingRewardUpdate) (targetEpochState ^. nesEsL)
-
+withRewards :: (EraGov era, EraCertState era) => NewEpochState era -> NewEpochState era
+withRewards st =
+    case nesRu st of
+        SNothing ->
+            st
+        SJust pulsingRewardUpdate ->
+            st { nesEs = applyRUpd (completeRewardUpdate pulsingRewardUpdate) (st ^. nesEsL) }
+  where
     completeRewardUpdate pulsingRewardUpdate =
         fst $
             runIdentity $

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -188,11 +188,12 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | `applying_overlay` | `TRACE` | public | Flushing the epoch transition overlay to disk | epoch | should_end_epoch, should_snapshot, should_begin_epoch |
 | `begin_epoch` | `TRACE` | public | Perform start-of-epoch epoch boundary computations |  |  |
 | `end_epoch` | `TRACE` | public | Perform end-of-epoch epoch boundary computations |  |  |
-| `epoch_transition` | `TRACE` | public | Epoch transition processing | from, into |  |
+| `epoch_transition` | `TRACE` | public | Epoch transition processing | from, into | skipped, resuming_from |
 | `new_governance_updates` | `TRACE` | public | Create governance updates (i.e. ratify proposals) at an epoch boundary. | proposals_count |  |
 | `new_pools_updates` | `TRACE` | public | Create pools updates |  |  |
 | `pay_or_refund_accounts` | `TRACE` | public | Pay withdrawals to accounts, or refund deposits | total_paid_or_refunded, treasury_leftovers |  |
 | `pay_rewards` | `TRACE` | public | Pay rewards to all accounts before the epoch end | accounts_paid, rewards_paid, treasury_delta, reserves_delta |  |
+| `record_pruned_proposals` | `TRACE` | public | Pruned proposals at an epoch boundary, recorded to facilitate future stake distribution calculations. |  |  |
 | `reset_blocks_count` | `TRACE` | public | Reset blocks count to zero |  |  |
 | `reset_fees` | `TRACE` | public | Reset fees to zero |  |  |
 | `update_constitutional_committee` | `TRACE` | public | Add or remove CC members; or switch to a no-confidence state | no_confidence |  |
@@ -215,6 +216,8 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | --- | --- | --- |
 | `from` | `integer` | ✓ |
 | `into` | `integer` | ✓ |
+| `skipped` | `boolean` |  |
+| `resuming_from` | `string` |  |
 
 </details>
 
@@ -325,7 +328,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | --- | --- | --- | --- | --- | --- |
 | `aggregate` | `TRACE` | public | Recompute the volatile aggregate used for fast lookups |  |  |
 | `apply_block` | `TRACE` | public | Apply a block to stable state | point_slot |  |
-| `compute_rewards` | `TRACE` | public | Compute rewards for epoch | current_epoch | stake_distribution_epoch |
+| `compute_rewards` | `TRACE` | public | Compute rewards for epoch | for_epoch | using_stake_distribution_from |
 | `compute_stake_distribution` | `TRACE` | public | Compute stake distribution for epoch | epoch |  |
 | `create_block_validation_context` | `TRACE` | public | Create validation context for a block | block_body_hash, block_number, block_body_size |  |
 | `create_transaction_validation_context` | `TRACE` | public | Create validation context for a block | transaction_id |  |
@@ -353,8 +356,8 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | field | type | required |
 | --- | --- | --- |
-| `current_epoch` | `integer` | ✓ |
-| `stake_distribution_epoch` | `integer` |  |
+| `for_epoch` | `integer` | ✓ |
+| `using_stake_distribution_from` | `integer` |  |
 
 </details>
 
@@ -644,7 +647,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `prune` | `TRACE` | public | Prune old snapshots | functional_minimum, db_system_name, db_operation_name |  |
+| `prune` | `TRACE` | public | Prune old snapshots | functional_minimum, desired_minimum, db_system_name, db_operation_name |  |
 | `snapshot` | `TRACE` | public | Create ledger snapshot for epoch | epoch, db_system_name, db_operation_name |  |
 | `try_epoch_transition` | `TRACE` | public | Epoch transition tracking | from, to, db_system_name, db_operation_name |  |
 
@@ -653,6 +656,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | field | type | required |
 | --- | --- | --- |
 | `functional_minimum` | `integer` | ✓ |
+| `desired_minimum` | `integer` | ✓ |
 | `db_system_name` | `string` | ✓ |
 | `db_operation_name` | `string` | ✓ |
 
@@ -703,6 +707,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | `proposals_add` | `TRACE` | public | Insert governance proposals | db_system_name, db_operation_name, db_collection_name |  |
 | `proposals_get` | `TRACE` | public | Point-read a governance proposal | db_system_name, db_operation_name, db_collection_name |  |
 | `proposals_remove` | `TRACE` | public | Remove enacted or expired proposals | db_system_name, db_operation_name, db_collection_name |  |
+| `recently_pruned_proposals_replace_all` | `TRACE` | public | Inserting recently pruned proposals | db_system_name, db_operation_name, db_collection_name |  |
 | `slots_get` | `TRACE` | public | Point-read a slot/block-issuer entry | db_system_name, db_operation_name, db_collection_name |  |
 | `slots_put` | `TRACE` | public | Write a slot/block-issuer entry | db_system_name, db_operation_name, db_collection_name |  |
 | `utxo_add` | `TRACE` | public | Batch-insert UTxO entries | db_system_name, db_operation_name, db_collection_name |  |
@@ -904,6 +909,16 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 </details>
 
 <details><summary>span: `proposals_remove`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `db_system_name` | `string` | ✓ |
+| `db_operation_name` | `string` | ✓ |
+| `db_collection_name` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `recently_pruned_proposals_replace_all`</summary>
 
 | field | type | required |
 | --- | --- | --- |

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -445,13 +445,22 @@
         },
         "into": {
           "type": "integer"
+        },
+        "skipped": {
+          "type": "boolean"
+        },
+        "resuming_from": {
+          "type": "string"
         }
       },
       "required": [
         "from",
         "into"
       ],
-      "optional": [],
+      "optional": [
+        "skipped",
+        "resuming_from"
+      ],
       "additionalProperties": false,
       "name": "epoch_transition",
       "level": "TRACE",
@@ -539,6 +548,18 @@
       "level": "TRACE",
       "target": "amaru::ledger::epoch_transition",
       "description": "Pay rewards to all accounts before the epoch end",
+      "public": true
+    },
+    "amaru::ledger::epoch_transition::RECORD_PRUNED_PROPOSALS": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "record_pruned_proposals",
+      "level": "TRACE",
+      "target": "amaru::ledger::epoch_transition",
+      "description": "Pruned proposals at an epoch boundary, recorded to facilitate future stake distribution calculations.",
       "public": true
     },
     "amaru::ledger::epoch_transition::RESET_BLOCKS_COUNT": {
@@ -774,18 +795,18 @@
     "amaru::ledger::state::COMPUTE_REWARDS": {
       "type": "object",
       "properties": {
-        "current_epoch": {
+        "for_epoch": {
           "type": "integer"
         },
-        "stake_distribution_epoch": {
+        "using_stake_distribution_from": {
           "type": "integer"
         }
       },
       "required": [
-        "current_epoch"
+        "for_epoch"
       ],
       "optional": [
-        "stake_distribution_epoch"
+        "using_stake_distribution_from"
       ],
       "additionalProperties": false,
       "name": "compute_rewards",
@@ -1476,6 +1497,9 @@
         "functional_minimum": {
           "type": "integer"
         },
+        "desired_minimum": {
+          "type": "integer"
+        },
         "db_system_name": {
           "type": "string"
         },
@@ -1485,6 +1509,7 @@
       },
       "required": [
         "functional_minimum",
+        "desired_minimum",
         "db_system_name",
         "db_operation_name"
       ],
@@ -2083,6 +2108,32 @@
       "level": "TRACE",
       "target": "amaru::stores::ledger::columns",
       "description": "Remove enacted or expired proposals",
+      "public": true
+    },
+    "amaru::stores::ledger::columns::RECENTLY_PRUNED_PROPOSALS_REPLACE_ALL": {
+      "type": "object",
+      "properties": {
+        "db_system_name": {
+          "type": "string"
+        },
+        "db_operation_name": {
+          "type": "string"
+        },
+        "db_collection_name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "db_system_name",
+        "db_operation_name",
+        "db_collection_name"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "recently_pruned_proposals_replace_all",
+      "level": "TRACE",
+      "target": "amaru::stores::ledger::columns",
+      "description": "Inserting recently pruned proposals",
       "public": true
     },
     "amaru::stores::ledger::columns::SLOTS_GET": {

--- a/scripts/check-changelog
+++ b/scripts/check-changelog
@@ -149,9 +149,32 @@ def next_thursday(today: date) -> date:
     return today + timedelta(days=days)
 
 
+def upcoming_thursday(today: date) -> date:
+    return today + timedelta(days=(3 - today.weekday()) % 7)
+
+
 def release_version(version_major_minor: tuple[str, str], release_day: date) -> str:
     major, minor = version_major_minor
     return f"v{major}.{minor}.{release_day.strftime('%Y%m%d')}"
+
+
+def expected_release_day(
+    today: date,
+    version_major_minor: tuple[str, str],
+    blocks: list[ReleaseBlock],
+) -> date:
+    release_day = upcoming_thursday(today)
+
+    if today.weekday() != 3:
+        return release_day
+
+    current_version = release_version(version_major_minor, release_day)
+    current_block = find_release(blocks, current_version)
+
+    if current_block is not None and current_block.released:
+        return next_thursday(today)
+
+    return release_day
 
 
 def parse_amaru_version(manifest_path: Path) -> tuple[str, str]:
@@ -489,7 +512,7 @@ def validate_release_order(
     if blocks[0].version != expected_version:
         message = (
             f"Latest changelog entry must be {expected_version}; found {blocks[0].version}. "
-            f"Add or update the top release header for the next Thursday release."
+            f"Add or update the top release header for the upcoming release."
         )
         record_failure(failures, message, line=blocks[0].line_number, title="Wrong top release")
 
@@ -669,11 +692,11 @@ def validate_changelog_contents(
     server_url = context.server_url
 
     today = date.today()
-    expected_day = next_thursday(today)
-    expected_version = release_version(parse_amaru_version(manifest_path), expected_day)
-
     lines = changelog_path.read_text().splitlines()
     blocks = parse_release_headers(lines)
+    version_major_minor = parse_amaru_version(manifest_path)
+    expected_day = expected_release_day(today, version_major_minor, blocks)
+    expected_version = release_version(version_major_minor, expected_day)
 
     failures: list[Failure] = []
     validate_references(lines, failures)

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -2,6 +2,23 @@
 
 set -e
 
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+echo "Running changelog checks..."
+
+if "$REPO_ROOT/scripts/check-changelog" 2>&1; then
+    echo ""
+else
+    echo "Discovered a changelog issue"
+    echo ""
+    echo "Please fix the changelog issues before committing."
+    echo "You can run './scripts/check-changelog' to see the full output."
+    echo ""
+    echo "To bypass this check (not recommended), use:"
+    echo "  git commit --no-verify"
+    exit 1
+fi
+
 echo "Running clippy..."
 
 if cargo clippy-amaru 2>&1; then


### PR DESCRIPTION
This now passes all epoch conformance tests on Preview between epoch 999 and 1100. I'll add more on Preview and also cover Preprod and Mainnet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated treasury donation tracking in the ledger, persisted through snapshot/bootstrap and stored pots.
  * Added ratification-status support for governance proposals and exposed recently-pruned proposal visibility (including status).

* **Bug Fixes**
  * Improved epoch transition/rewards and stake-distribution accounting near boundaries and across restarts, including treasury-withdrawal and delegation eligibility behavior.
  * Enhanced governance pruning/ratification bookkeeping and corrected pool retirement timing near epoch end.
  * Made pruning behavior more conservative during low-density operation periods.

* **Documentation**
  * Updated the unreleased changelog entry (and added the missing reference link).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->