### PR TITLE
StakePoolNotRegisteredOnKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Other guiding principles:
 ### Fixed
 
 - **amaru-ledger**: reject pool retirement when the retirement epoch is out of range. ([#1036][])
+- **amaru-ledger**: validate stake pool exists when attempting to unregister ([#912][], [#1034][])
 
 ## [v10.11.20260723](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260723)
 
@@ -185,6 +186,7 @@ Other guiding principles:
 [#896]: https://github.com/pragma-org/amaru/issues/896
 [#899]: https://github.com/pragma-org/amaru/issues/899
 [#902]: https://github.com/pragma-org/amaru/issues/902
+[#912]: https://github.com/pragma-org/amaru/issues/912
 [#915]: https://github.com/pragma-org/amaru/issues/915
 [#942]: https://github.com/pragma-org/amaru/pull/942
 [#951]: https://github.com/pragma-org/amaru/pull/951
@@ -211,6 +213,7 @@ Other guiding principles:
 [#1030]: https://github.com/pragma-org/amaru/pull/1030
 [#1031]: https://github.com/pragma-org/amaru/pull/1031
 [#1033]: https://github.com/pragma-org/amaru/pull/1033
+[#1034]: https://github.com/pragma-org/amaru/pull/1034
 [#1036]: https://github.com/pragma-org/amaru/pull/1036
 [#1039]: https://github.com/pragma-org/amaru/pull/1039
 [#1041]: https://github.com/pragma-org/amaru/pull/1041

--- a/crates/amaru-ledger/src/context.rs
+++ b/crates/amaru-ledger/src/context.rs
@@ -185,8 +185,7 @@ pub trait PoolsSlice {
 
     fn register(&mut self, params: PoolParams, pointer: CertificatePointer, deposit: Lovelace);
 
-    // FIXME: Should yield an error when pool doesn't exists.
-    fn retire(&mut self, pool: PoolId, epoch: Epoch);
+    fn retire(&mut self, pool: PoolId, epoch: Epoch) -> Result<(), UnregisterError<PoolId, PoolId>>;
 }
 
 /// An interface to help constructing the concrete PoolsSlice ahead of time.

--- a/crates/amaru-ledger/src/context/assert.rs
+++ b/crates/amaru-ledger/src/context/assert.rs
@@ -175,7 +175,7 @@ impl PoolsSlice for AssertValidationContext {
         unimplemented!()
     }
 
-    fn retire(&mut self, _pool: PoolId, _epoch: Epoch) {
+    fn retire(&mut self, _pool: PoolId, _epoch: Epoch) -> Result<(), UnregisterError<PoolId, PoolId>> {
         unimplemented!()
     }
 }

--- a/crates/amaru-ledger/src/context/default/validation.rs
+++ b/crates/amaru-ledger/src/context/default/validation.rs
@@ -143,14 +143,19 @@ impl PoolsSlice for DefaultValidationContext {
         self.state.pools.register(params.id, Arc::new((params, pointer, deposit)))
     }
 
-    fn retire(&mut self, pool: PoolId, epoch: Epoch) {
+    fn retire(&mut self, pool: PoolId, epoch: Epoch) -> Result<(), UnregisterError<PoolId, PoolId>> {
         let _span = trace_span!(
             ledger::transaction::CERTIFICATE_POOL_RETIREMENT,
             pool_id = %pool,
             epoch = epoch
         );
         let _guard = _span.enter();
-        self.state.pools.unregister(pool, epoch)
+        if !PoolsSlice::exists(self, pool) {
+            return Err(UnregisterError::Unknown(PhantomData {}, pool));
+        }
+        self.state.pools.unregister(pool, epoch);
+
+        Ok(())
     }
 }
 

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/certificates.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/certificates.rs
@@ -67,6 +67,9 @@ pub enum InvalidCertificates {
     #[error("pool retirement epoch out of range: epoch {epoch}, must satisfy {current_epoch} < epoch <= {max_epoch}")]
     PoolRetirementWrongEpoch { epoch: Epoch, current_epoch: Epoch, max_epoch: Epoch },
 
+    #[error("unknown pool: {0}")]
+    StakePoolUnknown(#[from] UnregisterError<PoolId, PoolId>),
+
     #[error("incorrect stake deposit: provided {provided}, expected {expected}")]
     IncorrectStakeDeposit { provided: Lovelace, expected: Lovelace },
 
@@ -224,7 +227,7 @@ where
                 });
             }
 
-            PoolsSlice::retire(context, id, Epoch::from(epoch));
+            PoolsSlice::retire(context, id, Epoch::from(epoch))?;
 
             Ok(())
         }

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/fixture.rs
@@ -196,6 +196,7 @@ pub(super) enum Predicate {
     StakeKeyHasNonZeroAccountBalance,
     StakeKeyRegistered,
     StakePoolRetirementWrongEpochPOOL,
+    StakePoolNotRegisteredOnKeyPOOL,
     ValueNotConservedUTxO,
     WrongNetworkInTxBody,
     WrongNetworkInTxOutput,
@@ -261,6 +262,9 @@ impl From<PhaseOneError> for Predicate {
             }
             PhaseOneError::Certificates(InvalidCertificates::PoolRetirementWrongEpoch { .. }) => {
                 Predicate::StakePoolRetirementWrongEpochPOOL
+            }
+            PhaseOneError::Certificates(InvalidCertificates::StakePoolUnknown(_)) => {
+                Predicate::StakePoolNotRegisteredOnKeyPOOL
             }
             PhaseOneError::Collateral(InvalidCollateral::UnknownInput(..)) => Predicate::BadInputsUTxO,
             PhaseOneError::Collateral(InvalidCollateral::InsufficientBalance { .. }) => {

--- a/crates/amaru-ledger/tests/data/phase-one/fail/StakePoolNotRegisteredOnKeyPOOL/0.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/StakePoolNotRegisteredOnKeyPOOL/0.json
@@ -1,0 +1,33 @@
+{
+  "title": "Retirement of a never-registered pool",
+  "description": "Pool retirement for a pool that was never registered.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "82582051adca15fb43fda038a2f0eed73fcfaa6bf26ea18d70d6c824448c05648c297000",
+        "output": "bf00581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40ff"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a400d901028182582051adca15fb43fda038a2f0eed73fcfaa6bf26ea18d70d6c824448c05648c2970000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d4004d90102818304581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd801a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258400c904e9351cef53e81df88b0f9b84553d57f6dcf4643686fac8b3676506bb62374fcbd2aebfcb5b1084dc041ae323087bb153c596c694f9e83f6f42385418c0df5f6",
+  "expected": {
+    "predicate": "StakePoolNotRegisteredOnKeyPOOL"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/fail/StakePoolNotRegisteredOnKeyPOOL/1.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/StakePoolNotRegisteredOnKeyPOOL/1.json
@@ -1,0 +1,33 @@
+{
+  "title": "Retirement of a pool absent from a non-empty pools set",
+  "description": "Pool retirement for a pool absent from a non-empty pools set.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "82582051adca15fb43fda038a2f0eed73fcfaa6bf26ea18d70d6c824448c05648c297000",
+        "output": "bf00581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40ff"
+      }
+    ],
+    "pools": ["dddddddddddddddddddddddddddddddddddddddddddddddddddddddd"],
+    "accounts": [],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a400d901028182582051adca15fb43fda038a2f0eed73fcfaa6bf26ea18d70d6c824448c05648c2970000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d4004d90102818304581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd801a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258400c904e9351cef53e81df88b0f9b84553d57f6dcf4643686fac8b3676506bb62374fcbd2aebfcb5b1084dc041ae323087bb153c596c694f9e83f6f42385418c0df5f6",
+  "expected": {
+    "predicate": "StakePoolNotRegisteredOnKeyPOOL"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/pass/certificate/pool-retirement.json
+++ b/crates/amaru-ledger/tests/data/phase-one/pass/certificate/pool-retirement.json
@@ -1,0 +1,31 @@
+{
+  "title": "retirement of a registered pool",
+  "description": "Retirement of a registered stake pool at a valid future epoch.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "82582051adca15fb43fda038a2f0eed73fcfaa6bf26ea18d70d6c824448c05648c297000",
+        "output": "bf00581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40ff"
+      }
+    ],
+    "pools": ["93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"],
+    "accounts": [],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a400d901028182582051adca15fb43fda038a2f0eed73fcfaa6bf26ea18d70d6c824448c05648c2970000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d4004d90102818304581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd801a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258400c904e9351cef53e81df88b0f9b84553d57f6dcf4643686fac8b3676506bb62374fcbd2aebfcb5b1084dc041ae323087bb153c596c694f9e83f6f42385418c0df5f6",
+  "expected": "Pass"
+}


### PR DESCRIPTION
Closes #912


Introduces logic which validates that a pool which is being retired exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stake pool retirement now validates that the pool exists before attempting to unregister it.
  * Attempts to retire an unknown stake pool now fail with a clear validation error rather than being ignored.
  * Failures are now properly propagated during certificate execution and mapped to the correct predicate.

* **Tests**
  * Added new phase-one JSON fixtures for both successful pool retirement and the unknown-pool failure case.

* **Documentation**
  * Updated the changelog to describe the new stake pool existence validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->