### PR TITLE
feat: normalize events

### DIFF
--- a/crates/amaru-consensus/src/stages/mempool/stage.rs
+++ b/crates/amaru-consensus/src/stages/mempool/stage.rs
@@ -152,7 +152,7 @@ async fn apply_new_tip(ledger: &Ledger, memory_pool: &MemoryPool, tip: Tip) -> R
 
     tracing::debug!(%tip, invalidated_txs = invalid_tx_ids.len(), "revalidated mempool after new tip");
     RevalidationOutcome {
-        tip_slot: u64::from(tip.slot()),
+        tip_slot: tip.slot(),
         total_before,
         evicted_tx_ids: invalid_tx_ids,
         duration_micros: started.elapsed().as_micros() as u64,

--- a/crates/amaru-consensus/src/stages/mempool/traces.rs
+++ b/crates/amaru-consensus/src/stages/mempool/traces.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::TransactionId;
+use amaru_kernel::{Slot, TransactionId};
 use amaru_metrics::mempool::{
     MempoolMetricEvent, MempoolMetrics, TxEvictedReason, TxInsertionOrigin, TxInsertionResult,
 };
@@ -24,9 +24,9 @@ use crate::effects::{Metrics, MetricsOps};
 
 /// Add traces for a transaction that is candidate for mempool insertion.
 pub(super) fn emit_tx_received(tx_id: &TransactionId, origin: &TxOrigin) {
-    trace_record!(mempool::transaction::RECEIVED, tx_id = tx_id.to_string(), origin = tx_origin_label(origin));
+    trace_record!(mempool::transaction::RECEIVED, tx_id = tx_id, origin = tx_origin_label(origin));
     if let TxOrigin::Remote(peer) = origin {
-        trace_record!(mempool::transaction::RECEIVED_DETAIL, tx_id = tx_id.to_string(), peer = peer.to_string());
+        trace_record!(mempool::transaction::RECEIVED_DETAIL, tx_id = tx_id, peer = peer);
     }
 }
 
@@ -42,7 +42,7 @@ pub(super) async fn record_insert(
         TxInsertResult::Accepted { tx_id, seq_no } => {
             trace_record!(
                 mempool::transaction::ACCEPTED,
-                tx_id = tx_id.to_string(),
+                tx_id = tx_id,
                 seq_no = seq_no.0,
                 origin = tx_origin_label(origin)
             );
@@ -54,13 +54,13 @@ pub(super) async fn record_insert(
                     let validation_error = err.to_string();
                     trace_record!(
                         mempool::transaction::REJECTED,
-                        tx_id = tx_id.to_string(),
+                        tx_id = tx_id,
                         reason = reason_label,
                         validation_error = validation_error
                     );
                 }
                 TxRejectReason::Duplicate | TxRejectReason::MempoolFull => {
-                    trace_record!(mempool::transaction::REJECTED, tx_id = tx_id.to_string(), reason = reason_label);
+                    trace_record!(mempool::transaction::REJECTED, tx_id = tx_id, reason = reason_label);
                 }
             }
         }
@@ -83,11 +83,7 @@ pub(super) async fn record_revalidation(
     let evicted_count = outcome.evicted_tx_ids.len() as u64;
 
     for tx_id in &outcome.evicted_tx_ids {
-        trace_record!(
-            mempool::transaction::EVICTED,
-            tx_id = tx_id.to_string(),
-            reason = "invalid_after_tip".to_string()
-        );
+        trace_record!(mempool::transaction::EVICTED, tx_id = tx_id, reason = "invalid_after_tip".to_string());
     }
     if evicted_count > 0 {
         emit_metrics(
@@ -111,7 +107,7 @@ pub(super) async fn record_revalidation(
 }
 
 pub(super) struct RevalidationOutcome {
-    pub(super) tip_slot: u64,
+    pub(super) tip_slot: Slot,
     pub(super) total_before: u64,
     pub(super) evicted_tx_ids: Vec<TransactionId>,
     pub(super) duration_micros: u64,

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -498,7 +498,7 @@ impl TrackPeers {
 }
 
 pub fn decode_header(raw_header: HeaderContent, peer: &Peer) -> Result<BlockHeader, ConsensusError> {
-    let span = debug_span!(consensus::header::DECODE, peer = peer.to_string(),);
+    let span = debug_span!(consensus::header::DECODE, peer = peer);
     let _guard = span.enter();
     // need to list all the variants supported by the current Amaru implementation
     if !matches!(raw_header.variant, EraName::Conway) {

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -28,6 +28,7 @@ use amaru_kernel::{
     cbor::{self, lazy::LazyDecoder},
     new_stake_address, protocol_version, reward_account_to_stake_credential, size,
 };
+use amaru_observability::{info, warn};
 use amaru_progress_bar::ProgressBar;
 
 use crate::{
@@ -46,18 +47,6 @@ static DEFAULT_CERTIFICATE_POINTER: LazyLock<CertificatePointer> = LazyLock::new
     transaction: TransactionPointer { slot: Slot::from(0), transaction_index: 0 },
     certificate_index: 0,
 });
-
-macro_rules! info {
-    ($name:literal $(, $($rest:tt)+)?) => {
-        amaru_observability::info!(target: "amaru::bootstrap", name: $name $(, $($rest)+)?);
-    };
-}
-
-macro_rules! warn {
-    ($name: literal $(, $($rest:tt)+)?) => {
-        amaru_observability::warn!(target: "amaru::bootstrap", name: $name $(, $($rest)+)?);
-    };
-}
 
 #[derive(Debug, thiserror::Error)]
 enum InitialSnapshotFormatError {
@@ -173,7 +162,7 @@ pub fn import_initial_snapshot(
         // Dormant Epoch
         let dormant_epoch: Epoch = d.decode()?;
         let governance_activity = GovernanceActivity { consecutive_dormant_epochs: u64::from(dormant_epoch) as u32 };
-        info!("governance_activity.import", dormant_epochs = governance_activity.consecutive_dormant_epochs);
+        info!(bootstrap::governance_activity::IMPORT, dormant_epochs = governance_activity.consecutive_dormant_epochs);
         Ok(governance_activity)
     })?;
 
@@ -404,7 +393,7 @@ fn import_block_issuers(
             fake_slot += 1;
         }
     }
-    info!("block_issuers.import", count = fake_slot);
+    info!(bootstrap::block_issuers::IMPORT, count = fake_slot);
     transaction.commit().map_err(Into::into)
 }
 
@@ -442,7 +431,7 @@ fn import_dreps(
         }
     })?;
 
-    info!("dreps.import", size = dreps.len());
+    info!(bootstrap::dreps::IMPORT, size = dreps.len());
 
     transaction.save(
         era_history,
@@ -484,12 +473,12 @@ fn import_proposals(
     proposals: &[ProposalState],
 ) -> Result<(), Box<dyn std::error::Error>> {
     if db.iter_proposals()?.next().is_some() {
-        warn!("proposals.is_not_empty");
+        warn!(bootstrap::proposals::IS_NOT_EMPTY);
     }
 
     let transaction = db.create_transaction();
 
-    info!("proposals.import", size = proposals.len());
+    info!(bootstrap::proposals::IMPORT, size = proposals.len());
 
     transaction.save(
         era_history,
@@ -556,7 +545,7 @@ fn import_stake_pools(
         state.unregister(pool, epoch);
     }
 
-    info!("stake_pools.import", registered = state.registered.len(), retiring = state.unregistered.len());
+    info!(bootstrap::stake_pools::IMPORT, registered = state.registered.len(), retiring = state.unregistered.len());
 
     let transaction = db.create_transaction();
     transaction.with_pools(|iterator| {
@@ -610,7 +599,7 @@ fn import_pots(db: &impl Store, pots: Pots) -> Result<(), Box<dyn std::error::Er
     })?;
     transaction.commit()?;
     let Pots { treasury, reserves, fees, donations } = pots;
-    info!("pots.import", treasury, reserves, fees, donations);
+    info!(bootstrap::pots::IMPORT, treasury, reserves, fees, donations);
     Ok(())
 }
 
@@ -624,7 +613,7 @@ fn import_accounts(
     rewards_updates: &mut BTreeMap<StakeCredential, Set<Reward>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if db.iter_accounts()?.next().is_some() {
-        warn!("accounts.is_not_empty");
+        warn!(bootstrap::accounts::IS_NOT_EMPTY);
     }
 
     let transaction = db.create_transaction();
@@ -669,7 +658,7 @@ fn import_accounts(
         })
         .collect::<Vec<_>>();
 
-    info!("accounts.import", size = credentials.len());
+    info!(bootstrap::accounts::IMPORT, size = credentials.len());
 
     let progress = with_progress(credentials.len(), "Accounts [{pos:>7}/{len:7}] {bar:40.green} ({eta} remaining)");
 
@@ -727,7 +716,7 @@ fn import_proposals_roots(
     let roots_protocol_parameters = roots.protocol_parameters.as_ref().map(|s| s.to_string());
 
     info!(
-        "proposal_roots.import",
+        bootstrap::proposal_roots::IMPORT,
         constitution = roots_constitution.as_deref().unwrap_or("none"),
         constitutional_committee = roots_constitutional_committee.as_deref().unwrap_or("none"),
         hard_fork = roots_hard_fork.as_deref().unwrap_or("none"),
@@ -744,7 +733,7 @@ fn import_constitution(db: &impl Store, constitution: Constitution) -> Result<()
     let transaction = db.create_transaction();
 
     info!(
-        "constitution.import",
+        bootstrap::constitution::IMPORT,
         anchor = constitution.anchor.url,
         guardrails = Option::from(constitution.guardrail_script.clone())
             .map(|s: Hash<28>| s.to_string().chars().take(8).collect())
@@ -778,12 +767,12 @@ fn import_constitutional_committee(
 
     let cc = match cc {
         StrictMaybe::Nothing => {
-            info!("constitutional_committee.import", state = "no_confidence");
+            info!(bootstrap::constitutional_committee::IMPORT, state = "no_confidence");
             amaru_kernel::ConstitutionalCommitteeStatus::NoConfidence
         }
         StrictMaybe::Just(ConstitutionalCommittee { threshold, members }) => {
             info!(
-                "constitutional_committee.import",
+                bootstrap::constitutional_committee::IMPORT,
                 state = "trusted",
                 threshold = format!("{}/{}", threshold.numerator, threshold.denominator),
                 members = members.len(),
@@ -878,7 +867,7 @@ fn import_votes(
         })
         .collect::<Vec<_>>();
 
-    info!("votes.import", size = votes.len());
+    info!(bootstrap::votes::IMPORT, size = votes.len());
 
     let transaction = db.create_transaction();
 

--- a/crates/amaru-ledger/src/context/default/validation.rs
+++ b/crates/amaru-ledger/src/context/default/validation.rs
@@ -147,7 +147,7 @@ impl PoolsSlice for DefaultValidationContext {
         let _span = trace_span!(
             ledger::transaction::CERTIFICATE_POOL_RETIREMENT,
             pool_id = %pool,
-            epoch = u64::from(epoch)
+            epoch = epoch
         );
         let _guard = _span.enter();
         self.state.pools.unregister(pool, epoch)

--- a/crates/amaru-ledger/src/epoch_transition/pools_updates.rs
+++ b/crates/amaru-ledger/src/epoch_transition/pools_updates.rs
@@ -22,9 +22,9 @@ use amaru_kernel::{
     Epoch, Hash, Lovelace, PoolId, PoolParams, RewardAccount, StakeCredential, expect_stake_credential, hash,
     pool_metadata, rational_number, relay,
 };
-use amaru_observability::info_span;
+use amaru_observability::{debug, info_span};
 
-use crate::{debug, store::columns::pools::Row as Pool};
+use crate::store::columns::pools::Row as Pool;
 
 /// Captures stake pool updates computed at the epoch transition, but not yet applied to the
 /// immutable storage. Those updates are meant to be updated only after `k` blocks have passed in
@@ -141,16 +141,16 @@ impl PoolsEpochTransitionUpdates {
             let metadata = set(&mut current_params.metadata, metadata, pool_metadata::fmt);
 
             debug!(
-                "epoch_transition.tick_pool",
+                ledger::epoch_transition::TICK_POOL,
                 id = %pool_id,
-                vrf,
-                pledge,
-                cost,
-                margin,
-                reward_account,
-                owners,
-                relays,
-                metadata,
+                @vrf,
+                @pledge,
+                @cost,
+                @margin,
+                @reward_account,
+                @owners,
+                @relays,
+                @metadata,
             );
 
             true
@@ -169,7 +169,7 @@ impl PoolsEpochTransitionUpdates {
     }
 
     fn retire_pool(&mut self, epoch: Epoch, pool: Pool) {
-        debug!("epoch_transition.retire_pool", id = %pool.id());
+        debug!(ledger::epoch_transition::RETIRE_POOL, id = %pool.id());
 
         self.retired.insert(pool.id());
         self.refunds

--- a/crates/amaru-ledger/src/epoch_transition/ratification.rs
+++ b/crates/amaru-ledger/src/epoch_transition/ratification.rs
@@ -34,14 +34,12 @@ use amaru_kernel::{
     expect_stake_credential,
     rational_number,
 };
-use amaru_observability::info_span;
+use amaru_observability::{debug, info, info_span};
 
 use crate::{
-    debug,
     governance::ratification::{
         CandidateProposal, CommitteeUpdate, ProposalsRoots, ProposalsRootsRc, RatificationContext,
     },
-    info,
     state::StateError,
     store::columns::proposals::Row as Proposal,
 };
@@ -179,7 +177,7 @@ impl GovernanceUpdates {
                     let ratified_or_evicted = ctx.pruned_proposals.contains_key(&id);
 
                     if expired || ratified_or_evicted {
-                        info!("proposal.drop", id = %id, expired, ratified_or_evicted);
+                        info!(ledger::proposal::DROP, id = %id, expired, ratified_or_evicted);
                         ctx.pruned_proposals.insert(id, RatificationStatus::NotRatified); // For expired proposals
                         let return_account = proposal.return_account;
                         let deposit = proposal.deposit;
@@ -240,20 +238,20 @@ impl GovernanceUpdates {
                     .collect();
 
                 debug!(
-                    "proposal_roots.summarize",
-                    constitution = opt_root(roots.constitution.as_deref()),
-                    constitutional_committee = opt_root(roots.constitutional_committee.as_deref()),
-                    hard_fork = opt_root(roots.hard_fork.as_deref()),
-                    protocol_parameters = opt_root(roots.protocol_parameters.as_deref()),
+                    ledger::proposal_roots::SUMMARIZE,
+                    constitution = @opt_root(roots.constitution.as_deref()),
+                    constitutional_committee = @opt_root(roots.constitutional_committee.as_deref()),
+                    hard_fork = @opt_root(roots.hard_fork.as_deref()),
+                    protocol_parameters = @opt_root(roots.protocol_parameters.as_deref()),
                 );
 
                 info!(
-                    "ratification.summarize",
-                    pruned_proposals = opt_str(pruned_proposals_str),
-                    payouts = opt_str(payouts_str),
+                    ledger::ratification::SUMMARIZE,
+                    pruned_proposals = @opt_str(pruned_proposals_str),
+                    payouts = @opt_str(payouts_str),
                     new_constitution =
-                        opt_str(ctx.new_constitution.as_ref().map(|c| c.anchor.url.clone()).unwrap_or_default()),
-                    constitutional_committee_update = opt_str(
+                        @opt_str(ctx.new_constitution.as_ref().map(|c| c.anchor.url.clone()).unwrap_or_default()),
+                    constitutional_committee_update = @opt_str(
                         ctx.constitutional_committee_update.as_ref().map(|c| c.to_string()).unwrap_or_default()
                     ),
                     is_dormant_epoch,
@@ -338,52 +336,52 @@ fn diff_protocol_parameters(old: &ProtocolParameters, new: &ProtocolParameters) 
     } = new;
 
     info!(
-        "protocol_parameters.ratify",
-        protocol_version = opt_field_with(&old.protocol_version, protocol_version, protocol_version::fmt),
-        max_block_body_size = opt_field(&old.max_block_body_size, max_block_body_size),
-        max_transaction_size = opt_field(&old.max_transaction_size, max_transaction_size),
-        max_block_header_size = opt_field(&old.max_block_header_size, max_block_header_size),
-        max_tx_ex_units = opt_field_with(&old.max_tx_ex_units, max_tx_ex_units, ex_units::fmt),
-        max_block_ex_units = opt_field_with(&old.max_block_ex_units, max_block_ex_units, ex_units::fmt),
-        max_value_size = opt_field(&old.max_value_size, max_value_size),
-        max_collateral_inputs = opt_field(&old.max_collateral_inputs, max_collateral_inputs),
-        min_fee_a = opt_field(&old.min_fee_a, min_fee_a),
-        min_fee_b = opt_field(&old.min_fee_b, min_fee_b),
-        stake_credential_deposit = opt_field(&old.stake_credential_deposit, stake_credential_deposit),
-        stake_pool_deposit = opt_field(&old.stake_pool_deposit, stake_pool_deposit),
+        ledger::protocol_parameters::RATIFY,
+        protocol_version = @opt_field_with(&old.protocol_version, protocol_version, protocol_version::fmt),
+        max_block_body_size = @opt_field(&old.max_block_body_size, max_block_body_size),
+        max_transaction_size = @opt_field(&old.max_transaction_size, max_transaction_size),
+        max_block_header_size = @opt_field(&old.max_block_header_size, max_block_header_size),
+        max_tx_ex_units = @opt_field_with(&old.max_tx_ex_units, max_tx_ex_units, ex_units::fmt),
+        max_block_ex_units = @opt_field_with(&old.max_block_ex_units, max_block_ex_units, ex_units::fmt),
+        max_value_size = @opt_field(&old.max_value_size, max_value_size),
+        max_collateral_inputs = @opt_field(&old.max_collateral_inputs, max_collateral_inputs),
+        min_fee_a = @opt_field(&old.min_fee_a, min_fee_a),
+        min_fee_b = @opt_field(&old.min_fee_b, min_fee_b),
+        stake_credential_deposit = @opt_field(&old.stake_credential_deposit, stake_credential_deposit),
+        stake_pool_deposit = @opt_field(&old.stake_pool_deposit, stake_pool_deposit),
         monetary_expansion_rate =
-            opt_field_with(&old.monetary_expansion_rate, monetary_expansion_rate, rational_number::fmt),
+            @opt_field_with(&old.monetary_expansion_rate, monetary_expansion_rate, rational_number::fmt),
         treasury_expansion_rate =
-            opt_field_with(&old.treasury_expansion_rate, treasury_expansion_rate, rational_number::fmt),
-        min_pool_cost = opt_field(&old.min_pool_cost, min_pool_cost),
-        lovelace_per_utxo_byte = opt_field(&old.lovelace_per_utxo_byte, lovelace_per_utxo_byte),
-        prices = opt_field_with(&old.prices, prices, ex_units_prices::fmt),
-        min_fee_ref_script_lovelace_per_byte = opt_field_with(
+            @opt_field_with(&old.treasury_expansion_rate, treasury_expansion_rate, rational_number::fmt),
+        min_pool_cost = @opt_field(&old.min_pool_cost, min_pool_cost),
+        lovelace_per_utxo_byte = @opt_field(&old.lovelace_per_utxo_byte, lovelace_per_utxo_byte),
+        prices = @opt_field_with(&old.prices, prices, ex_units_prices::fmt),
+        min_fee_ref_script_lovelace_per_byte = @opt_field_with(
             &old.min_fee_ref_script_lovelace_per_byte,
             min_fee_ref_script_lovelace_per_byte,
             rational_number::fmt,
         ),
-        max_ref_script_size_per_tx = opt_field(&old.max_ref_script_size_per_tx, max_ref_script_size_per_tx),
-        max_ref_script_size_per_block = opt_field(&old.max_ref_script_size_per_block, max_ref_script_size_per_block),
-        ref_script_cost_stride = opt_field(&old.ref_script_cost_stride, ref_script_cost_stride),
+        max_ref_script_size_per_tx = @opt_field(&old.max_ref_script_size_per_tx, max_ref_script_size_per_tx),
+        max_ref_script_size_per_block = @opt_field(&old.max_ref_script_size_per_block, max_ref_script_size_per_block),
+        ref_script_cost_stride = @opt_field(&old.ref_script_cost_stride, ref_script_cost_stride),
         ref_script_cost_multiplier =
-            opt_field_with(&old.ref_script_cost_multiplier, ref_script_cost_multiplier, rational_number::fmt),
+            @opt_field_with(&old.ref_script_cost_multiplier, ref_script_cost_multiplier, rational_number::fmt),
         stake_pool_max_retirement_epoch =
-            opt_field(&old.stake_pool_max_retirement_epoch, stake_pool_max_retirement_epoch),
-        optimal_stake_pools_count = opt_field(&old.optimal_stake_pools_count, optimal_stake_pools_count),
-        pledge_influence = opt_field_with(&old.pledge_influence, pledge_influence, rational_number::fmt),
-        collateral_percentage = opt_field(&old.collateral_percentage, collateral_percentage),
-        cost_models = opt_field_with(&old.cost_models, cost_models, cost_models::fmt),
+            @opt_field(&old.stake_pool_max_retirement_epoch, stake_pool_max_retirement_epoch),
+        optimal_stake_pools_count = @opt_field(&old.optimal_stake_pools_count, optimal_stake_pools_count),
+        pledge_influence = @opt_field_with(&old.pledge_influence, pledge_influence, rational_number::fmt),
+        collateral_percentage = @opt_field(&old.collateral_percentage, collateral_percentage),
+        cost_models = @opt_field_with(&old.cost_models, cost_models, cost_models::fmt),
         pool_voting_thresholds =
-            opt_field_with(&old.pool_voting_thresholds, pool_voting_thresholds, pool_voting_thresholds::fmt),
+            @opt_field_with(&old.pool_voting_thresholds, pool_voting_thresholds, pool_voting_thresholds::fmt),
         drep_voting_thresholds =
-            opt_field_with(&old.drep_voting_thresholds, drep_voting_thresholds, drep_voting_thresholds::fmt,),
-        min_committee_size = opt_field(&old.min_committee_size, min_committee_size),
-        max_committee_term_length = opt_field(&old.max_committee_term_length, max_committee_term_length),
-        gov_action_lifetime = opt_field(&old.gov_action_lifetime, gov_action_lifetime),
-        gov_action_deposit = opt_field(&old.gov_action_deposit, gov_action_deposit),
-        drep_deposit = opt_field(&old.drep_deposit, drep_deposit),
-        drep_expiry = opt_field(&old.drep_expiry, drep_expiry),
+            @opt_field_with(&old.drep_voting_thresholds, drep_voting_thresholds, drep_voting_thresholds::fmt,),
+        min_committee_size = @opt_field(&old.min_committee_size, min_committee_size),
+        max_committee_term_length = @opt_field(&old.max_committee_term_length, max_committee_term_length),
+        gov_action_lifetime = @opt_field(&old.gov_action_lifetime, gov_action_lifetime),
+        gov_action_deposit = @opt_field(&old.gov_action_deposit, gov_action_deposit),
+        drep_deposit = @opt_field(&old.drep_deposit, drep_deposit),
+        drep_expiry = @opt_field(&old.drep_expiry, drep_expiry),
     );
 }
 

--- a/crates/amaru-ledger/src/governance/ratification.rs
+++ b/crates/amaru-ledger/src/governance/ratification.rs
@@ -98,7 +98,7 @@ impl<'distr> RatificationContext<'distr> {
     ) -> Result<Self, StoreError> {
         let epoch = snapshot.epoch();
 
-        info_span!(ledger::governance::NEW_RATIFICATION_CONTEXT, ratifying_epoch = u64::from(epoch)).in_scope(|| {
+        info_span!(ledger::governance::NEW_RATIFICATION_CONTEXT, ratifying_epoch = epoch).in_scope(|| {
             let constitutional_committee = match snapshot.constitutional_committee()? {
                 ConstitutionalCommitteeStatus::NoConfidence => None,
                 ConstitutionalCommitteeStatus::Trusted { threshold } => {
@@ -155,7 +155,7 @@ impl<'distr> RatificationContext<'distr> {
     ) -> Result<ProposalsRootsRc, RatificationInternalError> {
         info_span!(
             ledger::governance::RATIFY_PROPOSALS,
-            epoch = u64::from(self.epoch),
+            epoch = self.epoch,
             roots_protocol_parameters = opt_root(roots.protocol_parameters.as_deref()),
             roots_hard_fork = opt_root(roots.hard_fork.as_deref()),
             roots_constitutional_committee = opt_root(roots.constitutional_committee.as_deref()),

--- a/crates/amaru-ledger/src/governance/ratification/constitutional_committee.rs
+++ b/crates/amaru-ledger/src/governance/ratification/constitutional_committee.rs
@@ -20,13 +20,11 @@ use std::{
 };
 
 use amaru_kernel::{Epoch, StakeCredential, Vote};
+use amaru_observability::warn;
 use num::Zero;
 
 use super::{OrphanProposal, ProposalEnum};
-use crate::{
-    summary::{SafeRatio, safe_ratio},
-    warn,
-};
+use crate::summary::{SafeRatio, safe_ratio};
 
 static ZERO: LazyLock<SafeRatio> = LazyLock::new(SafeRatio::zero);
 
@@ -127,8 +125,8 @@ impl ConstitutionalCommittee {
             | ProposalEnum::Orphan(OrphanProposal::TreasuryWithdrawal { .. }) => {
                 if self.active_members(current_epoch).len() < (min_committee_size as usize) {
                     warn!(
-                        "constitutional_committee.ignore",
-                        members.active = self.active_members(current_epoch).len(),
+                        ledger::constitutional_committee::IGNORE,
+                        active_members = self.active_members(current_epoch).len(),
                         min_committee_size = min_committee_size,
                         reason = "committee is below minimum size; ignoring voting threshold entirely"
                     );

--- a/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
+++ b/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
@@ -24,6 +24,7 @@ use amaru_kernel::{
     ProposalPointer, ProtocolParamUpdate, ProtocolParameters, ProtocolVersion, RatificationStatus,
     display_protocol_parameters_update, expect_stake_credential, utils::string::display_collection,
 };
+use amaru_observability::{debug, info};
 
 pub use super::proposals_tree::{ProposalsEnactError, ProposalsInsertError};
 use super::{
@@ -31,7 +32,7 @@ use super::{
     proposals_roots::ProposalsRootsRc,
     proposals_tree::{ProposalsTree, Sibling},
 };
-use crate::{debug, info, summary::into_safe_ratio};
+use crate::summary::into_safe_ratio;
 
 #[derive(Debug, Clone)]
 pub struct ProposalsForest {
@@ -291,7 +292,7 @@ impl ProposalsForest {
 
         if self.is_interrupted {
             info!(
-                "ratification.skip",
+                ledger::ratification::SKIP,
                 reason = "high-impact proposal was enacted; skipping ratification of other proposals for this epoch",
             );
         }
@@ -428,7 +429,7 @@ impl ProposalsForestCompass {
         // skip it.
         if proposed_in > &forest.current_epoch {
             debug!(
-                "proposal.skip",
+                ledger::proposal::SKIP,
                 id = %id,
                 %proposed_in,
                 ratifying_epoch = %forest.current_epoch,
@@ -447,7 +448,7 @@ impl ProposalsForestCompass {
             let total_withdrawn = withdrawals.values().fold(0_u64, |total, n| total.saturating_add(*n));
             if total_withdrawn > forest.treasury() {
                 debug!(
-                    "proposal.skip",
+                    ledger::proposal::SKIP,
                     id = %id,
                     withdrawal = total_withdrawn,
                     treasury = forest.treasury(),
@@ -469,7 +470,7 @@ impl ProposalsForestCompass {
                 let invalid_members =
                     added.iter().filter(|(_, v)| is_now_invalid(v)).map(|(k, _)| k.as_hash()).collect::<Vec<_>>();
                 debug!(
-                    "proposal.skip",
+                    ledger::proposal::SKIP,
                     id = %id,
                     invalid_members = display_collection(invalid_members),
                     reason = "proposed committee has invalid members; their term length (now) beyond limit"
@@ -492,7 +493,7 @@ impl ProposalsForestCompass {
         if forest.matching_root(proposal) {
             Some((id, (proposal, pointer)))
         } else {
-            debug!("proposal.skip", id = %id, reason = "non-matching root; proposal will be pruned later");
+            debug!(ledger::proposal::SKIP, id = %id, reason = "non-matching root; proposal will be pruned later");
             None
         }
     }

--- a/crates/amaru-ledger/src/lib.rs
+++ b/crates/amaru-ledger/src/lib.rs
@@ -35,41 +35,6 @@ macro_rules! tracing_enabled {
     };
 }
 
-#[macro_export]
-macro_rules! trace {
-    ($name:literal $(, $($rest:tt)+)?) => {
-        amaru_observability::trace!(target: "amaru::ledger", name: $name $(, $($rest)+)?);
-    };
-}
-
-#[macro_export]
-macro_rules! debug {
-    ($name:literal $(, $($rest:tt)+)?) => {
-        amaru_observability::debug!(target: "amaru::ledger", name: $name $(, $($rest)+)?);
-    };
-}
-
-#[macro_export]
-macro_rules! info {
-    ($name:literal $(, $($rest:tt)+)?) => {
-        amaru_observability::info!(target: "amaru::ledger", name: $name $(, $($rest)+)?);
-    };
-}
-
-#[macro_export]
-macro_rules! warn {
-    ($name: literal $(, $($rest:tt)+)?) => {
-        amaru_observability::warn!(target: "amaru::ledger", name: $name $(, $($rest)+)?);
-    };
-}
-
-#[macro_export]
-macro_rules! error {
-    ($name:literal $(, $($rest:tt)+)?) => {
-        amaru_observability::error!(target: "amaru::ledger", name: $name $(, $($rest)+)?);
-    };
-}
-
 #[cfg(test)]
 pub(crate) mod tests {
     use amaru_kernel::{Address, Hash, MemoizedTransactionOutput, MemoizedValue, TransactionInput, Value};

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -27,7 +27,7 @@ use amaru_kernel::{
     utils::string::display_collection,
 };
 use amaru_metrics::ledger::LedgerMetrics;
-use amaru_observability::{debug_span, info_span, trace_span};
+use amaru_observability::{debug_span, info, info_span, trace, trace_span, warn};
 use amaru_ouroboros_traits::{HasStakeDistribution, PoolSummary, has_stake_distribution::GetPoolError};
 use amaru_plutus::arena_pool::ArenaPool;
 use num::CheckedSub;
@@ -38,7 +38,6 @@ use crate::{
     context::{ContextHydratationError, DefaultPreparationContext, DefaultValidationContext, UnresolvedInputPolicy},
     epoch_transition::{self, GovernanceActivity},
     governance::ratification::RatificationContext,
-    info,
     rules::{
         self,
         block::{BlockValidation, TransactionInvalid},
@@ -52,7 +51,7 @@ use crate::{
         rewards::RewardsSummary,
         stake_distribution::StakeDistribution,
     },
-    trace, tracing_enabled, warn,
+    tracing_enabled,
 };
 
 pub mod diff_bind;
@@ -283,7 +282,7 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
         let immutable_slot = now_stable.anchor.0.slot();
         let immutable_epoch = unsafe_slot_to_epoch(&self.era_history, immutable_slot);
 
-        debug_span!(ledger::block::APPLY, point_slot = u64::from(immutable_slot)).in_scope(
+        debug_span!(ledger::block::APPLY, point_slot = immutable_slot).in_scope(
             || {
                 let protocol_parameters = self.protocol_parameters_for(immutable_epoch).unwrap_or_else(|| unreachable! {
                     "invariant violation: asking protocol parameters for an unreachable epoch; immutable epoch = {}; volatile epoch = {}",
@@ -344,7 +343,11 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
             let new_protocol_version = self.protocol_version();
 
             if old_protocol_version != new_protocol_version {
-                info!("protocol.upgrade", old_version = old_protocol_version.0, new_version = new_protocol_version.0);
+                info!(
+                    ledger::protocol::UPGRADE,
+                    old_version = old_protocol_version.0,
+                    new_version = new_protocol_version.0
+                );
             }
         }
 
@@ -352,108 +355,107 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
     }
 
     fn epoch_transition(&mut self, next_epoch: Epoch) -> Result<(), StateError> {
-        info_span!(ledger::epoch_transition::COMPUTE, from = u64::from(next_epoch - 1), into = u64::from(next_epoch))
-            .in_scope(|| {
-                let computed_rewards = self.volatile.take_computed_rewards();
+        info_span!(ledger::epoch_transition::COMPUTE, from = next_epoch - 1, into = next_epoch).in_scope(|| {
+            let computed_rewards = self.volatile.take_computed_rewards();
 
-                #[allow(clippy::unwrap_used)]
-                let db = self.stable.lock().unwrap();
+            #[allow(clippy::unwrap_used)]
+            let db = self.stable.lock().unwrap();
 
-                let progress = db.epoch_transition_progress()?;
+            let progress = db.epoch_transition_progress()?;
 
-                match progress {
-                    Some(resuming_from) => {
-                        Span::current().record("resuming_from", resuming_from.to_string());
-                    }
-                    // NOTE: Skipping epoch transition
-                    //
-                    // It is possible to interrupt Amaru just after the epoch transition was flushed
-                    // to disk. The consequence of that is: the tip of the immutable db is still in the
-                    // previous epoch which will cause the next block we see to trigger an epoch transition.
-                    //
-                    // However, the epoch transition had already happened and was even persisted to disk
-                    // already! So we must not redo it. This strange behaviour occurs because we do not
-                    // persist the volatile; so on restart, we rewind `k` blocks in the past, for which we
-                    // may or may not need to perform the transition again (depending where we interrupted).
-                    None if self.most_recent_snapshot() == next_epoch - 1 => {
-                        Span::current().record("skipped", true);
-                        return Ok(());
-                    }
-                    None => (),
+            match progress {
+                Some(resuming_from) => {
+                    Span::current().record("resuming_from", resuming_from.to_string());
                 }
-
-                // NOTE: Crossing states during epoch transition
+                // NOTE: Skipping epoch transition
                 //
-                // The volatile at this point MUST NOT contain any block applications belonging to
-                // two epochs; So it is crucical for this view to only be created before we introduce
-                // any block from the next epoch.
+                // It is possible to interrupt Amaru just after the epoch transition was flushed
+                // to disk. The consequence of that is: the tip of the immutable db is still in the
+                // previous epoch which will cause the next block we see to trigger an epoch transition.
                 //
-                // We could possible replace the direct access on the volatile here with an
-                // aggregated state as a proof that the volatile was indeed only containing the
-                // last k blocks for a single epoch. Or carry some kind of type-level guard that
-                // the this is called within an acceptable context (i.e. the volatile
-                // pre-conditions have been checked).
-                let mut volatile_view = VolatileView::new(&self.volatile, &*db);
+                // However, the epoch transition had already happened and was even persisted to disk
+                // already! So we must not redo it. This strange behaviour occurs because we do not
+                // persist the volatile; so on restart, we rewind `k` blocks in the past, for which we
+                // may or may not need to perform the transition again (depending where we interrupted).
+                None if self.most_recent_snapshot() == next_epoch - 1 => {
+                    Span::current().record("skipped", true);
+                    return Ok(());
+                }
+                None => (),
+            }
 
-                // NOTE: No rewards during epoch transition?
+            // NOTE: Crossing states during epoch transition
+            //
+            // The volatile at this point MUST NOT contain any block applications belonging to
+            // two epochs; So it is crucical for this view to only be created before we introduce
+            // any block from the next epoch.
+            //
+            // We could possible replace the direct access on the volatile here with an
+            // aggregated state as a proof that the volatile was indeed only containing the
+            // last k blocks for a single epoch. Or carry some kind of type-level guard that
+            // the this is called within an acceptable context (i.e. the volatile
+            // pre-conditions have been checked).
+            let mut volatile_view = VolatileView::new(&self.volatile, &*db);
+
+            // NOTE: No rewards during epoch transition?
+            //
+            // It is fine in some situation to compute an epoch transition and yet have no rewards.
+            // This happens if Amaru is interrupted *while it is flushing* an epoch transition to
+            // disk.
+            //
+            // This happens artificially every time someone bootstraps; because the bootstrapping
+            // process behaves as if we had interrupted the transition just after taking the
+            // snapshot. So we must proceed with computing the beginning of an epoch (ratification,
+            // pool updates, etc...) but not the end (rewards).
+            let (treasury, effective_rewards) = if progress.is_none() {
+                // FIXME: asynchronous rewards calculations
                 //
-                // It is fine in some situation to compute an epoch transition and yet have no rewards.
-                // This happens if Amaru is interrupted *while it is flushing* an epoch transition to
-                // disk.
-                //
-                // This happens artificially every time someone bootstraps; because the bootstrapping
-                // process behaves as if we had interrupted the transition just after taking the
-                // snapshot. So we must proceed with computing the beginning of an epoch (ratification,
-                // pool updates, etc...) but not the end (rewards).
-                let (treasury, effective_rewards) = if progress.is_none() {
-                    // FIXME: asynchronous rewards calculations
-                    //
-                    // This should eventually be a '.await', as we always expect to *eventually*
-                    // have some rewards summary being available. There's no way to continue progressing
-                    // the ledger if we don't.
-                    let effective_rewards = epoch_transition::end_epoch(
-                        &mut volatile_view,
-                        computed_rewards.ok_or(StateError::RewardsSummaryNotReady)?,
-                    )?;
-
-                    (db.pots()?.treasury + effective_rewards.delta_treasury(), Some(effective_rewards))
-                } else {
-                    (db.pots()?.treasury, None)
-                };
-
-                let protocol_parameters = self.protocol_parameters();
-
-                let ratification_context = RatificationContext::new(
-                    // Ratification happens with one epoch of delay, and at the next epoch transition. So,
-                    // if we ratify votes that happened in epoch `e`, the ratification is done during the
-                    // transition from `e + 1` to `e + 2`;
-                    //
-                    // Here, we have `next_epoch = e + 2`. And so, we have to pull the data and stake
-                    // distribution from at `next_epoch - 2`.
-                    self.snapshots.for_epoch(next_epoch - 2)?,
-                    self.stake_distribution(next_epoch - 2)?,
-                    protocol_parameters.clone(),
-                    // NOTE: ratification treasury value
-                    //
-                    // Ratification occurs after rewards have been paid out; and thus, uses the value
-                    // of the treasury that already includes any unpaid rewards.
-                    treasury,
-                )?;
-
-                let (pools_updates, governance_updates) = epoch_transition::begin_epoch(
+                // This should eventually be a '.await', as we always expect to *eventually*
+                // have some rewards summary being available. There's no way to continue progressing
+                // the ledger if we don't.
+                let effective_rewards = epoch_transition::end_epoch(
                     &mut volatile_view,
-                    next_epoch,
-                    &self.era_history,
-                    protocol_parameters,
-                    ratification_context,
+                    computed_rewards.ok_or(StateError::RewardsSummaryNotReady)?,
                 )?;
 
-                drop(db); // Dropping the *mutable reference*, not the *actual database* :)
+                (db.pots()?.treasury + effective_rewards.delta_treasury(), Some(effective_rewards))
+            } else {
+                (db.pots()?.treasury, None)
+            };
 
-                self.volatile.transition(effective_rewards, pools_updates, governance_updates);
+            let protocol_parameters = self.protocol_parameters();
 
-                Ok(())
-            })
+            let ratification_context = RatificationContext::new(
+                // Ratification happens with one epoch of delay, and at the next epoch transition. So,
+                // if we ratify votes that happened in epoch `e`, the ratification is done during the
+                // transition from `e + 1` to `e + 2`;
+                //
+                // Here, we have `next_epoch = e + 2`. And so, we have to pull the data and stake
+                // distribution from at `next_epoch - 2`.
+                self.snapshots.for_epoch(next_epoch - 2)?,
+                self.stake_distribution(next_epoch - 2)?,
+                protocol_parameters.clone(),
+                // NOTE: ratification treasury value
+                //
+                // Ratification occurs after rewards have been paid out; and thus, uses the value
+                // of the treasury that already includes any unpaid rewards.
+                treasury,
+            )?;
+
+            let (pools_updates, governance_updates) = epoch_transition::begin_epoch(
+                &mut volatile_view,
+                next_epoch,
+                &self.era_history,
+                protocol_parameters,
+                ratification_context,
+            )?;
+
+            drop(db); // Dropping the *mutable reference*, not the *actual database* :)
+
+            self.volatile.transition(effective_rewards, pools_updates, governance_updates);
+
+            Ok(())
+        })
     }
 
     fn try_compute_rewards(&mut self) -> Result<(), StateError> {
@@ -480,7 +482,7 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
 
     #[expect(clippy::unwrap_used)]
     fn compute_rewards(&mut self, for_epoch: Epoch) -> Result<RewardsSummary, StateError> {
-        let span = info_span!(ledger::rewards::COMPUTE, for_epoch = u64::from(for_epoch));
+        let span = info_span!(ledger::rewards::COMPUTE, for_epoch = for_epoch);
 
         // NOTE: Explicit span guard handling
         //
@@ -512,7 +514,7 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
         if stake_distributions.front().map(|distr| distr.epoch < snapshot.epoch()).unwrap_or(true) {
             stake_distributions.push_front(compute_stake_distribution(&snapshot, &self.era_history)?);
             info!(
-                "stake_distribution.rotate",
+                ledger::stake_distribution::ROTATE,
                 available_stake_distributions = display_collection(stake_distributions.iter().map(|distr| distr.epoch)),
             );
         }
@@ -542,7 +544,7 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
 
                 Some(now_stable)
             } else {
-                trace!("volatile.warm_up", size = self.volatile.len());
+                trace!(ledger::volatile::WARM_UP, size = self.volatile.len());
                 None
             };
 
@@ -566,7 +568,7 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
                 // Yet, we must produce a new snapshot in order to produce a new stake distribution
                 // to keep validating upcoming block headers.
                 warn!(
-                    "chain_growth.violate",
+                    ledger::chain_growth::VIOLATE,
                     unstable_tail_length = len,
                     reason = format!(
                         "chain growth violation: less than k={k} blocks seen in a window of \
@@ -818,7 +820,7 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
     }
 
     pub fn rollback_to(&mut self, to: &Point) -> Result<(), BackwardError> {
-        info_span!(ledger::state::ROLL_BACKWARD, rollback_point = to.to_string()).in_scope(|| {
+        info_span!(ledger::state::ROLL_BACKWARD, rollback_point = to).in_scope(|| {
             let immutable_tip = self.immutable_tip();
             let volatile_tip = self.volatile_tip().map(|t| t.point()).unwrap_or(immutable_tip);
 
@@ -904,7 +906,7 @@ pub fn compute_stake_distribution(
     snapshot: &impl Snapshot,
     era_history: &EraHistory,
 ) -> Result<StakeDistribution, StateError> {
-    info_span!(ledger::stake_distribution::COMPUTE, epoch = u64::from(snapshot.epoch()),).in_scope(|| {
+    info_span!(ledger::stake_distribution::COMPUTE, epoch = snapshot.epoch(),).in_scope(|| {
         StakeDistribution::new(snapshot, GovernanceSummary::new(snapshot, era_history)?).map_err(StateError::Storage)
     })
 }
@@ -983,7 +985,7 @@ impl HasStakeDistribution for StakeDistributionObserver {
 fn trace_block_transactions(point: &Point, block_height: u64, block: &Block) {
     let tx_count = block.transaction_bodies.len();
 
-    trace!("non_empty_block.found", %point, block_height, tx_count);
+    trace!(ledger::non_empty_block::FOUND, %point, block_height, tx_count);
 
     if !tracing_enabled!(tracing::Level::TRACE) {
         return;
@@ -991,7 +993,7 @@ fn trace_block_transactions(point: &Point, block_height: u64, block: &Block) {
 
     for (tx_index, body) in block.transaction_bodies.iter().enumerate() {
         let tx_id = body.tx_id();
-        trace!("transaction.found", %point, block_height, tx_index, tx_id = %tx_id);
+        trace!(ledger::transaction::FOUND, %point, block_height, tx_index, tx_id = %tx_id);
     }
 }
 

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -19,12 +19,12 @@ use amaru_kernel::{
     PREPROD_DEFAULT_PROTOCOL_PARAMETERS, Point, PoolId, ProtocolParameters, StakeCredential, TermLimit,
     TransactionInput,
 };
+use amaru_observability::{error, warn};
 
 use crate::{
     epoch_transition::{
         Computed, Effective, GovernanceActivity, GovernanceUpdates, PoolsEpochTransitionUpdates, Rewards, RewardsState,
     },
-    error,
     governance::ratification::ProposalsRoots,
     state::{
         AnchoredVolatileFragment, StateError,
@@ -34,7 +34,6 @@ use crate::{
         },
     },
     store::{HistoricalStores, Store},
-    warn,
 };
 
 pub struct VolatileDB {
@@ -225,7 +224,7 @@ impl VolatileSequence for VolatileDB {
             && last.slot() < target_slot
         {
             warn!(
-                "volatile.rollback_to",
+                ledger::volatile::ROLLBACK_TO,
                 %target_slot,
                 last_slot = ?last.slot(),
                 warning = "attempting to rollback to a point beyond the last known volatile fragment"
@@ -239,7 +238,7 @@ impl VolatileSequence for VolatileDB {
             && target_slot < first.slot()
         {
             error!(
-                "volatile.rollback_to",
+                ledger::volatile::ROLLBACK_TO,
                 %target_slot,
                 first_slot = ?first.slot(),
                 error = "attempting to rollback to a point before the first known of the volatile fragment"

--- a/crates/amaru-ledger/src/state/volatile/overlay.rs
+++ b/crates/amaru-ledger/src/state/volatile/overlay.rs
@@ -17,11 +17,10 @@ use std::{cell::RefCell, collections::BTreeMap, mem};
 use amaru_kernel::{
     ComparableProposalId, Epoch, Lovelace, PoolId, ProtocolParameters, RatificationStatus, StakeCredential, TermLimit,
 };
-use amaru_observability::info_span;
+use amaru_observability::{debug, info_span};
 use tracing::Span;
 
 use crate::{
-    debug,
     epoch_transition::{
         Computed, Effective, GovernanceActivity, GovernanceUpdates, PoolsEpochTransitionUpdates, Rewards, RewardsState,
     },
@@ -101,7 +100,7 @@ impl StateOverlay {
     /// Rollback an existing overlay, throwing away the epoch transition calculations.
     pub fn rollback(&mut self) {
         let to = self.epoch - 1;
-        debug!("epoch_transition.rollback", from = %self.epoch, %to);
+        debug!(ledger::epoch_transition::ROLLBACK, from = %self.epoch, %to);
         self.epoch = to;
         self.rewards = match mem::take(&mut self.rewards) {
             st @ RewardsState::NotReady | st @ RewardsState::Computed(..) => st,
@@ -119,7 +118,7 @@ impl StateOverlay {
         governance_updates: GovernanceUpdates,
     ) {
         let to = self.epoch + 1;
-        debug!("epoch_transition.record", from = %self.epoch, %to);
+        debug!(ledger::epoch_transition::RECORD, from = %self.epoch, %to);
         self.epoch = to;
         self.rewards = effective_rewards.map(RewardsState::Effective).unwrap_or(RewardsState::NotReady);
         self.pools_updates = Some(pools_updates);
@@ -132,7 +131,7 @@ impl StateOverlay {
     /// transition was applied, so the caller can refresh its cached copy. Returns `None` when there
     /// was no governance update to apply, in which case the cached values are left untouched.
     pub fn apply(&mut self, db: &impl Store) -> Result<Option<(ProtocolParameters, GovernanceActivity)>, StateError> {
-        let updated = info_span!(ledger::epoch_transition::APPLY, epoch = u64::from(self.epoch)).in_scope(|| {
+        let updated = info_span!(ledger::epoch_transition::APPLY, epoch = self.epoch).in_scope(|| {
             use EpochTransitionProgress::*;
 
             // ---------------------------------------------------------------------------- End of epoch
@@ -184,13 +183,13 @@ impl StateOverlay {
                         update_or_retire_pools(batch, pools_updates.take_updated(), pools_updates.take_retired())?;
                         pay_or_refund_accounts(batch, pools_updates.refunds())?;
                     } else {
-                        debug!("overlay.no_pools_updates");
+                        debug!(ledger::overlay::NO_POOLS_UPDATES);
                     }
 
                     if let Some(governance_updates) = mem::take(&mut self.governance_updates) {
                         Some(apply_governance_updates(batch, governance_updates)?)
                     } else {
-                        debug!("overlay.no_governance_updates");
+                        debug!(ledger::overlay::NO_GOVERNANCE_UPDATES);
                         None
                     }
                 } else {

--- a/crates/amaru-ledger/src/store/epoch_transition.rs
+++ b/crates/amaru-ledger/src/store/epoch_transition.rs
@@ -21,12 +21,11 @@ use amaru_kernel::{
     AsHash, ComparableProposalId, ConstitutionalCommitteeStatus, Lovelace, PoolId, ProtocolParameters,
     RatificationStatus, RationalNumber, StakeCredential, StakeCredentialKind,
 };
-use amaru_observability::debug_span;
+use amaru_observability::{debug, debug_span};
 use num::BigUint;
 use tracing::Span;
 
 use crate::{
-    debug,
     epoch_transition::{Effective, GovernanceActivity, GovernanceUpdates, Rewards},
     governance::ratification::CommitteeUpdate,
     store::{StoreError, TransactionalContext, columns::pools::Row as Pool},
@@ -143,8 +142,8 @@ pub fn pay_or_refund_accounts<'store, 'iter>(
             (0_u64, 0_u64),
             |(leftovers, paid), (account, deposit)| {
                 debug!(
-                    "account.pay_or_refund",
-                    type = %StakeCredentialKind::from(account),
+                    ledger::account::PAY_OR_REFUND,
+                    credential_type = %StakeCredentialKind::from(account),
                     account = %account.as_hash(),
                     %deposit,
                 );
@@ -236,7 +235,7 @@ pub fn apply_governance_updates<'store, 'iter>(
         if updates.is_dormant_epoch {
             governance_activity.consecutive_dormant_epochs += 1;
             debug!(
-                "governance_activity.update",
+                ledger::governance_activity::UPDATE,
                 consecutive_dormant_epochs = governance_activity.consecutive_dormant_epochs
             );
             db.set_governance_activity(governance_activity)?;

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -112,6 +112,7 @@ use std::collections::BTreeMap;
 use amaru_kernel::{
     Epoch, GlobalParameters, Lovelace, PoolId, ProtocolParameters, StakeCredential, expect_stake_credential,
 };
+use amaru_observability::info;
 use num::{
     BigUint,
     traits::{One, Zero},
@@ -120,7 +121,6 @@ use serde::ser::SerializeStruct;
 
 use crate::{
     epoch_transition::{Computed, PoolsEpochTransitionUpdates, Rewards},
-    info,
     store::{Snapshot, StoreError, columns::pots::Row as Pots},
     summary::{
         AccountState, PoolState, SafeRatio, floor_to_lovelace, safe_ratio, stake_distribution::StakeDistribution,
@@ -411,16 +411,16 @@ impl RewardsSummary {
             });
 
         info!(
-            "rewards.summarize",
+            ledger::rewards::SUMMARIZE,
             %efficiency,
             %incentives,
             %treasury_tax,
             %total_rewards,
             %available_rewards,
             %effective_rewards,
-            pots.reserves = %pots.reserves,
-            pots.treasury = %pots.treasury,
-            pots.fees = %pots.fees,
+            pots_reserves = %pots.reserves,
+            pots_treasury = %pots.treasury,
+            pots_fees = %pots.fees,
         );
 
         Ok(RewardsSummary {

--- a/crates/amaru-ledger/src/summary/stake_distribution.rs
+++ b/crates/amaru-ledger/src/summary/stake_distribution.rs
@@ -15,11 +15,11 @@
 use std::collections::BTreeMap;
 
 use amaru_kernel::{DRep, Epoch, HasLovelace, Hash, Lovelace, PoolId, StakeCredential, expect_stake_credential};
+use amaru_observability::info;
 use serde::ser::SerializeStruct;
 
 use crate::{
     epoch_transition::PoolsEpochTransitionUpdates,
-    info,
     store::{Snapshot, StoreError, columns::pots::Row as Pots},
     summary::{
         AccountState, PoolState,
@@ -200,7 +200,7 @@ impl StakeDistribution {
         let Pots { reserves, treasury, .. } = db.pots()?;
 
         info!(
-            "stake_distribution.snapshot",
+            ledger::stake_distribution::SNAPSHOT,
             accounts = %accounts.len(),
             dreps = %dreps.len(),
             pools = %pools.len(),

--- a/crates/amaru-observability/macros/src/define_schemas.rs
+++ b/crates/amaru-observability/macros/src/define_schemas.rs
@@ -382,7 +382,7 @@ impl ParserState {
             return;
         };
 
-        if name == "name" || name == "schema" {
+        if name == "name" || name == "schema" || name == "message" {
             errors.push(format!(
                 "Reserved field '{}' in schema {}. The tracing macros manage this field internally.",
                 name, schema.name
@@ -1085,6 +1085,30 @@ fn generate_record_macro(schema: &Schema, config: &GenerationConfig) -> proc_mac
         })
         .collect();
 
+    // Validation for pre-formatted event fields (`%expr` / `?expr` / `@expr`): the caller
+    // explicitly chose the rendering, so only check that the field is declared on the schema
+    // and that the value can actually be recorded with the requested formatter.
+    let validate_formatted_patterns: Vec<_> = all_fields
+        .iter()
+        .map(|field| {
+            let field_name = &field.name;
+            quote! {
+                (#field_name, $expr:expr, validate_event_display) => {{
+                    let __amaru_assert_display = |_: &dyn ::std::fmt::Display| {};
+                    __amaru_assert_display($expr);
+                }};
+                (#field_name, $expr:expr, validate_event_debug) => {{
+                    let __amaru_assert_debug = |_: &dyn ::std::fmt::Debug| {};
+                    __amaru_assert_debug($expr);
+                }};
+                (#field_name, $expr:expr, validate_event_value) => {{
+                    let __amaru_assert_value = |_: &dyn ::tracing::field::Value| {};
+                    __amaru_assert_value($expr);
+                }};
+            }
+        })
+        .collect();
+
     let all_field_names: Vec<_> = all_fields.iter().map(|f| f.name.as_str()).collect();
     let fields_list = all_field_names.join(", ");
 
@@ -1093,7 +1117,38 @@ fn generate_record_macro(schema: &Schema, config: &GenerationConfig) -> proc_mac
         #[doc(hidden)]
         macro_rules! #macro_ident {
             #(#validate_value_patterns)*
+            #(#validate_formatted_patterns)*
             ($name:literal, $expr:expr, validate_value) => {
+                compile_error!(concat!(
+                    "Unknown field '",
+                    $name,
+                    "' for schema ",
+                    #schema_name,
+                    ". Available fields: ",
+                    #fields_list
+                ));
+            };
+            ($name:literal, $expr:expr, validate_event_display) => {
+                compile_error!(concat!(
+                    "Unknown field '",
+                    $name,
+                    "' for schema ",
+                    #schema_name,
+                    ". Available fields: ",
+                    #fields_list
+                ));
+            };
+            ($name:literal, $expr:expr, validate_event_debug) => {
+                compile_error!(concat!(
+                    "Unknown field '",
+                    $name,
+                    "' for schema ",
+                    #schema_name,
+                    ". Available fields: ",
+                    #fields_list
+                ));
+            };
+            ($name:literal, $expr:expr, validate_event_value) => {
                 compile_error!(concat!(
                     "Unknown field '",
                     $name,

--- a/crates/amaru-observability/macros/src/lib.rs
+++ b/crates/amaru-observability/macros/src/lib.rs
@@ -128,6 +128,29 @@ pub fn trace_record(input: TokenStream) -> TokenStream {
     traces::expand_trace_record(input)
 }
 
+/// Emits a tracing event with a compile-time validated schema anchor.
+///
+/// The event `target` and `name` are derived from the schema constant, exactly
+/// like the spans created by [`trace_span!`](macro@trace_span). Emission is
+/// gated on the schema visibility (public schemas always emit; private ones
+/// only when `AMARU_TRACE_EMIT_PRIVATE` is set).
+///
+/// # Syntax
+///
+/// ```text
+/// trace_event!(LEVEL, SCHEMA, field = value, ...);
+/// ```
+///
+/// # Example
+///
+/// ```text
+/// trace_event!(ERROR, stores::ledger::accounts::RESET_MANY, ?credential, reason = "no account for given credential");
+/// ```
+#[proc_macro]
+pub fn trace_event(input: TokenStream) -> TokenStream {
+    traces::expand_trace_event(input)
+}
+
 /// Creates a tracing span with compile-time validated schema anchor.
 ///
 /// This macro creates spans with a schema-anchored approach that provides

--- a/crates/amaru-observability/macros/src/traces.rs
+++ b/crates/amaru-observability/macros/src/traces.rs
@@ -379,6 +379,246 @@ pub fn expand_trace_record(input: TokenStream) -> TokenStream {
     expanded.into()
 }
 
+/// Emits a tracing event with a compile-time validated schema anchor.
+///
+/// This macro emits a log event whose `target` and `name` are derived from the
+/// schema constant, exactly like the spans created by `debug_span!`. The schema
+/// path is validated at compile time, and emission is gated on the schema
+/// visibility (public schemas always emit; private ones only when
+/// `AMARU_TRACE_EMIT_PRIVATE` is set).
+///
+/// Fields are validated against the schema like span fields: required fields
+/// must be present, unknown fields are rejected, and plain `field = value`
+/// assignments are type-checked against the declared field type. Values are
+/// rendered with `Display` by default (`Debug` for `?value`), so field values
+/// do not need to implement `tracing::Value`.
+///
+/// # Syntax
+///
+/// ```text
+/// trace_event!(LEVEL, SCHEMA, field = value, ...);   // type-checked, Display-rendered
+/// trace_event!(LEVEL, SCHEMA, field = %value, ...);  // pre-formatted, Display-rendered
+/// trace_event!(LEVEL, SCHEMA, field = ?value, ...);  // pre-formatted, Debug-rendered
+/// trace_event!(LEVEL, SCHEMA, value, %value, ?value) // shorthands for the above
+/// ```
+///
+/// # Example
+///
+/// ```text
+/// trace_event!(ERROR, stores::ledger::accounts::RESET_MANY, ?credential, reason = "no account for given credential");
+/// ```
+pub fn expand_trace_event(input: TokenStream) -> TokenStream {
+    if crate::is_trace_no_emit() {
+        return quote! { { } }.into();
+    }
+
+    use syn::{
+        Token,
+        parse::{Parse, ParseStream},
+    };
+
+    enum TraceEventFormatter {
+        /// `field = value`: type-checked against the schema, rendered with Display
+        Typed,
+        /// `field = %value`: pre-formatted by the caller, rendered with Display
+        Display,
+        /// `field = ?value`: pre-formatted by the caller, rendered with Debug
+        Debug,
+        /// `field = @value`: a ready-made `tracing::Value`, recorded as-is. This is the
+        /// escape hatch for dynamically-absent fields (`Option<_>` / `field::Empty`).
+        Value,
+    }
+
+    struct TraceEventField {
+        name: syn::Ident,
+        value: syn::Expr,
+        formatter: TraceEventFormatter,
+    }
+
+    struct TraceEventArgs {
+        level: syn::Ident,
+        schema_path: syn::Path,
+        fields: Vec<TraceEventField>,
+    }
+
+    impl Parse for TraceEventArgs {
+        fn parse(input: ParseStream) -> syn::Result<Self> {
+            let level: syn::Ident = input.parse()?;
+            input.parse::<Token![,]>()?;
+            let schema_path: syn::Path = input.parse()?;
+
+            let mut fields = Vec::new();
+            while input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+
+                if input.is_empty() {
+                    break;
+                }
+
+                // Shorthands: `%ident`, `?ident` and `@ident` name the field after the variable.
+                if input.peek(Token![%]) || input.peek(Token![?]) || input.peek(Token![@]) {
+                    let formatter = if input.peek(Token![%]) {
+                        input.parse::<Token![%]>()?;
+                        TraceEventFormatter::Display
+                    } else if input.peek(Token![?]) {
+                        input.parse::<Token![?]>()?;
+                        TraceEventFormatter::Debug
+                    } else {
+                        input.parse::<Token![@]>()?;
+                        TraceEventFormatter::Value
+                    };
+                    let name: syn::Ident = input.parse()?;
+                    let value = syn::parse_quote!(#name);
+                    fields.push(TraceEventField { name, value, formatter });
+                    continue;
+                }
+
+                let name: syn::Ident = input.parse()?;
+
+                // Bare `ident` records the variable under its own name.
+                if !input.peek(Token![=]) {
+                    let value = syn::parse_quote!(#name);
+                    fields.push(TraceEventField { name, value, formatter: TraceEventFormatter::Typed });
+                    continue;
+                }
+
+                input.parse::<Token![=]>()?;
+
+                let formatter = if input.peek(Token![%]) {
+                    input.parse::<Token![%]>()?;
+                    TraceEventFormatter::Display
+                } else if input.peek(Token![?]) {
+                    input.parse::<Token![?]>()?;
+                    TraceEventFormatter::Debug
+                } else if input.peek(Token![@]) {
+                    input.parse::<Token![@]>()?;
+                    TraceEventFormatter::Value
+                } else {
+                    TraceEventFormatter::Typed
+                };
+                let value: syn::Expr = input.parse()?;
+
+                fields.push(TraceEventField { name, value, formatter });
+            }
+
+            if !input.is_empty() {
+                return Err(input.error("unexpected tokens after field assignments"));
+            }
+
+            Ok(TraceEventArgs { level, schema_path, fields })
+        }
+    }
+
+    let args = match syn::parse::<TraceEventArgs>(input) {
+        Ok(args) => args,
+        Err(err) => return err.to_compile_error().into(),
+    };
+
+    let level_str = args.level.to_string().to_lowercase();
+    if !matches!(level_str.as_str(), "trace" | "debug" | "info" | "warn" | "error") {
+        return syn::Error::new_spanned(
+            &args.level,
+            "Invalid tracing level. Must be one of: TRACE, DEBUG, INFO, WARN, ERROR",
+        )
+        .to_compile_error()
+        .into();
+    }
+    let level_macro = syn::Ident::new(&level_str, proc_macro2::Span::call_site());
+
+    let schema_const_tokens = &args.schema_path;
+    let full_path_tokens = quote! { #schema_const_tokens };
+    let path_str: String = full_path_tokens.to_string().chars().filter(|c| !c.is_whitespace()).collect();
+    let (schema_name, module_path, macro_module) = parse_full_schema_path(&path_str);
+    let meta = SchemaMeta { schema_name: schema_name.to_owned(), module_path, macro_module: macro_module.to_owned() };
+
+    let categories = meta.categories();
+    let target = categories.iter().take(2).map(|part| part.as_str()).collect::<Vec<_>>().join("::");
+    let name = categories
+        .iter()
+        .skip(2)
+        .map(|part| part.to_lowercase())
+        .chain(std::iter::once(meta.schema_name.to_lowercase()))
+        .collect::<Vec<_>>()
+        .join(".");
+    let name_literal = syn::LitStr::new(&name, proc_macro2::Span::call_site());
+    let target_literal = syn::LitStr::new(&target, proc_macro2::Span::call_site());
+
+    let record_macro_ident = make_ident(&make_record_macro_name(&categories, &meta.schema_name));
+    let field_names: Vec<_> = args.fields.iter().map(|field| field.name.to_string()).collect();
+    let required_fields_check = generate_required_fields_check(&meta, &field_names);
+
+    let value_bindings: Vec<_> = args
+        .fields
+        .iter()
+        .enumerate()
+        .map(|(index, field)| {
+            let field_name = field.name.to_string();
+            let expr = &field.value;
+            let value_ident = make_ident(&format!("__amaru_trace_value_{index}"));
+            let formatted_ident = make_ident(&format!("__amaru_trace_formatted_{index}"));
+            let (validation_mode, formatter_binding) = match field.formatter {
+                TraceEventFormatter::Typed => (
+                    quote! { validate_value },
+                    quote! { let #formatted_ident = ::tracing::field::display(&#value_ident); },
+                ),
+                TraceEventFormatter::Display => (
+                    quote! { validate_event_display },
+                    quote! { let #formatted_ident = ::tracing::field::display(&#value_ident); },
+                ),
+                TraceEventFormatter::Debug => (
+                    quote! { validate_event_debug },
+                    quote! { let #formatted_ident = ::tracing::field::debug(&#value_ident); },
+                ),
+                TraceEventFormatter::Value => {
+                    (quote! { validate_event_value }, quote! { let #formatted_ident = #value_ident; })
+                }
+            };
+            let validate_value_call =
+                meta.macro_call_stmt(&record_macro_ident, quote! { #field_name, &#value_ident, #validation_mode });
+            quote! {
+                let #value_ident = &(#expr);
+                #validate_value_call
+                #formatter_binding
+            }
+        })
+        .collect();
+
+    let event_fields: Vec<_> = args
+        .fields
+        .iter()
+        .enumerate()
+        .map(|(index, field)| {
+            let field_ident = &field.name;
+            let formatted_ident = make_ident(&format!("__amaru_trace_formatted_{index}"));
+            quote! { #field_ident = #formatted_ident }
+        })
+        .collect();
+
+    let public_const_path = build_public_const_path(&meta, &args.schema_path);
+    let private_emit_guard = private_emit_guard_tokens();
+
+    let expanded = wrap_in_module_validator(
+        &meta,
+        quote! {{
+            #required_fields_check
+            #private_emit_guard
+
+            if #public_const_path || __amaru_emit_private {
+                #(#value_bindings)*
+
+                ::tracing::#level_macro!(
+                    name: #name_literal,
+                    target: #target_literal,
+                    message = #name_literal
+                    #(, #event_fields)*
+                );
+            }
+        }},
+    );
+
+    expanded.into()
+}
+
 /// Creates a tracing span with compile-time validated schema anchor.
 ///
 /// This macro creates spans with a schema-anchored approach that provides

--- a/crates/amaru-observability/macros/tests/trace_event.rs
+++ b/crates/amaru-observability/macros/tests/trace_event.rs
@@ -1,0 +1,180 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests that verify runtime behavior of the trace_event! macro
+//!
+//! These tests verify:
+//! - Correct target and event names are derived from the schema constant
+//! - The requested level is used
+//! - Fields are validated against the schema and rendered with Display/Debug
+
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+};
+
+use amaru_observability_macros::{define_local_schemas, trace_event};
+use tracing::field::Visit;
+use tracing_subscriber::layer::SubscriberExt;
+
+define_local_schemas! {
+    amaru {
+        stores {
+            accounts {
+                /// Reset rewards counters for testing
+                public RESET_MANY {
+                    required credential: String
+                    required reason: String
+                    optional count: usize
+                }
+                /// Event without fields for testing
+                public FLUSH {}
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CapturedEvent {
+    name: String,
+    target: String,
+    level: tracing::Level,
+    values: BTreeMap<String, String>,
+}
+
+#[derive(Default)]
+struct FieldValueCollector {
+    values: BTreeMap<String, String>,
+}
+
+impl Visit for FieldValueCollector {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.values.insert(field.name().to_string(), format!("{:?}", value));
+    }
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.values.insert(field.name().to_string(), value.to_string());
+    }
+}
+
+struct EventCapturingLayer {
+    captured_events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+impl<S> tracing_subscriber::Layer<S> for EventCapturingLayer
+where
+    S: tracing::Subscriber + for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let mut collector = FieldValueCollector::default();
+        event.record(&mut collector);
+
+        self.captured_events.lock().unwrap().push(CapturedEvent {
+            name: event.metadata().name().to_string(),
+            target: event.metadata().target().to_string(),
+            level: *event.metadata().level(),
+            values: collector.values,
+        });
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use tracing_subscriber::Registry;
+
+    use super::*;
+
+    #[test]
+    fn test_event_target_name_level_and_fields() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = Registry::default().with(EventCapturingLayer { captured_events: captured.clone() });
+
+        tracing::subscriber::with_default(subscriber, || {
+            let credential = "stake-credential".to_string();
+            trace_event!(ERROR, crate::amaru::stores::accounts::RESET_MANY, ?credential, reason = "unknown account");
+        });
+
+        let events = captured.lock().unwrap();
+        assert_eq!(events.len(), 1);
+
+        assert_eq!(events[0].target, "amaru::stores");
+        assert_eq!(events[0].name, "accounts.reset_many");
+        assert_eq!(events[0].level, tracing::Level::ERROR);
+        assert_eq!(events[0].values.get("message").map(String::as_str), Some("accounts.reset_many"));
+        assert_eq!(events[0].values.get("credential").map(String::as_str), Some("\"stake-credential\""));
+        assert_eq!(events[0].values.get("reason").map(String::as_str), Some("unknown account"));
+    }
+
+    #[test]
+    fn test_event_typed_and_shorthand_fields() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = Registry::default().with(EventCapturingLayer { captured_events: captured.clone() });
+
+        tracing::subscriber::with_default(subscriber, || {
+            let count = 42_usize;
+            let credential = "stake-credential".to_string();
+            trace_event!(
+                INFO,
+                crate::amaru::stores::accounts::RESET_MANY,
+                credential = %credential,
+                reason = "unknown account".to_string(),
+                count
+            );
+        });
+
+        let events = captured.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].level, tracing::Level::INFO);
+        assert_eq!(events[0].values.get("credential").map(String::as_str), Some("stake-credential"));
+        assert_eq!(events[0].values.get("reason").map(String::as_str), Some("unknown account"));
+        assert_eq!(events[0].values.get("count").map(String::as_str), Some("42"));
+    }
+
+    #[test]
+    fn test_event_value_passthrough_records_dynamic_absence() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = Registry::default().with(EventCapturingLayer { captured_events: captured.clone() });
+
+        tracing::subscriber::with_default(subscriber, || {
+            let present: Option<usize> = Some(42);
+            let absent: Option<String> = None;
+            trace_event!(
+                INFO,
+                crate::amaru::stores::accounts::RESET_MANY,
+                credential = @absent,
+                reason = "unknown account".to_string(),
+                count = @present
+            );
+        });
+
+        let events = captured.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].values.get("count").map(String::as_str), Some("42"));
+        assert_eq!(events[0].values.get("credential"), None);
+    }
+
+    #[test]
+    fn test_event_without_fields() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = Registry::default().with(EventCapturingLayer { captured_events: captured.clone() });
+
+        tracing::subscriber::with_default(subscriber, || {
+            trace_event!(WARN, crate::amaru::stores::accounts::FLUSH);
+        });
+
+        let events = captured.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].level, tracing::Level::WARN);
+        assert_eq!(events[0].values.get("message").map(String::as_str), Some("accounts.flush"));
+    }
+}

--- a/crates/amaru-observability/src/lib.rs
+++ b/crates/amaru-observability/src/lib.rs
@@ -19,100 +19,45 @@ mod schemas;
 mod trace_context;
 
 // Re-export the macros for convenient use
-pub use amaru_observability_macros::{define_schemas, trace_record, trace_span};
+pub use amaru_observability_macros::{define_schemas, trace_event, trace_record, trace_span};
 pub use opentelemetry;
 pub use schemas::*;
 pub use trace_context::TraceContext;
 pub use tracing;
 pub use tracing_opentelemetry;
 
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __amaru_event_missing_metadata {
-    ($macro_name:literal) => {
-        compile_error!(concat!("missing 'target:' and 'name:' on ", $macro_name, "! macro"));
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __amaru_event_missing_target {
-    ($macro_name:literal) => {
-        compile_error!(concat!("missing 'target:' on ", $macro_name, "! macro"));
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __amaru_event_missing_name {
-    ($macro_name:literal) => {
-        compile_error!(concat!("missing 'name:' on ", $macro_name, "! macro"));
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __amaru_event_with_name {
-    ($level:ident, target: $target:expr, name: $name:expr $(, $($fields:tt)+)?) => {
-        $crate::tracing::$level!(name: $name, target: $target, message = $name $(, $($fields)+)?)
-    };
-    ($level:ident, name: $name:expr, target: $target:expr $(, $($fields:tt)+)?) => {
-        $crate::tracing::$level!(name: $name, target: $target, message = $name $(, $($fields)+)?)
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! __amaru_event {
-    ($level:ident, $macro_name:literal, target: $target:expr, name: $name:expr $(, $($fields:tt)+)?) => {
-        $crate::__amaru_event_with_name!($level, target: $target, name: $name $(, $($fields)+)?)
-    };
-    ($level:ident, $macro_name:literal, name: $name:expr, target: $target:expr $(, $($fields:tt)+)?) => {
-        $crate::__amaru_event_with_name!($level, name: $name, target: $target $(, $($fields)+)?)
-    };
-    ($level:ident, $macro_name:literal, target: $target:expr $(, $($rest:tt)+)?) => {
-        $crate::__amaru_event_missing_name!($macro_name);
-    };
-    ($level:ident, $macro_name:literal, name: $name:expr $(, $($rest:tt)+)?) => {
-        $crate::__amaru_event_missing_target!($macro_name);
-    };
-    ($level:ident, $macro_name:literal, $($rest:tt)*) => {
-        $crate::__amaru_event_missing_metadata!($macro_name);
-    };
-}
-
 #[macro_export]
 macro_rules! trace {
     ($($rest:tt)*) => {
-        $crate::__amaru_event!(trace, "trace", $($rest)*);
+        $crate::trace_event!(TRACE, $($rest)*);
     };
 }
 
 #[macro_export]
 macro_rules! debug {
     ($($rest:tt)*) => {
-        $crate::__amaru_event!(debug, "debug", $($rest)*);
+        $crate::trace_event!(DEBUG, $($rest)*);
     };
 }
 
 #[macro_export]
 macro_rules! info {
     ($($rest:tt)*) => {
-        $crate::__amaru_event!(info, "info", $($rest)*);
+        $crate::trace_event!(INFO, $($rest)*);
     };
 }
 
 #[macro_export]
 macro_rules! warn {
     ($($rest:tt)*) => {
-        $crate::__amaru_event!(warn, "warn", $($rest)*);
+        $crate::trace_event!(WARN, $($rest)*);
     };
 }
 
 #[macro_export]
 macro_rules! error {
     ($($rest:tt)*) => {
-        $crate::__amaru_event!(error, "error", $($rest)*);
+        $crate::trace_event!(ERROR, $($rest)*);
     };
 }
 

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -58,8 +58,8 @@ define_schemas! {
                 /// Find chain intersection point with peer
                 FIND_INTERSECTION {
                     tags: bootstrap
-                    required peer: String
-                    required intersection_slot: u64
+                    required peer: amaru_kernel::Peer
+                    required intersection_slot: amaru_kernel::Slot
                 }
                 /// Received a new tip from an upstream peer
                 SELECT_FROM_TIP {
@@ -104,7 +104,7 @@ define_schemas! {
                 tags: cpu
                 /// Decode header from raw bytes
                 DECODE {
-                    required peer: String
+                    required peer: amaru_kernel::Peer
                 }
                 /// Validate the whole header
                 VALIDATE {
@@ -159,7 +159,7 @@ define_schemas! {
                 public ROLL_FORWARD {}
                 /// Roll backward to a specific point
                 public ROLL_BACKWARD {
-                    required rollback_point: String
+                    required rollback_point: amaru_kernel::Point
                 }
                 /// Forward ledger state with new volatile state
                 public PUSH {}
@@ -167,20 +167,45 @@ define_schemas! {
             stake_distribution {
                 /// Compute stake distribution for epoch
                 public COMPUTE {
-                    required epoch: u64
+                    required epoch: amaru_kernel::Epoch
+                }
+                /// Rotate stake distributions at an epoch boundary
+                public ROTATE {
+                    required available_stake_distributions: String
+                }
+                /// Snapshot of the stake distribution taken at an epoch boundary
+                public SNAPSHOT {
+                    required accounts: usize
+                    required dreps: usize
+                    required pools: usize
+                    required active_stake: amaru_kernel::Lovelace
+                    required pools_voting_stake: amaru_kernel::Lovelace
+                    required dreps_voting_stake: amaru_kernel::Lovelace
                 }
             }
             rewards {
                 /// Compute rewards for epoch
                 public COMPUTE {
-                    required for_epoch: u64
-                    optional using_stake_distribution_epoch_from: u64
+                    required for_epoch: amaru_kernel::Epoch
+                    optional using_stake_distribution_epoch_from: amaru_kernel::Epoch
+                }
+                /// Summary of the rewards calculation for an epoch
+                public SUMMARIZE {
+                    required efficiency: String
+                    required incentives: amaru_kernel::Lovelace
+                    required treasury_tax: amaru_kernel::Lovelace
+                    required total_rewards: amaru_kernel::Lovelace
+                    required available_rewards: amaru_kernel::Lovelace
+                    required effective_rewards: amaru_kernel::Lovelace
+                    required pots_reserves: amaru_kernel::Lovelace
+                    required pots_treasury: amaru_kernel::Lovelace
+                    required pots_fees: amaru_kernel::Lovelace
                 }
             }
             block {
                 /// Apply a block to stable state
                 public APPLY {
-                    required point_slot: u64
+                    required point_slot: amaru_kernel::Slot
                 }
                 /// Prepare block for validation
                 public PREPARE {}
@@ -204,7 +229,7 @@ define_schemas! {
                 /// Register a DRep
                 public CERTIFICATE_DREP_REGISTRATION {
                     required drep: String
-                    required deposit: u64
+                    required deposit: amaru_kernel::Lovelace
                     optional anchor_url: String
                 }
                 /// Update DRep anchor
@@ -215,7 +240,7 @@ define_schemas! {
                 /// Unregister a DRep
                 public CERTIFICATE_DREP_RETIREMENT {
                     required drep: String
-                    required refund: u64
+                    required refund: amaru_kernel::Lovelace
                 }
                 /// Delegate vote to DRep
                 public CERTIFICATE_VOTE_DELEGATION {
@@ -229,7 +254,7 @@ define_schemas! {
                 /// Retire a pool
                 public CERTIFICATE_POOL_RETIREMENT {
                     required pool_id: amaru_kernel::PoolId
-                    required epoch: u64
+                    required epoch: amaru_kernel::Epoch
                 }
                 /// Delegate cold key to committee
                 public CERTIFICATE_COMMITTEE_DELEGATE {
@@ -240,6 +265,13 @@ define_schemas! {
                 public CERTIFICATE_COMMITTEE_RESIGN {
                     required cc_member: String
                     optional anchor_url: String
+                }
+                /// Found a transaction while applying a block
+                public FOUND {
+                    required point: amaru_kernel::Point
+                    required block_height: u64
+                    required tx_index: usize
+                    required tx_id: amaru_kernel::TransactionId
                 }
             }
             block_validation_context {
@@ -310,8 +342,8 @@ define_schemas! {
             epoch_transition {
                 /// Epoch transition processing
                 public COMPUTE {
-                    required from: u64
-                    required into: u64
+                    required from: amaru_kernel::Epoch
+                    required into: amaru_kernel::Epoch
                     optional skipped: bool
                     optional resuming_from: String
                 }
@@ -331,7 +363,7 @@ define_schemas! {
                 public APPLY {
                     /// Epoch for which this overlay is being flush; This is the *currently active*
                     /// epoch.
-                    required epoch: u64
+                    required epoch: amaru_kernel::Epoch
                     /// Whether to end the epoch; in case Amaru is restarting mid-update.
                     optional should_end_epoch: bool,
                     /// Whether to take an on-disk snapshot; in case Amaru is restarting mid-update.
@@ -339,20 +371,46 @@ define_schemas! {
                     /// Whether to begin the epoch; in case Amaru is restarting mid-update.
                     optional should_begin_epoch: bool,
                 }
+                /// Update a pool's parameters at an epoch boundary; only changed parameters are recorded
+                public TICK_POOL {
+                    required id: amaru_kernel::PoolId
+                    optional vrf: String
+                    optional pledge: String
+                    optional cost: String
+                    optional margin: String
+                    optional reward_account: String
+                    optional owners: String
+                    optional relays: String
+                    optional metadata: String
+                }
+                /// Retire a pool at an epoch boundary
+                public RETIRE_POOL {
+                    required id: amaru_kernel::PoolId
+                }
+                /// Rollback an in-flight epoch transition
+                public ROLLBACK {
+                    required from: amaru_kernel::Epoch
+                    required to: amaru_kernel::Epoch
+                }
+                /// Record an in-flight epoch transition
+                public RECORD {
+                    required from: amaru_kernel::Epoch
+                    required to: amaru_kernel::Epoch
+                }
             }
             governance {
                 /// Create ratification context
                 public NEW_RATIFICATION_CONTEXT {
                     /// Epoch to ratify; distinct from the actual epoch this calculation is happening.
-                    required ratifying_epoch: u64
+                    required ratifying_epoch: amaru_kernel::Epoch
                     /// Value of the treasury considered for this ratification round.
-                    optional treasury: u64
+                    optional treasury: amaru_kernel::Lovelace
                     /// Total number of votes to ratify.
                     optional votes: u64
                 }
                 /// Ratify proposals at epoch boundary
                 public RATIFY_PROPOSALS {
-                    required epoch: u64
+                    required epoch: amaru_kernel::Epoch
                     optional roots_protocol_parameters: String
                     optional roots_hard_fork: String
                     optional roots_constitutional_committee: String
@@ -379,6 +437,450 @@ define_schemas! {
             volatile {
                 /// Recompute the volatile aggregate
                 public AGGREGATE {}
+                /// Rollback the volatile state to a specific point
+                public ROLLBACK_TO {
+                    required target_slot: amaru_kernel::Slot
+                    optional last_slot: amaru_kernel::Slot
+                    optional first_slot: amaru_kernel::Slot
+                    optional warning: String
+                    optional error: String
+                }
+                /// The volatile db is still warming up and hasn't reached a stable point yet
+                public WARM_UP {
+                    required size: usize
+                }
+            }
+            account {
+                /// Pay withdrawals to an account, or refund its deposit
+                public PAY_OR_REFUND {
+                    required credential_type: amaru_kernel::StakeCredentialKind
+                    required account: amaru_kernel::Hash<28>
+                    required deposit: amaru_kernel::Lovelace
+                }
+            }
+            chain_growth {
+                /// Fewer than k blocks were seen within the stability window
+                public VIOLATE {
+                    required unstable_tail_length: usize
+                    required reason: String
+                }
+            }
+            constitutional_committee {
+                /// The constitutional committee votes were ignored during ratification
+                public IGNORE {
+                    required active_members: usize
+                    required min_committee_size: u16
+                    required reason: String
+                }
+            }
+            governance_activity {
+                /// Update the number of consecutive dormant epochs
+                public UPDATE {
+                    required consecutive_dormant_epochs: u32
+                }
+            }
+            non_empty_block {
+                /// Found a non-empty block while applying it to the ledger
+                public FOUND {
+                    required point: amaru_kernel::Point
+                    required block_height: u64
+                    required tx_count: usize
+                }
+            }
+            overlay {
+                /// No pools updates found in the epoch transition overlay
+                public NO_POOLS_UPDATES {}
+                /// No governance updates found in the epoch transition overlay
+                public NO_GOVERNANCE_UPDATES {}
+            }
+            proposal {
+                /// Drop an expired or ratified governance proposal
+                public DROP {
+                    required id: String
+                    required expired: bool
+                    required ratified_or_evicted: bool
+                }
+                /// Skip a governance proposal during ratification
+                public SKIP {
+                    required id: String
+                    required reason: String
+                    optional proposed_in: String
+                    optional ratifying_epoch: amaru_kernel::Epoch
+                    optional withdrawal: amaru_kernel::Lovelace
+                    optional treasury: amaru_kernel::Lovelace
+                    optional invalid_members: String
+                }
+            }
+            proposal_roots {
+                /// Summary of the governance proposal roots after ratification
+                public SUMMARIZE {
+                    optional constitution: String
+                    optional constitutional_committee: String
+                    optional hard_fork: String
+                    optional protocol_parameters: String
+                }
+            }
+            protocol {
+                /// Upgrade to a new protocol version
+                public UPGRADE {
+                    required old_version: u64
+                    required new_version: u64
+                }
+            }
+            protocol_parameters {
+                /// Ratify a protocol parameters update; only changed parameters are recorded
+                public RATIFY {
+                    optional protocol_version: String
+                    optional max_block_body_size: String
+                    optional max_transaction_size: String
+                    optional max_block_header_size: String
+                    optional max_tx_ex_units: String
+                    optional max_block_ex_units: String
+                    optional max_value_size: String
+                    optional max_collateral_inputs: String
+                    optional min_fee_a: String
+                    optional min_fee_b: String
+                    optional stake_credential_deposit: String
+                    optional stake_pool_deposit: String
+                    optional monetary_expansion_rate: String
+                    optional treasury_expansion_rate: String
+                    optional min_pool_cost: String
+                    optional lovelace_per_utxo_byte: String
+                    optional prices: String
+                    optional min_fee_ref_script_lovelace_per_byte: String
+                    optional max_ref_script_size_per_tx: String
+                    optional max_ref_script_size_per_block: String
+                    optional ref_script_cost_stride: String
+                    optional ref_script_cost_multiplier: String
+                    optional stake_pool_max_retirement_epoch: String
+                    optional optimal_stake_pools_count: String
+                    optional pledge_influence: String
+                    optional collateral_percentage: String
+                    optional cost_models: String
+                    optional pool_voting_thresholds: String
+                    optional drep_voting_thresholds: String
+                    optional min_committee_size: String
+                    optional max_committee_term_length: String
+                    optional gov_action_lifetime: String
+                    optional gov_action_deposit: String
+                    optional drep_deposit: String
+                    optional drep_expiry: String
+                }
+            }
+            ratification {
+                /// Summary of the outcome of a ratification round
+                public SUMMARIZE {
+                    required is_dormant_epoch: bool
+                    optional pruned_proposals: String
+                    optional payouts: String
+                    optional new_constitution: String
+                    optional constitutional_committee_update: String
+                }
+                /// Skip the remaining proposals for this epoch
+                public SKIP {
+                    required reason: String
+                }
+            }
+        }
+        bootstrap {
+            accounts {
+                /// Existing accounts found in the store before import
+                public IS_NOT_EMPTY {}
+                /// Import accounts from a snapshot
+                public IMPORT {
+                    required size: usize
+                }
+            }
+            block_issuers {
+                /// Import block issuers from a snapshot
+                public IMPORT {
+                    required count: u64
+                }
+            }
+            constitution {
+                /// Import the constitution from a snapshot
+                public IMPORT {
+                    required anchor: String
+                    required guardrails: String
+                }
+            }
+            constitutional_committee {
+                /// Import the constitutional committee from a snapshot
+                public IMPORT {
+                    required state: String
+                    optional threshold: String
+                    optional members: usize
+                }
+            }
+            dreps {
+                /// Import DReps from a snapshot
+                public IMPORT {
+                    required size: usize
+                }
+            }
+            fetch {
+                /// Received a rollback while fetching bootstrap headers
+                public ROLLBACK {
+                    required point: amaru_kernel::Point
+                    required tip: amaru_kernel::Tip
+                }
+            }
+            governance_activity {
+                /// Import the governance activity from a snapshot
+                public IMPORT {
+                    required dormant_epochs: u32
+                }
+            }
+            header {
+                /// Import a single header into the chain store
+                public IMPORT {
+                    required header: amaru_kernel::HeaderHash
+                }
+            }
+            headers {
+                /// Fetch bootstrap headers from a peer
+                public FETCH {
+                    required requested_point: amaru_kernel::Point
+                    required intersection: amaru_kernel::Point
+                    required headers_per_point: usize
+                }
+            }
+            import {
+                /// Import UTxO entries from a snapshot
+                public UTXO {
+                    required size: usize
+                }
+            }
+            local_snapshots {
+                /// Detect locally-created snapshots from create-snapshots
+                public DETECT {
+                    required count: usize
+                }
+            }
+            nonces {
+                /// Import initial nonces into the chain store
+                public IMPORT {
+                    required point: amaru_kernel::Point
+                }
+            }
+            peer {
+                /// Failed to connect to a peer while bootstrapping
+                public FAILED_TO_CONNECT {
+                    required peer: String
+                    required reason: String
+                }
+            }
+            pots {
+                /// Import treasury/reserves/fees pots from a snapshot
+                public IMPORT {
+                    required treasury: amaru_kernel::Lovelace
+                    required reserves: amaru_kernel::Lovelace
+                    required fees: amaru_kernel::Lovelace
+                    required donations: amaru_kernel::Lovelace
+                }
+            }
+            proposal_roots {
+                /// Import governance proposal roots from a snapshot
+                public IMPORT {
+                    required constitution: String
+                    required constitutional_committee: String
+                    required hard_fork: String
+                    required protocol_parameters: String
+                }
+            }
+            proposals {
+                /// Existing proposals found in the store before import
+                public IS_NOT_EMPTY {}
+                /// Import governance proposals from a snapshot
+                public IMPORT {
+                    required size: usize
+                }
+            }
+            snapshot {
+                /// Download a snapshot archive
+                public DOWNLOAD {
+                    required epoch: amaru_kernel::Epoch
+                    required point: amaru_kernel::Point
+                }
+                /// Snapshot already downloaded; skipping download
+                public SKIP_DOWNLOAD {
+                    required snapshot: String
+                }
+                /// Existing snapshot files are invalid and will be removed
+                public INVALID {
+                    required snapshot: String
+                }
+                /// Extract a snapshot archive
+                public EXTRACT {
+                    required snapshot: String
+                }
+                /// Import a single snapshot
+                public IMPORT_FILE {
+                    required path: String
+                }
+                /// Import a snapshot directory
+                public IMPORT_DIR {
+                    required path: String
+                }
+                /// Import from the tvar data
+                public IMPORT_TVAR {
+                    required point: amaru_kernel::Point
+                    required new_epoch_state_offset: usize
+                }
+            }
+            snapshots {
+                /// Import all snapshots
+                public IMPORT {
+                    required count: usize
+                }
+            }
+            stake_pools {
+                /// Import stake pools from a snapshot
+                public IMPORT {
+                    required registered: usize
+                    required retiring: usize
+                }
+            }
+            votes {
+                /// Import governance votes from a snapshot
+                public IMPORT {
+                    required size: usize
+                }
+            }
+        }
+        cli {
+            cardano_node_config {
+                /// Use an existing cardano-node configuration
+                public USE {
+                    required config_dir: String
+                    required network: amaru_kernel::NetworkName
+                }
+                /// Download the official cardano-node configuration bundle
+                public DOWNLOAD {
+                    required config_dir: String
+                    required network: amaru_kernel::NetworkName
+                }
+            }
+            chain_db {
+                /// Forcefully remove an existing chain database
+                public FORCEFULLY_REMOVE {
+                    required dir: String
+                }
+                /// Chain database already exists
+                public EXIST {
+                    required dir: String
+                    required hint: String
+                }
+            }
+            current_epoch {
+                /// Resolve the current epoch from Koios
+                public RESOLVE {
+                    required epoch: u64
+                }
+            }
+            db_analyser {
+                /// Run db-analyser to produce a ledger snapshot
+                public RUN {
+                    required epoch: amaru_kernel::Epoch
+                    required slot: amaru_kernel::Slot
+                    optional analyse_from: amaru_kernel::Slot
+                }
+                /// Reuse an existing db-analyser ledger snapshot
+                public REUSE_LEDGER_SNAPSHOT {
+                    required epoch: amaru_kernel::Epoch
+                    required slot: amaru_kernel::Slot
+                }
+                /// Progress reported by an external db-analyser command
+                public PROGRESS {
+                    required step: String
+                    required detail: String
+                }
+                /// Output line from an external db-analyser command
+                public LOG {
+                    required step: String
+                    required line: String
+                }
+            }
+            epoch_metadata {
+                /// Write the epoch metadata file for a snapshot
+                public WRITE {
+                    required epoch: amaru_kernel::Epoch
+                    required path: String
+                }
+            }
+            last_block {
+                /// Resolve the last produced block for an epoch
+                public RESOLVE {
+                    required epoch: amaru_kernel::Epoch
+                    required point: amaru_kernel::Point
+                }
+            }
+            ledger_db {
+                /// Forcefully remove an existing ledger database
+                public FORCEFULLY_REMOVE {
+                    required dir: String
+                }
+                /// Ledger database already exists
+                public EXIST {
+                    required dir: String
+                    required hint: String
+                }
+            }
+            mithril {
+                /// Synchronize the cardano-node database from Mithril
+                public DOWNLOAD {
+                    required from_chunk: u64
+                    required target_dir: String
+                }
+                /// Local cardano-node database is recent enough; skipping Mithril download
+                public SKIP_DOWNLOAD {
+                    required from_chunk: u64
+                    required required_chunk: u64
+                    required target_dir: String
+                    required reason: String
+                }
+            }
+            node {
+                /// Bootstrap a node from published snapshots
+                public BOOTSTRAP {
+                    required force: bool
+                    required chain_dir: String
+                    required ledger_dir: String
+                    required network: amaru_kernel::NetworkName
+                    optional epoch: amaru_kernel::Epoch
+                }
+            }
+            snapshot {
+                /// Create snapshots for the given network
+                public CREATE {
+                    required network: amaru_kernel::NetworkName
+                    optional epoch: amaru_kernel::Epoch
+                    required snapshot_output_dir: String
+                    required config_dir: String
+                    required cardano_node_db: String
+                    required dist_dir: String
+                    optional snapshots: String
+                }
+                /// Materialize a bootstrap snapshot directory
+                public MATERIALIZE {
+                    required epoch: amaru_kernel::Epoch
+                    required snapshot: String
+                }
+                /// Snapshot already materialized; skipping
+                public SKIP_MATERIALIZE {
+                    required epoch: amaru_kernel::Epoch
+                    required reason: String
+                }
+                /// Package a snapshot archive
+                public PACKAGE {
+                    required epoch: amaru_kernel::Epoch
+                    required archive: String
+                }
+                /// Snapshot archive already packaged; skipping
+                public SKIP_PACKAGE {
+                    required epoch: amaru_kernel::Epoch
+                    required reason: String
+                }
             }
         }
         stores {
@@ -393,12 +895,12 @@ define_schemas! {
                 epoch {
                     /// Create ledger snapshot for epoch
                     public CREATE_SNAPSHOT {
-                        required epoch: u64
+                        required epoch: amaru_kernel::Epoch
                     }
                     /// Prune old snapshots
                     public PRUNE_OLD_SNAPSHOTS {
-                        required functional_minimum: u64
-                        required desired_minimum: u64
+                        required functional_minimum: amaru_kernel::Epoch
+                        required desired_minimum: amaru_kernel::Epoch
                     }
                     /// Epoch transition tracking
                     public TRY_TRANSITION {
@@ -416,9 +918,9 @@ define_schemas! {
                         /// Total number of accounts that received non-zero rewards
                         optional accounts_paid: u64
                         /// Total rewards effectively paid to ALL accounts; does not include unassignable rewards
-                        optional rewards_paid: u64
+                        optional rewards_paid: amaru_kernel::Lovelace
                         /// Treasury increase; corresponding to both the treasury tax and the unpaid rewards
-                        optional treasury_delta: u64
+                        optional treasury_delta: amaru_kernel::Lovelace
                         /// Reserves depletion from incentives; always negative.
                         optional reserves_delta: i64
                     }
@@ -428,9 +930,9 @@ define_schemas! {
                     /// Pay withdrawals to accounts, or refund deposits
                     public PAY_OR_REFUND_ACCOUNTS {
                         /// Total quantity of ADA paid, excluding treasury leftovers
-                        optional total_paid_or_refunded: u64
+                        optional total_paid_or_refunded: amaru_kernel::Lovelace
                         /// Total amounts that couldn't be paid to accounts, going back to treasury instead.
-                        optional treasury_leftovers: u64
+                        optional treasury_leftovers: amaru_kernel::Lovelace
                     }
                     /// Updating pools metadata or retiring pools at an epoch boundary.
                     public UPDATE_OR_RETIRE_POOLS {
@@ -461,7 +963,10 @@ define_schemas! {
                     /// Batch-upsert pool entries
                     public ADD {}
                     /// Schedule pool retirement
-                    public REMOVE {}
+                    public REMOVE {
+                        optional pool: amaru_kernel::PoolId
+                        optional reason: String
+                    }
                 }
                 accounts {
                     /// Point-read an account entry
@@ -471,19 +976,35 @@ define_schemas! {
                     /// Batch-delete account entries
                     public REMOVE {}
                     /// Update rewards balance for a single account
-                    public SET {}
+                    public SET {
+                        optional credential_type: amaru_kernel::StakeCredentialKind
+                        optional account: amaru_kernel::Hash<28>
+                        optional reason: String
+                    }
                     /// Reset rewards counters for many accounts
-                    public RESET_MANY {}
+                    public RESET_MANY {
+                        optional credential: amaru_kernel::StakeCredential
+                        optional reason: String
+                    }
                 }
                 dreps {
                     /// Point-read a DRep entry
                     public GET {}
                     /// Batch-upsert DRep registrations
-                    public ADD {}
+                    public ADD {
+                        optional credential: amaru_kernel::StakeCredential
+                        optional reason: String
+                    }
                     /// Record DRep de-registration
-                    public REMOVE {}
+                    public REMOVE {
+                        optional drep: amaru_kernel::StakeCredential
+                        optional reason: String
+                    }
                     /// Refresh DRep expiry after a vote
-                    public SET_VALID_UNTIL {}
+                    public SET_VALID_UNTIL {
+                        optional credential: amaru_kernel::StakeCredential
+                        optional reason: String
+                    }
                 }
                 cc_members {
                     /// Read a constitutional committee member
@@ -551,12 +1072,12 @@ define_schemas! {
                     /// Roll forward the chain to a point
                     public ROLL_FORWARD {
                         required hash: amaru_kernel::HeaderHash
-                        required slot: u64
+                        required slot: amaru_kernel::Slot
                     }
                     /// Switch the chain to a new fork
                     public SWITCH_TO_FORK {
                         required hash: amaru_kernel::HeaderHash
-                        required slot: u64
+                        required slot: amaru_kernel::Slot
                     }
                 }
             }
@@ -565,35 +1086,35 @@ define_schemas! {
             transaction {
                 /// Transaction received by the mempool stage, before validation.
                 public RECEIVED {
-                    required tx_id: String
+                    required tx_id: amaru_kernel::TransactionId
                     required origin: String
                 }
                 /// Transaction validated and inserted into the mempool.
                 public ACCEPTED {
-                    required tx_id: String
+                    required tx_id: amaru_kernel::TransactionId
                     required seq_no: u64
                     required origin: String
                 }
                 /// Transaction rejected at insertion. Reason ∈ {invalid, duplicate, mempool_full}.
                 public REJECTED {
-                    required tx_id: String
+                    required tx_id: amaru_kernel::TransactionId
                     required reason: String
                     optional validation_error: String
                 }
                 /// Transaction removed from the mempool. Reason ∈ {invalid_after_tip}.
                 /// TODO: split the reason into invalid after tip + present in applied block
                 public EVICTED {
-                    required tx_id: String
+                    required tx_id: amaru_kernel::TransactionId
                     required reason: String
                 }
                 /// Detail trace carrying upstream peer attribution for a received tx.
                 RECEIVED_DETAIL {
-                    required tx_id: String
-                    required peer: String
+                    required tx_id: amaru_kernel::TransactionId
+                    required peer: amaru_kernel::Peer
                 }
                 /// Detail trace for a tip-driven revalidation pass.
                 REVALIDATION_DETAIL {
-                    required tip_slot: u64
+                    required tip_slot: amaru_kernel::Slot
                     required total_before: u64
                     required evicted_count: u64
                     required duration_micros: u64
@@ -607,7 +1128,7 @@ define_schemas! {
                     PROCESS {
                         required message_type: String
                         required conn_id: String
-                        required peer: String
+                        required peer: amaru_kernel::Peer
                         required role: String
                     }
                 }
@@ -622,24 +1143,24 @@ define_schemas! {
                 peer {
                     /// A new peer was added to the manager
                     public ADD {
-                        required peer: String
+                        required peer: amaru_kernel::Peer
                     }
                     /// Initiating an outbound connection to a peer
                     public CONNECT {
-                        required peer: String
+                        required peer: amaru_kernel::Peer
                     }
                     /// An inbound connection was accepted from a peer
                     public ACCEPTED {
-                        required peer: String
+                        required peer: amaru_kernel::Peer
                         required conn_id: String
                     }
                     /// A peer was removed from the manager
                     public REMOVE {
-                        required peer: String
+                        required peer: amaru_kernel::Peer
                     }
                     /// A peer connection has died
                     public CONNECTION_DIED {
-                        required peer: String
+                        required peer: amaru_kernel::Peer
                         required conn_id: String
                         required role: String
                     }
@@ -649,7 +1170,7 @@ define_schemas! {
                 peer {
                     /// A connection has been established and the handshake completed successfully.
                     public CONNECTED {
-                        required peer: String
+                        required peer: amaru_kernel::Peer
                         required conn_id: u64
                         required direction: String
                         required full_duplex_capable: bool
@@ -658,7 +1179,7 @@ define_schemas! {
                     /// A connection has been terminated (graceful disconnect, error, handshake refusal,
                     /// or network error).
                     public DISCONNECTED {
-                        required peer: String
+                        required peer: amaru_kernel::Peer
                         required conn_id: u64
                         required direction: String
                         optional reason: String
@@ -794,6 +1315,26 @@ define_schemas! {
                     }
                     /// Want next message for protocol
                     WANT_NEXT {}
+                }
+            }
+        }
+        setup {
+            observability {
+                /// Observability stack initialization
+                public INIT {
+                    required with_open_telemetry: bool
+                    required with_json_traces: bool
+                    required with_colors: bool
+                }
+            }
+            trace {
+                /// Resolution of a trace filter from the environment
+                public FILTER {
+                    required var: String
+                    required value: String
+                    required provided_by_user: bool
+                    optional provided_invalid: bool
+                    optional error: String
                 }
             }
         }

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -140,7 +140,7 @@ pub async fn stage(
 ) -> Connection {
     let message_type = msg.message_type().to_string();
     let conn_id = params.conn_id.to_string();
-    let peer = params.peer.to_string();
+    let peer = params.peer.clone();
     let role = format!("{:?}", params.role);
 
     async move {

--- a/crates/amaru-protocols/src/manager.rs
+++ b/crates/amaru-protocols/src/manager.rs
@@ -608,19 +608,15 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
     async move {
         match msg {
             ManagerMessage::AddPeer(peer) => {
-                let span = debug_span!(protocols::manager::peer::ADD, peer = peer.to_string());
+                let span = debug_span!(protocols::manager::peer::ADD, peer = &peer);
                 manager.add_peer(peer, &eff).instrument(span).await;
             }
             ManagerMessage::Accepted(peer, conn_id) => {
-                let span = debug_span!(
-                    protocols::manager::peer::ACCEPTED,
-                    peer = peer.to_string(),
-                    conn_id = conn_id.to_string()
-                );
+                let span = debug_span!(protocols::manager::peer::ACCEPTED, peer = &peer, conn_id = conn_id.to_string());
                 manager.accepted(peer, conn_id, &eff).instrument(span).await;
             }
             ManagerMessage::RemovePeer(peer) => {
-                let span = debug_span!(protocols::manager::peer::REMOVE, peer = peer.to_string());
+                let span = debug_span!(protocols::manager::peer::REMOVE, peer = &peer);
                 manager.remove_peer(peer, &eff).instrument(span).await;
             }
             ManagerMessage::Disconnect(peer, conn_id) => {
@@ -634,7 +630,7 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
             ManagerMessage::ConnectionDied(peer, conn_id, role) => {
                 let span = debug_span!(
                     protocols::manager::peer::CONNECTION_DIED,
-                    peer = peer.to_string(),
+                    peer = &peer,
                     conn_id = conn_id.to_string(),
                     role = role.to_string()
                 );

--- a/crates/amaru-stores/src/rocksdb/consensus/write_chain_store.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/write_chain_store.rs
@@ -68,11 +68,8 @@ impl WriteChainStore for RocksDBStore {
 
     fn switch_to_fork(&self, fork_point: &Point, forward_points: &[Point]) -> Result<(), StoreError> {
         let last = forward_points.last().unwrap_or(fork_point);
-        let span = debug_span!(
-            stores::consensus::chain::SWITCH_TO_FORK,
-            hash = last.hash(),
-            slot = u64::from(last.slot_or_default()),
-        );
+        let span =
+            debug_span!(stores::consensus::chain::SWITCH_TO_FORK, hash = last.hash(), slot = last.slot_or_default(),);
         let _guard = span.enter();
 
         let fork_slot = u64::from(fork_point.slot_or_default()).to_be_bytes();
@@ -123,11 +120,8 @@ impl WriteChainStore for RocksDBStore {
     }
 
     fn roll_forward_chain(&self, point: &Point) -> Result<(), StoreError> {
-        let span = debug_span!(
-            stores::consensus::chain::ROLL_FORWARD,
-            hash = point.hash(),
-            slot = u64::from(point.slot_or_default()),
-        );
+        let span =
+            debug_span!(stores::consensus::chain::ROLL_FORWARD, hash = point.hash(), slot = point.slot_or_default(),);
         let _guard = span.enter();
 
         self.with_batch(|batch| {

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/accounts.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/accounts.rs
@@ -75,12 +75,7 @@ pub fn reset_many<DB>(db: &Transaction<'_, DB>, rows: impl Iterator<Item = Key>)
                 row.rewards = 0;
                 db.put(key, as_value(row)).map_err(|err| StoreError::Internal(err.into()))?;
             } else {
-                error!(
-                    target: "amaru::stores",
-                    name: "accounts.reset_many",
-                    ?credential,
-                    reason = "no account for given credential"
-                )
+                error!(stores::ledger::accounts::RESET_MANY, ?credential, reason = "no account for given credential")
             }
         }
 
@@ -120,9 +115,8 @@ pub fn set<DB>(
 
         // TODO: Should probably be an error now that we have the overlay...
         debug!(
-            target: "amaru::stores",
-            name: "accounts.set",
-            type = %StakeCredentialKind::from(credential),
+            stores::ledger::accounts::SET,
+            credential_type = %StakeCredentialKind::from(credential),
             account = %credential.as_hash(),
             reason = "cannot set stake, account is gone"
         );

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/dreps.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/dreps.rs
@@ -84,12 +84,7 @@ pub fn add<DB>(
                     db.put(key, as_value(row)).map_err(|err| StoreError::Internal(err.into()))?;
                 }
                 None => {
-                    error!(
-                        target: "amaru::stores",
-                        name: "dreps.add",
-                        ?credential,
-                        reason = "registration without a deposit"
-                    )
+                    error!(stores::ledger::dreps::ADD, ?credential, reason = "registration without a deposit")
                 }
             }
         }
@@ -115,12 +110,7 @@ pub fn set_valid_until<DB>(
                 row.valid_until = valid_until;
                 db.put(key, as_value(row)).map_err(|err| StoreError::Internal(err.into()))?;
             } else {
-                warn!(
-                    target: "amaru::stores",
-                    name: "dreps.set_valid_until",
-                    ?credential,
-                    reason = "unknown drep",
-                )
+                warn!(stores::ledger::dreps::SET_VALID_UNTIL, ?credential, reason = "unknown drep")
             };
         }
 
@@ -140,12 +130,7 @@ pub fn remove<DB>(
             if db.get_pinned(&key).map_err(|err| StoreError::Internal(err.into()))?.is_some() {
                 db.delete(key).map_err(|err| StoreError::Internal(err.into()))?;
             } else {
-                error!(
-                    target: "amaru::stores",
-                    name: "dreps.remove",
-                    ?drep,
-                    reason = "unknown drep",
-                )
+                error!(stores::ledger::dreps::REMOVE, ?drep, reason = "unknown drep")
             }
         }
 

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/pools.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/pools.rs
@@ -73,7 +73,7 @@ pub fn remove<DB>(db: &Transaction<'_, DB>, rows: impl Iterator<Item = (Key, Epo
             // every epoch boundary.
             match db.get(as_key(&PREFIX, pool)).map_err(|err| StoreError::Internal(err.into()))? {
                 None => {
-                    error!(target: "amaru::stores", name: "pools.remove", ?pool, reason = "unknown pool")
+                    error!(stores::ledger::pools::REMOVE, ?pool, reason = "unknown pool")
                 }
                 Some(existing_params) => db
                     .put(as_key(&PREFIX, pool), Row::extend(existing_params, (None, epoch)))

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -264,7 +264,7 @@ impl Store for RocksDB {
     type Transaction<'a> = RocksDBTransactionalContext<'a>;
 
     fn next_snapshot(&'_ self, epoch: Epoch) -> Result<(), StoreError> {
-        info_span!(stores::ledger::epoch::CREATE_SNAPSHOT, epoch = u64::from(epoch)).in_scope(|| {
+        info_span!(stores::ledger::epoch::CREATE_SNAPSHOT, epoch = epoch).in_scope(|| {
             let path = self.dir.join(epoch.to_string());
 
             if path.exists() {
@@ -323,8 +323,8 @@ impl HistoricalStores for RocksDBHistoricalStores {
 
         info_span!(
             stores::ledger::epoch::PRUNE_OLD_SNAPSHOTS,
-            functional_minimum = u64::from(functional_minimum),
-            desired_minimum = u64::from(desired_minimum),
+            functional_minimum = functional_minimum,
+            desired_minimum = desired_minimum,
         )
         .in_scope(|| {
             with_snapshots(&self.config.dir, |path, epoch| {

--- a/crates/amaru/src/bin/amaru/cmd/node/bootstrap.rs
+++ b/crates/amaru/src/bin/amaru/cmd/node/bootstrap.rs
@@ -16,6 +16,7 @@ use std::{error::Error, fs::remove_dir_all, path::PathBuf};
 
 use amaru::{bootstrap::bootstrap, default_chain_dir, default_ledger_dir};
 use amaru_kernel::{Epoch, GlobalParameters, NetworkName, utils::path::relative_path};
+use amaru_observability::{info, warn};
 use clap::{ArgAction, Parser};
 
 #[derive(Debug, Parser)]
@@ -76,18 +77,6 @@ pub struct Args {
     pub(crate) help_global_parameters: bool,
 }
 
-macro_rules! info {
-    ($name:literal $(, $($rest:tt)+)?) => {
-        amaru_observability::info!(target: "amaru::cli", name: $name $(, $($rest)+)?);
-    };
-}
-
-macro_rules! warn {
-    ($name:literal $(, $($rest:tt)+)?) => {
-        amaru_observability::warn!(target: "amaru::cli", name: $name $(, $($rest)+)?);
-    };
-}
-
 pub async fn run(args: Args) -> Result<(), Box<dyn Error>> {
     let network = args.network;
 
@@ -98,30 +87,31 @@ pub async fn run(args: Args) -> Result<(), Box<dyn Error>> {
     let chain_dir = args.chain_dir.unwrap_or_else(|| default_chain_dir(network).into());
 
     info!(
-        "node.bootstrap",
-        force = %args.force,
+        cli::node::BOOTSTRAP,
+        force = args.force,
         chain_dir = %relative_path(&chain_dir)?.display(),
         ledger_dir = %relative_path(&ledger_dir)?.display(),
         network = %network,
-        epoch = args.epoch
-            .map(|e| Box::new(e.to_string()) as Box<dyn tracing::Value>)
-            .unwrap_or_else(|| Box::new(tracing::field::Empty)),
+        epoch = @args.epoch.map(|e| e.to_string()),
     );
 
     if ledger_dir.exists() || chain_dir.exists() {
         if !args.force {
-            warn!(
-                "snapshot.exist",
-                hint = "ledger or chain directory already exists: use another location, remove it or use --force"
-            );
+            if ledger_dir.exists() {
+                let dir = relative_path(&ledger_dir)?.display();
+                warn!(cli::ledger_db::EXIST, dir = %dir, hint = "ledger directory already exists: use another location, remove it or use --force");
+            } else {
+                let dir = relative_path(&chain_dir)?.display();
+                warn!(cli::chain_db::EXIST, dir = %dir, hint = "chain directory already exists: use another location, remove it or use --force");
+            }
             return Ok(());
         } else {
             if ledger_dir.exists() {
-                warn!("ledger_db.forcefully_remove", dir=%relative_path(&ledger_dir)?.display());
+                warn!(cli::ledger_db::FORCEFULLY_REMOVE, dir = %relative_path(&ledger_dir)?.display());
                 remove_dir_all(&ledger_dir)?;
             }
             if chain_dir.exists() {
-                warn!("chain_db.forcefully_remove", dir=%relative_path(&chain_dir)?.display());
+                warn!(cli::chain_db::FORCEFULLY_REMOVE, dir = %relative_path(&chain_dir)?.display());
                 remove_dir_all(&chain_dir)?;
             }
         }

--- a/crates/amaru/src/bin/amaru/cmd/snapshot/create/archive.rs
+++ b/crates/amaru/src/bin/amaru/cmd/snapshot/create/archive.rs
@@ -42,7 +42,7 @@ pub(super) fn write_epoch_metadata(
     target: &EpochTarget,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let path = metadata_path_for_epoch(metadata_dir, target.epoch);
-    info!(target: "amaru::cli", name: "epoch_metadata.write", epoch = %target.epoch, path = %relative_path(&path)?.display());
+    info!(cli::epoch_metadata::WRITE, epoch = %target.epoch, path = %relative_path(&path)?.display());
     fs::write(path, serde_json::to_vec_pretty(target)?)?;
     Ok(())
 }

--- a/crates/amaru/src/bin/amaru/cmd/snapshot/create/config.rs
+++ b/crates/amaru/src/bin/amaru/cmd/snapshot/create/config.rs
@@ -79,11 +79,11 @@ pub(super) async fn resolve_config_dir(
     if let Some(config_dir) = bundled_config_dir(network) {
         match validate_config_dir(&config_dir) {
             Ok(()) => {
-                info!(target: "amaru::cli", name: "cardano_node_config.use", config_dir = %config_dir.display(), network = %network);
+                info!(cli::cardano_node_config::USE, config_dir = %config_dir.display(), network = %network);
                 return Ok(config_dir);
             }
             Err(_) => {
-                info!(target: "amaru::cli", name: "cardano_node_config.download", config_dir = %config_dir.display(), network = %network);
+                info!(cli::cardano_node_config::DOWNLOAD, config_dir = %config_dir.display(), network = %network);
                 return download_official_config_bundle(client, network, &config_dir).await;
             }
         }

--- a/crates/amaru/src/bin/amaru/cmd/snapshot/create/db_analyser.rs
+++ b/crates/amaru/src/bin/amaru/cmd/snapshot/create/db_analyser.rs
@@ -115,7 +115,7 @@ where
 
                 match action {
                     DbAnalyserLogAction::Report(message) => {
-                        info!(target: "amaru::cli", name: "db_analyser.progress", step = %step, message = %message);
+                        info!(cli::db_analyser::PROGRESS, step = %step, detail = %message);
                         continue;
                     }
                     DbAnalyserLogAction::Suppress => continue,
@@ -124,9 +124,9 @@ where
             }
 
             if is_stderr {
-                warn!(target: "amaru::cli", name: "db_analyser.log", step = %step, line = %line);
+                warn!(cli::db_analyser::LOG, step = %step, line = %line);
             } else {
-                info!(target: "amaru::cli", name: "db_analyser.log", step = %step, line = %line);
+                info!(cli::db_analyser::LOG, step = %step, line = %line);
             }
         }
         Ok(())

--- a/crates/amaru/src/bin/amaru/cmd/snapshot/create/koios.rs
+++ b/crates/amaru/src/bin/amaru/cmd/snapshot/create/koios.rs
@@ -46,7 +46,7 @@ pub(super) async fn fetch_current_epoch(
 
     let tip = response.json::<Vec<KoiosTip>>().await?.into_iter().next().ok_or("Koios returned empty tip response")?;
 
-    info!(target: "amaru::cli", name: "current_epoch.resolve", epoch = tip.epoch_no);
+    info!(cli::current_epoch::RESOLVE, epoch = tip.epoch_no);
 
     Ok(Epoch::from(tip.epoch_no))
 }
@@ -106,7 +106,7 @@ pub(super) async fn fetch_last_block_for_epoch(
     let parent_block = fetch_block_by_hash(client, network, &block.parent_hash).await?;
     let parent_point = Point::from_str(&format!("{}.{}", parent_block.abs_slot, parent_block.hash))?;
 
-    info!(target: "amaru::cli", name: "last_block.resolve", %epoch, %point);
+    info!(cli::last_block::RESOLVE, %epoch, %point);
 
     Ok(EpochTarget { epoch, snapshot: SnapshotPoint { point, parent_point }, archive_path: None, snapshot_path: None })
 }

--- a/crates/amaru/src/bin/amaru/cmd/snapshot/create/mod.rs
+++ b/crates/amaru/src/bin/amaru/cmd/snapshot/create/mod.rs
@@ -28,6 +28,7 @@ use amaru_mithril::{
     chunk_for_slot, download_from_mithril, extract_block_header_cbor, first_missing_immutable_chunk,
     parse_header_slot_and_hash,
 };
+use amaru_observability::info;
 use anyhow::anyhow;
 use clap::{ArgAction, Parser};
 use num::{CheckedAdd, CheckedSub};
@@ -45,12 +46,6 @@ use archive::{
 use config::resolve_config_dir;
 use db_analyser::{ensure_db_analyser_binary, exact_snapshot_dir, run_db_analyser, select_analyse_from_slot};
 use koios::{fetch_current_epoch, fetch_last_block_for_epoch};
-
-macro_rules! info {
-    ($name:literal $(, $($rest:tt)+)?) => {
-        amaru_observability::info!(target: "amaru::cli", name: $name $(, $($rest)+)?);
-    };
-}
 
 const PACKAGED_HEADERS_FILE_NAME: &str = "bootstrap.headers.json";
 
@@ -270,16 +265,14 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     targets.sort_unstable_by_key(|target| target.slot());
 
     info!(
-        "snapshot.create",
+        cli::snapshot::CREATE,
         network = %network,
-        epoch = epoch
-            .map(|e| Box::new(e.to_string()) as Box<dyn tracing::Value>)
-            .unwrap_or_else(|| Box::new(tracing::field::Empty)),
+        epoch = @epoch.map(|e| e.to_string()),
         snapshot_output_dir = %relative_path(&snapshot_output_dir)?.display(),
         config_dir = %relative_path(&config_dir)?.display(),
         cardano_node_db = %relative_path(&cardano_node_db)?.display(),
         dist_dir = %relative_path(&dist_dir)?.display(),
-        snapshots = snapshots_field,
+        snapshots = @snapshots_field,
     );
 
     let mut target_snapshots = BTreeSet::new();
@@ -307,14 +300,14 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
         if from_chunk > required_chunk {
             info!(
-                "mithril.skip_download",
+                cli::mithril::SKIP_DOWNLOAD,
                 from_chunk,
                 required_chunk,
                 target_dir = %cardano_node_db.display(),
                 reason = "cardano-node db already covers all target slots",
             );
         } else {
-            info!("mithril.download", from_chunk, target_dir = %cardano_node_db.display());
+            info!(cli::mithril::DOWNLOAD, from_chunk, target_dir = %cardano_node_db.display());
             download_from_mithril(network, cardano_node_db.clone(), from_chunk).await?;
         }
 
@@ -339,13 +332,13 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
             let prepared_snapshot_path = snapshot_path_for_target(context.snapshot_output_dir, target);
             let snapshot_dir = resolve_or_create_snapshot_dir(target, previous_snapshot_slot, context)?;
 
-            info!("snapshot.materialize", epoch = %target.epoch, snapshot = %prepared_snapshot_path.display());
+            info!(cli::snapshot::MATERIALIZE, epoch = %target.epoch, snapshot = %prepared_snapshot_path.display());
             materialize_snapshot(&snapshot_dir, &prepared_snapshot_path)?;
             write_packaged_headers(target, context.immutable_dir, &prepared_snapshot_path)?;
             target.snapshot_path = Some(prepared_snapshot_path.to_string_lossy().into_owned());
             write_epoch_metadata(context.metadata_dir, target)?;
         } else {
-            info!("snapshot.skip_materialize", epoch = %targets[ix].epoch, reason = "already exists");
+            info!(cli::snapshot::SKIP_MATERIALIZE, epoch = %targets[ix].epoch, reason = "already exists");
         }
 
         // Create missing archives
@@ -353,12 +346,12 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
             let target = &mut targets[ix];
             let prepared_archive_path = archive_path_for_target(&snapshot_output_dir, target);
             let prepared_snapshot_path = snapshot_path_for_target(&snapshot_output_dir, target);
-            info!("snapshot.package", epoch = %target.epoch, archive = %prepared_archive_path.display());
+            info!(cli::snapshot::PACKAGE, epoch = %target.epoch, archive = %prepared_archive_path.display());
             write_snapshot_archive(&prepared_snapshot_path, &prepared_archive_path)?;
             target.archive_path = Some(prepared_archive_path.to_string_lossy().into_owned());
             write_epoch_metadata(&metadata_dir, target)?;
         } else {
-            info!("snapshot.skip_package", epoch = %targets[ix].epoch, reason = "already exists");
+            info!(cli::snapshot::SKIP_PACKAGE, epoch = %targets[ix].epoch, reason = "already exists");
         }
     }
 
@@ -381,17 +374,17 @@ fn resolve_or_create_snapshot_dir(
     context: &SnapshotBuildContext<'_>,
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
     if let Some(snapshot_dir) = exact_snapshot_dir(context.ledger_snapshot_dir, target.slot()) {
-        info!("db_analyser.reuse_ledger_snapshot", epoch = %target.epoch, slot = %target.slot());
+        info!(cli::db_analyser::REUSE_LEDGER_SNAPSHOT, epoch = %target.epoch, slot = %target.slot());
         return Ok(snapshot_dir);
     }
 
     let analyse_from = select_analyse_from_slot(context.ledger_snapshot_dir, target.slot(), previous_snapshot_slot)?;
 
     info!(
-        "db_analyser.run",
+        cli::db_analyser::RUN,
         epoch = %target.epoch,
         slot = %target.slot(),
-        analyse_from = analyse_from.map(|s| Box::new(s.to_string()) as Box<dyn tracing::Value>).unwrap_or_else(|| Box::new(tracing::field::Empty)),
+        analyse_from = @analyse_from.map(|s| s.to_string()),
     );
 
     run_db_analyser(

--- a/crates/amaru/src/bootstrap/chain_sync_client.rs
+++ b/crates/amaru/src/bootstrap/chain_sync_client.rs
@@ -44,8 +44,8 @@ impl ChainSyncClient {
         }
         .instrument(debug_span!(
             amaru::consensus::chain::FIND_INTERSECTION,
-            peer = &self.peer.name,
-            intersection_slot = u64::from(self.intersection.last().map(|p| p.slot_or_default()).unwrap_or_default())
+            peer = &self.peer,
+            intersection_slot = self.intersection.last().map(|p| p.slot_or_default()).unwrap_or_default()
         ))
         .await
     }

--- a/crates/amaru/src/bootstrap/mod.rs
+++ b/crates/amaru/src/bootstrap/mod.rs
@@ -30,6 +30,7 @@ use amaru_ledger::{
     bootstrap::import_initial_snapshot,
     store::{EpochTransitionProgress, Store, TransactionalContext},
 };
+use amaru_observability::{error, info};
 use amaru_ouroboros::{ChainStore, Nonces, WriteChainStore};
 use amaru_progress_bar::{ProgressBar, TerminalProgressBar};
 use amaru_stores::rocksdb::{RocksDB, RocksDbConfig, consensus::RocksDBStore};
@@ -53,18 +54,6 @@ use crate::{
     cardano_node::{ParsedStateSnapshot, parse_state_snapshot_with_nonces, tvar::import_snapshot_from_tvar},
     default_data_dir, default_snapshots_dir, get_bootstrap_file,
 };
-
-macro_rules! info {
-    ($name:literal $(, $($rest:tt)+)?) => {
-        amaru_observability::info!(target: "amaru::bootstrap", name: $name $(, $($rest)+)?);
-    };
-}
-
-macro_rules! error {
-    ($name:literal $(, $($rest:tt)+)?) => {
-        amaru_observability::error!(target: "amaru::bootstrap", name: $name $(, $($rest)+)?);
-    };
-}
 
 /// Configuration for a single ledger state's snapshot to be imported.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
@@ -176,7 +165,7 @@ fn bootstrap_snapshots(network: NetworkName) -> Result<(PathBuf, Vec<Snapshot>),
 
     let local_snapshots = load_local_epoch_snapshots(network);
     if !local_snapshots.is_empty() {
-        info!("local_snapshots.detect", count = local_snapshots.len());
+        info!(bootstrap::local_snapshots::DETECT, count = local_snapshots.len());
         for local_snapshot in local_snapshots {
             if !snapshots.iter().any(|s| s.epoch == local_snapshot.epoch) {
                 snapshots.push(local_snapshot);
@@ -315,13 +304,13 @@ async fn fetch_headers_from_point(
     headers_per_point: usize,
 ) -> Result<Vec<Vec<u8>>, Box<dyn Error>> {
     let peer_client = PeerClient::connect(peer_address, network.to_network_magic().as_u64()).await.map_err(|err| {
-        error!("peer.failed_to_connect", peer = %peer_address, reason = %err);
+        error!(bootstrap::peer::FAILED_TO_CONNECT, peer = %peer_address, reason = %err);
         err
     })?;
     let mut client = ChainSyncClient::new(Peer::new(peer_address), peer_client.chainsync, vec![point]);
     let intersection = client.find_intersection().await?;
 
-    info!("headers.fetch", requested_point = %point, intersection = %intersection, headers_per_point);
+    info!(bootstrap::headers::FETCH, requested_point = %point, intersection = %intersection, headers_per_point);
 
     let mut headers = Vec::with_capacity(headers_per_point);
     while headers.len() < headers_per_point {
@@ -346,7 +335,7 @@ async fn fetch_headers_from_point(
                 }
             }
             NextResponse::RollBackward(point, tip) => {
-                error!("fetch.rollback", ?point, ?tip);
+                error!(bootstrap::fetch::ROLLBACK, ?point, ?tip);
             }
             NextResponse::Await => continue,
         }
@@ -366,21 +355,21 @@ async fn download_snapshots(snapshots: &[&Snapshot], snapshots_dir: &Path) -> Re
         let snapshot_dir = snapshot_directory_path(snapshots_dir, snapshot);
         let snapshot_file = snapshot_file_path(snapshots_dir, snapshot);
         if let Some(snapshot_path) = resolve_snapshot_path(snapshots_dir, snapshot) {
-            info!("snapshot.skip_download", snapshot = %relative_path(&snapshot_path)?.display());
+            info!(bootstrap::snapshot::SKIP_DOWNLOAD, snapshot = %relative_path(&snapshot_path)?.display());
             continue;
         }
 
         if snapshot_dir.exists() {
-            error!("snapshot.invalid", snapshot = %relative_path(&snapshot_dir)?.display());
+            error!(bootstrap::snapshot::INVALID, snapshot = %relative_path(&snapshot_dir)?.display());
             return Err(anyhow!("snapshot directory exists but is not a valid tvar snapshot; try removing it"))?;
         }
 
         if snapshot_file.exists() && !is_cbor_snapshot_file(&snapshot_file) {
-            error!("snapshot.invalid", snapshot = %relative_path(&snapshot_file)?.display());
+            error!(bootstrap::snapshot::INVALID, snapshot = %relative_path(&snapshot_file)?.display());
             return Err(anyhow!("snapshot file exists but is not a valid cbor snapshot; try removing it"))?;
         }
 
-        info!("snapshot.download", epoch = %snapshot.epoch, point = %snapshot.point);
+        info!(bootstrap::snapshot::DOWNLOAD, epoch = %snapshot.epoch, point = %snapshot.point);
 
         if snapshot.url.ends_with(".cbor.gz") {
             let (tmp_path, mut file) = create_partial_file(&snapshot_file).await?;
@@ -401,7 +390,7 @@ async fn download_snapshots(snapshots: &[&Snapshot], snapshots_dir: &Path) -> Re
         file.sync_all().await?;
         drop(file);
 
-        info!("snapshot.extract", snapshot = %relative_path(&snapshot_dir)?.display());
+        info!(bootstrap::snapshot::EXTRACT, snapshot = %relative_path(&snapshot_dir)?.display());
 
         if let Err(err) = extract_snapshot_archive(&archive_path, &extract_path, &snapshot_dir) {
             let _ = fs::remove_file(&archive_path).await;
@@ -616,7 +605,7 @@ fn snapshot_epoch(parsed_snapshot: &ParsedStateSnapshot) -> Result<Epoch, Box<dy
 pub fn store_nonces(epoch: Epoch, db: &dyn ChainStore, initial_nonces: InitialNonces) -> Result<(), Box<dyn Error>> {
     let header_hash = Hash::from(&initial_nonces.at);
 
-    info!("nonces.import", point = %initial_nonces.at);
+    info!(bootstrap::nonces::IMPORT, point = %initial_nonces.at);
 
     let nonces = Nonces {
         epoch,
@@ -635,7 +624,7 @@ pub async fn import_headers(db: &RocksDBStore, headers: Vec<Vec<u8>>) -> Result<
     for header in headers {
         let block_header: BlockHeader = from_cbor(&header).ok_or("failed to decode packaged bootstrap header")?;
         let hash = block_header.hash();
-        info!("header.import", header = %hash);
+        info!(bootstrap::header::IMPORT, header = %hash);
         db.store_header(&block_header)?;
     }
 
@@ -680,7 +669,7 @@ pub async fn import_snapshots(
     snapshots: &[PathBuf],
     ledger_dir: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    info!("snapshots.import", count = snapshots.len());
+    info!(bootstrap::snapshots::IMPORT, count = snapshots.len());
     for snapshot in snapshots {
         import_snapshot(network, global_parameters, snapshot, ledger_dir).await?;
     }
@@ -740,7 +729,7 @@ async fn import_cbor_snapshot_file(
     ledger_dir: &Path,
     nonce_tail: Option<HeaderHash>,
 ) -> Result<ImportedSnapshot, Box<dyn std::error::Error>> {
-    info!("snapshot.import", file = %relative_path(snapshot)?.display());
+    info!(bootstrap::snapshot::IMPORT_FILE, path = %relative_path(snapshot)?.display());
 
     let point =
         Point::try_from(snapshot.file_stem().and_then(|s| s.to_str()).unwrap()).map_err(ImportError::MalformedDate)?;
@@ -793,7 +782,7 @@ async fn import_node_snapshot_dir(
     ledger_dir: &Path,
     nonce_tail: Option<HeaderHash>,
 ) -> Result<ImportedSnapshot, Box<dyn std::error::Error>> {
-    info!("snapshot.import", dir = %relative_path(snapshot_dir)?.display());
+    info!(bootstrap::snapshot::IMPORT_DIR, path = %relative_path(snapshot_dir)?.display());
 
     std::fs::create_dir_all(ledger_dir)?;
 

--- a/crates/amaru/src/cardano_node/tvar.rs
+++ b/crates/amaru/src/cardano_node/tvar.rs
@@ -65,7 +65,7 @@ where
     let point = Point::Specific(parsed_snapshot.slot.into(), parsed_snapshot.hash);
     let new_epoch_state_offset = parsed_snapshot.ledger_data_begin;
 
-    info!(target: "amaru::bootstrap", name: "snapshot.import", %point, new_epoch_state_offset);
+    info!(bootstrap::snapshot::IMPORT_TVAR, point = point, new_epoch_state_offset = new_epoch_state_offset);
 
     state_file.seek(SeekFrom::Start(new_epoch_state_offset as u64))?;
 
@@ -202,7 +202,7 @@ where
     }
 
     progress.clear();
-    info!(target: "amaru::bootstrap", name: "import.utxo", size = actual_size);
+    info!(bootstrap::import::UTXO, size = actual_size);
 
     Ok(())
 }

--- a/crates/amaru/src/observability.rs
+++ b/crates/amaru/src/observability.rs
@@ -480,9 +480,8 @@ fn new_default_filter(var: &str, default: &str) -> (ThrottledEnvFilter, DelayedW
         Ok(filter) => {
             let var = var.to_string();
             let value = std::env::var(&var).unwrap_or_default();
-            let notice = Box::new(
-                move || info!(target: "amaru::setup", name: "trace.filter", var, value, provided_by_user = true),
-            ) as Box<dyn FnOnce()>;
+            let notice =
+                Box::new(move || info!(setup::trace::FILTER, var, value, provided_by_user = true)) as Box<dyn FnOnce()>;
             (filter, Some(notice))
         }
         Err(e) => {
@@ -490,11 +489,12 @@ fn new_default_filter(var: &str, default: &str) -> (ThrottledEnvFilter, DelayedW
             let fallback = default.to_string();
             let var = var.to_string();
             let warning = match e.source().and_then(|e| e.downcast_ref::<VarError>()) {
-                Some(VarError::NotPresent) => Box::new(
-                    move || info!(target: "amaru::setup", name: "trace.filter", var, value = fallback, provided_by_user = false),
-                ) as Box<dyn FnOnce()>,
+                Some(VarError::NotPresent) => {
+                    Box::new(move || info!(setup::trace::FILTER, var, value = fallback, provided_by_user = false))
+                        as Box<dyn FnOnce()>
+                }
                 _ => Box::new(
-                    move || warn!(target: "amaru::setup", name: "trace.filter", var, value = fallback, provided_by_user = true, provided_invalid = true, error = %e),
+                    move || warn!(setup::trace::FILTER, var, value = fallback, provided_by_user = true, provided_invalid = true, error = %e),
                 ) as Box<dyn FnOnce()>,
             };
 
@@ -529,13 +529,7 @@ pub fn setup_observability(
         notify();
     }
 
-    info!(
-        target: "amaru::setup",
-        name: "observability.init",
-        with_open_telemetry,
-        with_json_traces,
-        with_colors = color,
-    );
+    info!(setup::observability::INIT, with_open_telemetry, with_json_traces, with_colors = color,);
 
     (metrics, teardown)
 }

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -5,6 +5,642 @@ This document lists all available spans in Amaru, auto-generated from the code.
 For information on how to use and filter these spans, see [monitoring/README.md](../monitoring/README.md).
 
 
+## target: `amaru::bootstrap::accounts`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `import` | `TRACE` | public | Import accounts from a snapshot | size |  |
+| `is_not_empty` | `TRACE` | public | Existing accounts found in the store before import |  |  |
+
+<details><summary>span: `import`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `size` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::block_issuers`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `import` | `TRACE` | public | Import block issuers from a snapshot | count |  |
+
+<details><summary>span: `import`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `count` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::constitution`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `import` | `TRACE` | public | Import the constitution from a snapshot | anchor, guardrails |  |
+
+<details><summary>span: `import`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `anchor` | `string` | ✓ |
+| `guardrails` | `string` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::constitutional_committee`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `import` | `TRACE` | public | Import the constitutional committee from a snapshot | state | threshold, members |
+
+<details><summary>span: `import`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `state` | `string` | ✓ |
+| `threshold` | `string` |  |
+| `members` | `integer` |  |
+
+</details>
+
+## target: `amaru::bootstrap::dreps`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `import` | `TRACE` | public | Import DReps from a snapshot | size |  |
+
+<details><summary>span: `import`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `size` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::fetch`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `rollback` | `TRACE` | public | Received a rollback while fetching bootstrap headers | point, tip |  |
+
+<details><summary>span: `rollback`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `point` | `string` | ✓ |
+| `tip` | `string` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::governance_activity`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `import` | `TRACE` | public | Import the governance activity from a snapshot | dormant_epochs |  |
+
+<details><summary>span: `import`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `dormant_epochs` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::header`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `import` | `TRACE` | public | Import a single header into the chain store | header |  |
+
+<details><summary>span: `import`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `header` | `string` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::headers`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `fetch` | `TRACE` | public | Fetch bootstrap headers from a peer | requested_point, intersection, headers_per_point |  |
+
+<details><summary>span: `fetch`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `requested_point` | `string` | ✓ |
+| `intersection` | `string` | ✓ |
+| `headers_per_point` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::import`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `utxo` | `TRACE` | public | Import UTxO entries from a snapshot | size |  |
+
+<details><summary>span: `utxo`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `size` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::local_snapshots`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `detect` | `TRACE` | public | Detect locally-created snapshots from create-snapshots | count |  |
+
+<details><summary>span: `detect`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `count` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::nonces`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `import` | `TRACE` | public | Import initial nonces into the chain store | point |  |
+
+<details><summary>span: `import`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `point` | `string` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::peer`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `failed_to_connect` | `TRACE` | public | Failed to connect to a peer while bootstrapping | peer, reason |  |
+
+<details><summary>span: `failed_to_connect`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `peer` | `string` | ✓ |
+| `reason` | `string` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::pots`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `import` | `TRACE` | public | Import treasury/reserves/fees pots from a snapshot | treasury, reserves, fees, donations |  |
+
+<details><summary>span: `import`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `treasury` | `integer` | ✓ |
+| `reserves` | `integer` | ✓ |
+| `fees` | `integer` | ✓ |
+| `donations` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::proposal_roots`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `import` | `TRACE` | public | Import governance proposal roots from a snapshot | constitution, constitutional_committee, hard_fork, protocol_parameters |  |
+
+<details><summary>span: `import`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `constitution` | `string` | ✓ |
+| `constitutional_committee` | `string` | ✓ |
+| `hard_fork` | `string` | ✓ |
+| `protocol_parameters` | `string` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::proposals`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `import` | `TRACE` | public | Import governance proposals from a snapshot | size |  |
+| `is_not_empty` | `TRACE` | public | Existing proposals found in the store before import |  |  |
+
+<details><summary>span: `import`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `size` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::snapshot`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `download` | `TRACE` | public | Download a snapshot archive | epoch, point |  |
+| `extract` | `TRACE` | public | Extract a snapshot archive | snapshot |  |
+| `import_dir` | `TRACE` | public | Import a snapshot directory | path |  |
+| `import_file` | `TRACE` | public | Import a single snapshot | path |  |
+| `import_tvar` | `TRACE` | public | Import from the tvar data | point, new_epoch_state_offset |  |
+| `invalid` | `TRACE` | public | Existing snapshot files are invalid and will be removed | snapshot |  |
+| `skip_download` | `TRACE` | public | Snapshot already downloaded; skipping download | snapshot |  |
+
+<details><summary>span: `download`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `epoch` | `string` | ✓ |
+| `point` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `extract`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `snapshot` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `import_dir`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `path` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `import_file`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `path` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `import_tvar`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `point` | `string` | ✓ |
+| `new_epoch_state_offset` | `integer` | ✓ |
+
+</details>
+
+<details><summary>span: `invalid`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `snapshot` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `skip_download`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `snapshot` | `string` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::snapshots`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `import` | `TRACE` | public | Import all snapshots | count |  |
+
+<details><summary>span: `import`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `count` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::stake_pools`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `import` | `TRACE` | public | Import stake pools from a snapshot | registered, retiring |  |
+
+<details><summary>span: `import`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `registered` | `integer` | ✓ |
+| `retiring` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::votes`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `import` | `TRACE` | public | Import governance votes from a snapshot | size |  |
+
+<details><summary>span: `import`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `size` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::cli::cardano_node_config`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `download` | `TRACE` | public | Download the official cardano-node configuration bundle | config_dir, network |  |
+| `use` | `TRACE` | public | Use an existing cardano-node configuration | config_dir, network |  |
+
+<details><summary>span: `download`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `config_dir` | `string` | ✓ |
+| `network` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `use`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `config_dir` | `string` | ✓ |
+| `network` | `string` | ✓ |
+
+</details>
+
+## target: `amaru::cli::chain_db`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `exist` | `TRACE` | public | Chain database already exists | dir, hint |  |
+| `forcefully_remove` | `TRACE` | public | Forcefully remove an existing chain database | dir |  |
+
+<details><summary>span: `exist`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `dir` | `string` | ✓ |
+| `hint` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `forcefully_remove`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `dir` | `string` | ✓ |
+
+</details>
+
+## target: `amaru::cli::current_epoch`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `resolve` | `TRACE` | public | Resolve the current epoch from Koios | epoch |  |
+
+<details><summary>span: `resolve`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `epoch` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::cli::db_analyser`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `log` | `TRACE` | public | Output line from an external db-analyser command | step, line |  |
+| `progress` | `TRACE` | public | Progress reported by an external db-analyser command | step, detail |  |
+| `reuse_ledger_snapshot` | `TRACE` | public | Reuse an existing db-analyser ledger snapshot | epoch, slot |  |
+| `run` | `TRACE` | public | Run db-analyser to produce a ledger snapshot | epoch, slot | analyse_from |
+
+<details><summary>span: `log`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `step` | `string` | ✓ |
+| `line` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `progress`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `step` | `string` | ✓ |
+| `detail` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `reuse_ledger_snapshot`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `epoch` | `string` | ✓ |
+| `slot` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `run`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `epoch` | `string` | ✓ |
+| `slot` | `string` | ✓ |
+| `analyse_from` | `string` |  |
+
+</details>
+
+## target: `amaru::cli::epoch_metadata`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `write` | `TRACE` | public | Write the epoch metadata file for a snapshot | epoch, path |  |
+
+<details><summary>span: `write`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `epoch` | `string` | ✓ |
+| `path` | `string` | ✓ |
+
+</details>
+
+## target: `amaru::cli::last_block`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `resolve` | `TRACE` | public | Resolve the last produced block for an epoch | epoch, point |  |
+
+<details><summary>span: `resolve`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `epoch` | `string` | ✓ |
+| `point` | `string` | ✓ |
+
+</details>
+
+## target: `amaru::cli::ledger_db`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `exist` | `TRACE` | public | Ledger database already exists | dir, hint |  |
+| `forcefully_remove` | `TRACE` | public | Forcefully remove an existing ledger database | dir |  |
+
+<details><summary>span: `exist`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `dir` | `string` | ✓ |
+| `hint` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `forcefully_remove`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `dir` | `string` | ✓ |
+
+</details>
+
+## target: `amaru::cli::mithril`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `download` | `TRACE` | public | Synchronize the cardano-node database from Mithril | from_chunk, target_dir |  |
+| `skip_download` | `TRACE` | public | Local cardano-node database is recent enough; skipping Mithril download | from_chunk, required_chunk, target_dir, reason |  |
+
+<details><summary>span: `download`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `from_chunk` | `integer` | ✓ |
+| `target_dir` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `skip_download`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `from_chunk` | `integer` | ✓ |
+| `required_chunk` | `integer` | ✓ |
+| `target_dir` | `string` | ✓ |
+| `reason` | `string` | ✓ |
+
+</details>
+
+## target: `amaru::cli::node`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `bootstrap` | `TRACE` | public | Bootstrap a node from published snapshots | force, chain_dir, ledger_dir, network | epoch |
+
+<details><summary>span: `bootstrap`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `force` | `boolean` | ✓ |
+| `chain_dir` | `string` | ✓ |
+| `ledger_dir` | `string` | ✓ |
+| `network` | `string` | ✓ |
+| `epoch` | `string` |  |
+
+</details>
+
+## target: `amaru::cli::snapshot`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `create` | `TRACE` | public | Create snapshots for the given network | network, snapshot_output_dir, config_dir, cardano_node_db, dist_dir | epoch, snapshots |
+| `materialize` | `TRACE` | public | Materialize a bootstrap snapshot directory | epoch, snapshot |  |
+| `package` | `TRACE` | public | Package a snapshot archive | epoch, archive |  |
+| `skip_materialize` | `TRACE` | public | Snapshot already materialized; skipping | epoch, reason |  |
+| `skip_package` | `TRACE` | public | Snapshot archive already packaged; skipping | epoch, reason |  |
+
+<details><summary>span: `create`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `network` | `string` | ✓ |
+| `snapshot_output_dir` | `string` | ✓ |
+| `config_dir` | `string` | ✓ |
+| `cardano_node_db` | `string` | ✓ |
+| `dist_dir` | `string` | ✓ |
+| `epoch` | `string` |  |
+| `snapshots` | `string` |  |
+
+</details>
+
+<details><summary>span: `materialize`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `epoch` | `string` | ✓ |
+| `snapshot` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `package`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `epoch` | `string` | ✓ |
+| `archive` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `skip_materialize`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `epoch` | `string` | ✓ |
+| `reason` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `skip_package`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `epoch` | `string` | ✓ |
+| `reason` | `string` | ✓ |
+
+</details>
+
+## target: `amaru::ledger::account`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `pay_or_refund` | `TRACE` | public | Pay withdrawals to an account, or refund its deposit | credential_type, account, deposit |  |
+
+<details><summary>span: `pay_or_refund`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `credential_type` | `string` | ✓ |
+| `account` | `string` | ✓ |
+| `deposit` | `integer` | ✓ |
+
+</details>
+
 ## target: `amaru::ledger::block`
 
 | name | level | public | description | required fields | optional fields |
@@ -17,7 +653,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | field | type | required |
 | --- | --- | --- |
-| `point_slot` | `integer` | ✓ |
+| `point_slot` | `string` | ✓ |
 
 </details>
 
@@ -38,6 +674,37 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 </details>
 
+## target: `amaru::ledger::chain_growth`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `violate` | `TRACE` | public | Fewer than k blocks were seen within the stability window | unstable_tail_length, reason |  |
+
+<details><summary>span: `violate`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `unstable_tail_length` | `integer` | ✓ |
+| `reason` | `string` | ✓ |
+
+</details>
+
+## target: `amaru::ledger::constitutional_committee`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `ignore` | `TRACE` | public | The constitutional committee votes were ignored during ratification | active_members, min_committee_size, reason |  |
+
+<details><summary>span: `ignore`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `active_members` | `integer` | ✓ |
+| `min_committee_size` | `integer` | ✓ |
+| `reason` | `string` | ✓ |
+
+</details>
+
 ## target: `amaru::ledger::epoch_transition`
 
 | name | level | public | description | required fields | optional fields |
@@ -48,12 +715,16 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | `end_epoch` | `TRACE` | public | Perform end-of-epoch epoch boundary computations |  |  |
 | `new_governance_updates` | `TRACE` | public | Create governance updates (i.e. ratify proposals) at an epoch boundary. | proposals_count |  |
 | `new_pools_updates` | `TRACE` | public | Create pools updates |  |  |
+| `record` | `TRACE` | public | Record an in-flight epoch transition | from, to |  |
+| `retire_pool` | `TRACE` | public | Retire a pool at an epoch boundary | id |  |
+| `rollback` | `TRACE` | public | Rollback an in-flight epoch transition | from, to |  |
+| `tick_pool` | `TRACE` | public | Update a pool's parameters at an epoch boundary; only changed parameters are recorded | id | vrf, pledge, cost, margin, reward_account, owners, relays, metadata |
 
 <details><summary>span: `apply`</summary>
 
 | field | type | required |
 | --- | --- | --- |
-| `epoch` | `integer` | ✓ |
+| `epoch` | `string` | ✓ |
 | `should_end_epoch` | `boolean` |  |
 | `should_snapshot` | `boolean` |  |
 | `should_begin_epoch` | `boolean` |  |
@@ -64,8 +735,8 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | field | type | required |
 | --- | --- | --- |
-| `from` | `integer` | ✓ |
-| `into` | `integer` | ✓ |
+| `from` | `string` | ✓ |
+| `into` | `string` | ✓ |
 | `skipped` | `boolean` |  |
 | `resuming_from` | `string` |  |
 
@@ -76,6 +747,48 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | field | type | required |
 | --- | --- | --- |
 | `proposals_count` | `integer` | ✓ |
+
+</details>
+
+<details><summary>span: `record`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `from` | `string` | ✓ |
+| `to` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `retire_pool`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `id` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `rollback`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `from` | `string` | ✓ |
+| `to` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `tick_pool`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `id` | `string` | ✓ |
+| `vrf` | `string` |  |
+| `pledge` | `string` |  |
+| `cost` | `string` |  |
+| `margin` | `string` |  |
+| `reward_account` | `string` |  |
+| `owners` | `string` |  |
+| `relays` | `string` |  |
+| `metadata` | `string` |  |
 
 </details>
 
@@ -102,7 +815,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | field | type | required |
 | --- | --- | --- |
-| `ratifying_epoch` | `integer` | ✓ |
+| `ratifying_epoch` | `string` | ✓ |
 | `treasury` | `integer` |  |
 | `votes` | `integer` |  |
 
@@ -112,7 +825,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | field | type | required |
 | --- | --- | --- |
-| `epoch` | `integer` | ✓ |
+| `epoch` | `string` | ✓ |
 | `roots_protocol_parameters` | `string` |  |
 | `roots_hard_fork` | `string` |  |
 | `roots_constitutional_committee` | `string` |  |
@@ -135,6 +848,181 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 </details>
 
+## target: `amaru::ledger::governance_activity`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `update` | `TRACE` | public | Update the number of consecutive dormant epochs | consecutive_dormant_epochs |  |
+
+<details><summary>span: `update`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `consecutive_dormant_epochs` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::ledger::non_empty_block`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `found` | `TRACE` | public | Found a non-empty block while applying it to the ledger | point, block_height, tx_count |  |
+
+<details><summary>span: `found`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `point` | `string` | ✓ |
+| `block_height` | `integer` | ✓ |
+| `tx_count` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::ledger::overlay`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `no_governance_updates` | `TRACE` | public | No governance updates found in the epoch transition overlay |  |  |
+| `no_pools_updates` | `TRACE` | public | No pools updates found in the epoch transition overlay |  |  |
+
+## target: `amaru::ledger::proposal`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `drop` | `TRACE` | public | Drop an expired or ratified governance proposal | id, expired, ratified_or_evicted |  |
+| `skip` | `TRACE` | public | Skip a governance proposal during ratification | id, reason | proposed_in, ratifying_epoch, withdrawal, treasury, invalid_members |
+
+<details><summary>span: `drop`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `id` | `string` | ✓ |
+| `expired` | `boolean` | ✓ |
+| `ratified_or_evicted` | `boolean` | ✓ |
+
+</details>
+
+<details><summary>span: `skip`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `id` | `string` | ✓ |
+| `reason` | `string` | ✓ |
+| `proposed_in` | `string` |  |
+| `ratifying_epoch` | `string` |  |
+| `withdrawal` | `integer` |  |
+| `treasury` | `integer` |  |
+| `invalid_members` | `string` |  |
+
+</details>
+
+## target: `amaru::ledger::proposal_roots`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `summarize` | `TRACE` | public | Summary of the governance proposal roots after ratification | constitution, constitutional_committee, hard_fork, protocol_parameters |  |
+
+<details><summary>span: `summarize`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `constitution` | `string` |  |
+| `constitutional_committee` | `string` |  |
+| `hard_fork` | `string` |  |
+| `protocol_parameters` | `string` |  |
+
+</details>
+
+## target: `amaru::ledger::protocol`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `upgrade` | `TRACE` | public | Upgrade to a new protocol version | old_version, new_version |  |
+
+<details><summary>span: `upgrade`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `old_version` | `integer` | ✓ |
+| `new_version` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::ledger::protocol_parameters`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `ratify` | `TRACE` | public | Ratify a protocol parameters update; only changed parameters are recorded | protocol_version, max_block_body_size, max_transaction_size, max_block_header_size, max_tx_ex_units, max_block_ex_units, max_value_size, max_collateral_inputs, min_fee_a, min_fee_b, stake_credential_deposit, stake_pool_deposit, monetary_expansion_rate, treasury_expansion_rate, min_pool_cost, lovelace_per_utxo_byte, prices, min_fee_ref_script_lovelace_per_byte, max_ref_script_size_per_tx, max_ref_script_size_per_block, ref_script_cost_stride, ref_script_cost_multiplier, stake_pool_max_retirement_epoch, optimal_stake_pools_count, pledge_influence, collateral_percentage, cost_models, pool_voting_thresholds, drep_voting_thresholds, min_committee_size, max_committee_term_length, gov_action_lifetime, gov_action_deposit, drep_deposit, drep_expiry |  |
+
+<details><summary>span: `ratify`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `protocol_version` | `string` |  |
+| `max_block_body_size` | `string` |  |
+| `max_transaction_size` | `string` |  |
+| `max_block_header_size` | `string` |  |
+| `max_tx_ex_units` | `string` |  |
+| `max_block_ex_units` | `string` |  |
+| `max_value_size` | `string` |  |
+| `max_collateral_inputs` | `string` |  |
+| `min_fee_a` | `string` |  |
+| `min_fee_b` | `string` |  |
+| `stake_credential_deposit` | `string` |  |
+| `stake_pool_deposit` | `string` |  |
+| `monetary_expansion_rate` | `string` |  |
+| `treasury_expansion_rate` | `string` |  |
+| `min_pool_cost` | `string` |  |
+| `lovelace_per_utxo_byte` | `string` |  |
+| `prices` | `string` |  |
+| `min_fee_ref_script_lovelace_per_byte` | `string` |  |
+| `max_ref_script_size_per_tx` | `string` |  |
+| `max_ref_script_size_per_block` | `string` |  |
+| `ref_script_cost_stride` | `string` |  |
+| `ref_script_cost_multiplier` | `string` |  |
+| `stake_pool_max_retirement_epoch` | `string` |  |
+| `optimal_stake_pools_count` | `string` |  |
+| `pledge_influence` | `string` |  |
+| `collateral_percentage` | `string` |  |
+| `cost_models` | `string` |  |
+| `pool_voting_thresholds` | `string` |  |
+| `drep_voting_thresholds` | `string` |  |
+| `min_committee_size` | `string` |  |
+| `max_committee_term_length` | `string` |  |
+| `gov_action_lifetime` | `string` |  |
+| `gov_action_deposit` | `string` |  |
+| `drep_deposit` | `string` |  |
+| `drep_expiry` | `string` |  |
+
+</details>
+
+## target: `amaru::ledger::ratification`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `skip` | `TRACE` | public | Skip the remaining proposals for this epoch | reason |  |
+| `summarize` | `TRACE` | public | Summary of the outcome of a ratification round | is_dormant_epoch | pruned_proposals, payouts, new_constitution, constitutional_committee_update |
+
+<details><summary>span: `skip`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `reason` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `summarize`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `is_dormant_epoch` | `boolean` | ✓ |
+| `pruned_proposals` | `string` |  |
+| `payouts` | `string` |  |
+| `new_constitution` | `string` |  |
+| `constitutional_committee_update` | `string` |  |
+
+</details>
+
 ## target: `amaru::ledger::relays`
 
 | name | level | public | description | required fields | optional fields |
@@ -154,13 +1042,30 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
 | `compute` | `TRACE` | public | Compute rewards for epoch | for_epoch | using_stake_distribution_epoch_from |
+| `summarize` | `TRACE` | public | Summary of the rewards calculation for an epoch | efficiency, incentives, treasury_tax, total_rewards, available_rewards, effective_rewards, pots_reserves, pots_treasury, pots_fees |  |
 
 <details><summary>span: `compute`</summary>
 
 | field | type | required |
 | --- | --- | --- |
-| `for_epoch` | `integer` | ✓ |
-| `using_stake_distribution_epoch_from` | `integer` |  |
+| `for_epoch` | `string` | ✓ |
+| `using_stake_distribution_epoch_from` | `string` |  |
+
+</details>
+
+<details><summary>span: `summarize`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `efficiency` | `string` | ✓ |
+| `incentives` | `integer` | ✓ |
+| `treasury_tax` | `integer` | ✓ |
+| `total_rewards` | `integer` | ✓ |
+| `available_rewards` | `integer` | ✓ |
+| `effective_rewards` | `integer` | ✓ |
+| `pots_reserves` | `integer` | ✓ |
+| `pots_treasury` | `integer` | ✓ |
+| `pots_fees` | `integer` | ✓ |
 
 </details>
 
@@ -169,12 +1074,35 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
 | `compute` | `TRACE` | public | Compute stake distribution for epoch | epoch |  |
+| `rotate` | `TRACE` | public | Rotate stake distributions at an epoch boundary | available_stake_distributions |  |
+| `snapshot` | `TRACE` | public | Snapshot of the stake distribution taken at an epoch boundary | accounts, dreps, pools, active_stake, pools_voting_stake, dreps_voting_stake |  |
 
 <details><summary>span: `compute`</summary>
 
 | field | type | required |
 | --- | --- | --- |
-| `epoch` | `integer` | ✓ |
+| `epoch` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `rotate`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `available_stake_distributions` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `snapshot`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `accounts` | `integer` | ✓ |
+| `dreps` | `integer` | ✓ |
+| `pools` | `integer` | ✓ |
+| `active_stake` | `integer` | ✓ |
+| `pools_voting_stake` | `integer` | ✓ |
+| `dreps_voting_stake` | `integer` | ✓ |
 
 </details>
 
@@ -209,6 +1137,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | `certificate_stake_deregistration` | `TRACE` | public | Unregister a stake credential | credential |  |
 | `certificate_stake_registration` | `TRACE` | public | Register a stake credential | credential |  |
 | `certificate_vote_delegation` | `TRACE` | public | Delegate vote to DRep | credential | drep |
+| `found` | `TRACE` | public | Found a transaction while applying a block | point, block_height, tx_index, tx_id |  |
 
 <details><summary>span: `certificate_committee_delegate`</summary>
 
@@ -269,7 +1198,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | field | type | required |
 | --- | --- | --- |
 | `pool_id` | `string` | ✓ |
-| `epoch` | `integer` | ✓ |
+| `epoch` | `string` | ✓ |
 
 </details>
 
@@ -304,6 +1233,17 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | --- | --- | --- |
 | `credential` | `string` | ✓ |
 | `drep` | `string` |  |
+
+</details>
+
+<details><summary>span: `found`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `point` | `string` | ✓ |
+| `block_height` | `integer` | ✓ |
+| `tx_index` | `integer` | ✓ |
+| `tx_id` | `string` | ✓ |
 
 </details>
 
@@ -416,6 +1356,28 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
 | `aggregate` | `TRACE` | public | Recompute the volatile aggregate |  |  |
+| `rollback_to` | `TRACE` | public | Rollback the volatile state to a specific point | target_slot | last_slot, first_slot, warning, error |
+| `warm_up` | `TRACE` | public | The volatile db is still warming up and hasn't reached a stable point yet | size |  |
+
+<details><summary>span: `rollback_to`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `target_slot` | `string` | ✓ |
+| `last_slot` | `string` |  |
+| `first_slot` | `string` |  |
+| `warning` | `string` |  |
+| `error` | `string` |  |
+
+</details>
+
+<details><summary>span: `warm_up`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `size` | `integer` | ✓ |
+
+</details>
 
 ## target: `amaru::mempool::transaction`
 
@@ -561,6 +1523,40 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 </details>
 
+## target: `amaru::setup::observability`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `init` | `TRACE` | public | Observability stack initialization | with_open_telemetry, with_json_traces, with_colors |  |
+
+<details><summary>span: `init`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `with_open_telemetry` | `boolean` | ✓ |
+| `with_json_traces` | `boolean` | ✓ |
+| `with_colors` | `boolean` | ✓ |
+
+</details>
+
+## target: `amaru::setup::trace`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `filter` | `TRACE` | public | Resolution of a trace filter from the environment | var, value, provided_by_user | provided_invalid, error |
+
+<details><summary>span: `filter`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `var` | `string` | ✓ |
+| `value` | `string` | ✓ |
+| `provided_by_user` | `boolean` | ✓ |
+| `provided_invalid` | `boolean` |  |
+| `error` | `string` |  |
+
+</details>
+
 ## target: `amaru::stores::batch`
 
 | name | level | public | description | required fields | optional fields |
@@ -594,7 +1590,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | field | type | required |
 | --- | --- | --- |
 | `hash` | `string` | ✓ |
-| `slot` | `integer` | ✓ |
+| `slot` | `string` | ✓ |
 
 </details>
 
@@ -603,7 +1599,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | field | type | required |
 | --- | --- | --- |
 | `hash` | `string` | ✓ |
-| `slot` | `integer` | ✓ |
+| `slot` | `string` | ✓ |
 
 </details>
 
@@ -645,8 +1641,27 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | `add` | `TRACE` | public | Batch-upsert account entries |  |  |
 | `get` | `TRACE` | public | Point-read an account entry |  |  |
 | `remove` | `TRACE` | public | Batch-delete account entries |  |  |
-| `reset_many` | `TRACE` | public | Reset rewards counters for many accounts |  |  |
-| `set` | `TRACE` | public | Update rewards balance for a single account |  |  |
+| `reset_many` | `TRACE` | public | Reset rewards counters for many accounts | credential, reason |  |
+| `set` | `TRACE` | public | Update rewards balance for a single account | credential_type, account, reason |  |
+
+<details><summary>span: `reset_many`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `credential` | `string` |  |
+| `reason` | `string` |  |
+
+</details>
+
+<details><summary>span: `set`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `credential_type` | `string` |  |
+| `account` | `string` |  |
+| `reason` | `string` |  |
+
+</details>
 
 ## target: `amaru::stores::ledger::cc_members`
 
@@ -659,10 +1674,37 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `add` | `TRACE` | public | Batch-upsert DRep registrations |  |  |
+| `add` | `TRACE` | public | Batch-upsert DRep registrations | credential, reason |  |
 | `get` | `TRACE` | public | Point-read a DRep entry |  |  |
-| `remove` | `TRACE` | public | Record DRep de-registration |  |  |
-| `set_valid_until` | `TRACE` | public | Refresh DRep expiry after a vote |  |  |
+| `remove` | `TRACE` | public | Record DRep de-registration | drep, reason |  |
+| `set_valid_until` | `TRACE` | public | Refresh DRep expiry after a vote | credential, reason |  |
+
+<details><summary>span: `add`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `credential` | `string` |  |
+| `reason` | `string` |  |
+
+</details>
+
+<details><summary>span: `remove`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `drep` | `string` |  |
+| `reason` | `string` |  |
+
+</details>
+
+<details><summary>span: `set_valid_until`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `credential` | `string` |  |
+| `reason` | `string` |  |
+
+</details>
 
 ## target: `amaru::stores::ledger::epoch`
 
@@ -676,7 +1718,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | field | type | required |
 | --- | --- | --- |
-| `epoch` | `integer` | ✓ |
+| `epoch` | `string` | ✓ |
 
 </details>
 
@@ -684,8 +1726,8 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | field | type | required |
 | --- | --- | --- |
-| `functional_minimum` | `integer` | ✓ |
-| `desired_minimum` | `integer` | ✓ |
+| `functional_minimum` | `string` | ✓ |
+| `desired_minimum` | `string` | ✓ |
 
 </details>
 
@@ -754,7 +1796,16 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | --- | --- | --- | --- | --- | --- |
 | `add` | `TRACE` | public | Batch-upsert pool entries |  |  |
 | `get` | `TRACE` | public | Point-read a pool entry |  |  |
-| `remove` | `TRACE` | public | Schedule pool retirement |  |  |
+| `remove` | `TRACE` | public | Schedule pool retirement | pool, reason |  |
+
+<details><summary>span: `remove`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `pool` | `string` |  |
+| `reason` | `string` |  |
+
+</details>
 
 ## target: `amaru::stores::ledger::pots`
 

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -4,11 +4,1121 @@
   "title": "Amaru Trace Schemas",
   "description": "JSON Schema definitions for all registered traces in Amaru",
   "definitions": {
+    "amaru::bootstrap::accounts::IMPORT": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "size"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "import",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::accounts",
+      "description": "Import accounts from a snapshot",
+      "public": true
+    },
+    "amaru::bootstrap::accounts::IS_NOT_EMPTY": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "is_not_empty",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::accounts",
+      "description": "Existing accounts found in the store before import",
+      "public": true
+    },
+    "amaru::bootstrap::block_issuers::IMPORT": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "import",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::block_issuers",
+      "description": "Import block issuers from a snapshot",
+      "public": true
+    },
+    "amaru::bootstrap::constitution::IMPORT": {
+      "type": "object",
+      "properties": {
+        "anchor": {
+          "type": "string"
+        },
+        "guardrails": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "anchor",
+        "guardrails"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "import",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::constitution",
+      "description": "Import the constitution from a snapshot",
+      "public": true
+    },
+    "amaru::bootstrap::constitutional_committee::IMPORT": {
+      "type": "object",
+      "properties": {
+        "state": {
+          "type": "string"
+        },
+        "threshold": {
+          "type": "string"
+        },
+        "members": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "state"
+      ],
+      "optional": [
+        "threshold",
+        "members"
+      ],
+      "additionalProperties": false,
+      "name": "import",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::constitutional_committee",
+      "description": "Import the constitutional committee from a snapshot",
+      "public": true
+    },
+    "amaru::bootstrap::dreps::IMPORT": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "size"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "import",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::dreps",
+      "description": "Import DReps from a snapshot",
+      "public": true
+    },
+    "amaru::bootstrap::fetch::ROLLBACK": {
+      "type": "object",
+      "properties": {
+        "point": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Point"
+        },
+        "tip": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Tip"
+        }
+      },
+      "required": [
+        "point",
+        "tip"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "rollback",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::fetch",
+      "description": "Received a rollback while fetching bootstrap headers",
+      "public": true
+    },
+    "amaru::bootstrap::governance_activity::IMPORT": {
+      "type": "object",
+      "properties": {
+        "dormant_epochs": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "dormant_epochs"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "import",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::governance_activity",
+      "description": "Import the governance activity from a snapshot",
+      "public": true
+    },
+    "amaru::bootstrap::header::IMPORT": {
+      "type": "object",
+      "properties": {
+        "header": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::HeaderHash"
+        }
+      },
+      "required": [
+        "header"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "import",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::header",
+      "description": "Import a single header into the chain store",
+      "public": true
+    },
+    "amaru::bootstrap::headers::FETCH": {
+      "type": "object",
+      "properties": {
+        "requested_point": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Point"
+        },
+        "intersection": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Point"
+        },
+        "headers_per_point": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "requested_point",
+        "intersection",
+        "headers_per_point"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "fetch",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::headers",
+      "description": "Fetch bootstrap headers from a peer",
+      "public": true
+    },
+    "amaru::bootstrap::import::UTXO": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "size"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "utxo",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::import",
+      "description": "Import UTxO entries from a snapshot",
+      "public": true
+    },
+    "amaru::bootstrap::local_snapshots::DETECT": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "detect",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::local_snapshots",
+      "description": "Detect locally-created snapshots from create-snapshots",
+      "public": true
+    },
+    "amaru::bootstrap::nonces::IMPORT": {
+      "type": "object",
+      "properties": {
+        "point": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Point"
+        }
+      },
+      "required": [
+        "point"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "import",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::nonces",
+      "description": "Import initial nonces into the chain store",
+      "public": true
+    },
+    "amaru::bootstrap::peer::FAILED_TO_CONNECT": {
+      "type": "object",
+      "properties": {
+        "peer": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "peer",
+        "reason"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "failed_to_connect",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::peer",
+      "description": "Failed to connect to a peer while bootstrapping",
+      "public": true
+    },
+    "amaru::bootstrap::pots::IMPORT": {
+      "type": "object",
+      "properties": {
+        "treasury": {
+          "type": "integer"
+        },
+        "reserves": {
+          "type": "integer"
+        },
+        "fees": {
+          "type": "integer"
+        },
+        "donations": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "treasury",
+        "reserves",
+        "fees",
+        "donations"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "import",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::pots",
+      "description": "Import treasury/reserves/fees pots from a snapshot",
+      "public": true
+    },
+    "amaru::bootstrap::proposal_roots::IMPORT": {
+      "type": "object",
+      "properties": {
+        "constitution": {
+          "type": "string"
+        },
+        "constitutional_committee": {
+          "type": "string"
+        },
+        "hard_fork": {
+          "type": "string"
+        },
+        "protocol_parameters": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "constitution",
+        "constitutional_committee",
+        "hard_fork",
+        "protocol_parameters"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "import",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::proposal_roots",
+      "description": "Import governance proposal roots from a snapshot",
+      "public": true
+    },
+    "amaru::bootstrap::proposals::IMPORT": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "size"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "import",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::proposals",
+      "description": "Import governance proposals from a snapshot",
+      "public": true
+    },
+    "amaru::bootstrap::proposals::IS_NOT_EMPTY": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "is_not_empty",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::proposals",
+      "description": "Existing proposals found in the store before import",
+      "public": true
+    },
+    "amaru::bootstrap::snapshot::DOWNLOAD": {
+      "type": "object",
+      "properties": {
+        "epoch": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
+        },
+        "point": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Point"
+        }
+      },
+      "required": [
+        "epoch",
+        "point"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "download",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::snapshot",
+      "description": "Download a snapshot archive",
+      "public": true
+    },
+    "amaru::bootstrap::snapshot::EXTRACT": {
+      "type": "object",
+      "properties": {
+        "snapshot": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "snapshot"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "extract",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::snapshot",
+      "description": "Extract a snapshot archive",
+      "public": true
+    },
+    "amaru::bootstrap::snapshot::IMPORT_DIR": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "import_dir",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::snapshot",
+      "description": "Import a snapshot directory",
+      "public": true
+    },
+    "amaru::bootstrap::snapshot::IMPORT_FILE": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "import_file",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::snapshot",
+      "description": "Import a single snapshot",
+      "public": true
+    },
+    "amaru::bootstrap::snapshot::IMPORT_TVAR": {
+      "type": "object",
+      "properties": {
+        "point": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Point"
+        },
+        "new_epoch_state_offset": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "point",
+        "new_epoch_state_offset"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "import_tvar",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::snapshot",
+      "description": "Import from the tvar data",
+      "public": true
+    },
+    "amaru::bootstrap::snapshot::INVALID": {
+      "type": "object",
+      "properties": {
+        "snapshot": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "snapshot"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "invalid",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::snapshot",
+      "description": "Existing snapshot files are invalid and will be removed",
+      "public": true
+    },
+    "amaru::bootstrap::snapshot::SKIP_DOWNLOAD": {
+      "type": "object",
+      "properties": {
+        "snapshot": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "snapshot"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "skip_download",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::snapshot",
+      "description": "Snapshot already downloaded; skipping download",
+      "public": true
+    },
+    "amaru::bootstrap::snapshots::IMPORT": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "count"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "import",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::snapshots",
+      "description": "Import all snapshots",
+      "public": true
+    },
+    "amaru::bootstrap::stake_pools::IMPORT": {
+      "type": "object",
+      "properties": {
+        "registered": {
+          "type": "integer"
+        },
+        "retiring": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "registered",
+        "retiring"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "import",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::stake_pools",
+      "description": "Import stake pools from a snapshot",
+      "public": true
+    },
+    "amaru::bootstrap::votes::IMPORT": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "size"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "import",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::votes",
+      "description": "Import governance votes from a snapshot",
+      "public": true
+    },
+    "amaru::cli::cardano_node_config::DOWNLOAD": {
+      "type": "object",
+      "properties": {
+        "config_dir": {
+          "type": "string"
+        },
+        "network": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::NetworkName"
+        }
+      },
+      "required": [
+        "config_dir",
+        "network"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "download",
+      "level": "TRACE",
+      "target": "amaru::cli::cardano_node_config",
+      "description": "Download the official cardano-node configuration bundle",
+      "public": true
+    },
+    "amaru::cli::cardano_node_config::USE": {
+      "type": "object",
+      "properties": {
+        "config_dir": {
+          "type": "string"
+        },
+        "network": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::NetworkName"
+        }
+      },
+      "required": [
+        "config_dir",
+        "network"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "use",
+      "level": "TRACE",
+      "target": "amaru::cli::cardano_node_config",
+      "description": "Use an existing cardano-node configuration",
+      "public": true
+    },
+    "amaru::cli::chain_db::EXIST": {
+      "type": "object",
+      "properties": {
+        "dir": {
+          "type": "string"
+        },
+        "hint": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "dir",
+        "hint"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "exist",
+      "level": "TRACE",
+      "target": "amaru::cli::chain_db",
+      "description": "Chain database already exists",
+      "public": true
+    },
+    "amaru::cli::chain_db::FORCEFULLY_REMOVE": {
+      "type": "object",
+      "properties": {
+        "dir": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "dir"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "forcefully_remove",
+      "level": "TRACE",
+      "target": "amaru::cli::chain_db",
+      "description": "Forcefully remove an existing chain database",
+      "public": true
+    },
+    "amaru::cli::current_epoch::RESOLVE": {
+      "type": "object",
+      "properties": {
+        "epoch": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "epoch"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "resolve",
+      "level": "TRACE",
+      "target": "amaru::cli::current_epoch",
+      "description": "Resolve the current epoch from Koios",
+      "public": true
+    },
+    "amaru::cli::db_analyser::LOG": {
+      "type": "object",
+      "properties": {
+        "step": {
+          "type": "string"
+        },
+        "line": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "step",
+        "line"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "log",
+      "level": "TRACE",
+      "target": "amaru::cli::db_analyser",
+      "description": "Output line from an external db-analyser command",
+      "public": true
+    },
+    "amaru::cli::db_analyser::PROGRESS": {
+      "type": "object",
+      "properties": {
+        "step": {
+          "type": "string"
+        },
+        "detail": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "step",
+        "detail"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "progress",
+      "level": "TRACE",
+      "target": "amaru::cli::db_analyser",
+      "description": "Progress reported by an external db-analyser command",
+      "public": true
+    },
+    "amaru::cli::db_analyser::REUSE_LEDGER_SNAPSHOT": {
+      "type": "object",
+      "properties": {
+        "epoch": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
+        },
+        "slot": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Slot"
+        }
+      },
+      "required": [
+        "epoch",
+        "slot"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "reuse_ledger_snapshot",
+      "level": "TRACE",
+      "target": "amaru::cli::db_analyser",
+      "description": "Reuse an existing db-analyser ledger snapshot",
+      "public": true
+    },
+    "amaru::cli::db_analyser::RUN": {
+      "type": "object",
+      "properties": {
+        "epoch": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
+        },
+        "slot": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Slot"
+        },
+        "analyse_from": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Slot"
+        }
+      },
+      "required": [
+        "epoch",
+        "slot"
+      ],
+      "optional": [
+        "analyse_from"
+      ],
+      "additionalProperties": false,
+      "name": "run",
+      "level": "TRACE",
+      "target": "amaru::cli::db_analyser",
+      "description": "Run db-analyser to produce a ledger snapshot",
+      "public": true
+    },
+    "amaru::cli::epoch_metadata::WRITE": {
+      "type": "object",
+      "properties": {
+        "epoch": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "epoch",
+        "path"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "write",
+      "level": "TRACE",
+      "target": "amaru::cli::epoch_metadata",
+      "description": "Write the epoch metadata file for a snapshot",
+      "public": true
+    },
+    "amaru::cli::last_block::RESOLVE": {
+      "type": "object",
+      "properties": {
+        "epoch": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
+        },
+        "point": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Point"
+        }
+      },
+      "required": [
+        "epoch",
+        "point"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "resolve",
+      "level": "TRACE",
+      "target": "amaru::cli::last_block",
+      "description": "Resolve the last produced block for an epoch",
+      "public": true
+    },
+    "amaru::cli::ledger_db::EXIST": {
+      "type": "object",
+      "properties": {
+        "dir": {
+          "type": "string"
+        },
+        "hint": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "dir",
+        "hint"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "exist",
+      "level": "TRACE",
+      "target": "amaru::cli::ledger_db",
+      "description": "Ledger database already exists",
+      "public": true
+    },
+    "amaru::cli::ledger_db::FORCEFULLY_REMOVE": {
+      "type": "object",
+      "properties": {
+        "dir": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "dir"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "forcefully_remove",
+      "level": "TRACE",
+      "target": "amaru::cli::ledger_db",
+      "description": "Forcefully remove an existing ledger database",
+      "public": true
+    },
+    "amaru::cli::mithril::DOWNLOAD": {
+      "type": "object",
+      "properties": {
+        "from_chunk": {
+          "type": "integer"
+        },
+        "target_dir": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "from_chunk",
+        "target_dir"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "download",
+      "level": "TRACE",
+      "target": "amaru::cli::mithril",
+      "description": "Synchronize the cardano-node database from Mithril",
+      "public": true
+    },
+    "amaru::cli::mithril::SKIP_DOWNLOAD": {
+      "type": "object",
+      "properties": {
+        "from_chunk": {
+          "type": "integer"
+        },
+        "required_chunk": {
+          "type": "integer"
+        },
+        "target_dir": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "from_chunk",
+        "required_chunk",
+        "target_dir",
+        "reason"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "skip_download",
+      "level": "TRACE",
+      "target": "amaru::cli::mithril",
+      "description": "Local cardano-node database is recent enough; skipping Mithril download",
+      "public": true
+    },
+    "amaru::cli::node::BOOTSTRAP": {
+      "type": "object",
+      "properties": {
+        "force": {
+          "type": "boolean"
+        },
+        "chain_dir": {
+          "type": "string"
+        },
+        "ledger_dir": {
+          "type": "string"
+        },
+        "network": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::NetworkName"
+        },
+        "epoch": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
+        }
+      },
+      "required": [
+        "force",
+        "chain_dir",
+        "ledger_dir",
+        "network"
+      ],
+      "optional": [
+        "epoch"
+      ],
+      "additionalProperties": false,
+      "name": "bootstrap",
+      "level": "TRACE",
+      "target": "amaru::cli::node",
+      "description": "Bootstrap a node from published snapshots",
+      "public": true
+    },
+    "amaru::cli::snapshot::CREATE": {
+      "type": "object",
+      "properties": {
+        "network": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::NetworkName"
+        },
+        "snapshot_output_dir": {
+          "type": "string"
+        },
+        "config_dir": {
+          "type": "string"
+        },
+        "cardano_node_db": {
+          "type": "string"
+        },
+        "dist_dir": {
+          "type": "string"
+        },
+        "epoch": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
+        },
+        "snapshots": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "network",
+        "snapshot_output_dir",
+        "config_dir",
+        "cardano_node_db",
+        "dist_dir"
+      ],
+      "optional": [
+        "epoch",
+        "snapshots"
+      ],
+      "additionalProperties": false,
+      "name": "create",
+      "level": "TRACE",
+      "target": "amaru::cli::snapshot",
+      "description": "Create snapshots for the given network",
+      "public": true
+    },
+    "amaru::cli::snapshot::MATERIALIZE": {
+      "type": "object",
+      "properties": {
+        "epoch": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
+        },
+        "snapshot": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "epoch",
+        "snapshot"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "materialize",
+      "level": "TRACE",
+      "target": "amaru::cli::snapshot",
+      "description": "Materialize a bootstrap snapshot directory",
+      "public": true
+    },
+    "amaru::cli::snapshot::PACKAGE": {
+      "type": "object",
+      "properties": {
+        "epoch": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
+        },
+        "archive": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "epoch",
+        "archive"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "package",
+      "level": "TRACE",
+      "target": "amaru::cli::snapshot",
+      "description": "Package a snapshot archive",
+      "public": true
+    },
+    "amaru::cli::snapshot::SKIP_MATERIALIZE": {
+      "type": "object",
+      "properties": {
+        "epoch": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "epoch",
+        "reason"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "skip_materialize",
+      "level": "TRACE",
+      "target": "amaru::cli::snapshot",
+      "description": "Snapshot already materialized; skipping",
+      "public": true
+    },
+    "amaru::cli::snapshot::SKIP_PACKAGE": {
+      "type": "object",
+      "properties": {
+        "epoch": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "epoch",
+        "reason"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "skip_package",
+      "level": "TRACE",
+      "target": "amaru::cli::snapshot",
+      "description": "Snapshot archive already packaged; skipping",
+      "public": true
+    },
+    "amaru::ledger::account::PAY_OR_REFUND": {
+      "type": "object",
+      "properties": {
+        "credential_type": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::StakeCredentialKind"
+        },
+        "account": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Hash<28>"
+        },
+        "deposit": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "credential_type",
+        "account",
+        "deposit"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "pay_or_refund",
+      "level": "TRACE",
+      "target": "amaru::ledger::account",
+      "description": "Pay withdrawals to an account, or refund its deposit",
+      "public": true
+    },
     "amaru::ledger::block::APPLY": {
       "type": "object",
       "properties": {
         "point_slot": {
-          "type": "integer"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Slot"
         }
       },
       "required": [
@@ -78,11 +1188,60 @@
       "description": "Create validation context for a block",
       "public": true
     },
+    "amaru::ledger::chain_growth::VIOLATE": {
+      "type": "object",
+      "properties": {
+        "unstable_tail_length": {
+          "type": "integer"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "unstable_tail_length",
+        "reason"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "violate",
+      "level": "TRACE",
+      "target": "amaru::ledger::chain_growth",
+      "description": "Fewer than k blocks were seen within the stability window",
+      "public": true
+    },
+    "amaru::ledger::constitutional_committee::IGNORE": {
+      "type": "object",
+      "properties": {
+        "active_members": {
+          "type": "integer"
+        },
+        "min_committee_size": {
+          "type": "integer"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "active_members",
+        "min_committee_size",
+        "reason"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "ignore",
+      "level": "TRACE",
+      "target": "amaru::ledger::constitutional_committee",
+      "description": "The constitutional committee votes were ignored during ratification",
+      "public": true
+    },
     "amaru::ledger::epoch_transition::APPLY": {
       "type": "object",
       "properties": {
         "epoch": {
-          "type": "integer"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
         },
         "should_end_epoch": {
           "type": "boolean"
@@ -125,10 +1284,12 @@
       "type": "object",
       "properties": {
         "from": {
-          "type": "integer"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
         },
         "into": {
-          "type": "integer"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
         },
         "skipped": {
           "type": "boolean"
@@ -194,6 +1355,125 @@
       "description": "Create pools updates",
       "public": true
     },
+    "amaru::ledger::epoch_transition::RECORD": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
+        },
+        "to": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
+        }
+      },
+      "required": [
+        "from",
+        "to"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "record",
+      "level": "TRACE",
+      "target": "amaru::ledger::epoch_transition",
+      "description": "Record an in-flight epoch transition",
+      "public": true
+    },
+    "amaru::ledger::epoch_transition::RETIRE_POOL": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::PoolId"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "retire_pool",
+      "level": "TRACE",
+      "target": "amaru::ledger::epoch_transition",
+      "description": "Retire a pool at an epoch boundary",
+      "public": true
+    },
+    "amaru::ledger::epoch_transition::ROLLBACK": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
+        },
+        "to": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
+        }
+      },
+      "required": [
+        "from",
+        "to"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "rollback",
+      "level": "TRACE",
+      "target": "amaru::ledger::epoch_transition",
+      "description": "Rollback an in-flight epoch transition",
+      "public": true
+    },
+    "amaru::ledger::epoch_transition::TICK_POOL": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::PoolId"
+        },
+        "vrf": {
+          "type": "string"
+        },
+        "pledge": {
+          "type": "string"
+        },
+        "cost": {
+          "type": "string"
+        },
+        "margin": {
+          "type": "string"
+        },
+        "reward_account": {
+          "type": "string"
+        },
+        "owners": {
+          "type": "string"
+        },
+        "relays": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "optional": [
+        "vrf",
+        "pledge",
+        "cost",
+        "margin",
+        "reward_account",
+        "owners",
+        "relays",
+        "metadata"
+      ],
+      "additionalProperties": false,
+      "name": "tick_pool",
+      "level": "TRACE",
+      "target": "amaru::ledger::epoch_transition",
+      "description": "Update a pool's parameters at an epoch boundary; only changed parameters are recorded",
+      "public": true
+    },
     "amaru::ledger::governance::ENACTING": {
       "type": "object",
       "properties": {
@@ -225,7 +1505,8 @@
       "type": "object",
       "properties": {
         "ratifying_epoch": {
-          "type": "integer"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
         },
         "treasury": {
           "type": "integer"
@@ -299,7 +1580,8 @@
       "type": "object",
       "properties": {
         "epoch": {
-          "type": "integer"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
         },
         "roots_protocol_parameters": {
           "type": "string"
@@ -330,6 +1612,404 @@
       "description": "Ratify proposals at epoch boundary",
       "public": true
     },
+    "amaru::ledger::governance_activity::UPDATE": {
+      "type": "object",
+      "properties": {
+        "consecutive_dormant_epochs": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "consecutive_dormant_epochs"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "update",
+      "level": "TRACE",
+      "target": "amaru::ledger::governance_activity",
+      "description": "Update the number of consecutive dormant epochs",
+      "public": true
+    },
+    "amaru::ledger::non_empty_block::FOUND": {
+      "type": "object",
+      "properties": {
+        "point": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Point"
+        },
+        "block_height": {
+          "type": "integer"
+        },
+        "tx_count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "point",
+        "block_height",
+        "tx_count"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "found",
+      "level": "TRACE",
+      "target": "amaru::ledger::non_empty_block",
+      "description": "Found a non-empty block while applying it to the ledger",
+      "public": true
+    },
+    "amaru::ledger::overlay::NO_GOVERNANCE_UPDATES": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "no_governance_updates",
+      "level": "TRACE",
+      "target": "amaru::ledger::overlay",
+      "description": "No governance updates found in the epoch transition overlay",
+      "public": true
+    },
+    "amaru::ledger::overlay::NO_POOLS_UPDATES": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "no_pools_updates",
+      "level": "TRACE",
+      "target": "amaru::ledger::overlay",
+      "description": "No pools updates found in the epoch transition overlay",
+      "public": true
+    },
+    "amaru::ledger::proposal::DROP": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "expired": {
+          "type": "boolean"
+        },
+        "ratified_or_evicted": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id",
+        "expired",
+        "ratified_or_evicted"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "drop",
+      "level": "TRACE",
+      "target": "amaru::ledger::proposal",
+      "description": "Drop an expired or ratified governance proposal",
+      "public": true
+    },
+    "amaru::ledger::proposal::SKIP": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "proposed_in": {
+          "type": "string"
+        },
+        "ratifying_epoch": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
+        },
+        "withdrawal": {
+          "type": "integer"
+        },
+        "treasury": {
+          "type": "integer"
+        },
+        "invalid_members": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "reason"
+      ],
+      "optional": [
+        "proposed_in",
+        "ratifying_epoch",
+        "withdrawal",
+        "treasury",
+        "invalid_members"
+      ],
+      "additionalProperties": false,
+      "name": "skip",
+      "level": "TRACE",
+      "target": "amaru::ledger::proposal",
+      "description": "Skip a governance proposal during ratification",
+      "public": true
+    },
+    "amaru::ledger::proposal_roots::SUMMARIZE": {
+      "type": "object",
+      "properties": {
+        "constitution": {
+          "type": "string"
+        },
+        "constitutional_committee": {
+          "type": "string"
+        },
+        "hard_fork": {
+          "type": "string"
+        },
+        "protocol_parameters": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "optional": [
+        "constitution",
+        "constitutional_committee",
+        "hard_fork",
+        "protocol_parameters"
+      ],
+      "additionalProperties": false,
+      "name": "summarize",
+      "level": "TRACE",
+      "target": "amaru::ledger::proposal_roots",
+      "description": "Summary of the governance proposal roots after ratification",
+      "public": true
+    },
+    "amaru::ledger::protocol::UPGRADE": {
+      "type": "object",
+      "properties": {
+        "old_version": {
+          "type": "integer"
+        },
+        "new_version": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "old_version",
+        "new_version"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "upgrade",
+      "level": "TRACE",
+      "target": "amaru::ledger::protocol",
+      "description": "Upgrade to a new protocol version",
+      "public": true
+    },
+    "amaru::ledger::protocol_parameters::RATIFY": {
+      "type": "object",
+      "properties": {
+        "protocol_version": {
+          "type": "string"
+        },
+        "max_block_body_size": {
+          "type": "string"
+        },
+        "max_transaction_size": {
+          "type": "string"
+        },
+        "max_block_header_size": {
+          "type": "string"
+        },
+        "max_tx_ex_units": {
+          "type": "string"
+        },
+        "max_block_ex_units": {
+          "type": "string"
+        },
+        "max_value_size": {
+          "type": "string"
+        },
+        "max_collateral_inputs": {
+          "type": "string"
+        },
+        "min_fee_a": {
+          "type": "string"
+        },
+        "min_fee_b": {
+          "type": "string"
+        },
+        "stake_credential_deposit": {
+          "type": "string"
+        },
+        "stake_pool_deposit": {
+          "type": "string"
+        },
+        "monetary_expansion_rate": {
+          "type": "string"
+        },
+        "treasury_expansion_rate": {
+          "type": "string"
+        },
+        "min_pool_cost": {
+          "type": "string"
+        },
+        "lovelace_per_utxo_byte": {
+          "type": "string"
+        },
+        "prices": {
+          "type": "string"
+        },
+        "min_fee_ref_script_lovelace_per_byte": {
+          "type": "string"
+        },
+        "max_ref_script_size_per_tx": {
+          "type": "string"
+        },
+        "max_ref_script_size_per_block": {
+          "type": "string"
+        },
+        "ref_script_cost_stride": {
+          "type": "string"
+        },
+        "ref_script_cost_multiplier": {
+          "type": "string"
+        },
+        "stake_pool_max_retirement_epoch": {
+          "type": "string"
+        },
+        "optimal_stake_pools_count": {
+          "type": "string"
+        },
+        "pledge_influence": {
+          "type": "string"
+        },
+        "collateral_percentage": {
+          "type": "string"
+        },
+        "cost_models": {
+          "type": "string"
+        },
+        "pool_voting_thresholds": {
+          "type": "string"
+        },
+        "drep_voting_thresholds": {
+          "type": "string"
+        },
+        "min_committee_size": {
+          "type": "string"
+        },
+        "max_committee_term_length": {
+          "type": "string"
+        },
+        "gov_action_lifetime": {
+          "type": "string"
+        },
+        "gov_action_deposit": {
+          "type": "string"
+        },
+        "drep_deposit": {
+          "type": "string"
+        },
+        "drep_expiry": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "optional": [
+        "protocol_version",
+        "max_block_body_size",
+        "max_transaction_size",
+        "max_block_header_size",
+        "max_tx_ex_units",
+        "max_block_ex_units",
+        "max_value_size",
+        "max_collateral_inputs",
+        "min_fee_a",
+        "min_fee_b",
+        "stake_credential_deposit",
+        "stake_pool_deposit",
+        "monetary_expansion_rate",
+        "treasury_expansion_rate",
+        "min_pool_cost",
+        "lovelace_per_utxo_byte",
+        "prices",
+        "min_fee_ref_script_lovelace_per_byte",
+        "max_ref_script_size_per_tx",
+        "max_ref_script_size_per_block",
+        "ref_script_cost_stride",
+        "ref_script_cost_multiplier",
+        "stake_pool_max_retirement_epoch",
+        "optimal_stake_pools_count",
+        "pledge_influence",
+        "collateral_percentage",
+        "cost_models",
+        "pool_voting_thresholds",
+        "drep_voting_thresholds",
+        "min_committee_size",
+        "max_committee_term_length",
+        "gov_action_lifetime",
+        "gov_action_deposit",
+        "drep_deposit",
+        "drep_expiry"
+      ],
+      "additionalProperties": false,
+      "name": "ratify",
+      "level": "TRACE",
+      "target": "amaru::ledger::protocol_parameters",
+      "description": "Ratify a protocol parameters update; only changed parameters are recorded",
+      "public": true
+    },
+    "amaru::ledger::ratification::SKIP": {
+      "type": "object",
+      "properties": {
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "reason"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "skip",
+      "level": "TRACE",
+      "target": "amaru::ledger::ratification",
+      "description": "Skip the remaining proposals for this epoch",
+      "public": true
+    },
+    "amaru::ledger::ratification::SUMMARIZE": {
+      "type": "object",
+      "properties": {
+        "is_dormant_epoch": {
+          "type": "boolean"
+        },
+        "pruned_proposals": {
+          "type": "string"
+        },
+        "payouts": {
+          "type": "string"
+        },
+        "new_constitution": {
+          "type": "string"
+        },
+        "constitutional_committee_update": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "is_dormant_epoch"
+      ],
+      "optional": [
+        "pruned_proposals",
+        "payouts",
+        "new_constitution",
+        "constitutional_committee_update"
+      ],
+      "additionalProperties": false,
+      "name": "summarize",
+      "level": "TRACE",
+      "target": "amaru::ledger::ratification",
+      "description": "Summary of the outcome of a ratification round",
+      "public": true
+    },
     "amaru::ledger::relays::COLLECT": {
       "type": "object",
       "properties": {
@@ -352,10 +2032,12 @@
       "type": "object",
       "properties": {
         "for_epoch": {
-          "type": "integer"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
         },
         "using_stake_distribution_epoch_from": {
-          "type": "integer"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
         }
       },
       "required": [
@@ -371,11 +2053,62 @@
       "description": "Compute rewards for epoch",
       "public": true
     },
+    "amaru::ledger::rewards::SUMMARIZE": {
+      "type": "object",
+      "properties": {
+        "efficiency": {
+          "type": "string"
+        },
+        "incentives": {
+          "type": "integer"
+        },
+        "treasury_tax": {
+          "type": "integer"
+        },
+        "total_rewards": {
+          "type": "integer"
+        },
+        "available_rewards": {
+          "type": "integer"
+        },
+        "effective_rewards": {
+          "type": "integer"
+        },
+        "pots_reserves": {
+          "type": "integer"
+        },
+        "pots_treasury": {
+          "type": "integer"
+        },
+        "pots_fees": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "efficiency",
+        "incentives",
+        "treasury_tax",
+        "total_rewards",
+        "available_rewards",
+        "effective_rewards",
+        "pots_reserves",
+        "pots_treasury",
+        "pots_fees"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "summarize",
+      "level": "TRACE",
+      "target": "amaru::ledger::rewards",
+      "description": "Summary of the rewards calculation for an epoch",
+      "public": true
+    },
     "amaru::ledger::stake_distribution::COMPUTE": {
       "type": "object",
       "properties": {
         "epoch": {
-          "type": "integer"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
         }
       },
       "required": [
@@ -387,6 +2120,62 @@
       "level": "TRACE",
       "target": "amaru::ledger::stake_distribution",
       "description": "Compute stake distribution for epoch",
+      "public": true
+    },
+    "amaru::ledger::stake_distribution::ROTATE": {
+      "type": "object",
+      "properties": {
+        "available_stake_distributions": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "available_stake_distributions"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "rotate",
+      "level": "TRACE",
+      "target": "amaru::ledger::stake_distribution",
+      "description": "Rotate stake distributions at an epoch boundary",
+      "public": true
+    },
+    "amaru::ledger::stake_distribution::SNAPSHOT": {
+      "type": "object",
+      "properties": {
+        "accounts": {
+          "type": "integer"
+        },
+        "dreps": {
+          "type": "integer"
+        },
+        "pools": {
+          "type": "integer"
+        },
+        "active_stake": {
+          "type": "integer"
+        },
+        "pools_voting_stake": {
+          "type": "integer"
+        },
+        "dreps_voting_stake": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "accounts",
+        "dreps",
+        "pools",
+        "active_stake",
+        "pools_voting_stake",
+        "dreps_voting_stake"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "snapshot",
+      "level": "TRACE",
+      "target": "amaru::ledger::stake_distribution",
+      "description": "Snapshot of the stake distribution taken at an epoch boundary",
       "public": true
     },
     "amaru::ledger::state::PUSH": {
@@ -405,7 +2194,8 @@
       "type": "object",
       "properties": {
         "rollback_point": {
-          "type": "string"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Point"
         }
       },
       "required": [
@@ -575,7 +2365,8 @@
           "description": "Custom type: amaru_kernel::PoolId"
         },
         "epoch": {
-          "type": "integer"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
         }
       },
       "required": [
@@ -670,6 +2461,38 @@
       "level": "TRACE",
       "target": "amaru::ledger::transaction",
       "description": "Delegate vote to DRep",
+      "public": true
+    },
+    "amaru::ledger::transaction::FOUND": {
+      "type": "object",
+      "properties": {
+        "point": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Point"
+        },
+        "block_height": {
+          "type": "integer"
+        },
+        "tx_index": {
+          "type": "integer"
+        },
+        "tx_id": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::TransactionId"
+        }
+      },
+      "required": [
+        "point",
+        "block_height",
+        "tx_index",
+        "tx_id"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "found",
+      "level": "TRACE",
+      "target": "amaru::ledger::transaction",
+      "description": "Found a transaction while applying a block",
       "public": true
     },
     "amaru::ledger::transaction_validation_context::CREATE": {
@@ -835,11 +2658,68 @@
       "description": "Recompute the volatile aggregate",
       "public": true
     },
+    "amaru::ledger::volatile::ROLLBACK_TO": {
+      "type": "object",
+      "properties": {
+        "target_slot": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Slot"
+        },
+        "last_slot": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Slot"
+        },
+        "first_slot": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Slot"
+        },
+        "warning": {
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "target_slot"
+      ],
+      "optional": [
+        "last_slot",
+        "first_slot",
+        "warning",
+        "error"
+      ],
+      "additionalProperties": false,
+      "name": "rollback_to",
+      "level": "TRACE",
+      "target": "amaru::ledger::volatile",
+      "description": "Rollback the volatile state to a specific point",
+      "public": true
+    },
+    "amaru::ledger::volatile::WARM_UP": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "size"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "warm_up",
+      "level": "TRACE",
+      "target": "amaru::ledger::volatile",
+      "description": "The volatile db is still warming up and hasn't reached a stable point yet",
+      "public": true
+    },
     "amaru::mempool::transaction::ACCEPTED": {
       "type": "object",
       "properties": {
         "tx_id": {
-          "type": "string"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::TransactionId"
         },
         "seq_no": {
           "type": "integer"
@@ -865,7 +2745,8 @@
       "type": "object",
       "properties": {
         "tx_id": {
-          "type": "string"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::TransactionId"
         },
         "reason": {
           "type": "string"
@@ -887,7 +2768,8 @@
       "type": "object",
       "properties": {
         "tx_id": {
-          "type": "string"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::TransactionId"
         },
         "origin": {
           "type": "string"
@@ -909,7 +2791,8 @@
       "type": "object",
       "properties": {
         "tx_id": {
-          "type": "string"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::TransactionId"
         },
         "reason": {
           "type": "string"
@@ -954,7 +2837,8 @@
       "type": "object",
       "properties": {
         "peer": {
-          "type": "string"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Peer"
         },
         "conn_id": {
           "type": "string"
@@ -976,7 +2860,8 @@
       "type": "object",
       "properties": {
         "peer": {
-          "type": "string"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Peer"
         }
       },
       "required": [
@@ -994,7 +2879,8 @@
       "type": "object",
       "properties": {
         "peer": {
-          "type": "string"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Peer"
         }
       },
       "required": [
@@ -1012,7 +2898,8 @@
       "type": "object",
       "properties": {
         "peer": {
-          "type": "string"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Peer"
         },
         "conn_id": {
           "type": "string"
@@ -1038,7 +2925,8 @@
       "type": "object",
       "properties": {
         "peer": {
-          "type": "string"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Peer"
         }
       },
       "required": [
@@ -1056,7 +2944,8 @@
       "type": "object",
       "properties": {
         "peer": {
-          "type": "string"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Peer"
         },
         "conn_id": {
           "type": "integer"
@@ -1090,7 +2979,8 @@
       "type": "object",
       "properties": {
         "peer": {
-          "type": "string"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Peer"
         },
         "conn_id": {
           "type": "integer"
@@ -1115,6 +3005,67 @@
       "level": "TRACE",
       "target": "amaru::protocols::peer_selection::peer",
       "description": "A connection has been terminated (graceful disconnect, error, handshake refusal, or network error).",
+      "public": true
+    },
+    "amaru::setup::observability::INIT": {
+      "type": "object",
+      "properties": {
+        "with_open_telemetry": {
+          "type": "boolean"
+        },
+        "with_json_traces": {
+          "type": "boolean"
+        },
+        "with_colors": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "with_open_telemetry",
+        "with_json_traces",
+        "with_colors"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "init",
+      "level": "TRACE",
+      "target": "amaru::setup::observability",
+      "description": "Observability stack initialization",
+      "public": true
+    },
+    "amaru::setup::trace::FILTER": {
+      "type": "object",
+      "properties": {
+        "var": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        },
+        "provided_by_user": {
+          "type": "boolean"
+        },
+        "provided_invalid": {
+          "type": "boolean"
+        },
+        "error": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "var",
+        "value",
+        "provided_by_user"
+      ],
+      "optional": [
+        "provided_invalid",
+        "error"
+      ],
+      "additionalProperties": false,
+      "name": "filter",
+      "level": "TRACE",
+      "target": "amaru::setup::trace",
+      "description": "Resolution of a trace filter from the environment",
       "public": true
     },
     "amaru::stores::batch::COMMIT": {
@@ -1168,7 +3119,8 @@
           "description": "Custom type: amaru_kernel::HeaderHash"
         },
         "slot": {
-          "type": "integer"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Slot"
         }
       },
       "required": [
@@ -1191,7 +3143,8 @@
           "description": "Custom type: amaru_kernel::HeaderHash"
         },
         "slot": {
-          "type": "integer"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Slot"
         }
       },
       "required": [
@@ -1294,9 +3247,20 @@
     },
     "amaru::stores::ledger::accounts::RESET_MANY": {
       "type": "object",
-      "properties": {},
+      "properties": {
+        "credential": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::StakeCredential"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
       "required": [],
-      "optional": [],
+      "optional": [
+        "credential",
+        "reason"
+      ],
       "additionalProperties": false,
       "name": "reset_many",
       "level": "TRACE",
@@ -1306,9 +3270,25 @@
     },
     "amaru::stores::ledger::accounts::SET": {
       "type": "object",
-      "properties": {},
+      "properties": {
+        "credential_type": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::StakeCredentialKind"
+        },
+        "account": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Hash<28>"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
       "required": [],
-      "optional": [],
+      "optional": [
+        "credential_type",
+        "account",
+        "reason"
+      ],
       "additionalProperties": false,
       "name": "set",
       "level": "TRACE",
@@ -1342,9 +3322,20 @@
     },
     "amaru::stores::ledger::dreps::ADD": {
       "type": "object",
-      "properties": {},
+      "properties": {
+        "credential": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::StakeCredential"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
       "required": [],
-      "optional": [],
+      "optional": [
+        "credential",
+        "reason"
+      ],
       "additionalProperties": false,
       "name": "add",
       "level": "TRACE",
@@ -1366,9 +3357,20 @@
     },
     "amaru::stores::ledger::dreps::REMOVE": {
       "type": "object",
-      "properties": {},
+      "properties": {
+        "drep": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::StakeCredential"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
       "required": [],
-      "optional": [],
+      "optional": [
+        "drep",
+        "reason"
+      ],
       "additionalProperties": false,
       "name": "remove",
       "level": "TRACE",
@@ -1378,9 +3380,20 @@
     },
     "amaru::stores::ledger::dreps::SET_VALID_UNTIL": {
       "type": "object",
-      "properties": {},
+      "properties": {
+        "credential": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::StakeCredential"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
       "required": [],
-      "optional": [],
+      "optional": [
+        "credential",
+        "reason"
+      ],
       "additionalProperties": false,
       "name": "set_valid_until",
       "level": "TRACE",
@@ -1392,7 +3405,8 @@
       "type": "object",
       "properties": {
         "epoch": {
-          "type": "integer"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
         }
       },
       "required": [
@@ -1410,10 +3424,12 @@
       "type": "object",
       "properties": {
         "functional_minimum": {
-          "type": "integer"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
         },
         "desired_minimum": {
-          "type": "integer"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Epoch"
         }
       },
       "required": [
@@ -1616,9 +3632,20 @@
     },
     "amaru::stores::ledger::pools::REMOVE": {
       "type": "object",
-      "properties": {},
+      "properties": {
+        "pool": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::PoolId"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
       "required": [],
-      "optional": [],
+      "optional": [
+        "pool",
+        "reason"
+      ],
       "additionalProperties": false,
       "name": "remove",
       "level": "TRACE",


### PR DESCRIPTION
This PR:

 1. Modifies the event macros to access a schema entry and apply the same checks as the ones existing for spans.
 2. Modifies some schema entries attributes to be better typed.
 
 Note that some event names for the `stores` target got an additional prefix because of the way the schema entries are translated to target + names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compile-time validated `trace_event!` for structured tracing, including schema-gated emission.
  * Added a new `trace_event!` test suite to verify emitted event names, fields, and formatting behavior.
* **Documentation**
  * Updated trace documentation and `traces-schema` for many new events and stricter typed fields (peers, epochs, slots, points, transaction IDs).
* **Refactor**
  * Standardized tracing to structured event identifiers and reduced string conversions across consensus, ledger, mempool, storage, and CLI/bootstrap flows, including typed span/event payloads.
* **Chores**
  * Consolidated observability macro usage and improved consistency of logged field names/metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->