### PR TITLE
track chainsync proto lifecycle in track_peers to release resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Other guiding principles:
 - **amaru-ledger**: restore some spans in the ledger at the debug level. ([#1056][])
 - **amaru**: bootstrap creates the chain DB at the current schema version instead of replaying migrations on an empty store (avoids a spurious migration warning). ([#1060](https://github.com/pragma-org/amaru/pull/1062))
 - **amaru-protocols**: delegate connection attempts to connector stage to avoid blocking the manager and allow up to 10 concurrent connections. ([#1058](https://github.com/pragma-org/amaru/pull/1058))
+- **amaru-consensus**: fix chainsync mini-protocol lifecycle handling in `track_peers` stage to properly clean up resources when stopping to sync from a peer. ([#1059](https://github.com/pragma-org/amaru/pull/1059))
 
 ## [v10.11.20260716](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260716)
 

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -23,7 +23,7 @@ use amaru_kernel::{
     from_cbor_no_leftovers, num::CheckedSub,
 };
 use amaru_observability::{TraceContext, debug_record, debug_span};
-use amaru_ouroboros::praos::header::AssertHeaderError;
+use amaru_ouroboros::{ConnectionId, praos::header::AssertHeaderError};
 use amaru_ouroboros_traits::has_stake_distribution::GetPoolError;
 use amaru_protocols::{
     chainsync::{self, ChainSyncInitiatorMsg, HeaderContent},
@@ -42,11 +42,15 @@ use crate::{
 /// Poll interval while headers are deferred on applied ledger height.
 pub const HEIGHT_RECHECK_INTERVAL: Duration = Duration::from_millis(200);
 
-/// Stage that tracks peers from whom we receive headers over ChainSync.
+/// Stage that tracks chainsync sessions from whom we receive headers.
 ///
-/// For each peer it keeps the current and highest advertised tip, validates incoming headers for
-/// protocol conformance and Praos rules, stores new headers, and notifies `downstream` of new
-/// tips. Misbehaving peers are reported to `peer_selection` as adversarial.
+/// Sessions are keyed by [`ConnectionId`]. On `Initialize` a session is recorded as connecting;
+/// after `IntersectFound` tips are tracked. `Terminated` (from the connection stage when chainsync
+/// ends or the connection dies) purges all per-connection state, including deferred headers.
+///
+/// For each established session it keeps the current and highest advertised tip, validates
+/// incoming headers for protocol conformance and Praos rules, stores new headers, and notifies
+/// `downstream` of new tips. Misbehaving peers are reported to `peer_selection` as adversarial.
 ///
 /// # Construction
 ///
@@ -124,7 +128,7 @@ pub const HEIGHT_RECHECK_INTERVAL: Duration = Duration::from_millis(200);
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct TrackPeers {
     era_history: EraHistory,
-    upstream: BTreeMap<Peer, PerPeer>,
+    upstream: BTreeMap<ConnectionId, PerPeer>,
     peer_selection: StageRef<PeerSelectionMsg>,
     downstream: StageRef<NewTip>,
     max_peer_lead: u64,
@@ -136,10 +140,29 @@ pub struct TrackPeers {
     recheck_timer: Option<ScheduleId>,
 }
 
+/// Per-connection tip tracking for a chainsync session.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-struct PerPeer {
-    current: Tip,
-    highest: Tip,
+enum PerPeer {
+    /// Session started (`Initialize`); intersection not yet established.
+    Connecting { peer: Peer },
+    /// Intersection established; tips are tracked.
+    Established { peer: Peer, current: Tip, highest: Tip },
+}
+
+impl PerPeer {
+    fn established(&self) -> Option<(&Tip, &Tip)> {
+        match self {
+            PerPeer::Established { current, highest, .. } => Some((current, highest)),
+            PerPeer::Connecting { .. } => None,
+        }
+    }
+
+    fn established_mut(&mut self) -> Option<(&mut Tip, &mut Tip)> {
+        match self {
+            PerPeer::Established { current, highest, .. } => Some((current, highest)),
+            PerPeer::Connecting { .. } => None,
+        }
+    }
 }
 
 #[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -163,6 +186,7 @@ enum DeferReason {
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 struct DeferredHeader {
     peer: Peer,
+    conn_id: ConnectionId,
     handler: StageRef<chainsync::InitiatorMessage>,
     reason: DeferReason,
     trace_context: TraceContext,
@@ -171,6 +195,7 @@ impl Default for DeferredHeader {
     fn default() -> Self {
         Self {
             peer: Peer::new(""),
+            conn_id: ConnectionId::initial(),
             handler: StageRef::blackhole(),
             reason: DeferReason::default(),
             trace_context: Default::default(),
@@ -180,6 +205,7 @@ impl Default for DeferredHeader {
 
 struct RollForwardArgs {
     peer: Peer,
+    conn_id: ConnectionId,
     sent_request_next: bool,
     handler: StageRef<chainsync::InitiatorMessage>,
     variant: EraName,
@@ -190,21 +216,49 @@ struct RollForwardArgs {
 
 impl From<DeferredHeader> for RollForwardArgs {
     fn from(dh: DeferredHeader) -> RollForwardArgs {
-        let DeferredHeader { peer, handler, reason, trace_context } = dh;
+        let DeferredHeader { peer, conn_id, handler, reason, trace_context } = dh;
         #[expect(clippy::panic)]
         match reason {
-            DeferReason::LedgerHeight { header, tip, variant, .. } => {
-                RollForwardArgs { peer, sent_request_next: false, handler, variant, header, tip, trace_context }
-            }
-            DeferReason::StakeDistribution { header, tip, variant, rn_sent, .. } => {
-                RollForwardArgs { peer, sent_request_next: rn_sent, handler, variant, header, tip, trace_context }
-            }
-            DeferReason::ClockSkew { header, tip, variant, rn_sent, .. } => {
-                RollForwardArgs { peer, sent_request_next: rn_sent, handler, variant, header, tip, trace_context }
-            }
-            DeferReason::FollowUp { header, tip, variant } => {
-                RollForwardArgs { peer, sent_request_next: false, handler, variant, header, tip, trace_context }
-            }
+            DeferReason::LedgerHeight { header, tip, variant, .. } => RollForwardArgs {
+                peer,
+                conn_id,
+                sent_request_next: false,
+                handler,
+                variant,
+                header,
+                tip,
+                trace_context,
+            },
+            DeferReason::StakeDistribution { header, tip, variant, rn_sent, .. } => RollForwardArgs {
+                peer,
+                conn_id,
+                sent_request_next: rn_sent,
+                handler,
+                variant,
+                header,
+                tip,
+                trace_context,
+            },
+            DeferReason::ClockSkew { header, tip, variant, rn_sent, .. } => RollForwardArgs {
+                peer,
+                conn_id,
+                sent_request_next: rn_sent,
+                handler,
+                variant,
+                header,
+                tip,
+                trace_context,
+            },
+            DeferReason::FollowUp { header, tip, variant } => RollForwardArgs {
+                peer,
+                conn_id,
+                sent_request_next: false,
+                handler,
+                variant,
+                header,
+                tip,
+                trace_context,
+            },
             DeferReason::Placeholder => panic!("cannot convert Placeholder to RollForwardArgs"),
         }
     }
@@ -228,8 +282,8 @@ pub struct NewTip {
 
 pub async fn stage(mut state: TrackPeers, msg: TrackPeersMsg, eff: Effects<TrackPeersMsg>) -> TrackPeers {
     match msg {
-        TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg { peer, conn_id: _, handler, msg }) => {
-            state.handle_from_upstream(peer, handler, msg, eff).await;
+        TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg { peer, conn_id, handler, msg }) => {
+            state.handle_from_upstream(peer, conn_id, handler, msg, eff).await;
         }
         TrackPeersMsg::StakeDistUpdated(max_epoch) => {
             state.max_epoch = max_epoch;
@@ -265,18 +319,45 @@ impl TrackPeers {
         }
     }
 
-    /// Insert or replace a peer's current and highest tip. For use in tests.
+    /// Insert or replace an established session's tips. For use in tests.
     #[cfg(test)]
-    pub fn insert_peer(&mut self, peer: Peer, current: Tip, highest: Tip) {
-        self.upstream.insert(peer, PerPeer { current, highest });
+    pub fn insert_peer(&mut self, peer: Peer, conn_id: ConnectionId, current: Tip, highest: Tip) {
+        self.upstream.insert(conn_id, PerPeer::Established { peer, current, highest });
+    }
+
+    /// Record a connecting session. For use in tests.
+    #[cfg(test)]
+    pub fn record_connecting(&mut self, peer: Peer, conn_id: ConnectionId) {
+        self.upstream.insert(conn_id, PerPeer::Connecting { peer });
+    }
+
+    /// Push a deferred FollowUp for tests (so purge can be exercised without full roll-forward setup).
+    #[cfg(test)]
+    pub fn push_deferred_for_tests(
+        &mut self,
+        peer: Peer,
+        conn_id: ConnectionId,
+        handler: StageRef<chainsync::InitiatorMessage>,
+        header: BlockHeader,
+        tip: Tip,
+    ) {
+        self.deferred.push(DeferredHeader {
+            peer,
+            conn_id,
+            handler,
+            reason: DeferReason::FollowUp { header, tip, variant: EraName::Conway },
+            trace_context: TraceContext::default(),
+        });
     }
 
     /// Validate an incoming header for protocol conformance and store it in the chain store.
     ///
     /// The received `tip` is the highest advertised tip for the peer as part of the RollForward message.
+    #[expect(clippy::too_many_arguments)]
     async fn validate_header(
         &mut self,
         peer: &Peer,
+        conn_id: ConnectionId,
         variant: EraName,
         header: &BlockHeader,
         tip: Tip,
@@ -288,21 +369,21 @@ impl TrackPeers {
             return Err(ConsensusError::EraNameMismatch { from_raw_header: variant, from_slot: era_name });
         }
 
-        let Some(per_peer) = self.upstream.get(peer) else {
+        let Some((current, _highest)) = self.upstream.get(&conn_id).and_then(PerPeer::established) else {
             return Err(ConsensusError::UnknownPeer(peer.clone()));
         };
-        if header.parent_hash().unwrap_or(ORIGIN_HASH) != per_peer.current.hash() {
+        if header.parent_hash().unwrap_or(ORIGIN_HASH) != current.hash() {
             return Err(ConsensusError::InvalidHeaderParent(Box::new(InvalidHeaderParentData {
                 peer: peer.clone(),
                 forwarded: header.point(),
                 actual: header.parent_hash(),
-                expected: per_peer.current.point(),
+                expected: current.point(),
             })));
         }
-        if header.block_height() != per_peer.current.block_height() + 1 {
+        if header.block_height() != current.block_height() + 1 {
             return Err(ConsensusError::InvalidHeaderHeight {
                 actual: header.block_height(),
-                expected: per_peer.current.block_height() + 1,
+                expected: current.block_height() + 1,
             });
         }
 
@@ -311,10 +392,10 @@ impl TrackPeers {
         let highest = tip.point();
 
         // check that slot time progresses monotonically
-        if header.slot() <= per_peer.current.slot() {
+        if header.slot() <= current.slot() {
             return Err(ConsensusError::InvalidHeaderPoint(Box::new(InvalidHeaderPoint {
                 actual: header.point(),
-                parent: per_peer.current.point(),
+                parent: current.point(),
                 highest,
             })));
         }
@@ -328,7 +409,7 @@ impl TrackPeers {
             if delta_slots > 2 {
                 return Err(ConsensusError::InvalidHeaderPoint(Box::new(InvalidHeaderPoint {
                     actual: header.point(),
-                    parent: per_peer.current.point(),
+                    parent: current.point(),
                     highest,
                 })));
             }
@@ -336,15 +417,15 @@ impl TrackPeers {
         }
 
         ledger.validate_header(header).await.map_err(|e| ConsensusError::InvalidHeader(header.point(), Box::new(e)))?;
-        Ok(per_peer.current.point())
+        Ok(current.point())
     }
 
-    async fn roll_forward(&mut self, peer: &Peer, header: &BlockHeader, tip: Tip) {
-        let Some(per_peer) = self.upstream.get_mut(peer) else {
+    async fn roll_forward(&mut self, conn_id: ConnectionId, header: &BlockHeader, tip: Tip) {
+        let Some((current, highest)) = self.upstream.get_mut(&conn_id).and_then(PerPeer::established_mut) else {
             return;
         };
-        per_peer.current = header.tip();
-        per_peer.highest = tip;
+        *current = header.tip();
+        *highest = tip;
     }
 
     async fn maybe_store_header(&mut self, header: BlockHeader, store: &Store) -> Result<bool, ConsensusError> {
@@ -360,6 +441,7 @@ impl TrackPeers {
     async fn roll_backward(
         &mut self,
         peer: &Peer,
+        conn_id: ConnectionId,
         current: Point,
         tip: Tip,
         store: &Store,
@@ -367,12 +449,19 @@ impl TrackPeers {
         let Some(current_tip) = store.load_tip(&current.hash()).await else {
             return Err(ConsensusError::UnknownPoint(current.hash()));
         };
-        let Some(per_peer) = self.upstream.get_mut(peer) else {
+        let Some((current_ref, highest_ref)) = self.upstream.get_mut(&conn_id).and_then(PerPeer::established_mut)
+        else {
             return Err(ConsensusError::UnknownPeer(peer.clone()));
         };
-        per_peer.current = current_tip;
-        per_peer.highest = tip;
+        *current_ref = current_tip;
+        *highest_ref = tip;
         Ok(())
+    }
+
+    /// Remove all per-connection state for a chainsync session. Idempotent.
+    fn purge_connection(&mut self, conn_id: ConnectionId) {
+        self.upstream.remove(&conn_id);
+        self.deferred.retain(|d| d.conn_id != conn_id);
     }
 
     /// Try to defer this header validation due to missing stake distribution.
@@ -393,6 +482,7 @@ impl TrackPeers {
         }
         Some(DeferredHeader {
             peer: args.peer.clone(),
+            conn_id: args.conn_id,
             handler: args.handler.clone(),
             reason: DeferReason::StakeDistribution {
                 epoch: *target,
@@ -423,6 +513,7 @@ impl TrackPeers {
         let wait = onset.saturating_sub(elapsed);
         Some(DeferredHeader {
             peer: args.peer.clone(),
+            conn_id: args.conn_id,
             handler: args.handler.clone(),
             reason: DeferReason::ClockSkew {
                 min_time: now + wait,
@@ -477,8 +568,8 @@ impl TrackPeers {
         }
     }
 
-    fn is_deferred(&self, peer: &Peer) -> bool {
-        self.deferred.iter().any(|d| d.peer == *peer)
+    fn is_deferred(&self, conn_id: ConnectionId) -> bool {
+        self.deferred.iter().any(|d| d.conn_id == conn_id)
     }
 
     /// Try to execute a roll forward from a peer. Preconditions like maximum distance from applied
@@ -491,12 +582,12 @@ impl TrackPeers {
         eff: &Effects<TrackPeersMsg>,
         now: Instant,
     ) -> Result<(), DeferredHeader> {
-        let RollForwardArgs { peer, variant, header, tip, trace_context, .. } = &args;
+        let RollForwardArgs { peer, conn_id, variant, header, tip, trace_context, .. } = &args;
 
         let ledger = Ledger::new(eff.clone()).with_trace_context(trace_context);
         let store = Store::new(eff.clone()).with_trace_context(trace_context);
 
-        let result = self.validate_header(peer, *variant, header, *tip, &ledger, now).await;
+        let result = self.validate_header(peer, *conn_id, *variant, header, *tip, &ledger, now).await;
         let parent = match result {
             Ok(parent) => parent,
             Err(error) => {
@@ -506,13 +597,13 @@ impl TrackPeers {
                     return Err(dh);
                 }
                 tracing::error!(%error, %peer, "chain_sync.validate_header.failed");
-                self.upstream.remove(peer);
+                self.purge_connection(*conn_id);
                 eff.send(&self.peer_selection, PeerSelectionMsg::Adversarial(args.peer, args.trace_context)).await;
                 return Ok(());
             }
         };
         // at this point the evolved nonces have been stored and follow-up headers can be validated
-        self.roll_forward(peer, header, *tip).await;
+        self.roll_forward(*conn_id, header, *tip).await;
 
         // now we can destructure to consume the pieces
         let RollForwardArgs { peer, header, tip, sent_request_next, handler, trace_context, .. } = args;
@@ -540,6 +631,7 @@ impl TrackPeers {
     async fn handle_from_upstream(
         &mut self,
         peer: Peer,
+        conn_id: ConnectionId,
         handler: StageRef<chainsync::InitiatorMessage>,
         msg: chainsync::InitiatorResult,
         eff: Effects<TrackPeersMsg>,
@@ -547,8 +639,22 @@ impl TrackPeers {
         use amaru_protocols::chainsync::InitiatorResult::*;
         match msg {
             Initialize => {
-                // FIXME record this connection and create a mechanism for removing upon disconnect
-                tracing::info!(%peer,"initializing chainsync");
+                let had_state =
+                    self.upstream.contains_key(&conn_id) || self.deferred.iter().any(|d| d.conn_id == conn_id);
+                if had_state {
+                    tracing::warn!(
+                        %peer,
+                        %conn_id,
+                        "unexpected re-initialize of an active chainsync session; purging prior state"
+                    );
+                    self.purge_connection(conn_id);
+                }
+                tracing::info!(%peer, %conn_id, "initializing chainsync");
+                self.upstream.insert(conn_id, PerPeer::Connecting { peer });
+            }
+            Terminated => {
+                tracing::info!(%peer, %conn_id, "chainsync terminated, purging connection state");
+                self.purge_connection(conn_id);
             }
             IntersectFound(current, tip) => {
                 let current_tip = Store::new(eff.clone()).load_tip(&current.hash()).await;
@@ -557,13 +663,13 @@ impl TrackPeers {
                     eff.send(&handler, chainsync::InitiatorMessage::Done).await;
                     return;
                 };
-                tracing::info!(%peer, %current, highest = %tip.point(), "intersect found");
-                self.upstream.insert(peer, PerPeer { current: current_tip, highest: tip });
+                tracing::info!(%peer, %conn_id, %current, highest = %tip.point(), "intersect found");
+                self.upstream.insert(conn_id, PerPeer::Established { peer, current: current_tip, highest: tip });
             }
             IntersectNotFound(tip) => {
                 tracing::info!(%peer, highest = %tip.point(), reason = "intersect not found", "stopping chainsync");
                 eff.send(&handler, chainsync::InitiatorMessage::Done).await;
-                self.upstream.remove(&peer);
+                self.purge_connection(conn_id);
             }
             RollForward(header_content, tip) => {
                 let peer_clone = peer.clone();
@@ -578,7 +684,7 @@ impl TrackPeers {
                         Ok(h) => h,
                         Err(error) => {
                             tracing::error!(%error, %peer, "chain_sync.decode_header.failed");
-                            self.upstream.remove(&peer);
+                            self.purge_connection(conn_id);
                             eff.send(
                                 &self.peer_selection,
                                 PeerSelectionMsg::Adversarial(peer, trace_context.clone()),
@@ -589,9 +695,10 @@ impl TrackPeers {
                     };
                     debug_record!(consensus::roll_forward::PROCESS, header_hash = header.hash());
 
-                    if self.is_deferred(&peer) {
+                    if self.is_deferred(conn_id) {
                         self.deferred.push(DeferredHeader {
                             peer,
+                            conn_id,
                             handler,
                             reason: DeferReason::FollowUp { header, tip, variant },
                             trace_context,
@@ -617,6 +724,7 @@ impl TrackPeers {
                         tracing::debug!(%peer, %header_height, %ledger_height, %limit, "track_peers.defer_request_next");
                         self.deferred.push(DeferredHeader {
                             peer: peer.clone(),
+                            conn_id,
                             handler: handler.clone(),
                             reason: DeferReason::LedgerHeight {
                                 header: header.clone(),
@@ -633,6 +741,7 @@ impl TrackPeers {
                     eff.send(&handler, chainsync::InitiatorMessage::RequestNext).await;
                     let args = RollForwardArgs {
                         peer,
+                        conn_id,
                         sent_request_next: true,
                         handler,
                         variant,
@@ -664,9 +773,9 @@ impl TrackPeers {
                     eff.send(&handler, chainsync::InitiatorMessage::RequestNext).await;
 
                     let store = Store::new(eff.clone()).with_trace_context(&trace_context);
-                    if let Err(error) = self.roll_backward(&peer, current, tip, &store).await {
+                    if let Err(error) = self.roll_backward(&peer, conn_id, current, tip, &store).await {
                         tracing::error!(%error, %peer, "chain_sync.roll_backward.failed");
-                        self.upstream.remove(&peer);
+                        self.purge_connection(conn_id);
                         eff.send(&self.peer_selection, PeerSelectionMsg::Adversarial(peer, trace_context)).await;
                     }
                 }
@@ -686,8 +795,8 @@ impl TrackPeers {
         let mut pos = 0;
         for idx in 0..self.deferred.len() {
             let d = take(&mut self.deferred[idx]);
-            let peer = &d.peer;
-            let defer = blocked.contains(peer)
+            let conn_id = d.conn_id;
+            let defer = blocked.contains(&conn_id)
                 || match &d.reason {
                     DeferReason::LedgerHeight { min_height, .. } => curr_height < *min_height,
                     DeferReason::StakeDistribution { epoch, .. } => self.max_epoch < *epoch,
@@ -696,7 +805,7 @@ impl TrackPeers {
                     DeferReason::Placeholder => false,
                 };
             if defer {
-                blocked.insert(d.peer.clone());
+                blocked.insert(conn_id);
                 self.deferred[pos] = d;
                 pos += 1;
                 continue;

--- a/crates/amaru-consensus/src/stages/track_peers/tests.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/tests.rs
@@ -15,7 +15,7 @@
 use std::{self, slice, time::Duration};
 
 use amaru_kernel::{BlockHeight, Epoch, EraHistory, EraName, HeaderHash, IsHeader, Peer, Point, Tip, num::CheckedSub};
-use amaru_ouroboros::praos::header::AssertHeaderError;
+use amaru_ouroboros::{ConnectionId, praos::header::AssertHeaderError};
 use amaru_ouroboros_traits::has_stake_distribution::GetPoolError;
 use amaru_protocols::chainsync::{
     self, ChainSyncInitiatorMsg, HeaderContent, InitiatorMessage, InitiatorMessage::RequestNext,
@@ -49,15 +49,19 @@ use crate::{
 fn test_new_peer() {
     let prep = test_prep();
     let state = prep.state.clone();
+    let peer = Peer::new("peer1");
     let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
-        peer: Peer::new("peer1"),
+        peer: peer.clone(),
         conn_id: prep.conn_id,
         handler: prep.handler.clone(),
         msg: chainsync::InitiatorResult::Initialize,
     });
 
+    let mut expected = state.clone();
+    expected.record_connecting(peer, prep.conn_id);
+
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
-    assert_trace(&running, &[te_state("tp-1", &state), te_input("tp-1", &msg), te_state("tp-1", &state)]);
+    assert_trace(&running, &[te_state("tp-1", &state), te_input("tp-1", &msg), te_state("tp-1", &expected)]);
     logs.assert_and_remove(Level::INFO, &["initializing chainsync"]).assert_no_remaining_at([
         Level::INFO,
         Level::WARN,
@@ -66,21 +70,83 @@ fn test_new_peer() {
 }
 
 #[test]
-fn test_initialize_existing_peer() {
+fn test_initialize_resets_established_session() {
     let prep = test_prep();
     let peer = Peer::new("peer1");
+    let header = &prep.headers[1];
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), Tip::origin(), Tip::origin());
+    state.insert_peer(peer.clone(), prep.conn_id, Tip::origin(), Tip::origin());
+    state.push_deferred_for_tests(peer.clone(), prep.conn_id, prep.handler.clone(), header.clone(), header.tip());
     let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
-        peer,
+        peer: peer.clone(),
         conn_id: prep.conn_id,
         handler: prep.handler.clone(),
         msg: chainsync::InitiatorResult::Initialize,
     });
 
+    let mut expected = prep.state.clone();
+    expected.record_connecting(peer, prep.conn_id);
+
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
-    assert_trace(&running, &[te_state("tp-1", &state), te_input("tp-1", &msg), te_state("tp-1", &state)]);
-    logs.assert_and_remove(Level::INFO, &["initializing chainsync"]).assert_no_remaining_at([
+    assert_trace(&running, &[te_state("tp-1", &state), te_input("tp-1", &msg), te_state("tp-1", &expected)]);
+    logs.assert_and_remove(Level::WARN, &["unexpected re-initialize"])
+        .assert_and_remove(Level::INFO, &["initializing chainsync"])
+        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_terminated_purges_upstream_and_deferred() {
+    let prep = test_prep_with_max_peer_lead(0);
+    let peer = Peer::new("peer1");
+    let parent = &prep.headers[0];
+    let header = &prep.headers[1];
+    let mut state = prep.state.clone();
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), parent.tip());
+    state.push_deferred_for_tests(peer.clone(), prep.conn_id, prep.handler.clone(), header.clone(), header.tip());
+
+    let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
+        peer: peer.clone(),
+        conn_id: prep.conn_id,
+        handler: prep.handler.clone(),
+        msg: chainsync::InitiatorResult::Terminated,
+    });
+
+    let expected = prep.state.clone(); // empty upstream + deferred
+
+    let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
+    assert_trace(&running, &[te_state("tp-1", &state), te_input("tp-1", &msg), te_state("tp-1", &expected)]);
+    logs.assert_and_remove(Level::INFO, &["chainsync terminated"]).assert_no_remaining_at([
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
+}
+
+#[test]
+fn test_terminated_only_purges_matching_connection() {
+    let prep = test_prep();
+    let peer = Peer::new("peer1");
+    let mut other_id = ConnectionId::initial();
+    let conn_a = other_id.get_and_increment();
+    let conn_b = other_id.get_and_increment();
+
+    let mut state = prep.state.clone();
+    state.insert_peer(peer.clone(), conn_a, Tip::origin(), Tip::origin());
+    state.insert_peer(peer.clone(), conn_b, prep.headers[0].tip(), prep.headers[0].tip());
+
+    let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
+        peer: peer.clone(),
+        conn_id: conn_a,
+        handler: prep.handler.clone(),
+        msg: chainsync::InitiatorResult::Terminated,
+    });
+
+    let mut expected = prep.state.clone();
+    expected.insert_peer(peer, conn_b, prep.headers[0].tip(), prep.headers[0].tip());
+
+    let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
+    assert_trace(&running, &[te_state("tp-1", &state), te_input("tp-1", &msg), te_state("tp-1", &expected)]);
+    logs.assert_and_remove(Level::INFO, &["chainsync terminated"]).assert_no_remaining_at([
         Level::INFO,
         Level::WARN,
         Level::ERROR,
@@ -133,7 +199,7 @@ fn test_intersect_found_tracks_peer() {
     });
 
     let mut expected = state.clone();
-    expected.insert_peer(Peer::new("peer1"), header.tip(), tip);
+    expected.insert_peer(Peer::new("peer1"), prep.conn_id, header.tip(), tip);
 
     let (running, _guards, mut logs) =
         setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(slice::from_ref(header)));
@@ -187,7 +253,7 @@ fn test_intersect_not_found_removes_peer() {
     let peer = Peer::new("peer1");
     let expected = prep.state.clone();
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), Tip::origin(), Tip::origin());
+    state.insert_peer(peer.clone(), prep.conn_id, Tip::origin(), Tip::origin());
     let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
         peer,
         conn_id: prep.conn_id,
@@ -256,10 +322,10 @@ fn test_roll_forward_known_peer_header_already_stored() {
     });
 
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), parent.tip(), parent.tip());
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), parent.tip());
 
     let mut expected = prep.state.clone();
-    expected.insert_peer(peer.clone(), header.tip(), header.tip());
+    expected.insert_peer(peer.clone(), prep.conn_id, header.tip(), header.tip());
 
     let (running, _guards, mut logs) =
         setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(slice::from_ref(header)));
@@ -296,10 +362,10 @@ fn test_roll_forward_known_peer_new_header_forwards_tip() {
     });
 
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), parent.tip(), parent.tip());
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), parent.tip());
 
     let mut expected = prep.state.clone();
-    expected.insert_peer(peer.clone(), header.tip(), header.tip());
+    expected.insert_peer(peer.clone(), prep.conn_id, header.tip(), header.tip());
 
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
     assert_trace_match(
@@ -337,7 +403,7 @@ fn test_roll_forward_invalid_variant_removes_peer() {
 
     let expected = prep.state.clone();
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), parent.tip(), parent.tip());
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), parent.tip());
 
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
     assert_trace(
@@ -370,7 +436,7 @@ fn test_roll_forward_invalid_cbor_removes_peer() {
 
     let expected = prep.state.clone();
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), parent.tip(), parent.tip());
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), parent.tip());
 
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
     assert_trace(
@@ -402,7 +468,7 @@ fn test_roll_forward_invalid_parent_removes_peer() {
 
     let expected = prep.state.clone();
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), parent.tip(), parent.tip());
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), parent.tip());
 
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
     assert_trace_match(
@@ -435,7 +501,7 @@ fn test_roll_forward_invalid_height_removes_peer() {
 
     let expected = prep.state.clone();
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), parent.tip(), parent.tip());
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), parent.tip());
 
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
     assert_trace_match(
@@ -468,7 +534,7 @@ fn test_roll_forward_invalid_point_removes_peer() {
 
     let expected = prep.state.clone();
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), parent.tip(), parent.tip());
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), parent.tip());
 
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
     assert_trace_match(
@@ -501,7 +567,7 @@ fn test_roll_forward_header_validation_failure_removes_peer() {
 
     let expected = prep.state.clone();
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), parent.tip(), header.tip());
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), header.tip());
 
     // Use empty store so evolve_nonce fails (unknown parent), exercising the real validate_header fn failure path.
     let (running, _guards, mut logs) =
@@ -551,7 +617,7 @@ fn test_roll_forward_header_slot_too_far_future_adversarial() {
 
     let expected = prep.state.clone();
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), parent.tip(), header.tip());
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), header.tip());
 
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
 
@@ -591,7 +657,7 @@ fn test_roll_forward_header_slot_near_future_defers() {
     });
 
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), parent.tip(), header.tip());
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), header.tip());
 
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
 
@@ -631,7 +697,7 @@ fn test_roll_forward_stake_dist_far_ahead_rejects() {
 
     let expected = prep.state.clone();
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), parent.tip(), header.tip());
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), header.tip());
 
     // More than one epoch beyond known max_epoch (start-2) → adversarial, not defer.
     let far_epoch = prep.start_times.epoch;
@@ -680,10 +746,10 @@ fn test_roll_backward_updates_peer() {
     });
 
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), Tip::origin(), Tip::origin());
+    state.insert_peer(peer.clone(), prep.conn_id, Tip::origin(), Tip::origin());
 
     let mut expected = prep.state.clone();
-    expected.insert_peer(peer, header.tip(), tip);
+    expected.insert_peer(peer, prep.conn_id, header.tip(), tip);
 
     let (running, _guards, mut logs) =
         setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(slice::from_ref(header)));
@@ -751,7 +817,7 @@ fn test_roll_backward_unknown_point_removes_peer() {
 
     let expected = prep.state.clone();
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), Tip::origin(), Tip::origin());
+    state.insert_peer(peer.clone(), prep.conn_id, Tip::origin(), Tip::origin());
 
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
     assert_trace(
@@ -781,7 +847,7 @@ fn test_roll_forward_defers_request_next() {
     let tip = header.tip();
 
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), Tip::origin(), tip);
+    state.insert_peer(peer.clone(), prep.conn_id, Tip::origin(), tip);
 
     let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
         peer: peer.clone(),
@@ -846,7 +912,7 @@ fn test_pipelined_headers_after_height_defer() {
     });
 
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), parent.tip(), h2.tip());
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), h2.tip());
 
     let sid = height_recheck_schedule_id();
 
@@ -895,7 +961,7 @@ fn test_height_defer_recheck_when_ledger_advances() {
     let tip = header.tip();
 
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), Tip::origin(), tip);
+    state.insert_peer(peer.clone(), prep.conn_id, Tip::origin(), tip);
 
     let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
         peer: peer.clone(),
@@ -976,7 +1042,7 @@ fn test_pipelined_headers_after_slot_near_future_defer() {
     });
 
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), parent.tip(), h2.tip());
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), h2.tip());
 
     let (running, _guards, mut logs) =
         setup_base(&prep.rt_handle(), state.clone(), [msg1.clone(), msg2.clone()], build_store(&[]), |running| {
@@ -1024,7 +1090,7 @@ fn test_pipelined_stake_defer_and_wake_sequence() {
     let wake = TrackPeersMsg::StakeDistUpdated(prep.start_times.epoch);
 
     let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), parent.tip(), h2.tip());
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), h2.tip());
 
     let slot1 = h1.slot();
     // One epoch ahead of known max_epoch (start-2) → defer, not reject.
@@ -1086,7 +1152,9 @@ fn test_pipelined_stake_defer_and_wake_sequence() {
                 |s| {
                     s.deferred.is_empty()
                         && s.recheck_timer.is_none()
-                        && s.upstream.get(&peer).is_some_and(|p| p.current.block_height() == 3.into())
+                        && s.upstream.get(&prep.conn_id).is_some_and(|p| {
+                            p.established().is_some_and(|(current, _)| current.block_height() == 3.into())
+                        })
                 },
                 "both processed after wake",
             ),

--- a/crates/amaru-protocols/src/blockfetch/mod.rs
+++ b/crates/amaru-protocols/src/blockfetch/mod.rs
@@ -64,16 +64,17 @@ pub enum State {
     Done,
 }
 
-pub async fn register_blockfetch_initiator<M>(
+pub async fn register_blockfetch_initiator<M: amaru_pure_stage::SendData>(
     muxer: &StageRef<MuxMessage>,
     peer: Peer,
     conn_id: ConnectionId,
     eff: &Effects<M>,
+    tombstone: M,
 ) -> StageRef<BlockFetchMessage> {
     use crate::protocol::PROTO_N2N_BLOCK_FETCH;
-    let blockfetch = eff
-        .wire_up(eff.stage("blockfetch", initiator()).await, BlockFetchInitiator::new(muxer.clone(), peer, conn_id))
-        .await;
+    let blockfetch = eff.stage("blockfetch", initiator()).await;
+    let blockfetch = eff.supervise(blockfetch, tombstone);
+    let blockfetch = eff.wire_up(blockfetch, BlockFetchInitiator::new(muxer.clone(), peer, conn_id)).await;
     eff.send(
         muxer,
         MuxMessage::Register {
@@ -87,13 +88,15 @@ pub async fn register_blockfetch_initiator<M>(
     eff.contramap(&blockfetch, "blockfetch_bytes", Inputs::Local).await
 }
 
-pub async fn register_blockfetch_responder<M>(
+pub async fn register_blockfetch_responder<M: amaru_pure_stage::SendData>(
     muxer: &StageRef<MuxMessage>,
     eff: &Effects<M>,
+    tombstone: M,
 ) -> StageRef<StreamBlocks> {
     use crate::protocol::PROTO_N2N_BLOCK_FETCH;
-    let blockfetch =
-        eff.wire_up(eff.stage("blockfetch", responder()).await, BlockFetchResponder::new(muxer.clone())).await;
+    let blockfetch = eff.stage("blockfetch", responder()).await;
+    let blockfetch = eff.supervise(blockfetch, tombstone);
+    let blockfetch = eff.wire_up(blockfetch, BlockFetchResponder::new(muxer.clone())).await;
     eff.send(
         muxer,
         MuxMessage::Register {

--- a/crates/amaru-protocols/src/chainsync/initiator.rs
+++ b/crates/amaru-protocols/src/chainsync/initiator.rs
@@ -78,6 +78,7 @@ impl ChainSyncInitiatorMsg {
             InitiatorResult::IntersectNotFound(_) => "IntersectNotFound",
             InitiatorResult::RollForward(_, _) => "RollForward",
             InitiatorResult::RollBackward(_, _) => "RollBackward",
+            InitiatorResult::Terminated => "Terminated",
         }
     }
 }
@@ -149,6 +150,7 @@ impl StageState<InitiatorState, Initiator> for ChainSyncInitiator {
                     self.upstream = Some(*tip);
                     None
                 }
+                InitiatorResult::Terminated => None,
             };
             eff.send(
                 &self.pipeline,
@@ -195,6 +197,11 @@ pub enum InitiatorResult {
     IntersectNotFound(Tip),
     RollForward(HeaderContent, Tip),
     RollBackward(Point, Tip),
+    /// Chainsync session ended (connection teardown or mini-protocol stage death).
+    ///
+    /// Emitted by the connection stage (not by the protocol state machine) so `track_peers`
+    /// can purge per-connection state. Correlates with `Initialize` via [`ConnectionId`].
+    Terminated,
 }
 
 impl InitiatorResult {
@@ -205,6 +212,7 @@ impl InitiatorResult {
             InitiatorResult::IntersectNotFound(_) => "IntersectNotFound",
             InitiatorResult::RollForward(_, _) => "RollForward",
             InitiatorResult::RollBackward(_, _) => "RollBackward",
+            InitiatorResult::Terminated => "Terminated",
         }
     }
 }

--- a/crates/amaru-protocols/src/chainsync/mod.rs
+++ b/crates/amaru-protocols/src/chainsync/mod.rs
@@ -55,13 +55,11 @@ mod register {
         conn_id: ConnectionId,
         pipeline: StageRef<ChainSyncInitiatorMsg>,
         eff: &Effects<ConnectionMessage>,
+        tombstone: ConnectionMessage,
     ) -> StageRef<InitiatorMessage> {
-        let chainsync = eff
-            .wire_up(
-                eff.stage("chainsync", initiator()).await,
-                ChainSyncInitiator::new(peer, conn_id, muxer.clone(), pipeline),
-            )
-            .await;
+        let chainsync = eff.stage("chainsync", initiator()).await;
+        let chainsync = eff.supervise(chainsync, tombstone);
+        let chainsync = eff.wire_up(chainsync, ChainSyncInitiator::new(peer, conn_id, muxer.clone(), pipeline)).await;
         eff.send(
             muxer,
             MuxMessage::Register {
@@ -81,13 +79,11 @@ mod register {
         peer: Peer,
         conn_id: ConnectionId,
         eff: &Effects<ConnectionMessage>,
+        tombstone: ConnectionMessage,
     ) -> StageRef<ResponderMessage> {
-        let chainsync = eff
-            .wire_up(
-                eff.stage("chainsync", responder()).await,
-                ChainSyncResponder::new(upstream, peer, conn_id, muxer.clone()),
-            )
-            .await;
+        let chainsync = eff.stage("chainsync", responder()).await;
+        let chainsync = eff.supervise(chainsync, tombstone);
+        let chainsync = eff.wire_up(chainsync, ChainSyncResponder::new(upstream, peer, conn_id, muxer.clone())).await;
         eff.send(
             muxer,
             MuxMessage::Register {

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -24,7 +24,9 @@ use crate::{
     blockfetch::{
         self, BlockFetchMessage, Blocks, StreamBlocks, register_blockfetch_initiator, register_blockfetch_responder,
     },
-    chainsync::{self, ChainSyncInitiatorMsg, register_chainsync_initiator, register_chainsync_responder},
+    chainsync::{
+        self, ChainSyncInitiatorMsg, InitiatorResult, register_chainsync_initiator, register_chainsync_responder,
+    },
     handshake,
     keepalive::register_keepalive,
     manager::{ManagerConfig, ManagerMessage},
@@ -107,14 +109,31 @@ struct StateResponder {
     blockfetch_responder: StageRef<StreamBlocks>,
 }
 
+/// Identity of a supervised child stage of a connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ChildId {
+    Mux,
+    Handshake,
+    KeepAlive,
+    TxSubmission,
+    ChainSync,
+    BlockFetch,
+}
+
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum ConnectionMessage {
     Initialize,
     Disconnect,
     Handshake(HandshakeResult),
-    FetchBlocks { from: Point, through: Point, id: u64, cr: StageRef<Blocks> },
+    FetchBlocks {
+        from: Point,
+        through: Point,
+        id: u64,
+        cr: StageRef<Blocks>,
+    },
     NewTip(Tip, TraceContext),
-    // LATER: make full duplex, etc.
+    /// A supervised mini-protocol or mux stage terminated.
+    ChildDied(ChildId),
 }
 
 impl ConnectionMessage {
@@ -125,6 +144,7 @@ impl ConnectionMessage {
             ConnectionMessage::Handshake(_) => "Handshake",
             ConnectionMessage::FetchBlocks { .. } => "FetchBlocks",
             ConnectionMessage::NewTip(_, _) => "NewTip",
+            ConnectionMessage::ChildDied(_) => "ChildDied",
         }
     }
 
@@ -145,7 +165,13 @@ pub async fn stage(
 
     async move {
         let state = match (state, msg) {
-            (_, ConnectionMessage::Disconnect) => return eff.terminate().await,
+            (state, ConnectionMessage::Disconnect) => {
+                return teardown(state, &params, &eff).await;
+            }
+            (state, ConnectionMessage::ChildDied(child)) => {
+                tracing::info!(?child, peer = %params.peer, conn_id = %params.conn_id, "connection child died");
+                return teardown(state, &params, &eff).await;
+            }
             (State::Initial, ConnectionMessage::Initialize) => do_initialize(&params, eff).await,
             (State::Handshake { muxer, handshake }, ConnectionMessage::Handshake(handshake_result)) => {
                 do_handshake(&params, muxer, params.pipeline.clone(), handshake, handshake_result, eff).await
@@ -189,16 +215,46 @@ pub async fn stage(
     .await
 }
 
+/// Notify track_peers that the initiator chainsync session ended, then terminate this connection.
+///
+/// Parent termination aborts children without delivering their tombstones, so the chainsync
+/// purge signal must be sent explicitly here whenever an initiator session may have been started.
+async fn teardown(state: State, params: &Params, eff: &Effects<ConnectionMessage>) -> Connection {
+    match state {
+        State::Initiator(..) => {
+            notify_chainsync_terminated(params, eff).await;
+        }
+        State::Initial | State::Handshake { .. } | State::Responder(_) => {}
+    }
+    eff.terminate().await
+}
+
+async fn notify_chainsync_terminated(params: &Params, eff: &Effects<ConnectionMessage>) {
+    eff.send(
+        &params.pipeline,
+        ChainSyncInitiatorMsg {
+            peer: params.peer.clone(),
+            conn_id: params.conn_id,
+            handler: StageRef::blackhole(),
+            msg: InitiatorResult::Terminated,
+        },
+    )
+    .await;
+}
+
 async fn do_initialize(Params { conn_id, role, magic, .. }: &Params, eff: Effects<ConnectionMessage>) -> State {
     let muxer = eff.stage("mux", mux::stage).await;
+    let muxer = eff.supervise(muxer, ConnectionMessage::ChildDied(ChildId::Mux));
     let muxer = eff.wire_up(muxer, mux::State::new(*conn_id, &[(PROTO_HANDSHAKE.erase(), 5760)], *role)).await;
 
     let handshake_result = eff.contramap(eff.me(), "handshake_result", ConnectionMessage::Handshake).await;
 
     let handshake = match role {
         Role::Initiator => {
+            let hs = eff.stage("handshake", handshake::initiator()).await;
+            let hs = eff.supervise(hs, ConnectionMessage::ChildDied(ChildId::Handshake));
             eff.wire_up(
-                eff.stage("handshake", handshake::initiator()).await,
+                hs,
                 handshake::HandshakeInitiator::new(
                     muxer.clone(),
                     handshake_result,
@@ -208,8 +264,10 @@ async fn do_initialize(Params { conn_id, role, magic, .. }: &Params, eff: Effect
             .await
         }
         Role::Responder => {
+            let hs = eff.stage("handshake", handshake::responder()).await;
+            let hs = eff.supervise(hs, ConnectionMessage::ChildDied(ChildId::Handshake));
             eff.wire_up(
-                eff.stage("handshake", handshake::responder()).await,
+                hs,
                 handshake::HandshakeResponder::new(
                     muxer.clone(),
                     handshake_result,
@@ -237,7 +295,7 @@ async fn do_initialize(Params { conn_id, role, magic, .. }: &Params, eff: Effect
 async fn do_handshake(
     Params { role, peer, conn_id, manager, era_history, mempool_stage, config, .. }: &Params,
     muxer: StageRef<MuxMessage>,
-    pipeline: StageRef<ChainSyncInitiatorMsg>,
+    pipeline_ref: StageRef<ChainSyncInitiatorMsg>,
     handshake: StageRef<Inputs<Void>>,
     handshake_result: HandshakeResult,
     eff: Effects<ConnectionMessage>,
@@ -271,7 +329,8 @@ async fn do_handshake(
     )
     .await;
 
-    let keepalive = register_keepalive(*role, muxer.clone(), &eff).await;
+    let keepalive =
+        register_keepalive(*role, muxer.clone(), &eff, ConnectionMessage::ChildDied(ChildId::KeepAlive)).await;
     let tx_submission = register_tx_submission(
         *role,
         muxer.clone(),
@@ -280,12 +339,28 @@ async fn do_handshake(
         mempool_stage.clone(),
         config.tx_submission_params,
         era_history.clone(),
+        ConnectionMessage::ChildDied(ChildId::TxSubmission),
     )
     .await;
 
     if *role == Role::Initiator {
-        let chainsync_initiator = register_chainsync_initiator(&muxer, peer.clone(), *conn_id, pipeline, &eff).await;
-        let blockfetch_initiator = register_blockfetch_initiator(&muxer, peer.clone(), *conn_id, &eff).await;
+        let chainsync_initiator = register_chainsync_initiator(
+            &muxer,
+            peer.clone(),
+            *conn_id,
+            pipeline_ref,
+            &eff,
+            ConnectionMessage::ChildDied(ChildId::ChainSync),
+        )
+        .await;
+        let blockfetch_initiator = register_blockfetch_initiator(
+            &muxer,
+            peer.clone(),
+            *conn_id,
+            &eff,
+            ConnectionMessage::ChildDied(ChildId::BlockFetch),
+        )
+        .await;
         State::Initiator(StateInitiator {
             chainsync_initiator,
             blockfetch_initiator,
@@ -299,8 +374,17 @@ async fn do_handshake(
     } else {
         let store = Store::new(eff.clone());
         let upstream = store.get_best_chain_tip().await;
-        let chainsync_responder = register_chainsync_responder(&muxer, upstream, peer.clone(), *conn_id, &eff).await;
-        let blockfetch_responder = register_blockfetch_responder(&muxer, &eff).await;
+        let chainsync_responder = register_chainsync_responder(
+            &muxer,
+            upstream,
+            peer.clone(),
+            *conn_id,
+            &eff,
+            ConnectionMessage::ChildDied(ChildId::ChainSync),
+        )
+        .await;
+        let blockfetch_responder =
+            register_blockfetch_responder(&muxer, &eff, ConnectionMessage::ChildDied(ChildId::BlockFetch)).await;
 
         State::Responder(StateResponder {
             chainsync_responder,

--- a/crates/amaru-protocols/src/keepalive/mod.rs
+++ b/crates/amaru-protocols/src/keepalive/mod.rs
@@ -57,14 +57,19 @@ pub async fn register_keepalive(
     role: crate::protocol::Role,
     muxer: StageRef<crate::mux::MuxMessage>,
     eff: &Effects<ConnectionMessage>,
+    tombstone: ConnectionMessage,
 ) -> StageRef<crate::mux::HandlerMessage> {
     let keepalive = if role == crate::protocol::Role::Initiator {
         let (state, stage) = initiator::KeepAliveInitiator::new(muxer.clone());
-        let keepalive = eff.wire_up(eff.stage("keepalive", initiator::initiator()).await, (state, stage)).await;
+        let keepalive = eff.stage("keepalive", initiator::initiator()).await;
+        let keepalive = eff.supervise(keepalive, tombstone);
+        let keepalive = eff.wire_up(keepalive, (state, stage)).await;
         eff.contramap(&keepalive, "keepalive_handler", Inputs::<initiator::InitiatorMessage>::Network).await
     } else {
         let (state, stage) = responder::KeepAliveResponder::new(muxer.clone());
-        let keepalive = eff.wire_up(eff.stage("keepalive", responder::responder()).await, (state, stage)).await;
+        let keepalive = eff.stage("keepalive", responder::responder()).await;
+        let keepalive = eff.supervise(keepalive, tombstone);
+        let keepalive = eff.wire_up(keepalive, (state, stage)).await;
         eff.contramap(&keepalive, "keepalive_handler", Inputs::<Void>::Network).await
     };
 

--- a/crates/amaru-protocols/src/tests/chainsync_stage.rs
+++ b/crates/amaru-protocols/src/tests/chainsync_stage.rs
@@ -248,6 +248,9 @@ pub(super) async fn test_chainsync_stage(
             tracing::info!(peer = %msg.peer, %point, %tip, "roll backward");
             eff.send(&msg.handler, chainsync::InitiatorMessage::RequestNext).await;
         }
+        Terminated => {
+            tracing::info!(peer = %msg.peer, "chainsync terminated");
+        }
     }
     state
 }

--- a/crates/amaru-protocols/src/tx_submission/mod.rs
+++ b/crates/amaru-protocols/src/tx_submission/mod.rs
@@ -71,6 +71,7 @@ where
     spec
 }
 
+#[expect(clippy::too_many_arguments)]
 pub async fn register_tx_submission(
     role: Role,
     muxer: StageRef<mux::MuxMessage>,
@@ -79,15 +80,20 @@ pub async fn register_tx_submission(
     mempool_stage: StageRef<MempoolMsg>,
     params: ResponderParams,
     era_history: Arc<EraHistory>,
+    tombstone: ConnectionMessage,
 ) -> StageRef<mux::HandlerMessage> {
     let tx_submission = if role == Role::Initiator {
         let (state, stage) = initiator::TxSubmissionInitiator::new(muxer.clone(), mempool_stage.clone(), era_history);
-        let tx_submission = eff.wire_up(eff.stage("tx_submission", initiator::initiator()).await, (state, stage)).await;
+        let tx_submission = eff.stage("tx_submission", initiator::initiator()).await;
+        let tx_submission = eff.supervise(tx_submission, tombstone);
+        let tx_submission = eff.wire_up(tx_submission, (state, stage)).await;
         eff.contramap(&tx_submission, "tx_submission_handler", Inputs::<initiator::InitiatorLocalIn>::Network).await
     } else {
         let (state, stage) =
             responder::TxSubmissionResponder::new(muxer.clone(), params, origin, mempool_stage, era_history);
-        let tx_submission = eff.wire_up(eff.stage("tx_submission", responder::responder()).await, (state, stage)).await;
+        let tx_submission = eff.stage("tx_submission", responder::responder()).await;
+        let tx_submission = eff.supervise(tx_submission, tombstone);
+        let tx_submission = eff.wire_up(tx_submission, (state, stage)).await;
         eff.contramap(&tx_submission, "tx_submission_handler", Inputs::<ResponderLocalIn>::Network).await
     };
 


### PR DESCRIPTION
fixes #906

This also corrected the mistake of `track_peers` only using `Peer` to identify a connection. With
other node implementations using `bind()` before `connect()` we might actually have two connections
with the same `Peer`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when peer synchronization stops or a connection terminates.
  * Prevented stale synchronization state from affecting replacement or re-established connections.
  * Preserved correct ordering for deferred synchronization work on each connection.
  * Improved handling of terminated chain-sync sessions so they stop cleanly without producing extra actions.

* **Reliability**
  * Added supervised lifecycle handling across connection and network protocol sessions, improving detection and cleanup of stopped components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->