### PR TITLE
fix: properly import pool without metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Other guiding principles:
 
 - **amaru**: more robust procedure and tooling to produce stake-distribution epoch snapshots for conformance testing and comparison with the haskell node. ([#985][])
 
+- **amaru**: fix snapshot import of pool with no metadata. ([#1013][])
+
 ## [v10.10.20260702](https://github.com/pragma-org/amaru/releases/tag/v10.10.20260702)
 
 ### Added
@@ -114,3 +116,4 @@ Other guiding principles:
 [#985]: https://github.com/pragma-org/amaru/pull/985
 [#988]: https://github.com/pragma-org/amaru/pull/988
 [#1000]: https://github.com/pragma-org/amaru/pull/1000
+[#1013]: https://github.com/pragma-org/amaru/pull/1013

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -1229,6 +1229,10 @@ impl<'b> cbor::decode::Decode<'b, NetworkName> for NodePoolUpdateMetadata {
     #[allow(clippy::wildcard_enum_match_arm)]
     fn decode(d: &mut cbor::Decoder<'b>, ctx: &mut NetworkName) -> Result<Self, cbor::decode::Error> {
         match d.datatype()? {
+            cbor::data::Type::Null => {
+                d.skip()?;
+                Ok(Self(StrictMaybe::Nothing))
+            }
             cbor::data::Type::Array | cbor::data::Type::ArrayIndef => {
                 let mut probe = d.probe();
                 let len = probe.array()?;


### PR DESCRIPTION
Fix an issue when importing snapshot for epoch 267.

With an amaru modified to load local snapshots:

```shell
> AMARU_NETWORK=preprod AMARU_EPOCH=267 make create-snapshots ARGS=--force

> AMARU_NETWORK=preprod AMARU_EPOCH=270 make bootstrap ARGS=--force

...
2026-07-07T13:26:29.902085Z  INFO amaru::bootstrap: Imported node snapshot directory epoch=267 snapshot=/Users/julien/Documents/Projects/pragma-org/amaru/snapshots/preprod/114134379.5d6df52f0f67f7e33a3165739f8dfbd81eb8ac2c9eb815125e821345735abc10
2026-07-07T13:26:29.906775Z  INFO amaru::bootstrap: Importing node snapshot directory snapshot=/Users/julien/Documents/Projects/pragma-org/amaru/snapshots/preprod/114566354.d4c4fe7cb5329d8446b7e69162c4ce377cae99fa13f523b5451f86bc5d3ba244
2026-07-07T13:26:29.936850Z  INFO amaru::cardano_node::tvar: importing state snapshot with external utxo source point=114566354.d4c4fe7cb5329d8446b7e69162c4ce377cae99fa13f523b5451f86bc5d3ba244 new_epoch_state_offset=262
2026-07-07T13:26:29.937750Z  INFO amaru_ledger::bootstrap: governance activity dormant_epochs=15
Error: "decode pool state: decode error: node pool updates value at entry 0 offset 944221: decode error: node pool update metadata: unexpected type null"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when reading ledger metadata by correctly handling `null` values during decoding.
  * Records and pool snapshot imports with missing update metadata now load successfully instead of failing with a type-mismatch error.
* **Documentation**
  * Updated the unreleased changelog entry to reflect the pool snapshot import fix when no metadata is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->