### PR TITLE
Add predicate StakePoolRetirementWrongEpochPOOL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Other guiding principles:
 
 ## v10.11.20260730 _[unreleased; planned for 2026-07-30]_
 
+### Fixed
+
+- **amaru-ledger**: reject pool retirement when the retirement epoch is out of range. ([#1036][])
+
 ## [v10.11.20260723](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260723)
 
 ### Added
@@ -207,6 +211,7 @@ Other guiding principles:
 [#1030]: https://github.com/pragma-org/amaru/pull/1030
 [#1031]: https://github.com/pragma-org/amaru/pull/1031
 [#1033]: https://github.com/pragma-org/amaru/pull/1033
+[#1036]: https://github.com/pragma-org/amaru/pull/1036
 [#1039]: https://github.com/pragma-org/amaru/pull/1039
 [#1041]: https://github.com/pragma-org/amaru/pull/1041
 [#1043]: https://github.com/pragma-org/amaru/pull/1043

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/fixture.rs
@@ -195,6 +195,7 @@ pub(super) enum Predicate {
     StakeCredentialInvalidVoteDelegation,
     StakeKeyHasNonZeroAccountBalance,
     StakeKeyRegistered,
+    StakePoolRetirementWrongEpochPOOL,
     ValueNotConservedUTxO,
     WrongNetworkInTxBody,
     WrongNetworkInTxOutput,
@@ -257,6 +258,9 @@ impl From<PhaseOneError> for Predicate {
             }
             PhaseOneError::Certificates(InvalidCertificates::DRepAlreadyRegistered(_)) => {
                 Predicate::DRepAlreadyRegistered
+            }
+            PhaseOneError::Certificates(InvalidCertificates::PoolRetirementWrongEpoch { .. }) => {
+                Predicate::StakePoolRetirementWrongEpochPOOL
             }
             PhaseOneError::Collateral(InvalidCollateral::UnknownInput(..)) => Predicate::BadInputsUTxO,
             PhaseOneError::Collateral(InvalidCollateral::InsufficientBalance { .. }) => {

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
@@ -369,6 +369,7 @@ mod tests {
             .unwrap_or_else(|e| panic!("cannot read fixture {fixture_path}: {e}"));
         let fixture: Fixture =
             json::from_str(&raw).unwrap_or_else(|e| panic!("invalid json fixture {fixture_path}: {e}"));
+
         // Fixtures encode a standalone conway transaction (a 4-element array including the is_valid byte)
         // but the ledger expects a transaction to be the 3-element array (without the is_valid byte), so we subtract one byte to
         // match the size used for fee calculation. See the matching note in evaluate_ledger_states.rs.

--- a/crates/amaru-ledger/tests/data/phase-one/fail/StakePoolRetirementWrongEpochPOOL/0.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/StakePoolRetirementWrongEpochPOOL/0.json
@@ -1,0 +1,41 @@
+{
+  "title": "pool retirement at current epoch",
+  "description": "Pool retirement with epoch 0, which is not greater than the current epoch (0).",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "bf00581d60e4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec011a004c4b40ff"
+      }
+    ],
+    "pools": [
+      "e4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec"
+    ],
+    "accounts": [
+      {
+        "credential": "8200581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84bf00d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181bf00581d60e4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec011a00493e00ff021a00030d4004d90102818304581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec000800ffa100d9010281825820e734ea6c2b6257de72355e472aa05a4c487e6b463c029ed306df2f01b5636b58584080c3d51785de014cd521067b538d8786e0fe3f392d387677ccfdeecbff6f2a3608268e2344e8cebbe2dbc69a946697e4503bf27eb3508ce20dcd6dd64ec44903f5f6",
+  "expected": {
+    "predicate": "StakePoolRetirementWrongEpochPOOL"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/fail/StakePoolRetirementWrongEpochPOOL/1.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/StakePoolRetirementWrongEpochPOOL/1.json
@@ -1,0 +1,41 @@
+{
+  "title": "pool retirement beyond max epoch",
+  "description": "Pool retirement with epoch 19, which exceeds the max retirement epoch (current 0 + eMax 18 = 18).",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "bf00581d60e4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec011a004c4b40ff"
+      }
+    ],
+    "pools": [
+      "e4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec"
+    ],
+    "accounts": [
+      {
+        "credential": "8200581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84bf00d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181bf00581d60e4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec011a00493e00ff021a00030d4004d90102818304581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec130800ffa100d9010281825820e734ea6c2b6257de72355e472aa05a4c487e6b463c029ed306df2f01b5636b585840bb06d0c42c06581d609cce598ed08e88a5bc60b8ec11f0c9e39118ac09c25a956c84326c7690ae12c64966dcc531bc33a430c8e72f6c68d4efa02f4da4320106f5f6",
+  "expected": {
+    "predicate": "StakePoolRetirementWrongEpochPOOL"
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly rejects stake pool retirement transactions when the retirement epoch is outside the permitted range.
  * Added validation coverage for epochs that are too early and too far in the future.
* **Tests**
  * Added new phase-one failure fixtures for the “wrong epoch” pool retirement scenario, asserting the expected failure outcome.
* **Documentation**
  * Updated the unreleased changelog entry to reflect the corrected pool retirement validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->