### PR TITLE
feat: track deregistrations for rewards

### DIFF
--- a/crates/amaru-ledger/src/epoch_transition.rs
+++ b/crates/amaru-ledger/src/epoch_transition.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{Epoch, EraHistory, ProtocolParameters};
+use std::collections::BTreeSet;
+
+use amaru_kernel::{Epoch, EraHistory, ProtocolParameters, StakeCredential};
 use amaru_observability::info_span;
 
 use crate::{
@@ -20,6 +22,12 @@ use crate::{
     state::{StateError, volatile::VolatileView},
     store::{ReadStore, StoreError},
 };
+
+mod stable_deregistrations;
+pub use stable_deregistrations::StableDeregistrations;
+
+mod volatile_registrations;
+pub use volatile_registrations::{VolatileRegistrationStatus, VolatileRegistrations};
 
 mod pools_updates;
 pub use pools_updates::PoolsEpochTransitionUpdates;
@@ -35,10 +43,60 @@ pub use ratification::{GovernanceActivity, GovernanceUpdates};
 ///
 pub fn end_epoch<'volatile, 'store, DB: ReadStore>(
     view: &mut VolatileView<'volatile, 'store, DB>,
+    stable_deregistrations: &StableDeregistrations,
     computed_rewards: Rewards<Computed>,
+    next_epoch: Epoch,
 ) -> Result<Rewards<Effective>, StoreError> {
-    info_span!(ledger::epoch_transition::END_EPOCH)
-        .in_scope(|| Ok(Rewards::<Effective>::new(computed_rewards, view.iter_accounts()?)))
+    info_span!(ledger::epoch_transition::END_EPOCH).in_scope(|| {
+        // The reward window opens at `next_epoch - 4` (snapshot epoch = (next_epoch - 1) - 3).
+        // Until the stable_deregistrations has covered it, we fall back to a full accounts db scan in
+        // order to find out which accounts are unclaimed to get effective rewards.
+        if !stable_deregistrations.covers(next_epoch - 4) {
+            return Ok(Rewards::<Effective>::new(computed_rewards, view.iter_accounts()?));
+        }
+
+        // Otherwise, get the member registrations / deregistrations that happened in the volatile view.
+        let volatile_registrations = view.volatile_registrations();
+
+        let leaders = computed_rewards.leader_accounts();
+        let mut unclaimed: BTreeSet<StakeCredential> = BTreeSet::new();
+
+        // Members still unregistered at the end of the volatile window are unclaimed accounts
+        for account in volatile_registrations.unregistered() {
+            if !leaders.contains(account) && computed_rewards.has_reward(account) {
+                unclaimed.insert(account.clone());
+            }
+        }
+
+        // Members unregistered in stable blocks, and not since re-registered are also
+        // unclaimed accounts
+        for account in stable_deregistrations.unregistered_accounts() {
+            if !volatile_registrations.is_registered(account)
+                && !leaders.contains(account)
+                && computed_rewards.has_reward(account)
+            {
+                unclaimed.insert(account.clone());
+            }
+        }
+
+        // Leaders accounts are unclaimed if they have been deregistered in the volatile view.
+        // If no change happened in the volatile view, we check the stable db to see if the account is
+        // still there. This is a disk read but only on leader accounts which is a smaller subset of accounts
+        // than member accounts.
+        for leader in leaders.iter() {
+            let unregistered = match volatile_registrations.latest_registration(leader) {
+                VolatileRegistrationStatus::Registered => false,
+                VolatileRegistrationStatus::Unregistered => true,
+                VolatileRegistrationStatus::Unknown => !view.account_exists(leader)?,
+            };
+
+            if unregistered {
+                unclaimed.insert(leader.clone());
+            }
+        }
+
+        Ok(Rewards::<Effective>::from_unclaimed(computed_rewards, unclaimed))
+    })
 }
 
 pub fn begin_epoch<'distr, 'volatile, 'store, DB: ReadStore>(

--- a/crates/amaru-ledger/src/epoch_transition/rewards_state.rs
+++ b/crates/amaru-ledger/src/epoch_transition/rewards_state.rs
@@ -165,6 +165,13 @@ pub struct Rewards<STEP: KnownRewardState> {
     /// `Effective` back to a `Computed` is therefore just dropping this set, and the reverse is
     /// re-attaching it. Neither touches `accounts`.
     unclaimed: STEP::UnclaimedRewards,
+
+    /// The subset of `accounts` that received a stake pool *leader* reward. Unlike member accounts,
+    /// a leader reward account need not have been registered when the reward was computed, so whether
+    /// it is unclaimed at the boundary cannot be inferred from deregistrations alone and must be
+    /// resolved by a direct lookup. Kept behind an `Arc` (there are at most as many as there are
+    /// pools) so snapshotting shares it rather than copying.
+    leader_accounts: Arc<BTreeSet<StakeCredential>>,
 }
 
 impl<STEP: KnownRewardState> Rewards<STEP>
@@ -182,7 +189,17 @@ where
             delta_treasury: self.delta_treasury,
             accounts: Arc::clone(&self.accounts),
             unclaimed: self.unclaimed.clone(),
+            leader_accounts: Arc::clone(&self.leader_accounts),
         }
+    }
+
+    pub fn has_reward(&self, account: &StakeCredential) -> bool {
+        self.accounts.contains_key(account)
+    }
+
+    /// The accounts that received a stake pool leader reward.
+    pub fn leader_accounts(&self) -> &BTreeSet<StakeCredential> {
+        &self.leader_accounts
     }
 }
 
@@ -191,8 +208,16 @@ impl Rewards<Computed> {
         delta_reserves: Lovelace,
         delta_treasury: Lovelace,
         accounts: BTreeMap<StakeCredential, Lovelace>,
+        leader_accounts: BTreeSet<StakeCredential>,
     ) -> Self {
-        Self { delta_reserves, delta_treasury, accounts: Arc::new(accounts), unclaimed: (), step: PhantomData }
+        Self {
+            delta_reserves,
+            delta_treasury,
+            accounts: Arc::new(accounts),
+            unclaimed: (),
+            leader_accounts: Arc::new(leader_accounts),
+            step: PhantomData,
+        }
     }
 }
 
@@ -235,6 +260,19 @@ impl Rewards<Effective> {
             delta_treasury: computed_rewards.delta_treasury,
             accounts: computed_rewards.accounts,
             unclaimed,
+            leader_accounts: computed_rewards.leader_accounts,
+        }
+    }
+
+    /// Build effective rewards from an already-computed unclaimed set.
+    pub fn from_unclaimed(computed_rewards: Rewards<Computed>, unclaimed: BTreeSet<StakeCredential>) -> Self {
+        Rewards {
+            step: PhantomData,
+            delta_reserves: computed_rewards.delta_reserves,
+            delta_treasury: computed_rewards.delta_treasury,
+            accounts: computed_rewards.accounts,
+            unclaimed,
+            leader_accounts: computed_rewards.leader_accounts,
         }
     }
 
@@ -272,6 +310,7 @@ impl Rewards<Effective> {
             delta_treasury: self.delta_treasury,
             accounts: self.accounts,
             unclaimed: (),
+            leader_accounts: self.leader_accounts,
         }
     }
 }
@@ -299,11 +338,16 @@ mod test {
 
         let delta_reserves = 1_000;
         let delta_treasury = 7;
-        let computed_rewards = Rewards::<Computed>::new(delta_reserves, delta_treasury, accounts);
+        let leader_accounts = BTreeSet::from([registered.clone()]);
+        let computed_rewards =
+            Rewards::<Computed>::new(delta_reserves, delta_treasury, accounts, leader_accounts.clone());
 
         // `unregistered` unregistered during the epoch, so its rewards can no longer be paid out.
         let effective_rewards =
             Rewards::<Effective>::new(computed_rewards.snapshot(), [registered.clone()].into_iter());
+
+        // Leader accounts travel with the rewards through the computed/effective transition.
+        assert_eq!(effective_rewards.leader_accounts(), &leader_accounts);
 
         // The still-registered account is paid its reward; the unregistered one is not (its reward
         // is folded back into the treasury instead).

--- a/crates/amaru-ledger/src/epoch_transition/stable_deregistrations.rs
+++ b/crates/amaru-ledger/src/epoch_transition/stable_deregistrations.rs
@@ -1,0 +1,170 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use amaru_kernel::{Epoch, StakeCredential};
+
+/// `StableDeregistrations` answer the question "is this account deregistered, as far as the stable db is concerned?"
+///
+/// In order to avoid accessing the database, this data structure is updated every time we process an
+/// block, with member accounts that have been registered or de-registered.
+///
+/// The epoch at which we learn this information for a given account is stored alongside the account
+/// so that we can prune the data that goes outside the reward window. If an account has been
+/// deregistered for the length of the reward window, then it cannot get any rewards and
+/// doesn't need to be considered in the computation of unclaimed rewards.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct StableDeregistrations {
+    /// Credential to the epoch in which it was most recently deregistered, for credentials that have
+    /// not since been re-registered.
+    unregistered_since: BTreeMap<StakeCredential, Epoch>,
+
+    /// Earliest epoch for which this process has fed stable blocks. Until it predates a reward
+    /// window, the accumulator is missing older deregistrations (a restart rewinds only `k` blocks,
+    /// far less than the window), so boundary checks against it must be skipped.
+    tracked_since: Option<Epoch>,
+}
+
+impl StableDeregistrations {
+    /// Record that `credential` was (re-)registered; it is no longer considered deregistered.
+    pub fn register(&mut self, credential: &StakeCredential) {
+        self.unregistered_since.remove(credential);
+    }
+
+    /// Record that `credential` was deregistered during `epoch`. A subsequent deregistration of the
+    /// same credential (after a re-registration) overwrites the recorded epoch, keeping only the most
+    /// recent one.
+    pub fn deregister(&mut self, credential: StakeCredential, epoch: Epoch) {
+        self.unregistered_since.insert(credential, epoch);
+    }
+
+    // Stable deregistrations
+    pub fn unregistered_accounts(&self) -> impl Iterator<Item = &StakeCredential> {
+        self.unregistered_since.keys()
+    }
+
+    /// A credential is still registered if it hasn't been deregistered and not re-registered
+    pub fn is_registered(&self, credential: &StakeCredential) -> bool {
+        !self.unregistered_since.contains_key(credential)
+    }
+
+    /// Drop deregistrations that occurred strictly before `oldest`, i.e. that fell out of the reward
+    /// window and can no longer contribute to any future unclaimed-rewards determination.
+    pub fn prune(&mut self, oldest: Epoch) {
+        self.unregistered_since.retain(|_, epoch| *epoch >= oldest);
+    }
+
+    /// Record that a stable block from `epoch` has been applied to the ledger
+    pub fn track(&mut self, epoch: Epoch) {
+        self.tracked_since.get_or_insert(epoch);
+    }
+
+    /// Whether this struct has been updated continuously since `epoch`
+    pub fn covers(&self, epoch: Epoch) -> bool {
+        self.tracked_since.map(|first| first <= epoch).unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+impl StableDeregistrations {
+    pub fn is_empty(&self) -> bool {
+        self.unregistered_since.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.unregistered_since.len()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use amaru_kernel::Hash;
+
+    use super::*;
+
+    #[test]
+    fn deregistered_credentials_are_tracked() {
+        let mut deregistrations = StableDeregistrations::default();
+        deregistrations.deregister(credentials(1), Epoch::from(10));
+
+        assert!(!deregistrations.is_registered(&credentials(1)), "a deregistered account is no longer registered");
+        assert!(deregistrations.is_registered(&credentials(2)), "an untouched account is still registered");
+    }
+
+    #[test]
+    fn re_registration_clears_a_deregistration() {
+        let mut deregistrations = StableDeregistrations::default();
+        deregistrations.deregister(credentials(1), Epoch::from(10));
+        deregistrations.register(&credentials(1));
+
+        assert!(deregistrations.is_registered(&credentials(1)), "a re-registered account is registered again");
+        assert!(deregistrations.is_empty());
+    }
+
+    #[test]
+    fn re_deregistration_after_re_registration_keeps_latest_epoch() {
+        let mut deregistrations = StableDeregistrations::default();
+        deregistrations.deregister(credentials(1), Epoch::from(10));
+        deregistrations.register(&credentials(1));
+        deregistrations.deregister(credentials(1), Epoch::from(12));
+
+        // Pruning up to epoch 11 must NOT drop it: its most recent deregistration was in epoch 12.
+        deregistrations.prune(Epoch::from(11));
+        assert!(
+            !deregistrations.is_registered(&credentials(1)),
+            "still deregistered: latest deregistration (epoch 12) is retained"
+        );
+    }
+
+    #[test]
+    fn pruning_drops_entries_older_than_the_window() {
+        let mut deregistrations = StableDeregistrations::default();
+        deregistrations.deregister(credentials(1), Epoch::from(7));
+        deregistrations.deregister(credentials(2), Epoch::from(9));
+
+        deregistrations.prune(Epoch::from(9));
+
+        assert!(
+            deregistrations.is_registered(&credentials(1)),
+            "epoch 7 is outside the [9, _] window, so it is forgotten"
+        );
+        assert!(!deregistrations.is_registered(&credentials(2)), "epoch 9 is on the window boundary and retained");
+    }
+
+    #[test]
+    fn register_of_unknown_credential_is_a_noop() {
+        let mut deregistrations = StableDeregistrations::default();
+        deregistrations.register(&credentials(1));
+        assert!(deregistrations.is_empty());
+    }
+
+    #[test]
+    fn warmth_tracks_the_first_stable_epoch() {
+        let mut deregistrations = StableDeregistrations::default();
+        assert!(!deregistrations.covers(Epoch::from(10)), "cold before any stable block");
+
+        deregistrations.track(Epoch::from(8));
+        deregistrations.track(Epoch::from(9)); // later blocks don't move it back
+
+        assert!(deregistrations.covers(Epoch::from(8)), "window opening at 8 is covered");
+        assert!(!deregistrations.covers(Epoch::from(7)), "window opening at 7 predates our data");
+    }
+
+    // HELPERS
+
+    fn credentials(b: u8) -> StakeCredential {
+        StakeCredential::ScriptHash(Hash::from([b; 28]))
+    }
+}

--- a/crates/amaru-ledger/src/epoch_transition/volatile_registrations.rs
+++ b/crates/amaru-ledger/src/epoch_transition/volatile_registrations.rs
@@ -1,0 +1,62 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeSet;
+
+use amaru_kernel::StakeCredential;
+
+/// This data type tracks the accounts registered and deregistered in a volatile view.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct VolatileRegistrations<'volatile> {
+    /// Accounts registered in the volatile view
+    registered: BTreeSet<&'volatile StakeCredential>,
+
+    /// Accounts deregistered in the volatile view
+    deregistered: BTreeSet<&'volatile StakeCredential>,
+}
+
+impl<'volatile> VolatileRegistrations<'volatile> {
+    pub fn new(
+        registered: BTreeSet<&'volatile StakeCredential>,
+        deregistered: BTreeSet<&'volatile StakeCredential>,
+    ) -> Self {
+        Self { registered, deregistered }
+    }
+
+    /// Return the most recent registration status in the volatile window.
+    pub fn latest_registration(&self, credential: &StakeCredential) -> VolatileRegistrationStatus {
+        if self.registered.contains(credential) {
+            VolatileRegistrationStatus::Registered
+        } else if self.deregistered.contains(credential) {
+            VolatileRegistrationStatus::Unregistered
+        } else {
+            VolatileRegistrationStatus::Unknown
+        }
+    }
+
+    pub fn unregistered(&self) -> impl Iterator<Item = &StakeCredential> {
+        self.deregistered.iter().copied()
+    }
+
+    pub fn is_registered(&self, credential: &StakeCredential) -> bool {
+        self.registered.contains(credential)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum VolatileRegistrationStatus {
+    Registered,
+    Unregistered,
+    Unknown,
+}

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -36,7 +36,7 @@ use tracing::Span;
 
 use crate::{
     context::{ContextHydratationError, DefaultPreparationContext, DefaultValidationContext, UnresolvedInputPolicy},
-    epoch_transition::{self, GovernanceActivity},
+    epoch_transition::{self, GovernanceActivity, StableDeregistrations},
     governance::ratification::RatificationContext,
     rules::{
         self,
@@ -106,6 +106,14 @@ where
     /// for each key. On a distribution of 1M+ stake credentials, that's ~26MB of memory per
     /// duplicate.
     stake_distributions: Arc<Mutex<VecDeque<StakeDistribution>>>,
+
+    /// Accounts deregistered in stable (flushed) blocks within the reward window, used to identify
+    /// unclaimed member rewards at the epoch boundary without scanning every account.
+    deregistrations: StableDeregistrations,
+
+    /// Epoch of the first block that became stable in this process. Until the accumulator has been
+    /// fed continuously since before a reward window opened, it is incomplete (a restart rewinds
+    /// only `k` blocks, far less than the window), so boundary checks against it must be skipped.
 
     /// The era history for the network this store is related to.
     era_history: Arc<EraHistory>,
@@ -219,6 +227,8 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
             global_parameters: Arc::new(global_parameters),
 
             stake_distributions: Arc::new(Mutex::new(stake_distributions)),
+
+            deregistrations: StableDeregistrations::default(),
 
             era_history: Arc::new(era_history),
 
@@ -422,26 +432,28 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
             // pre-conditions have been checked).
             let mut volatile_view = VolatileView::new(&self.volatile, &*db);
 
-            // NOTE: No rewards during epoch transition?
-            //
-            // It is fine in some situation to compute an epoch transition and yet have no rewards.
-            // This happens if Amaru is interrupted *while it is flushing* an epoch transition to
-            // disk.
-            //
-            // This happens artificially every time someone bootstraps; because the bootstrapping
-            // process behaves as if we had interrupted the transition just after taking the
-            // snapshot. So we must proceed with computing the beginning of an epoch (ratification,
-            // pool updates, etc...) but not the end (rewards).
-            let (treasury, effective_rewards) = if progress.is_none() {
-                // FIXME: asynchronous rewards calculations
+                // NOTE: No rewards during epoch transition?
                 //
-                // This should eventually be a '.await', as we always expect to *eventually*
-                // have some rewards summary being available. There's no way to continue progressing
-                // the ledger if we don't.
-                let effective_rewards = epoch_transition::end_epoch(
-                    &mut volatile_view,
-                    computed_rewards.ok_or(StateError::RewardsSummaryNotReady)?,
-                )?;
+                // It is fine in some situation to compute an epoch transition and yet have no rewards.
+                // This happens if Amaru is interrupted *while it is flushing* an epoch transition to
+                // disk.
+                //
+                // This happens artificially every time someone bootstraps; because the bootstrapping
+                // process behaves as if we had interrupted the transition just after taking the
+                // snapshot. So we must proceed with computing the beginning of an epoch (ratification,
+                // pool updates, etc...) but not the end (rewards).
+                let (treasury, effective_rewards) = if progress.is_none() {
+                    // FIXME: asynchronous rewards calculations
+                    //
+                    // This should eventually be a '.await', as we always expect to *eventually*
+                    // have some rewards summary being available. There's no way to continue progressing
+                    // the ledger if we don't.
+                    let effective_rewards = epoch_transition::end_epoch(
+                        &mut volatile_view,
+                        &self.deregistrations,
+                        computed_rewards.ok_or(StateError::RewardsSummaryNotReady)?,
+                        next_epoch,
+                    )?;
 
                 (db.pots()?.treasury + effective_rewards.delta_treasury(), Some(effective_rewards))
             } else {
@@ -479,8 +491,17 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
 
             self.volatile.transition(effective_rewards, pools_updates, governance_updates);
 
-            Ok(())
-        })
+                // Retain only what a still-open reward window can need: the oldest live distribution's
+                // epoch. (The one consumed at this boundary was already popped at compute time.)
+                let horizon = {
+                    #[allow(clippy::unwrap_used)]
+                    let distributions = self.stake_distributions.lock().unwrap();
+                    distributions.back().map(|d| d.epoch).unwrap_or(next_epoch)
+                };
+                self.deregistrations.prune(horizon);
+
+                Ok(())
+            })
     }
 
     fn try_compute_rewards(&mut self) -> Result<(), StateError> {
@@ -570,6 +591,17 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
                         self.global_parameters.consensus_security_param
                     )
                 });
+
+                // Feed the deregistration accumulator as blocks become stable. A re-registration
+                // supersedes an earlier deregistration. Both sets are disjoint within a fragment.
+                let epoch = unsafe_slot_to_epoch(&self.era_history, now_stable.slot());
+                for credential in now_stable.fragment.accounts.registered.keys() {
+                    self.deregistrations.register(credential);
+                }
+                for credential in now_stable.fragment.accounts.unregistered.iter() {
+                    self.deregistrations.deregister(credential.clone(), epoch);
+                }
+                self.deregistrations.track(epoch);
 
                 Some(now_stable)
             } else {

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -1119,7 +1119,7 @@ mod tests {
     #[test]
     fn reward_balance_folds_in_the_pending_overlay_credit_during_the_straddle() {
         let mut db = VolatileDB::default();
-        let computed = Rewards::<Computed>::new(0, 0, BTreeMap::from([(cred(1), 5_000_000)]));
+        let computed = Rewards::<Computed>::new(0, 0, BTreeMap::from([(cred(1), 5_000_000)]), BTreeSet::new());
         let effective = Rewards::<Effective>::new(computed, std::iter::once(cred(1)));
 
         // The pending boundary credit is added on top of the stable base.
@@ -1158,7 +1158,7 @@ mod tests {
     #[test_case(None, None => Expect::Unknown ; "untouched everywhere defers to the stable store")]
     fn resolve_committee_precedence(draining: Option<CommitteeAct>, current: Option<CommitteeAct>) -> Expect {
         let mut db = VolatileDB::default();
-        let computed = Rewards::<Computed>::new(0, 0, BTreeMap::new());
+        let computed = Rewards::<Computed>::new(0, 0, BTreeMap::new(), BTreeSet::new());
         let effective = Rewards::<Effective>::new(computed, std::iter::empty());
         if let Some(act) = draining {
             db.push_back(committee_block(10, act));
@@ -1251,7 +1251,7 @@ mod tests {
     /// Effective boundary rewards crediting a single account, to give the overlay non-trivial,
     /// observable state (its pending reward credit surfaces through `resolve_account`).
     fn effective_reward(credential: StakeCredential, amount: u64) -> Rewards<Effective> {
-        let computed = Rewards::<Computed>::new(0, 0, BTreeMap::from([(credential.clone(), amount)]));
+        let computed = Rewards::<Computed>::new(0, 0, BTreeMap::from([(credential.clone(), amount)]), BTreeSet::new());
         Rewards::<Effective>::new(computed, std::iter::once(credential))
     }
 

--- a/crates/amaru-ledger/src/state/volatile/overlay.rs
+++ b/crates/amaru-ledger/src/state/volatile/overlay.rs
@@ -351,7 +351,7 @@ impl StateOverlay {
 
 #[cfg(test)]
 mod test {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
 
     use amaru_kernel::{Hash, PREPROD_DEFAULT_PROTOCOL_PARAMETERS};
 
@@ -399,7 +399,12 @@ mod test {
     /// Effective rewards where `credential(1)` is still registered while `credential(2)` unregistered during
     /// the epoch, so its rewards are unclaimed and returned to the treasury.
     fn effective_rewards() -> Rewards<Effective> {
-        let computed = Rewards::<Computed>::new(1_000, 7, BTreeMap::from([(credential(1), 100), (credential(2), 42)]));
+        let computed = Rewards::<Computed>::new(
+            1_000,
+            7,
+            BTreeMap::from([(credential(1), 100), (credential(2), 42)]),
+            BTreeSet::new(),
+        );
         Rewards::<Effective>::new(computed, std::iter::once(credential(1)))
     }
 

--- a/crates/amaru-ledger/src/state/volatile/view.rs
+++ b/crates/amaru-ledger/src/state/volatile/view.rs
@@ -24,6 +24,7 @@ use amaru_kernel::{
 };
 
 use crate::{
+    epoch_transition::VolatileRegistrations,
     governance::ratification::ProposalsRootsRc,
     state::{
         VolatileDB,
@@ -131,6 +132,24 @@ impl<'volatile, 'db, DB: ReadStore> VolatileView<'volatile, 'db, DB> {
                 &mut accounts.unregistered,
             )),
         }
+    }
+
+    /// Move the volatile account changes out of the view (no clone). Consumes the same `accounts`
+    /// state as `iter_accounts`, so the two are mutually exclusive within one epoch transition.
+    pub fn volatile_registrations(&mut self) -> VolatileRegistrations<'volatile> {
+        match self.accounts.take() {
+            None => {
+                // Just being careful here. There's no reason to ever call this twice; but if it
+                // ever happens, this line might save us from hours of debugging.
+                unreachable!(".volatile_registrations() called twice on the same VolatileView! Don't do that.")
+            }
+            Some(accounts) => VolatileRegistrations::new(accounts.registered, accounts.unregistered),
+        }
+    }
+
+    // Return true if an account exists in the stable db for that credential
+    pub fn account_exists(&self, credential: &StakeCredential) -> Result<bool, StoreError> {
+        self.db.account_exists(credential)
     }
 
     /// A view on the proposal roots; this doesn't really require any volatile update but is

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -272,6 +272,8 @@ pub trait ReadStore {
     /// Get details about all accounts
     fn iter_accounts(&self) -> Result<impl Iterator<Item = (accounts::Key, accounts::Row)>>;
 
+    fn account_exists(&self, credential: &StakeCredential) -> Result<bool>;
+
     /// Get details about all dreps
     fn iter_dreps(&self) -> Result<impl Iterator<Item = (dreps::Key, dreps::Row)>>;
 

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -107,7 +107,7 @@ the system at a certain point in time. We always take snapshots _at the end of e
 certain mutations are applied to the system.
 */
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use amaru_kernel::{
     Epoch, GlobalParameters, Lovelace, PoolId, ProtocolParameters, StakeCredential, expect_stake_credential,
@@ -327,6 +327,11 @@ pub struct RewardsSummary {
 
     /// Per-account rewards, determined from their relative stake and their delegatee.
     accounts: BTreeMap<StakeCredential, Lovelace>,
+
+    /// The subset of `accounts` that received a stake pool leader reward. Retained so the epoch
+    /// boundary can resolve whether those accounts are still registered without relying on the
+    /// (member-only) deregistration bookkeeping.
+    leader_accounts: BTreeSet<StakeCredential>,
 }
 
 impl RewardsSummary {
@@ -369,11 +374,14 @@ impl RewardsSummary {
 
         let mut accounts: BTreeMap<StakeCredential, Lovelace> = BTreeMap::new();
 
+        let mut leader_accounts: BTreeSet<StakeCredential> = BTreeSet::new();
+
         let mut pools: BTreeMap<PoolId, PoolRewards> = BTreeMap::new();
 
         let mut effective_rewards = stake_distribution.pools.iter().fold(0, |effective_rewards, (pool_id, pool)| {
             let pool_rewards = RewardsSummary::apply_leader_rewards(
                 &mut accounts,
+                &mut leader_accounts,
                 &mut blocks_per_pool,
                 blocks_count,
                 available_rewards,
@@ -431,6 +439,7 @@ impl RewardsSummary {
             effective_rewards,
             pots,
             accounts,
+            leader_accounts,
         })
     }
 
@@ -513,6 +522,7 @@ impl RewardsSummary {
     #[expect(clippy::too_many_arguments)]
     fn apply_leader_rewards(
         accounts: &mut BTreeMap<StakeCredential, Lovelace>,
+        leader_accounts: &mut BTreeSet<StakeCredential>,
         blocks_per_pool: &mut BTreeMap<PoolId, u64>,
         blocks_count: u64,
         available_rewards: Lovelace,
@@ -535,10 +545,12 @@ impl RewardsSummary {
         let rewards_leader = pool.leader_rewards(rewards_pot, owner_stake, total_stake);
 
         if rewards_leader > 0 {
+            let reward_account = expect_stake_credential(&pool.parameters.reward_account);
             accounts
-                .entry(expect_stake_credential(&pool.parameters.reward_account))
+                .entry(reward_account.clone())
                 .and_modify(|rewards| *rewards += rewards_leader)
                 .or_insert(rewards_leader);
+            leader_accounts.insert(reward_account);
         }
 
         PoolRewards { leader: rewards_leader, pot: rewards_pot }
@@ -557,6 +569,11 @@ impl RewardsSummary {
 
 impl From<RewardsSummary> for Rewards<Computed> {
     fn from(summary: RewardsSummary) -> Self {
-        Rewards::<Computed>::new(summary.delta_reserves(), summary.delta_treasury(), summary.accounts)
+        Rewards::<Computed>::new(
+            summary.delta_reserves(),
+            summary.delta_treasury(),
+            summary.accounts,
+            summary.leader_accounts,
+        )
     }
 }

--- a/crates/amaru-ledger/tests/state_rollback.rs
+++ b/crates/amaru-ledger/tests/state_rollback.rs
@@ -19,7 +19,7 @@ use std::{
 
 use amaru_kernel::{
     Block, BlockHeight, Epoch, EraHistory, GlobalParameters, Hash, NetworkName, PREPROD_DEFAULT_PROTOCOL_PARAMETERS,
-    PREPROD_ERA_HISTORY, PREPROD_GLOBAL_PARAMETERS, Point, ProtocolParameters, Slot, Tip,
+    PREPROD_ERA_HISTORY, PREPROD_GLOBAL_PARAMETERS, Point, ProtocolParameters, Slot, StakeCredential, Tip,
 };
 use amaru_ledger::{
     epoch_transition::GovernanceActivity,
@@ -333,6 +333,10 @@ impl ReadStore for MockStore {
         impl Iterator<Item = (amaru_ledger::store::columns::accounts::Key, amaru_ledger::store::columns::accounts::Row)>,
     > {
         Err::<std::iter::Empty<_>, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
+    }
+
+    fn account_exists(&self, _credential: &StakeCredential) -> amaru_ledger::store::Result<bool> {
+        Err::<bool, _>(StoreError::Internal(anyhow::anyhow!("mock").into()))
     }
 
     fn iter_dreps(

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -1014,6 +1014,8 @@ define_schemas! {
                 accounts {
                     /// Point-read an account entry
                     public GET {}
+                    /// Return true if an account entry exists
+                    public EXISTS {}
                     /// Batch-upsert account entries
                     public ADD {}
                     /// Batch-delete account entries

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/accounts.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/accounts.rs
@@ -95,6 +95,17 @@ pub fn get<'a>(
     })
 }
 
+/// Whether an account exists in the store, without decoding its row.
+pub fn exists<'a>(
+    db_get: impl Fn(&[u8]) -> Result<Option<DBPinnableSlice<'a>>, rocksdb::Error>,
+    credential: &Key,
+) -> Result<bool, StoreError> {
+    trace_span!(stores::ledger::accounts::EXISTS).in_scope(|| {
+        let key = as_key(&PREFIX, credential);
+        db_get(&key).map_err(|err| StoreError::Internal(err.into())).map(|opt| opt.is_some())
+    })
+}
+
 /// Alter balance of a specific account. If the account did not exist, returns the leftovers
 /// amount that couldn't be allocated to the account.
 pub fn set<DB>(

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -432,6 +432,10 @@ macro_rules! impl_ReadStore_body {
                 accounts::get(|key| self.db.get_pinned(key), credential)
             }
 
+            fn account_exists(&self, credential: &StakeCredential) -> Result<bool, StoreError> {
+                accounts::exists(|key| self.db.get_pinned(key), credential)
+            }
+
             fn drep(
                 &self,
                 credential: &StakeCredential,

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -1664,6 +1664,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
 | `add` | `TRACE` | public | Batch-upsert account entries |  |  |
+| `exists` | `TRACE` | public | Return true if an account entry exists |  |  |
 | `get` | `TRACE` | public | Point-read an account entry |  |  |
 | `remove` | `TRACE` | public | Batch-delete account entries |  |  |
 | `reset_many` | `TRACE` | public | Reset rewards counters for many accounts | credential, reason |  |

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -3452,6 +3452,18 @@
       "description": "Batch-upsert account entries",
       "public": true
     },
+    "amaru::stores::ledger::accounts::EXISTS": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "exists",
+      "level": "TRACE",
+      "target": "amaru::stores::ledger::accounts",
+      "description": "Return true if an account entry exists",
+      "public": true
+    },
     "amaru::stores::ledger::accounts::GET": {
       "type": "object",
       "properties": {},


### PR DESCRIPTION
This PR avoids querying all the accounts on disk to check which accounts have unclaimed rewards:

 - It populates a struct containing all the de-registrations as known by the stable db, as of 3 epochs ago.
 - It populates a struct containing the volatile de-registrations (net de-registrations, an account could be registered / deregistered several times).
 - From these 2 structs, it computes the set of unclaimed accounts in order to calculate the effective rewards at the end of an epoch.

Notes:

 - If we have processed less than 3 epochs, we still go to the database in order to know which accounts are de-registered.
 - Every time we process a new epoch we can prune the `StableDegistrations` because an account that has been de-registered for more than 3 epochs cannot be considered for unclaimed rewards (since there will be no rewards for that account)
 - Leader accounts are processed separately. We might not know from the volatile view if they had ever been registered. So, unless they have been de-registered in the volatile view, we get their status from the stable DB. But since there less pools than members accounts, this is a lot less accounts to look at.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved epoch reward processing for deregistered accounts and accurate handling of stake pool leader reward recipients.
  * Added tracking and reporting of leader reward recipients through reward calculation and rollback recovery.
  * Introduced efficient ledger “account exists” checks to support reward computations and state transitions.
* **Bug Fixes**
  * More reliable reward outcomes when stable-block deregistration coverage applies.
* **Documentation**
  * Documented a new tracing event and schema for account existence checks.
* **Tests**
  * Updated reward recovery and state rollback tests to validate leader tracking and new query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->