### PR TITLE
Add predicate StakePoolCostTooLowPOOL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Other guiding principles:
 
 - **amaru-ledger**: reject pool retirement when the retirement epoch is out of range. ([#1036][])
 - **amaru-ledger**: validate stake pool exists when attempting to unregister ([#912][], [#1034][])
+- **amaru-ledger**: introduce `StakePoolCostTooLowPOOL` implementation and coverage. ([#1037][])
 
 ## [v10.11.20260723](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260723)
 
@@ -230,3 +231,4 @@ Other guiding principles:
 [#1055]: https://github.com/pragma-org/amaru/pull/1055
 [#1056]: https://github.com/pragma-org/amaru/pull/1056
 [#1060]: https://github.com/pragma-org/amaru/issues/1060
+[#1037]: https://github.com/pragma-org/amaru/pull/1037

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Other guiding principles:
 
 - **amaru-ledger**: reject pool retirement when the retirement epoch is out of range. ([#1036][])
 - **amaru-ledger**: validate stake pool exists when attempting to unregister ([#912][], [#1034][])
-- **amaru-ledger**: introduce `StakePoolCostTooLowPOOL` implementation and coverage. ([#1037][])
+- **amaru-ledger**: introduce `StakePoolCostTooLowPOOL` implementation and coverage. ([#1037][], [#909][])
 
 ## [v10.11.20260723](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260723)
 
@@ -192,6 +192,7 @@ Other guiding principles:
 [#896]: https://github.com/pragma-org/amaru/issues/896
 [#899]: https://github.com/pragma-org/amaru/issues/899
 [#902]: https://github.com/pragma-org/amaru/issues/902
+[#909]: https://github.com/pragma-org/amaru/issues/909
 [#912]: https://github.com/pragma-org/amaru/issues/912
 [#915]: https://github.com/pragma-org/amaru/issues/915
 [#929]: https://github.com/pragma-org/amaru/issues/929
@@ -223,6 +224,7 @@ Other guiding principles:
 [#1033]: https://github.com/pragma-org/amaru/pull/1033
 [#1034]: https://github.com/pragma-org/amaru/pull/1034
 [#1036]: https://github.com/pragma-org/amaru/pull/1036
+[#1037]: https://github.com/pragma-org/amaru/pull/1037
 [#1039]: https://github.com/pragma-org/amaru/pull/1039
 [#1041]: https://github.com/pragma-org/amaru/pull/1041
 [#1043]: https://github.com/pragma-org/amaru/pull/1043
@@ -231,4 +233,3 @@ Other guiding principles:
 [#1055]: https://github.com/pragma-org/amaru/pull/1055
 [#1056]: https://github.com/pragma-org/amaru/pull/1056
 [#1060]: https://github.com/pragma-org/amaru/issues/1060
-[#1037]: https://github.com/pragma-org/amaru/pull/1037

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,13 +41,12 @@ Other guiding principles:
 ### Added
 
 - **amaru-ledger**: reject treasury withdrawal proposals that reference unregistered reward accounts.  ([#1032][], [#929][])
-
+- **amaru-ledger**: introduce `StakePoolCostTooLowPOOL` coverage. ([#1037][], [#909][])
 
 ### Fixed
 
 - **amaru-ledger**: reject pool retirement when the retirement epoch is out of range. ([#1036][])
 - **amaru-ledger**: validate stake pool exists when attempting to unregister ([#912][], [#1034][])
-- **amaru-ledger**: introduce `StakePoolCostTooLowPOOL` implementation and coverage. ([#1037][], [#909][])
 
 ## [v10.11.20260723](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260723)
 

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/fixture.rs
@@ -199,6 +199,7 @@ pub(super) enum Predicate {
     StakeKeyRegistered,
     StakePoolRetirementWrongEpochPOOL,
     StakePoolNotRegisteredOnKeyPOOL,
+    StakePoolCostTooLowPOOL,
     ValueNotConservedUTxO,
     WrongNetworkInTxBody,
     WrongNetworkInTxOutput,
@@ -270,6 +271,9 @@ impl From<PhaseOneError> for Predicate {
             }
             PhaseOneError::Certificates(InvalidCertificates::StakePoolUnknown(_)) => {
                 Predicate::StakePoolNotRegisteredOnKeyPOOL
+            }
+            PhaseOneError::Certificates(InvalidCertificates::PoolCostTooLow { .. }) => {
+                Predicate::StakePoolCostTooLowPOOL
             }
             PhaseOneError::Collateral(InvalidCollateral::UnknownInput(..)) => Predicate::BadInputsUTxO,
             PhaseOneError::Collateral(InvalidCollateral::InsufficientBalance { .. }) => {

--- a/crates/amaru-ledger/tests/data/phase-one/fail/StakePoolCostTooLowPOOL/0.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/StakePoolCostTooLowPOOL/0.json
@@ -1,0 +1,33 @@
+{
+  "title": "pool registration with cost zero",
+  "description": "A pool registration certificate with cost set to zero, well below minStakePoolCost (340 ADA).",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "bf00581d60e4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec011a1e19b040ff"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84bf00d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181bf00581d60e4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec011a00493e00ff021a00030d4004d90102818a03581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec5820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb0000d81e82010a581de0e4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cecd9010281581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec80f60800ffa100d9010281825820e734ea6c2b6257de72355e472aa05a4c487e6b463c029ed306df2f01b5636b585840226859785708222d83f582e5b148965d5500e2735f9132089659eb85b7e4e6d7657918b05000e44ff33ce4cdf36a9f9cef0145de8126fa8cb01afb7bf28ca607f5f6",
+  "expected": {
+    "predicate": "StakePoolCostTooLowPOOL"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/fail/StakePoolCostTooLowPOOL/1.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/StakePoolCostTooLowPOOL/1.json
@@ -1,0 +1,33 @@
+{
+  "title": "pool registration with cost one below minimum",
+  "description": "A pool registration certificate with cost one lovelace below minStakePoolCost (339,999,999 vs 340,000,000).",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "bf00581d60e4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec011a1e19b040ff"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84bf00d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181bf00581d60e4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec011a00493e00ff021a00030d4004d90102818a03581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec5820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb001a1443fcffd81e82010a581de0e4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cecd9010281581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec80f60800ffa100d9010281825820e734ea6c2b6257de72355e472aa05a4c487e6b463c029ed306df2f01b5636b585840e7370fab158e66451d75955217d825e54fefe125d1931a67f2a498576b213dbf993ad99997daafda96d1cc7665f14a9920984aed132e214337c6d2985bc9a90cf5f6",
+  "expected": {
+    "predicate": "StakePoolCostTooLowPOOL"
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Phase One stake pool validation to report “pool cost too low” failures using the correct predicate, including the boundary where the cost falls below the minimum.
* **Tests**
  * Added new Phase One failure fixtures for stake pool cost-too-low scenarios (including the minimum-boundary case) to strengthen regression coverage.
* **Documentation**
  * Updated the unreleased changelog entry and reference links for the new coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->