### PR TITLE
fix: reduce rationale number before serializing them to JSON in epoch summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ Other guiding principles:
   ```
 -->
 
-
 ## v10.10.20260716 _[unreleased; planned for 2026-07-16]_
 
 ### Added
@@ -46,6 +45,7 @@ Other guiding principles:
 ### Fixed
 
 - **amaru-consensus**: use slot height instead of block height for block forecast, to allow coping better with low density chains (fixes the regression in syncing time on Preview/PreProd). ([#1027][])
+- **amaru-ledger**: reduce rationale number before serializing them to JSON in epoch summary. ([#1024][])
 
 ## [v10.10.20260709](https://github.com/pragma-org/amaru/releases/tag/v10.10.20260709)
 
@@ -156,4 +156,5 @@ Other guiding principles:
 [#1000]: https://github.com/pragma-org/amaru/pull/1000
 [#1010]: https://github.com/pragma-org/amaru/pull/1010
 [#1013]: https://github.com/pragma-org/amaru/pull/1013
+[#1024]: https://github.com/pragma-org/amaru/pull/1024
 [#1027]: https://github.com/pragma-org/amaru/pull/1027

--- a/crates/amaru-ledger/src/summary/mod.rs
+++ b/crates/amaru-ledger/src/summary/mod.rs
@@ -79,9 +79,12 @@ impl ::serde::Serialize for PoolState {
     fn serialize<S: ::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut s = serializer.serialize_struct("PoolState", 10)?;
 
+        // Force reduction of the numerator and denominator
+        let r = Ratio::new(self.parameters.margin.numerator, self.parameters.margin.denominator);
+
         s.serialize_field("blocks_count", &self.blocks_count)?;
         s.serialize_field("cost", &self.parameters.cost)?;
-        s.serialize_field("margin", &[self.parameters.margin.numerator, self.parameters.margin.denominator])?;
+        s.serialize_field("margin", &[r.numer(), r.denom()])?;
         s.serialize_field(
             "metadata",
             &pool_metadata::as_option_ref(&self.parameters.metadata).map(pool_metadata::AsJson),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed epoch summary JSON output to serialize the margin as a normalized, reduced fraction rather than an unreduced numerator/denominator.
* **Documentation**
  * Updated the changelog with a new unreleased entry describing the fix for margin serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->