### PR TITLE
fix: wrong copy-pasting around error event helper in amaru-ledger

### DIFF
--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -442,7 +442,7 @@ fn import_dreps(
         }
     })?;
 
-    info!("dreps.imports", size = dreps.len());
+    info!("dreps.import", size = dreps.len());
 
     transaction.save(
         era_history,

--- a/crates/amaru-ledger/src/lib.rs
+++ b/crates/amaru-ledger/src/lib.rs
@@ -66,7 +66,7 @@ macro_rules! warn {
 #[macro_export]
 macro_rules! error {
     ($name:literal $(, $($rest:tt)+)?) => {
-        amaru_observability::debug!(error: "amaru::ledger", name: $name $(, $($rest)+)?);
+        amaru_observability::error!(target: "amaru::ledger", name: $name $(, $($rest)+)?);
     };
 }
 

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -24,6 +24,7 @@ use crate::{
     epoch_transition::{
         Computed, Effective, GovernanceActivity, GovernanceUpdates, PoolsEpochTransitionUpdates, Rewards, RewardsState,
     },
+    error,
     governance::ratification::ProposalsRoots,
     state::{
         AnchoredVolatileFragment, StateError,
@@ -33,6 +34,7 @@ use crate::{
         },
     },
     store::{HistoricalStores, Store},
+    warn,
 };
 
 pub struct VolatileDB {
@@ -222,11 +224,11 @@ impl VolatileSequence for VolatileDB {
         if let Some(last) = self.view_back()
             && last.slot() < target_slot
         {
-            tracing::warn!(
-                name: "rollback_to.beyond",
+            warn!(
+                "volatile.rollback_to",
                 %target_slot,
                 last_slot = ?last.slot(),
-                "Attempting to rollback to a point beyond the last known volatile fragment"
+                warning = "attempting to rollback to a point beyond the last known volatile fragment"
             );
             return Ok(());
         }
@@ -236,11 +238,11 @@ impl VolatileSequence for VolatileDB {
         if let Some(first) = self.view_front()
             && target_slot < first.slot()
         {
-            tracing::error!(
-                name: "rollback_to.before",
+            error!(
+                "volatile.rollback_to",
                 %target_slot,
                 first_slot = ?first.slot(),
-                "Attempting to rollback to a point before the first known of the volatile fragment"
+                error = "attempting to rollback to a point before the first known of the volatile fragment"
             );
             return Err(point);
         }


### PR DESCRIPTION
Oopsie.

no-changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ledger `error!` macro behavior so emitted logs use the proper error level instead of debug level.
  * Improved rollback logging for out-of-range targets by switching to structured `warn`/`error` entries under a dedicated rollback log target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->