### PR TITLE
fix: use slot height instead of block height for block forecast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Other guiding principles:
 
 ## v10.10.20260716 _[unreleased; planned for 2026-07-16]_
 
+### Fixed
+
+- **amaru-consensus**: use slot height instead of block height for block forecast, to allow coping better with low density chains (fixes the regression in syncing time on Preview/PreProd). ([#1027][])
+
 ## [v10.10.20260709](https://github.com/pragma-org/amaru/releases/tag/v10.10.20260709)
 
 ### Added
@@ -144,3 +148,4 @@ Other guiding principles:
 [#1000]: https://github.com/pragma-org/amaru/pull/1000
 [#1010]: https://github.com/pragma-org/amaru/pull/1010
 [#1013]: https://github.com/pragma-org/amaru/pull/1013
+[#1027]: https://github.com/pragma-org/amaru/pull/1027

--- a/crates/amaru-consensus/src/stages/track_peers/defer_req_next.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/defer_req_next.rs
@@ -17,21 +17,21 @@
 
 use std::time::Duration;
 
-use amaru_kernel::BlockHeight;
+use amaru_kernel::Slot;
 use amaru_protocols::chainsync::InitiatorMessage;
 use amaru_pure_stage::{Effects, StageRef};
 
-use super::ledger_applied_block_height;
+use super::ledger_applied_slot;
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum DeferReqNextMsg {
-    Register { handler: StageRef<InitiatorMessage>, min_ledger_height: BlockHeight },
+    Register { handler: StageRef<InitiatorMessage>, min_ledger_slot: Slot },
     Poll,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct DeferReqNext {
     pub poll_interval_ms: u64,
-    pub pending: Vec<(StageRef<InitiatorMessage>, BlockHeight)>,
+    pub pending: Vec<(StageRef<InitiatorMessage>, Slot)>,
 }
 
 impl DeferReqNext {
@@ -43,8 +43,8 @@ impl DeferReqNext {
 pub async fn stage(mut state: DeferReqNext, msg: DeferReqNextMsg, eff: Effects<DeferReqNextMsg>) -> DeferReqNext {
     use DeferReqNextMsg::*;
     match msg {
-        Register { handler, min_ledger_height } => {
-            state.pending.push((handler, min_ledger_height));
+        Register { handler, min_ledger_slot } => {
+            state.pending.push((handler, min_ledger_slot));
         }
         Poll => {
             dispatch_ready(&mut state, &eff).await;
@@ -56,13 +56,13 @@ pub async fn stage(mut state: DeferReqNext, msg: DeferReqNextMsg, eff: Effects<D
 }
 
 async fn dispatch_ready(state: &mut DeferReqNext, eff: &Effects<DeferReqNextMsg>) {
-    let ledger_height = ledger_applied_block_height(eff).await;
+    let ledger_slot = ledger_applied_slot(eff).await;
     let mut remaining = Vec::new();
-    for (handler, min_h) in std::mem::take(&mut state.pending) {
-        if ledger_height >= min_h {
+    for (handler, min_slot) in std::mem::take(&mut state.pending) {
+        if ledger_slot >= min_slot {
             eff.send(&handler, InitiatorMessage::RequestNext).await;
         } else {
-            remaining.push((handler, min_h));
+            remaining.push((handler, min_slot));
         }
     }
     state.pending = remaining;

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -17,7 +17,7 @@ mod defer_req_next;
 use std::{collections::BTreeMap, time::Duration};
 
 use amaru_kernel::{
-    BlockHeader, BlockHeight, EraHistory, EraName, IsHeader, ORIGIN_HASH, Peer, Point, Tip, from_cbor_no_leftovers,
+    BlockHeader, EraHistory, EraName, IsHeader, ORIGIN_HASH, Peer, Point, Slot, SlotDelta, Tip, from_cbor_no_leftovers,
 };
 use amaru_observability::trace_span;
 use amaru_protocols::{
@@ -35,10 +35,10 @@ use crate::{
     errors::{ConsensusError, InvalidHeaderParentData, InvalidHeaderPoint},
 };
 
-/// Block height of the furthest ledger-applied state: volatile tip if present, otherwise stable tip.
-pub(super) async fn ledger_applied_block_height<T: amaru_pure_stage::SendData + Sync>(eff: &Effects<T>) -> BlockHeight {
+/// Slot of the furthest ledger-applied state: volatile tip if present, otherwise stable tip.
+pub(super) async fn ledger_applied_slot<T: amaru_pure_stage::SendData + Sync>(eff: &Effects<T>) -> Slot {
     let ledger = Ledger::new(eff.clone());
-    ledger.volatile_tip().await.block_height()
+    ledger.volatile_tip().await.slot()
 }
 
 /// This is the state of the [`stage`] that tracks peers from whom we are receiving headers.
@@ -55,7 +55,7 @@ pub(super) async fn ledger_applied_block_height<T: amaru_pure_stage::SendData + 
 ///
 /// # Construction
 /// - Created via [`TrackPeers::new`] with an `EraHistory`, `StageRef`s for peer_selection and
-///   downstream, the `consensus_security_parameter` (k-like value), and `defer_req_next_poll_ms`.
+///   downstream, the maximum tolerated slot forecast, and `defer_req_next_poll_ms`.
 /// - The `defer_req_next` child ref starts as `StageRef::blackhole()` and is materialized lazily
 ///   (see below).
 ///
@@ -80,11 +80,11 @@ pub(super) async fn ledger_applied_block_height<T: amaru_pure_stage::SendData + 
 ///
 ///   - `RollForward(header_content, tip)`: TRACE log. Decodes via `decode_header` (only Conway
 ///     supported; errors → ERROR + remove + `peer_selection` ← `Adversarial` + return).
-///     Computes `min_ledger_height = header.block_height() - consensus_security_parameter`.
-///     Conditionally refreshes cached `ledger_applied_block_height` (via helper +
+///     Computes `min_ledger_slot = header.slot() - max_forecast`.
+///     Conditionally refreshes cached `ledger_applied_slot` (via helper +
 ///     `eff.clock()`, rate-limited to 5s or initial, mod.rs:316-322; uses `VolatileTipEffect`).
 ///     Chooses `RollForwardMode`:
-///     - If ledger height < min → DEBUG "track_peers.defer_request_next" + `DeferTrailingRequestNext`.
+///     - If ledger slot < min → DEBUG "track_peers.defer_request_next" + `DeferTrailingRequestNext`.
 ///     - Else → `PipelineRequestNext`.
 ///       Then calls `execute_roll_forward`.
 ///
@@ -104,7 +104,7 @@ pub(super) async fn ledger_applied_block_height<T: amaru_pure_stage::SendData + 
 ///   returns `Some(new_tip)` only on actual store) (mod.rs:184-202). On store success → send
 ///   `(tip, parent_point)` to `downstream`. On store error → remove + `Adversarial`.
 /// - *Only* for `DeferTrailingRequestNext` (and only after success): `ensure_defer_req_next_stage` +
-///   `Register { handler, min_ledger_height }` to the child (mod.rs:267-270).
+///   `Register { handler, min_ledger_slot }` to the child (mod.rs:267-270).
 ///
 /// # The Defer Child Stage ("defer_req_next")
 ///
@@ -112,16 +112,16 @@ pub(super) async fn ledger_applied_block_height<T: amaru_pure_stage::SendData + 
 /// - `eff.stage("track_peers/defer_req_next", defer_req_next::stage)` + `wire_up` + store the ref +
 ///   initial `Poll`.
 /// - Protocol (`DeferReqNextMsg`):
-///   - `Register { handler, min_ledger_height }`: appends to `pending` vec (no immediate dispatch).
-///   - `Poll`: `dispatch_ready` (queries `ledger_applied_block_height` via shared helper, sends
-///     `InitiatorMessage::RequestNext` to every handler where current ledger >= min_h, retains
+///   - `Register { handler, min_ledger_slot }`: appends to `pending` vec (no immediate dispatch).
+///   - `Poll`: `dispatch_ready` (queries `ledger_applied_slot` via shared helper, sends
+///     `InitiatorMessage::RequestNext` to every handler where current ledger >= min_slot, retains
 ///     others) then `eff.schedule_after(Poll, Duration::from_millis(poll_interval_ms.max(1)))`.
 ///     Self-perpetuating polling loop once started.
-/// - State: `DeferReqNext { poll_interval_ms, pending: Vec<(StageRef, BlockHeight)> }`.
+/// - State: `DeferReqNext { poll_interval_ms, pending: Vec<(StageRef, Slot)> }`.
 ///   Created with the configured poll ms (default 200 in tests).
 /// - Used exclusively to throttle `RequestNext` until the ledger has applied far enough
-///   (security parameter purpose). The child is never terminated. (Tests: `test_roll_forward_defers_*`
-///   using `setup_with_ledger_tip` + security_param=0 + `tm_add_stage`/`tm_wire_stage_state`/
+///   for the configured slot forecast. The child is never terminated. (Tests: `test_roll_forward_defers_*`
+///   using `setup_with_ledger_tip` + max_forecast=0 + `tm_add_stage`/`tm_wire_stage_state`/
 ///   `assert_trace_does_not_contain` for immediate `RequestNext`.)
 ///
 /// # External Effects, Scheduling, and Other Behaviours
@@ -142,7 +142,7 @@ pub(super) async fn ledger_applied_block_height<T: amaru_pure_stage::SendData + 
 /// # State Transitions
 /// - `upstream` inserts on successful `IntersectFound` or test helper; mutates `current`/`highest`
 ///   on successful roll forward/backward; removes on any error or `IntersectNotFound`.
-/// - Cached `ledger_applied_block_height` / `ledger_last_checked_at` updated opportunistically.
+/// - Cached `ledger_applied_slot` / `ledger_last_checked_at` updated opportunistically.
 /// - `defer_req_next` transitions from blackhole → wired ref exactly once (on first defer decision).
 ///
 /// The stage is exercised exclusively via simulation harness in `test_setup.rs` (resource
@@ -155,11 +155,11 @@ pub struct TrackPeers {
     upstream: BTreeMap<Peer, PerPeer>,
     peer_selection: StageRef<PeerSelectionMsg>,
     downstream: StageRef<(Tip, Point)>,
-    consensus_security_parameter: u64,
+    max_forecast: SlotDelta,
     /// Lazily populated via [`Effects::stage`](amaru_pure_stage::Effects::stage) on first deferred `RequestNext`.
     defer_req_next: StageRef<DeferReqNextMsg>,
     defer_req_next_poll_ms: u64,
-    ledger_applied_block_height: BlockHeight,
+    ledger_applied_slot: Slot,
     ledger_last_checked_at: Instant,
 }
 
@@ -179,7 +179,7 @@ enum RollForwardMode {
     /// Send [`InitiatorMessage::RequestNext`](amaru_protocols::chainsync::InitiatorMessage::RequestNext) before validating (pipelined fetch).
     PipelineRequestNext,
     /// Skip the leading `RequestNext`; after a successful roll-forward, register a deferred `RequestNext`.
-    DeferTrailingRequestNext { min_ledger_height: BlockHeight },
+    DeferTrailingRequestNext { min_ledger_slot: Slot },
 }
 
 pub async fn stage(mut state: TrackPeers, msg: TrackPeersMsg, eff: Effects<TrackPeersMsg>) -> TrackPeers {
@@ -196,7 +196,7 @@ impl TrackPeers {
         era_history: EraHistory,
         peer_selection: StageRef<PeerSelectionMsg>,
         downstream: StageRef<(Tip, Point)>,
-        consensus_security_parameter: u64,
+        max_forecast: SlotDelta,
         defer_req_next_poll_ms: u64,
     ) -> Self {
         Self {
@@ -204,10 +204,10 @@ impl TrackPeers {
             upstream: BTreeMap::new(),
             peer_selection,
             downstream,
-            consensus_security_parameter,
+            max_forecast,
             defer_req_next: StageRef::blackhole(),
             defer_req_next_poll_ms,
-            ledger_applied_block_height: BlockHeight::from(0),
+            ledger_applied_slot: Slot::from(0),
             ledger_last_checked_at: Instant::at_offset(Duration::from_secs(0)),
         }
     }
@@ -366,9 +366,9 @@ impl TrackPeers {
             }
         };
 
-        if let RollForwardMode::DeferTrailingRequestNext { min_ledger_height } = mode {
+        if let RollForwardMode::DeferTrailingRequestNext { min_ledger_slot } = mode {
             self.ensure_defer_req_next_stage(&eff).await;
-            eff.send(&self.defer_req_next, DeferReqNextMsg::Register { handler, min_ledger_height }).await;
+            eff.send(&self.defer_req_next, DeferReqNextMsg::Register { handler, min_ledger_slot }).await;
         }
     }
 
@@ -415,61 +415,24 @@ impl TrackPeers {
                     }
                 };
 
-                // FIXME: Handle missing stake distributions by deferring request next instead of this
-                //
-                // Here, we have to artificially lower the forecast window we want because of a
-                // period on the network (November 2025) where the chain coped with a long fork
-                // (thousands of blocks) that actually violated a few of the chain growth
-                // properties.
-                //
-                // For example on Preview, the epoch 1123 has only seen 251 blocks; which is far
-                // less than `k=432` blocks on Preview. So we had a scenario where a window of more
-                // than `3*k/f` slots have seen less than `k` blocks. This happened because of a bug
-                // which partitioned the chain into two; until the initially-loosing-chain was
-                // adopted by majority (by fixing the bug and having the majority of the stake
-                // endorsing that fork).
-                //
-                // The consequences of this makes the following check too optimistic when using `k`;
-                // because we end up trying to validate headers that are too far and for which we
-                // don't yet have a stake distribution ready in the ledger.
-                //
-                // The temporary fix for now is to simply avoid looking too far ahead, while we're
-                // working on the proper fix which would consist in handling the missing stake
-                // distributions from the ledger as an event that *can* happen, and that should
-                // simply cause the header validation to be postponed (to until the stake
-                // distribution is available).
-                //
-                // How much is too far ahead? On Preview (where the problem is the most visible),
-                // the stake distribution required for 1124 will be calculated after about ~80
-                // blocks in the epoch 1123. So that means, we cannot go more than 171 blocks. So we
-                // use `k / 3 = 144` which is well below, and still a function of `k`, so that on
-                // Mainnet or PreProd, we can still fetch a fair amount of blocks ahead of us and
-                // not impact synchronization too much.
-                //
-                // /!\ IMPORTANT /!\
-                // To fix this properly, we not only need to handle the error from here; but we also
-                // need to ensure that the ledger produces stake distributions at least once per
-                // epoch. Currently, in the extreme scenario where no blocks would be produced for
-                // the last 2/3rd of an epoch, the ledger would not have produced a stake
-                // distribution and arrive at an epoch boundary with a big problem.
-                let min_ledger_height = header.block_height() - self.consensus_security_parameter / 3;
-                if min_ledger_height > self.ledger_applied_block_height
+                let min_ledger_slot = Slot::new(header.slot().as_u64().saturating_sub(self.max_forecast.as_u64()));
+                if min_ledger_slot > self.ledger_applied_slot
                     && let now = eff.clock().await
                     && (now.saturating_since(self.ledger_last_checked_at) > Duration::from_secs(5)
-                        || self.ledger_applied_block_height == BlockHeight::from(0))
+                        || self.ledger_applied_slot == Slot::from(0))
                 {
                     self.ledger_last_checked_at = now;
-                    self.ledger_applied_block_height = ledger_applied_block_height(&eff).await;
+                    self.ledger_applied_slot = ledger_applied_slot(&eff).await;
                 }
-                let mode = if self.ledger_applied_block_height < min_ledger_height {
+                let mode = if self.ledger_applied_slot < min_ledger_slot {
                     tracing::debug!(
                         %peer,
-                        header_height = %header.block_height(),
-                        ledger_height = %self.ledger_applied_block_height,
-                        limit = %min_ledger_height,
+                        header_slot = %header.slot(),
+                        ledger_slot = %self.ledger_applied_slot,
+                        limit = %min_ledger_slot,
                         "track_peers.defer_request_next",
                     );
-                    RollForwardMode::DeferTrailingRequestNext { min_ledger_height }
+                    RollForwardMode::DeferTrailingRequestNext { min_ledger_slot }
                 } else {
                     RollForwardMode::PipelineRequestNext
                 };

--- a/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use amaru_kernel::{BlockHeader, EraHistory, HeaderHash, Tip, make_header};
+use amaru_kernel::{BlockHeader, EraHistory, HeaderHash, SlotDelta, Tip, make_header};
 use amaru_ouroboros::ConnectionId;
 use amaru_ouroboros_traits::{
     CanValidateHeaders, HeaderValidationError, MockCanValidateBlocks, MockCanValidateHeaders, WriteChainStore,
@@ -73,16 +73,16 @@ impl TestPrep {
 
 /// Creates basic state, runtime, handler, conn_id, and three properly linked headers for tests.
 pub fn test_prep() -> TestPrep {
-    test_prep_with_security_param(10_000_000)
+    test_prep_with_max_forecast(SlotDelta::from(10_000_000))
 }
 
-/// Creates a `TestPrep` with a configurable consensus security parameter (for testing defer logic).
-pub fn test_prep_with_security_param(security_param: u64) -> TestPrep {
+/// Creates a `TestPrep` with a configurable slot forecast limit (for testing defer logic).
+pub fn test_prep_with_max_forecast(max_forecast: SlotDelta) -> TestPrep {
     let state = TrackPeers::new(
         EraHistory::default(),
         StageRef::named_for_tests("peer_selection"),
         StageRef::named_for_tests("downstream"),
-        security_param,
+        max_forecast,
         200,
     );
     let rt = Builder::new_current_thread().build().unwrap();

--- a/crates/amaru-consensus/src/stages/track_peers/tests.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/tests.rs
@@ -14,7 +14,7 @@
 
 use std::{slice, sync::Arc};
 
-use amaru_kernel::{BlockHeight, EraName, HeaderHash, IsHeader, Peer, Point, Tip};
+use amaru_kernel::{BlockHeight, EraName, HeaderHash, IsHeader, Peer, Point, SlotDelta, Tip};
 use amaru_protocols::chainsync::{
     self, ChainSyncInitiatorMsg, HeaderContent, InitiatorMessage, InitiatorMessage::RequestNext,
 };
@@ -33,7 +33,7 @@ use crate::stages::{
         test_setup::{
             FailingHeaderValidation, build_store, make_block_header, setup, setup_with_ledger_tip,
             setup_with_validation, te_has_header, te_load_tip, te_store_header, te_validate_header, test_prep,
-            test_prep_with_security_param, tm_store_header,
+            test_prep_with_max_forecast, tm_store_header,
         },
     },
 };
@@ -626,8 +626,8 @@ fn test_roll_backward_unknown_point_removes_peer() {
 /// for a deferred RequestNext (instead of immediately pipelining RequestNext to the handler).
 #[test]
 fn test_roll_forward_defers_request_next_and_creates_defer_child() {
-    // Use security_param = 0 so any header taller than the known ledger height triggers defer.
-    let prep = test_prep_with_security_param(0);
+    // Use max_forecast = 0 so any header beyond the known ledger slot triggers defer.
+    let prep = test_prep_with_max_forecast(SlotDelta::from(0));
     let peer = Peer::new("peer1");
     let header = prep.headers[0].clone();
     let tip = header.tip();

--- a/crates/amaru-kernel/src/cardano/slot.rs
+++ b/crates/amaru-kernel/src/cardano/slot.rs
@@ -24,6 +24,8 @@ use minicbor::{Decode, Decoder, Encode};
 #[repr(transparent)]
 pub struct Slot(u64);
 
+pub type SlotDelta = Slot;
+
 impl fmt::Display for Slot {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -133,7 +133,7 @@ pub use cardano::{
     script_context::ScriptContext,
     script_info::{ScriptInfo, ScriptPurpose},
     script_integrity_data::{ScriptIntegrityData, compute_script_integrity_hash},
-    slot::{Slot, SlotArithmeticError},
+    slot::{Slot, SlotArithmeticError, SlotDelta},
     stake_credential::{BorrowedStakeCredential, StakeCredential, parse_reward_account},
     stake_credential_kind::StakeCredentialKind,
     term_limit::TermLimit,

--- a/crates/amaru/src/stages/build_stage_graph.rs
+++ b/crates/amaru/src/stages/build_stage_graph.rs
@@ -24,7 +24,7 @@ use amaru_consensus::stages::{
     track_peers::{self, TrackPeers, TrackPeersMsg},
     validate_block::{self, ValidateBlock, ValidateBlockMsg},
 };
-use amaru_kernel::{EraHistory, GlobalParameters, HeaderHash, Peer, Tip};
+use amaru_kernel::{EraHistory, GlobalParameters, HeaderHash, Peer, Slot, Tip};
 use amaru_ouroboros::MempoolMsg;
 use amaru_protocols::{
     manager,
@@ -94,6 +94,10 @@ pub fn build_stage_graph(
     let block_source_sender = block_source_stage.sender();
 
     let k = global_parameters.consensus_security_param;
+    // `track_peers` can safely look ahead by at most 4*k/f slots: one stability window for the
+    // previous epoch stake distribution to become due, plus one more window to observe a block
+    // that advances the ledger clock far enough to compute it.
+    let max_forecast = Slot::new(global_parameters.randomness_stabilization_window());
 
     // Wire mempool (from main) — kept for its own use even if not passed to adopt_chain in this resolution
     let mempool_stage = stage_graph.wire_up(mempool_stage, MempoolStageState::default()).without_state();
@@ -152,7 +156,13 @@ pub fn build_stage_graph(
 
     let track_peers = stage_graph.wire_up(
         track_peers,
-        TrackPeers::new(era_history.clone(), peer_selection_ref, select_chain_input, k, config.defer_req_next_poll_ms),
+        TrackPeers::new(
+            era_history.clone(),
+            peer_selection_ref,
+            select_chain_input,
+            max_forecast,
+            config.defer_req_next_poll_ms,
+        ),
     );
     let track_peers_input = stage_graph.contramap(track_peers, "track_peers_input", TrackPeersMsg::FromUpstream);
 


### PR DESCRIPTION
Allow coping better with low density chains and fixes the regression in syncing time on Preview/PreProd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block forecasting on low-density chains by using slot progression rather than block height.
  * Reduced unnecessary delays when requesting the next block from peers.

* **Documentation**
  * Added an Unreleased changelog entry describing the forecasting fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->