### PR TITLE
Fix ratio encoding divergences in script context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,12 @@ Other guiding principles:
   ```
 -->
 
-
 ## v10.11.20260723 _[unreleased; planned for 2026-07-23]_
 
 ### Fixed
 
 - **amaru-ledger**: use effective collateral when collecting epoch fees for phase-2-invalid transactions. ([#1048][])
+- **amaru-plutus**: encoding divergence between rational number present in governance actions and those present in protocol parameters. ([#1053][])
 
 ## [v10.11.20260716](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260716)
 
@@ -181,3 +181,4 @@ Other guiding principles:
 [#1039]: https://github.com/pragma-org/amaru/pull/1039
 [#1043]: https://github.com/pragma-org/amaru/pull/1043
 [#1048]: https://github.com/pragma-org/amaru/pull/1048
+[#1053]: https://github.com/pragma-org/amaru/pull/1053

--- a/crates/amaru-kernel/src/cardano/script_context.rs
+++ b/crates/amaru-kernel/src/cardano/script_context.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{ExUnits, MemoizedDatum, PlutusData, RedeemerKey, RedeemerTag, ScriptPurpose, TxInfo};
+use crate::{ExUnits, MemoizedDatum, PlutusData, RedeemerEntry, RedeemerKey, RedeemerTag, ScriptPurpose, TxInfo};
 
 /// One of the arguments passed to a Plutus validator.
 ///
@@ -35,9 +35,7 @@ impl<'a> ScriptContext<'a> {
     /// Construct a new [`ScriptContext`] for a specific script execution (identified by its [`RedeemerKey`]).
     ///
     /// Returns `None` if no entry exists in `tx_info.redeemers` for the given key.
-    pub fn new(tx_info: &'a TxInfo<'a>, redeemer_key: &RedeemerKey) -> Option<Self> {
-        let entry = tx_info.redeemers.get(redeemer_key)?;
-
+    pub fn new(tx_info: &'a TxInfo<'a>, redeemer_key: &RedeemerKey, redeemer_entry: &'a RedeemerEntry<'a>) -> Self {
         let datum = if redeemer_key.tag == RedeemerTag::Spend {
             tx_info.inputs.get(redeemer_key.index as usize).and_then(|output_ref| match &output_ref.output.datum {
                 MemoizedDatum::None => None,
@@ -48,13 +46,13 @@ impl<'a> ScriptContext<'a> {
             None
         };
 
-        Some(ScriptContext {
+        ScriptContext {
             tx_info,
-            redeemer_data: entry.data,
-            redeemer_ex_units: entry.ex_units,
+            redeemer_data: redeemer_entry.data,
+            redeemer_ex_units: redeemer_entry.ex_units,
             datum,
-            script_purpose: &entry.purpose,
-        })
+            script_purpose: &redeemer_entry.purpose,
+        }
     }
 
     pub fn budget(&self) -> &ExUnits {

--- a/crates/amaru-kernel/src/cardano/tx_info.rs
+++ b/crates/amaru-kernel/src/cardano/tx_info.rs
@@ -187,14 +187,8 @@ impl<'a> TxInfo<'a> {
     }
 
     /// Construct all script contexts for this TxInfo
-    pub fn to_script_contexts(&self) -> Vec<(ScriptContext<'_>, &BorrowedScript<'_>)> {
-        self.redeemers
-            .iter()
-            .filter_map(|(key, entry)| {
-                let script_context = ScriptContext::new(self, key)?;
-                Some((script_context, &entry.script))
-            })
-            .collect()
+    pub fn to_script_contexts(&self) -> Vec<(&RedeemerKey, ScriptContext<'_>, &BorrowedScript<'_>)> {
+        self.redeemers.iter().map(|(key, entry)| (key, ScriptContext::new(self, key, entry), &entry.script)).collect()
     }
 
     fn translate_inputs(

--- a/crates/amaru-ledger/src/rules/transaction/phase_two/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_two/mod.rs
@@ -15,9 +15,9 @@
 use std::{collections::BTreeMap, fmt};
 
 use amaru_kernel::{
-    BorrowedScript, EraHistory, GlobalParameters, HasTransactionId, PlutusVersion, ProtocolParameters, TransactionBody,
-    TransactionInput, TransactionPointer, TxInfo, TxInfoTranslationError, Utxos, WitnessSet, cbor, to_cbor,
-    transaction_input_to_string,
+    BorrowedScript, EraHistory, GlobalParameters, HasTransactionId, PlutusVersion, ProtocolParameters, RedeemerKey,
+    TransactionBody, TransactionInput, TransactionPointer, TxInfo, TxInfoTranslationError, Utxos, WitnessSet, cbor,
+    to_cbor, transaction_input_to_string,
 };
 use amaru_plutus::{
     arena_pool::ArenaPool,
@@ -61,6 +61,7 @@ pub enum PhaseTwoError {
 pub struct UplcMachineError {
     pub plutus_version: PlutusVersion,
     pub info: MachineInfo,
+    pub redeemer: RedeemerKey,
     // TODO: Proper type with lifetime
     // This should be a `MachineError`, but I'm avoiding lifetime hell for now
     pub err: String,
@@ -136,7 +137,7 @@ where
 
     let script_results = scripts_to_execute
         .into_iter()
-        .map(|(script_context, script)| {
+        .map(|(redeemer, script_context, script)| {
             let arena = arena_pool.acquire();
 
             // TODO: The following code screams for traits.
@@ -220,48 +221,29 @@ where
                 uplc_budget,
             );
 
+            let uplc_machine_error = |err| {
+                Err(PhaseTwoError::UplcMachineError(UplcMachineError {
+                    plutus_version,
+                    info: result.info,
+                    err,
+                    redeemer: redeemer.clone(),
+                    program: encode_program(program),
+                }))
+            };
+
             match plutus_version {
                 PlutusVersion::V1 | PlutusVersion::V2 => match result.term {
-                    Ok(term) => match term {
-                        Term::Error => Err(PhaseTwoError::UplcMachineError(UplcMachineError {
-                            plutus_version,
-                            info: result.info,
-                            err: "Error term evaluated".into(),
-                            program: encode_program(program),
-                        })),
-                        Term::Var(_)
-                        | Term::Lambda { .. }
-                        | Term::Apply { .. }
-                        | Term::Delay(_)
-                        | Term::Force(_)
-                        | Term::Case { .. }
-                        | Term::Constr { .. }
-                        | Term::Constant(_)
-                        | Term::Builtin(_) => Ok(()),
-                    },
-                    Err(e) => Err(PhaseTwoError::UplcMachineError(UplcMachineError {
-                        plutus_version,
-                        info: result.info,
-                        err: e.to_string(),
-                        program: encode_program(program),
-                    })),
+                    Ok(Term::Error) => uplc_machine_error("evaluated to error term".to_owned()),
+                    Ok(_) => Ok(()),
+                    Err(e) => uplc_machine_error(e.to_string()),
                 },
 
-                // According to [CIP-117](https://cips.cardano.org/cip/CIP-0117), Plutus V3 scripts must evaluate to a constant term of unit
+                // According to [CIP-117](https://cips.cardano.org/cip/CIP-0117),
+                // Plutus V3 scripts must evaluate to a constant term of unit
                 PlutusVersion::V3 => match result.term {
                     Ok(Term::Constant(Constant::Unit)) => Ok(()),
-                    Ok(_) => Err(PhaseTwoError::UplcMachineError(UplcMachineError {
-                        plutus_version,
-                        info: result.info,
-                        err: "evaluated to a non-unit term".to_string(),
-                        program: encode_program(program),
-                    })),
-                    Err(e) => Err(PhaseTwoError::UplcMachineError(UplcMachineError {
-                        plutus_version,
-                        info: result.info,
-                        err: e.to_string(),
-                        program: encode_program(program),
-                    })),
+                    Ok(_) => uplc_machine_error("evaluated to a non-unit term".to_owned()),
+                    Err(e) => uplc_machine_error(e.to_string()),
                 },
             }
         })

--- a/crates/amaru-plutus/src/script_context/v1.rs
+++ b/crates/amaru-plutus/src/script_context/v1.rs
@@ -286,9 +286,9 @@ mod tests {
 
         let produced_contexts = tx_info
             .redeemers
-            .keys()
-            .map(|key| {
-                let script_context = ScriptContext::new(&tx_info, key).unwrap();
+            .iter()
+            .map(|(key, entry)| {
+                let script_context = ScriptContext::new(&tx_info, key, entry);
                 let plutus_data = to_cbor(
                     &<ScriptContext<'_> as ToPlutusData<1>>::to_plutus_data(&script_context)
                         .expect("failed to ScriptContext convert to PlutusData"),

--- a/crates/amaru-plutus/src/script_context/v3.rs
+++ b/crates/amaru-plutus/src/script_context/v3.rs
@@ -254,6 +254,7 @@ impl ToPlutusData<3> for GovernanceAction {
                 constr_v3!(3, [previous_action])
             }
             GovernanceAction::UpdateCommittee(previous_action, removed, added, quorum) => {
+                let quorum = governance_action_ratio(quorum)?;
                 constr_v3!(4, [previous_action, removed.deref(), added, quorum])
             }
             GovernanceAction::NewConstitution(previous_action, constitution) => {
@@ -328,15 +329,15 @@ impl ToPlutusData<3> for ProtocolParamUpdate {
         }
 
         if let Some(ref p) = self.pool_pledge_influence {
-            push(9, p.to_plutus_data())?;
+            push(9, protocol_parameter_ratio(p))?;
         }
 
         if let Some(ref p) = self.expansion_rate {
-            push(10, p.to_plutus_data())?;
+            push(10, protocol_parameter_ratio(p))?;
         }
 
         if let Some(ref p) = self.treasury_growth_rate {
-            push(11, p.to_plutus_data())?;
+            push(11, protocol_parameter_ratio(p))?;
         }
 
         if let Some(p) = self.min_pool_cost {
@@ -409,7 +410,7 @@ impl ToPlutusData<3> for ProtocolParamUpdate {
         }
 
         if let Some(ref p) = self.minfee_refscript_cost_per_byte {
-            push(33, p.to_plutus_data())?;
+            push(33, protocol_parameter_ratio(p))?;
         }
 
         Ok(PlutusData::Map(pallas_codec::utils::KeyValuePairs::Def(pparams)))
@@ -430,47 +431,56 @@ impl ToPlutusData<3> for CostModels {
     }
 }
 
-impl ToPlutusData<3> for RationalNumber {
-    fn to_plutus_data(&self) -> Result<PlutusData, PlutusDataError> {
-        let gcd = self.numerator.gcd(&self.denominator);
-        <Vec<_> as ToPlutusData<3>>::to_plutus_data(&vec![self.numerator / gcd, self.denominator / gcd])
-    }
+fn normalized_ratio(ratio: &RationalNumber) -> (u64, u64) {
+    let gcd = ratio.numerator.gcd(&ratio.denominator);
+    (ratio.numerator / gcd, ratio.denominator / gcd)
+}
+
+fn governance_action_ratio(ratio: &RationalNumber) -> Result<PlutusData, PlutusDataError> {
+    let (numerator, denominator) = normalized_ratio(ratio);
+    constr_v3!(0, [numerator, denominator])
+}
+
+fn protocol_parameter_ratio(ratio: &RationalNumber) -> Result<PlutusData, PlutusDataError> {
+    let (numerator, denominator) = normalized_ratio(ratio);
+    <Vec<_> as ToPlutusData<3>>::to_plutus_data(&vec![numerator, denominator])
 }
 
 impl ToPlutusData<3> for ExUnitPrices {
     fn to_plutus_data(&self) -> Result<PlutusData, PlutusDataError> {
-        vec![&self.mem_price, &self.step_price].to_plutus_data()
+        <Vec<_> as ToPlutusData<3>>::to_plutus_data(&vec![
+            protocol_parameter_ratio(&self.mem_price)?,
+            protocol_parameter_ratio(&self.step_price)?,
+        ])
     }
 }
 
 impl ToPlutusData<3> for PoolVotingThresholds {
     fn to_plutus_data(&self) -> Result<PlutusData, PlutusDataError> {
-        vec![
-            &self.motion_no_confidence,
-            &self.committee_normal,
-            &self.committee_no_confidence,
-            &self.hard_fork_initiation,
-            &self.security_voting_threshold,
-        ]
-        .to_plutus_data()
+        <Vec<_> as ToPlutusData<3>>::to_plutus_data(&vec![
+            protocol_parameter_ratio(&self.motion_no_confidence)?,
+            protocol_parameter_ratio(&self.committee_normal)?,
+            protocol_parameter_ratio(&self.committee_no_confidence)?,
+            protocol_parameter_ratio(&self.hard_fork_initiation)?,
+            protocol_parameter_ratio(&self.security_voting_threshold)?,
+        ])
     }
 }
 
 impl ToPlutusData<3> for DRepVotingThresholds {
     fn to_plutus_data(&self) -> Result<PlutusData, PlutusDataError> {
-        vec![
-            &self.motion_no_confidence,
-            &self.committee_normal,
-            &self.committee_no_confidence,
-            &self.update_constitution,
-            &self.hard_fork_initiation,
-            &self.pp_network_group,
-            &self.pp_economic_group,
-            &self.pp_technical_group,
-            &self.pp_governance_group,
-            &self.treasury_withdrawal,
-        ]
-        .to_plutus_data()
+        <Vec<_> as ToPlutusData<3>>::to_plutus_data(&vec![
+            protocol_parameter_ratio(&self.motion_no_confidence)?,
+            protocol_parameter_ratio(&self.committee_normal)?,
+            protocol_parameter_ratio(&self.committee_no_confidence)?,
+            protocol_parameter_ratio(&self.update_constitution)?,
+            protocol_parameter_ratio(&self.hard_fork_initiation)?,
+            protocol_parameter_ratio(&self.pp_network_group)?,
+            protocol_parameter_ratio(&self.pp_economic_group)?,
+            protocol_parameter_ratio(&self.pp_technical_group)?,
+            protocol_parameter_ratio(&self.pp_governance_group)?,
+            protocol_parameter_ratio(&self.treasury_withdrawal)?,
+        ])
     }
 }
 
@@ -531,7 +541,7 @@ impl ToPlutusData<3> for PlutusStakeAddress {
 
 #[cfg(test)]
 mod tests {
-    use amaru_kernel::{PREPROD_ERA_HISTORY, PREPROD_GLOBAL_PARAMETERS, Transaction, cbor, to_cbor};
+    use amaru_kernel::{Nullable, PREPROD_ERA_HISTORY, PREPROD_GLOBAL_PARAMETERS, Set, Transaction, cbor, to_cbor};
     use test_case::test_case;
 
     use super::{
@@ -591,6 +601,49 @@ mod tests {
             "No redeemer produced the expected script context: {}\nProduced script contexts: {}",
             test_vector.expectations.script_context,
             produced_contexts.join("\n\n")
+        );
+    }
+
+    #[test]
+    fn governance_quorum_uses_constr_encoding() {
+        let action = GovernanceAction::UpdateCommittee(
+            Nullable::Null,
+            Set::from(vec![]),
+            pallas_codec::utils::KeyValuePairs::Def(vec![]),
+            RationalNumber { numerator: 2, denominator: 4 },
+        );
+
+        let PlutusData::Constr(constr) = action.to_plutus_data().expect("governance action should encode") else {
+            panic!("governance action should encode as a constructor")
+        };
+
+        let quorum = constr.fields.last().expect("update committee should contain quorum");
+        let PlutusData::Constr(quorum) = quorum else { panic!("governance quorum should encode as a constructor") };
+
+        assert_eq!(quorum.tag, 121);
+        assert_eq!(
+            quorum.fields.deref(),
+            &[
+                <u64 as ToPlutusData<3>>::to_plutus_data(&1).unwrap(),
+                <u64 as ToPlutusData<3>>::to_plutus_data(&2).unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn protocol_parameter_ratios_keep_array_encoding() {
+        let ratio = RationalNumber { numerator: 2, denominator: 4 };
+
+        let PlutusData::Array(values) = protocol_parameter_ratio(&ratio).expect("ratio should encode") else {
+            panic!("protocol parameter ratio should encode as an array")
+        };
+
+        assert_eq!(
+            values.deref(),
+            &[
+                <u64 as ToPlutusData<3>>::to_plutus_data(&1).unwrap(),
+                <u64 as ToPlutusData<3>>::to_plutus_data(&2).unwrap(),
+            ]
         );
     }
 }

--- a/crates/amaru-plutus/src/script_context/v3.rs
+++ b/crates/amaru-plutus/src/script_context/v3.rs
@@ -572,9 +572,9 @@ mod tests {
 
         let produced_contexts = tx_info
             .redeemers
-            .keys()
-            .map(|key| {
-                let script_context = ScriptContext::new(&tx_info, key).unwrap();
+            .iter()
+            .map(|(key, entry)| {
+                let script_context = ScriptContext::new(&tx_info, key, entry);
                 let plutus_data = to_cbor(
                     &<ScriptContext<'_> as ToPlutusData<3>>::to_plutus_data(&script_context)
                         .expect("failed to encode as PlutusData"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Plutus script evaluation handling across supported language versions, including stricter Plutus V3 success criteria.
  * Error reports now include the redeemer key associated with a failed evaluation.
  * Corrected Plutus V3 encoding for governance quorum and protocol parameter ratios, ensuring consistent normalized numerator/denominator forms.
  * Ensured all transaction redeemers are processed consistently during script execution.

* **Tests**
  * Added/updated coverage to verify governance quorum constructor encoding and protocol parameter ratio array encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->