### PR TITLE
fix: do not validate max protocol version + bump to 10.11.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Other guiding principles:
   ```
 -->
 
-## v10.10.20260716 _[unreleased; planned for 2026-07-16]_
+## v10.11.20260716 _[unreleased; planned for 2026-07-16]_
 
 ### Added
 
@@ -57,6 +57,7 @@ Other guiding principles:
 - **amaru-ledger**: reduce rationale number before serializing them to JSON in epoch summary. ([#1024][])
 - **amaru-ledger**: store the stake pool deposit for refunds instead of defaulting protocol parameters. ([#1031][])
 - **amaru-ledger**: do not overwrite already counted pool deposit refunds with newer refund from same credential. ([#1026][])
+- **amaru-ledger**: do not enforce max protocol version in block header; fix node stalling after hard fork on Preview. ([#1043][])
 - **amaru**: normalize snapshot metadata (all having a parent point now) and ensure better discoverability of local snapshots. ([#1039][])
 
 ## [v10.10.20260709](https://github.com/pragma-org/amaru/releases/tag/v10.10.20260709)
@@ -171,3 +172,4 @@ Other guiding principles:
 [#1031]: https://github.com/pragma-org/amaru/pull/1031
 [#1033]: https://github.com/pragma-org/amaru/pull/1033
 [#1039]: https://github.com/pragma-org/amaru/pull/1039
+[#1043]: https://github.com/pragma-org/amaru/pull/1043

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "amaru"
-version = "10.10.0"
+version = "10.11.0"
 dependencies = [
  "amaru-consensus",
  "amaru-deps",
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "amaru-deps"
-version = "10.10.0"
+version = "0.0.0"
 dependencies = [
  "bitflags 2.10.0",
  "blst",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ zeroize = "1.8.2"
 
 # Internal dependencies
 amaru = { path = "crates/amaru" }
-amaru-deps = { path = "crates/amaru-deps", version = "10.10.0" }
+amaru-deps = { path = "crates/amaru-deps", version = "0.0.0" }
 amaru-consensus = { path = "crates/amaru-consensus", version = "0.1.2" }
 amaru-fixture-builder = { path = "crates/amaru-fixture-builder", version = "0.1.2" }
 amaru-iter-borrow = { path = "crates/amaru-iter-borrow", version = "0.1.2" }

--- a/crates/amaru-deps/Cargo.toml
+++ b/crates/amaru-deps/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "amaru-deps"
-version = "10.10.0"
+version = "0.0.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/amaru-ledger/src/rules/block.rs
+++ b/crates/amaru-ledger/src/rules/block.rs
@@ -212,7 +212,13 @@ where
 
     with_block_context(body_hash::block_body_hash_valid(&block))?;
 
-    with_block_context(header_version::block_header_version_valid(&block, protocol_params))?;
+    // NOTE: No protocol major version in block header
+    //
+    // See: https://github.com/IntersectMBO/ouroboros-consensus/issues/2127
+    //
+    // ```
+    // with_block_context(header_version::block_header_version_valid(&block, protocol_params))?;
+    // ```
 
     with_block_context(ex_units::block_ex_units_valid(&block, protocol_params))?;
 

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -2,7 +2,7 @@ lints.workspace = true
 
 [package]
 name = "amaru"
-version = "10.10.0"
+version = "10.11.0"
 edition.workspace = true
 description.workspace = true
 license.workspace = true


### PR DESCRIPTION
See also: https://github.com/IntersectMBO/ouroboros-consensus/issues/2127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved block validation to prevent node stalling after a hard fork.
  - Blocks are no longer rejected based on an unavailable protocol major version in the block header.

- **Release**
  - Updated the upcoming release to version 10.11.0.

- **Documentation**
  - Added a changelog entry describing the hard-fork stability fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->