### PR TITLE
fix warning about chain DB migration in bootstrap

### DIFF
--- a/.github/workflows/publish-bootstrap-snapshots.yml
+++ b/.github/workflows/publish-bootstrap-snapshots.yml
@@ -126,7 +126,6 @@ jobs:
           set -euo pipefail
           ./target/release/amaru create-snapshots \
             --network "$AMARU_NETWORK" \
-            --force \
             ${INPUT_EPOCH:+--epoch "$INPUT_EPOCH"}
 
       - name: Publish snapshots to R2 and update manifest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,17 @@ Other guiding principles:
 - **amaru-ledger**: trace spans for the ledger rules (phase-one and phase-two). ([#1056][])
 - **amaru-ledger**: run scripts in parallel within the same transaction. ([#1056][])
 
+### Removed
+
+- **amaru**: no more `--force` flag on `node bootstrap`; if chain or ledger directories already exist, bootstrap aborts and asks the operator to remove them manually. ([#1062](https://github.com/pragma-org/amaru/pull/1062))
+
 ### Fixed
 
 - **amaru-ledger**: use effective collateral when collecting epoch fees for phase-2-invalid transactions. ([#1048][])
 - **amaru-consensus / amaru-protocols**: do not log an ERROR when block-fetch is paused because no upstream peers are connected yet; keep ERROR for real fetch timeouts after peers were contacted. ([#1050](https://github.com/pragma-org/amaru/issues/1050))
 - **amaru-plutus**: encoding divergence between rational number present in governance actions and those present in protocol parameters. ([#1053][])
 - **amaru-ledger**: restore some spans in the ledger at the debug level. ([#1056][])
+- **amaru**: bootstrap creates the chain DB at the current schema version instead of replaying migrations on an empty store (avoids a spurious migration warning). ([#1060](https://github.com/pragma-org/amaru/pull/1062))
 
 ## [v10.11.20260716](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260716)
 
@@ -190,3 +195,4 @@ Other guiding principles:
 [#1048]: https://github.com/pragma-org/amaru/pull/1048
 [#1053]: https://github.com/pragma-org/amaru/pull/1053
 [#1056]: https://github.com/pragma-org/amaru/pull/1056
+[#1060]: https://github.com/pragma-org/amaru/issues/1060

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -819,10 +819,6 @@ define_schemas! {
                 }
             }
             chain_db {
-                /// Forcefully remove an existing chain database
-                public FORCEFULLY_REMOVE {
-                    required dir: String
-                }
                 /// Chain database already exists
                 public EXIST {
                     required dir: String
@@ -873,10 +869,6 @@ define_schemas! {
                 }
             }
             ledger_db {
-                /// Forcefully remove an existing ledger database
-                public FORCEFULLY_REMOVE {
-                    required dir: String
-                }
                 /// Ledger database already exists
                 public EXIST {
                     required dir: String
@@ -900,7 +892,6 @@ define_schemas! {
             node {
                 /// Bootstrap a node from published snapshots
                 public BOOTSTRAP {
-                    required force: bool
                     required chain_dir: String
                     required ledger_dir: String
                     required network: amaru_kernel::NetworkName

--- a/crates/amaru-stores/src/rocksdb/consensus/rocksdb_store.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/rocksdb_store.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use amaru_kernel::{HeaderHash, IsHeader as _};
 use amaru_ouroboros_traits::{BaseReadChainStore, StoreError};
@@ -27,6 +30,13 @@ use crate::rocksdb::{
         },
     },
 };
+
+fn is_absent_or_empty_dir(path: &Path) -> bool {
+    match fs::read_dir(path) {
+        Err(_) => true,
+        Ok(entries) => entries.count() == 0,
+    }
+}
 
 pub struct RocksDBStore<T: DbOps = DB> {
     pub basedir: PathBuf,
@@ -72,10 +82,18 @@ impl RocksDBStore<DB> {
 
     /// Open or create a `RocksDBStore` with given configuration.
     ///
-    /// This function is deemed "unsafe" because it automatically tries to migrate the
-    /// DB it opens or creates which can potentially causes data corruption.
+    /// When the directory does not exist or is empty, creates a fresh database at the
+    /// current `CHAIN_DB_VERSION` without replaying historical migrations.
+    ///
+    /// When the directory already contains a database, opens it and applies migrations
+    /// up to the current version. This path is deemed "unsafe" because automatic
+    /// migration can potentially cause data corruption.
     pub fn open_and_migrate(config: &RocksDbConfig) -> Result<Self, StoreError> {
-        let (basedir, db) = open_or_create_db(config)?;
+        if is_absent_or_empty_dir(&config.dir) {
+            return Self::create(config.clone());
+        }
+
+        let (basedir, db) = open_db(config)?;
         let store = Self { db, basedir };
 
         migrate_db(&store)?;

--- a/crates/amaru-stores/src/rocksdb/consensus/tests.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/tests.rs
@@ -1165,6 +1165,30 @@ fn creates_a_database_with_current_version_given_directory_is_empty() {
     assert_eq!(version, CHAIN_DB_VERSION);
 }
 
+#[test]
+fn open_and_migrate_creates_current_version_given_directory_is_empty() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let basedir = init_dir(tempdir.path());
+    let config = RocksDbConfig::new(basedir);
+
+    let store = RocksDBStore::open_and_migrate(&config).expect("should create DB successfully");
+    let version = get_version(&store).expect("should read version successfully");
+
+    assert_eq!(version, CHAIN_DB_VERSION);
+}
+
+#[test]
+fn open_and_migrate_creates_current_version_given_directory_is_absent() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let basedir = tempdir.path().join("new-chain-db");
+    let config = RocksDbConfig::new(basedir);
+
+    let store = RocksDBStore::open_and_migrate(&config).expect("should create DB successfully");
+    let version = get_version(&store).expect("should read version successfully");
+
+    assert_eq!(version, CHAIN_DB_VERSION);
+}
+
 #[cfg(not(target_os = "windows"))]
 #[test]
 fn can_convert_v0_sample_db_to_v1() {

--- a/crates/amaru/src/bin/amaru/cmd/node/bootstrap.rs
+++ b/crates/amaru/src/bin/amaru/cmd/node/bootstrap.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{error::Error, fs::remove_dir_all, path::PathBuf};
+use std::{error::Error, path::PathBuf};
 
 use amaru::{bootstrap::bootstrap, default_chain_dir, default_ledger_dir};
 use amaru_kernel::{Epoch, GlobalParameters, NetworkName, utils::path::relative_path};
 use amaru_observability::{info, warn};
-use clap::{ArgAction, Parser};
+use clap::Parser;
 
 #[derive(Debug, Parser)]
 pub struct Args {
@@ -30,14 +30,6 @@ pub struct Args {
         env = amaru::env_vars::CHAIN_DIR,
     )]
     chain_dir: Option<PathBuf>,
-
-    /// Forcefully erase and overwrite the ledger database if it already exists.
-    #[arg(
-        long,
-        action = ArgAction::SetTrue,
-        default_value_t = false,
-    )]
-    force: bool,
 
     /// Path of the ledger on-disk storage.
     ///
@@ -88,7 +80,6 @@ pub async fn run(args: Args) -> Result<(), Box<dyn Error>> {
 
     info!(
         cli::node::BOOTSTRAP,
-        force = args.force,
         chain_dir = %relative_path(&chain_dir)?.display(),
         ledger_dir = %relative_path(&ledger_dir)?.display(),
         network = %network,
@@ -96,25 +87,23 @@ pub async fn run(args: Args) -> Result<(), Box<dyn Error>> {
     );
 
     if ledger_dir.exists() || chain_dir.exists() {
-        if !args.force {
-            if ledger_dir.exists() {
-                let dir = relative_path(&ledger_dir)?.display();
-                warn!(cli::ledger_db::EXIST, dir = %dir, hint = "ledger directory already exists: use another location, remove it or use --force");
-            } else {
-                let dir = relative_path(&chain_dir)?.display();
-                warn!(cli::chain_db::EXIST, dir = %dir, hint = "chain directory already exists: use another location, remove it or use --force");
-            }
-            return Ok(());
-        } else {
-            if ledger_dir.exists() {
-                warn!(cli::ledger_db::FORCEFULLY_REMOVE, dir = %relative_path(&ledger_dir)?.display());
-                remove_dir_all(&ledger_dir)?;
-            }
-            if chain_dir.exists() {
-                warn!(cli::chain_db::FORCEFULLY_REMOVE, dir = %relative_path(&chain_dir)?.display());
-                remove_dir_all(&chain_dir)?;
-            }
+        let mut messages = Vec::new();
+
+        if ledger_dir.exists() {
+            let dir = relative_path(&ledger_dir)?.display().to_string();
+            let hint = "ledger directory already exists: use another location or remove it manually";
+            warn!(cli::ledger_db::EXIST, dir = %dir, hint = hint);
+            messages.push(format!("{hint} ({dir})"));
         }
+
+        if chain_dir.exists() {
+            let dir = relative_path(&chain_dir)?.display().to_string();
+            let hint = "chain directory already exists: use another location or remove it manually";
+            warn!(cli::chain_db::EXIST, dir = %dir, hint = hint);
+            messages.push(format!("{hint} ({dir})"));
+        }
+
+        return Err(messages.join("; ").into());
     }
 
     bootstrap(network, &global_parameters, ledger_dir, chain_dir, args.epoch).await

--- a/crates/amaru/src/bootstrap/mod.rs
+++ b/crates/amaru/src/bootstrap/mod.rs
@@ -541,7 +541,7 @@ pub async fn bootstrap(
     )
     .await?;
 
-    let chain_db = RocksDBStore::open_and_migrate(&RocksDbConfig::new(chain_dir.clone()))?;
+    let chain_db = RocksDBStore::create(RocksDbConfig::new(chain_dir.clone()))?;
     let initial_nonces =
         imported_third_snapshot.initial_nonces.ok_or("bootstrap import must produce nonces for the latest snapshot")?;
     store_nonces(imported_third_snapshot.epoch, &chain_db, initial_nonces)?;

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -387,7 +387,6 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
 | `exist` | `TRACE` | public | Chain database already exists | dir, hint |  |
-| `forcefully_remove` | `TRACE` | public | Forcefully remove an existing chain database | dir |  |
 
 <details><summary>span: `exist`</summary>
 
@@ -395,14 +394,6 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | --- | --- | --- |
 | `dir` | `string` | ✓ |
 | `hint` | `string` | ✓ |
-
-</details>
-
-<details><summary>span: `forcefully_remove`</summary>
-
-| field | type | required |
-| --- | --- | --- |
-| `dir` | `string` | ✓ |
 
 </details>
 
@@ -501,7 +492,6 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
 | `exist` | `TRACE` | public | Ledger database already exists | dir, hint |  |
-| `forcefully_remove` | `TRACE` | public | Forcefully remove an existing ledger database | dir |  |
 
 <details><summary>span: `exist`</summary>
 
@@ -509,14 +499,6 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | --- | --- | --- |
 | `dir` | `string` | ✓ |
 | `hint` | `string` | ✓ |
-
-</details>
-
-<details><summary>span: `forcefully_remove`</summary>
-
-| field | type | required |
-| --- | --- | --- |
-| `dir` | `string` | ✓ |
 
 </details>
 
@@ -551,13 +533,12 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `bootstrap` | `TRACE` | public | Bootstrap a node from published snapshots | force, chain_dir, ledger_dir, network | epoch |
+| `bootstrap` | `TRACE` | public | Bootstrap a node from published snapshots | chain_dir, ledger_dir, network | epoch |
 
 <details><summary>span: `bootstrap`</summary>
 
 | field | type | required |
 | --- | --- | --- |
-| `force` | `boolean` | ✓ |
 | `chain_dir` | `string` | ✓ |
 | `ledger_dir` | `string` | ✓ |
 | `network` | `string` | ✓ |

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -638,24 +638,6 @@
       "description": "Chain database already exists",
       "public": true
     },
-    "amaru::cli::chain_db::FORCEFULLY_REMOVE": {
-      "type": "object",
-      "properties": {
-        "dir": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "dir"
-      ],
-      "optional": [],
-      "additionalProperties": false,
-      "name": "forcefully_remove",
-      "level": "TRACE",
-      "target": "amaru::cli::chain_db",
-      "description": "Forcefully remove an existing chain database",
-      "public": true
-    },
     "amaru::cli::current_epoch::RESOLVE": {
       "type": "object",
       "properties": {
@@ -841,24 +823,6 @@
       "description": "Ledger database already exists",
       "public": true
     },
-    "amaru::cli::ledger_db::FORCEFULLY_REMOVE": {
-      "type": "object",
-      "properties": {
-        "dir": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "dir"
-      ],
-      "optional": [],
-      "additionalProperties": false,
-      "name": "forcefully_remove",
-      "level": "TRACE",
-      "target": "amaru::cli::ledger_db",
-      "description": "Forcefully remove an existing ledger database",
-      "public": true
-    },
     "amaru::cli::mithril::DOWNLOAD": {
       "type": "object",
       "properties": {
@@ -914,9 +878,6 @@
     "amaru::cli::node::BOOTSTRAP": {
       "type": "object",
       "properties": {
-        "force": {
-          "type": "boolean"
-        },
         "chain_dir": {
           "type": "string"
         },
@@ -933,7 +894,6 @@
         }
       },
       "required": [
-        "force",
         "chain_dir",
         "ledger_dir",
         "network"

--- a/engineering-decision-records/017-version-and-migrate-db.md
+++ b/engineering-decision-records/017-version-and-migrate-db.md
@@ -19,7 +19,7 @@ status: accepted
 * The current version is a constant `CHAIN_DB_VERSION` in the code
 * When Amaru starts from an existing database it will check its version and if the binary and stored versions don't match, will refuse to start with a message
 * We provide a `migrate-chain-db` command that gives user the possibility to migrate an existing database up to the currently supported version
-* When bootstrapping Amaru from scratch, we make sure to migrate the (empty) database being bootstrapped
+* When bootstrapping Amaru from scratch, we create a fresh database already at the current `CHAIN_DB_VERSION` (no migration of an empty DB)
 * When migrating a database, we record the execution of each _migration step_ in the database with some metadata (timestamp, git commit, name of step)
 
 ## Consequences

--- a/scripts/refresh-from-mithril
+++ b/scripts/refresh-from-mithril
@@ -132,8 +132,7 @@ bootstrap_refresh() {
     --network "$NETWORK" \
     --chain-dir "$chain_dir" \
     --ledger-dir "$ledger_dir" \
-    --epoch "$((BOOTSTRAP_START_EPOCH + 3))" \
-    --force
+    --epoch "$((BOOTSTRAP_START_EPOCH + 3))"
 }
 
 prepare_latest_bootstrap_config() {
@@ -149,8 +148,7 @@ prepare_latest_bootstrap_config() {
   if ! latest_bootstrap_metadata_available "$metadata_dir" "$BOOTSTRAP_START_EPOCH"; then
     cargo run --profile "$BUILD_PROFILE" -- create-snapshots \
       --network "$NETWORK" \
-      --epoch "$((BOOTSTRAP_START_EPOCH + 3))" \
-      --force
+      --epoch "$((BOOTSTRAP_START_EPOCH + 3))"
   fi
 
   bootstrap_network_dir="$BOOTSTRAP_CONFIG_DIR/$NETWORK"


### PR DESCRIPTION
fixes #1060

also removes `--force` option as per EDR 19


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the `--force` option from node bootstrap and snapshot creation commands.
  * Bootstrap now stops with a warning when chain or ledger directories already exist; remove them manually before retrying.

* **Bug Fixes**
  * New chain databases are created directly at the current schema version, avoiding unnecessary migration warnings.

* **Documentation**
  * Updated changelog, trace documentation, and operational guidance to reflect the revised bootstrap behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->