### PR TITLE
test: relay-1 demo updates

### DIFF
--- a/.flox/env.json
+++ b/.flox/env.json
@@ -1,4 +1,4 @@
 {
-  "name": "amaru-1",
+  "name": "amaru",
   "version": 1
 }

--- a/scripts/demos/README.md
+++ b/scripts/demos/README.md
@@ -90,6 +90,19 @@ the selected snapshot changed.
 | `MITHRIL_REFRESH_DIR`            | `$RUNDIR/mithril-refresh`                       | Directory containing refreshed Amaru databases                                                                          |
 | `AMARU_MITHRIL_SNAPSHOTS_DIR`    | `mithril-snapshots`                             | Directory holding downloaded Mithril immutable chunks                                                                   |
 
+A refresh uses `db-analyser` from `$CARDANO_NODE_HOME/bin` to create the epoch snapshots, and first
+probes that it honours `--analyse-from`: the db-analyser bundled with cardano-node releases up to
+11.0.1 silently ignores the option
+([ouroboros-consensus#2061](https://github.com/IntersectMBO/ouroboros-consensus/pull/2061)) and
+replays every epoch snapshot from genesis, ~25 minutes per epoch instead of about a minute. When the
+probe fails, the refresh aborts with instructions; until a cardano-node release ships the fix, build
+a fixed db-analyser and drop it into place:
+
+```bash
+nix build "github:IntersectMBO/ouroboros-consensus/aa96807e6891071c3553d19c07be2d39ab5c0a78#db-analyser"
+install -m 755 result/bin/db-analyser "$CARDANO_NODE_HOME/bin/db-analyser"
+```
+
 
 ### Wallet preparation
 

--- a/scripts/demos/README.md
+++ b/scripts/demos/README.md
@@ -158,13 +158,14 @@ the `monitoring` directory, first removing the previous volumes so every run sta
 and metrics. The Amaru nodes export their traces and metrics to the collector using the OpenTelemetry
 settings below, and `telemetry-open` opens preconfigured Grafana Explore tabs on the collected data.
 
-| Variable                   | Default                                                                                                                                    | Description                                                              |
-|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
-| `START_TELEMETRY`          | `true`                                                                                                                                     | Start Grafana, Tempo, Prometheus, and the OTLP collector before the demo |
-| `TELEMETRY_DIR`            | `$AMARU_DIR/monitoring`                                                                                                                    | Directory containing the telemetry Docker Compose files                  |
-| `TELEMETRY_PROFILES`       | `prometheus grafana tempo`                                                                                                                 | Docker Compose profiles started for telemetry; each profile's `profiles/<name>/docker-compose.yml` is included automatically when present |
-| `TELEMETRY_GRAFANA_URL`    | `http://localhost`                                                                                                                         | Grafana URL opened by `telemetry-open`                                   |
-| `TELEMETRY_PROMETHEUS_URL` | `http://localhost:9090`                                                                                                                    | Prometheus URL opened by `telemetry-open`                                |
+| Variable                          | Default                                   | Description                                                                                                                               |
+|-----------------------------------|-------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `START_TELEMETRY`                 | `true`                                    | Start Grafana, Tempo, Prometheus, and the OTLP collector before the demo                                                                  |
+| `TELEMETRY_DIR`                   | `$AMARU_DIR/monitoring`                   | Directory containing the telemetry Docker Compose files                                                                                   |
+| `TELEMETRY_PROFILES`              | `prometheus grafana tempo`                | Docker Compose profiles started for telemetry; each profile's `profiles/<name>/docker-compose.yml` is included automatically when present |
+| `TELEMETRY_GRAFANA_URL`           | `http://localhost`                        | Grafana URL opened by `telemetry-open`                                                                                                    |
+| `TELEMETRY_PROMETHEUS_URL`        | `http://localhost:9090`                   | Prometheus URL opened by `telemetry-open`                                                                                                 |
+| `TELEMETRY_COMPOSE_OVERRIDE_FILE` | `<demo dir>/telemetry/docker-compose.yml` | Extra Docker Compose file layered onto the shared stack, e.g. to provision demo-owned Grafana dashboards                                  |
 
 ### OpenTelemetry export
 

--- a/scripts/demos/common/cardano-node.sh
+++ b/scripts/demos/common/cardano-node.sh
@@ -74,6 +74,89 @@ cardano_node_topology_file() {
   echo "$CARDANO_NODE_CONFIG_DIR/topology.json"
 }
 
+official_cardano_node_config_base_url() {
+  case "$NETWORK" in
+    mainnet | preprod | preview) echo "https://book.world.dev.cardano.org/environments/$NETWORK" ;;
+    *) return 1 ;;
+  esac
+}
+
+download_official_cardano_node_config_file() {
+  local base_url="$1" file_name="$2" target_dir="$3" target
+  target="$target_dir/$file_name"
+  mkdir -p "$(dirname "$target")"
+  curl -fsSL "$base_url/$file_name" -o "$target"
+}
+
+cardano_node_config_referenced_files() {
+  jq -r '
+    [
+      .AlonzoGenesisFile,
+      .ByronGenesisFile,
+      .CheckpointsFile,
+      .ConwayGenesisFile,
+      .ShelleyGenesisFile
+    ]
+    | map(select(. != null and . != ""))
+    | unique
+    | .[]
+  ' "$1"
+}
+
+cardano_node_config_complete() {
+  local file_name files
+
+  [[ -f "$(cardano_node_config_file)" && -f "$(cardano_node_topology_file)" ]] || return 1
+  have jq || return 0
+
+  files="$(cardano_node_config_referenced_files "$(cardano_node_config_file)")" || return 1
+  while IFS= read -r file_name; do
+    [[ -n "$file_name" ]] || continue
+    [[ -f "$CARDANO_NODE_CONFIG_DIR/$file_name" ]] || return 1
+  done <<< "$files"
+}
+
+download_official_cardano_node_config() {
+  local base_url tmp_dir file_name files
+
+  if cardano_node_config_complete; then
+    echo "[setup] using existing cardano-node config in $CARDANO_NODE_CONFIG_DIR"
+    return
+  fi
+
+  base_url="$(official_cardano_node_config_base_url || true)"
+  [[ -n "$base_url" ]] ||
+    die "CARDANO_NODE_CONFIG_DIR does not exist: $CARDANO_NODE_CONFIG_DIR; automatic config download is only supported for mainnet, preprod, and preview"
+  have curl || die "curl not found; cannot download cardano-node config"
+  have jq || die "jq not found; cannot inspect cardano-node config"
+
+  tmp_dir="$CARDANO_NODE_CONFIG_DIR.download.$$"
+  rm -rf "$tmp_dir"
+  mkdir -p "$tmp_dir"
+
+  echo "[setup] downloading cardano-node config for $NETWORK"
+  download_official_cardano_node_config_file "$base_url" "config.json" "$tmp_dir"
+  download_official_cardano_node_config_file "$base_url" "topology.json" "$tmp_dir"
+
+  files="$(cardano_node_config_referenced_files "$tmp_dir/config.json")"
+
+  while IFS= read -r file_name; do
+    [[ -n "$file_name" ]] || continue
+    download_official_cardano_node_config_file "$base_url" "$file_name" "$tmp_dir"
+  done <<< "$files"
+
+  mkdir -p "$CARDANO_NODE_CONFIG_DIR"
+  find "$tmp_dir" -type f | while IFS= read -r file_name; do
+    local relative target
+    relative="${file_name#"$tmp_dir"/}"
+    target="$CARDANO_NODE_CONFIG_DIR/$relative"
+    mkdir -p "$(dirname "$target")"
+    mv "$file_name" "$target"
+  done
+  rm -rf "$tmp_dir"
+  echo "[setup] cardano-node config ready in $CARDANO_NODE_CONFIG_DIR"
+}
+
 cardano_node_socket_file() {
   echo "$CARDANO_NODE_SOCKET_FILE"
 }
@@ -298,8 +381,29 @@ repair_downloaded_cardano_node_home() {
   codesign --force --sign - "$CARDANO_NODE_HOME/bin/cardano-node" "$CARDANO_NODE_HOME/bin/db-analyser"
 }
 
+# Verifies that db-analyser honours --analyse-from by probing an empty database: a fixed
+# build fails to resolve the requested slot, while builds that predate the fix
+# (ouroboros-consensus#2061, anything up to cardano-node 11.0.1) silently ignore the option
+# and replay every epoch snapshot from genesis, which turns a Mithril refresh into
+# ~25 minutes per epoch.
+require_db_analyser_with_analyse_from() {
+  local db_analyser="$CARDANO_NODE_HOME/bin/db-analyser" probe_db output
+  [[ -x "$db_analyser" ]] || die "db-analyser not found at $db_analyser; run setup first"
+  probe_db="$(mktemp -d)"
+  output="$("$db_analyser" --config "$(cardano_node_config_file)" --db "$probe_db" --in-mem --analyse-from 999 --store-ledger 1000 2>&1 || true)"
+  rm -rf "$probe_db"
+  if ! grep -q "No block with given slot" <<<"$output"; then
+    die "db-analyser at $db_analyser silently ignores --analyse-from (see https://github.com/IntersectMBO/ouroboros-consensus/pull/2061, not fixed in cardano-node releases up to 11.0.1), so a Mithril refresh would replay every epoch snapshot from genesis (~25 minutes each).
+Replace it with a build that contains the fix, for example:
+  nix build \"github:IntersectMBO/ouroboros-consensus/aa96807e6891071c3553d19c07be2d39ab5c0a78#db-analyser\"
+  install -m 755 result/bin/db-analyser \"$db_analyser\"
+Probe output was: $output"
+  fi
+}
+
 setup() {
   require_unscaled_process setup
+  download_official_cardano_node_config
   if [[ "$CARDANO_NODE_HOME_WAS_SET" == true ]]; then
     echo "[setup] CARDANO_NODE_HOME is set: $CARDANO_NODE_HOME"
   elif [[ -x "$CARDANO_NODE_HOME/bin/cardano-node" && -x "$CARDANO_NODE_HOME/bin/db-analyser" ]]; then

--- a/scripts/demos/common/databases.sh
+++ b/scripts/demos/common/databases.sh
@@ -46,6 +46,7 @@ initialize_cardano_node_database() {
 
   if [[ -f "$target_db/immutable/00000.primary" ]] && same_mithril_snapshot_metadata "$source_marker" "$target_marker"; then
     if ! truthy "$CARDANO_NODE_INIT_FROM_MITHRIL"; then
+      ensure_cardano_node_db_marker "$target_db" "$(dirname "$source_immutable")"
       echo "[initialize] cardano-node database already initialized from selected Mithril snapshot; skipping sync"
       return 0
     fi
@@ -61,9 +62,26 @@ initialize_cardano_node_database() {
   rm -rf "$target_db/ledger" "$target_db/volatile"
   mkdir -p "$target_db/immutable"
   rsync -a --delete "$source_immutable"/ "$target_db/immutable"/
+  ensure_cardano_node_db_marker "$target_db" "$(dirname "$source_immutable")"
   cp "$source_marker" "$target_marker"
   echo "[initialize] cardano-node immutable database initialized from $source_immutable"
   echo "[initialize] cardano-node will rebuild ledger and volatile state on next start"
+}
+
+# cardano-node refuses to open a non-empty database directory that lacks the protocolMagicId
+# marker file it normally writes itself (NoDbMarkerAndNotEmpty), so provide one when only the
+# immutable files were synchronized.
+ensure_cardano_node_db_marker() {
+  local target_db="$1" source_root="$2"
+  if [[ -f "$source_root/clean" && ! -f "$target_db/clean" ]]; then
+    cp "$source_root/clean" "$target_db/clean"
+  fi
+  [[ -f "$target_db/protocolMagicId" ]] && return 0
+  if [[ -f "$source_root/protocolMagicId" ]]; then
+    cp "$source_root/protocolMagicId" "$target_db/protocolMagicId"
+  else
+    jq -j '.networkMagic' "$CARDANO_NODE_CONFIG_DIR/shelley-genesis.json" > "$target_db/protocolMagicId"
+  fi
 }
 
 same_mithril_snapshot_metadata() {
@@ -95,6 +113,7 @@ mark_database_dir_dirty() {
 }
 
 refresh_from_mithril() {
+  require_db_analyser_with_analyse_from
   cd "$AMARU_DIR" || return
   mkdir -p "$(dirname "$MITHRIL_REFRESH_LOG_FILE")"
   AMARU_NETWORK="$NETWORK" \

--- a/scripts/demos/common/orchestration.sh
+++ b/scripts/demos/common/orchestration.sh
@@ -17,7 +17,11 @@ require_runtime_processes_stopped() {
 }
 
 validate_up() {
-  validate_config
+  if declare -F validate_startup_config >/dev/null; then
+    validate_startup_config
+  else
+    validate_config
+  fi
   case "$REFRESH_FROM_MITHRIL" in
     auto | true | TRUE | 1 | yes | YES | on | ON) ;;
     false | FALSE | 0 | no | NO | off | OFF) validate_amaru_source_databases ;;
@@ -72,7 +76,6 @@ up() {
   validate_up
   local compose_file
   compose_file="$(process_compose_file)"
-  telemetry_up
   cd "$SCRIPT_DIR" || return
   exec process-compose -f "$compose_file" up --ordered-shutdown
 }

--- a/scripts/demos/common/telemetry.sh
+++ b/scripts/demos/common/telemetry.sh
@@ -12,6 +12,7 @@ telemetry_compose() {
   have docker || die "docker not found; install Docker or set START_TELEMETRY=false"
   local -a compose_args=()
   local -a profile_args=()
+  local -a collector_configs=("--config=/etc/otlp-collector.yml")
   local profile profile_compose_file
   [[ -f "$TELEMETRY_DIR/docker-compose.yml" ]] || die "telemetry compose file not found: $TELEMETRY_DIR/docker-compose.yml"
   compose_args=(-f "$TELEMETRY_DIR/docker-compose.yml")
@@ -21,7 +22,19 @@ telemetry_compose() {
     if [[ -f "$profile_compose_file" ]]; then
       compose_args+=(-f "$profile_compose_file")
     fi
+    if [[ -f "$TELEMETRY_DIR/profiles/$profile/otlp-collector.yml" ]]; then
+      collector_configs+=("--config=/etc/otlp-collector-$profile.yml")
+    fi
   done
+  # Exported for override compose files (e.g. a demo layer) whose command must restate the
+  # collector configs contributed by the active profiles, since Docker Compose replaces the
+  # command list rather than appending to it.
+  export TELEMETRY_COLLECTOR_CONFIGS="${collector_configs[*]}"
+  if [[ -n "${TELEMETRY_COMPOSE_OVERRIDE_FILE:-}" ]]; then
+    [[ -f "$TELEMETRY_COMPOSE_OVERRIDE_FILE" ]] || die "telemetry compose override not found: $TELEMETRY_COMPOSE_OVERRIDE_FILE"
+    export TELEMETRY_COMPOSE_OVERRIDE_DIR="$(cd "$(dirname "$TELEMETRY_COMPOSE_OVERRIDE_FILE")" && pwd)"
+    compose_args+=(-f "$TELEMETRY_COMPOSE_OVERRIDE_FILE")
+  fi
   docker compose "${compose_args[@]}" "${profile_args[@]}" "$@"
 }
 

--- a/scripts/demos/common/telemetry.sh
+++ b/scripts/demos/common/telemetry.sh
@@ -7,6 +7,10 @@
 # printing the Grafana URLs that open_telemetry opens in the browser. The Docker Compose
 # files are the base $TELEMETRY_DIR/docker-compose.yml plus, for each selected profile,
 # its $TELEMETRY_DIR/profiles/<profile>/docker-compose.yml when that file exists.
+#
+# A demo can layer its own services or mounts (e.g. Grafana dashboards) on top of the shared
+# stack by setting TELEMETRY_COMPOSE_OVERRIDE_FILE to an extra compose file; that file can
+# anchor host paths on the exported TELEMETRY_COMPOSE_OVERRIDE_DIR.
 
 telemetry_compose() {
   have docker || die "docker not found; install Docker or set START_TELEMETRY=false"
@@ -121,34 +125,9 @@ grafana_metrics_url() {
   printf '%s/explore?orgId=1&schemaVersion=1&refresh=5s&panes=%s\n' "$TELEMETRY_GRAFANA_URL" "$(urlencode "$panes")"
 }
 
-grafana_mempool_dashboard_url() {
-  grafana_metrics_url '[
-    {
-      "name": "A",
-      "expr": "sum by (origin, result) (increase(amaru_metrics_mempoolTxInsertionsNum_int[5m]))",
-      "legend": "mempool insertions {{origin}} {{result}}"
-    },
-    {
-      "name": "B",
-      "expr": "cardano_node_metrics_mempoolBytes_int",
-      "legend": "mempool bytes"
-    },
-    {
-      "name": "C",
-      "expr": "cardano_node_metrics_blockNum_int",
-      "legend": "block height"
-    },
-    {
-      "name": "D",
-      "expr": "process_memory_live_resident",
-      "legend": "resident memory"
-    },
-    {
-      "name": "E",
-      "expr": "process_cpu_live",
-      "legend": "cpu"
-    }
-  ]'
+# Prints the URL of a provisioned Grafana dashboard identified by its uid.
+grafana_dashboard_url() {
+  printf '%s/d/%s?orgId=1&refresh=5s\n' "$TELEMETRY_GRAFANA_URL" "$1"
 }
 
 open_telemetry() {

--- a/scripts/demos/relay-1/README.md
+++ b/scripts/demos/relay-1/README.md
@@ -46,10 +46,11 @@ export AMARU_NETWORK=preprod
 ./process-compose.sh status  # check process status
 ```
 
-Running `./process-compose.sh up` starts the Grafana/Tempo/Prometheus telemetry stack, opens the process-compose TUI,
-downloads local cardano-node tools when needed, refreshes the Amaru databases from Mithril if no complete local refresh
-exists, prepares the isolated run directories, and starts the relay processes. Use the wrapper instead of running
-`process-compose up` directly so telemetry and the configured process dependencies are used.
+Running `./process-compose.sh up` opens the process-compose TUI. The `8-telemetry-setup` process starts the
+Grafana/Tempo/Prometheus telemetry stack while the setup and initialization processes download local cardano-node tools
+when needed, refresh the Amaru databases from Mithril if no complete local refresh exists, prepare the isolated run
+directories, and start the relay processes. Use the wrapper instead of running `process-compose up` directly so telemetry
+and the configured process dependencies are used.
 
 👉 Set `START_TELEMETRY=false` to keep the demo in node-only mode.
 
@@ -136,11 +137,12 @@ directly instead of invoking `cargo run`.
 
 ### Setup and Initialize Processes
 
-The `0-setup` process is a one-shot tool bootstrap step. When `CARDANO_NODE_HOME` is unset, it downloads the configured
-cardano-node release into `/tmp/amaru-relay-1`, verifies the archive checksum when `shasum` is available, and exposes
-`bin/cardano-node` and `bin/db-analyser` from that temp directory. Because that directory lives under `/tmp`, the tools
-are re-downloaded after a reboot or periodic temp cleanup. When `CARDANO_NODE_HOME` is set, it validates that
-the configured directory already contains `bin/db-analyser` and that `CARDANO_NODE` points at an executable.
+The `8-telemetry-setup` process starts the telemetry stack when `START_TELEMETRY=true`. The `0-setup` process is a one-shot
+tool bootstrap step. When `CARDANO_NODE_HOME` is unset, it downloads the configured cardano-node release into
+`/tmp/amaru-relay-1`, verifies the archive checksum when `shasum` is available, and exposes `bin/cardano-node` and
+`bin/db-analyser` from that temp directory. Because that directory lives under `/tmp`, the tools are re-downloaded after
+a reboot or periodic temp cleanup. When `CARDANO_NODE_HOME` is set, it validates that the configured directory already
+contains `bin/db-analyser` and that `CARDANO_NODE` points at an executable.
 
 The `2-initialize` process is a one-shot preparation step that runs after `1-mithril-refresh` and before any
 long-running node process starts. It validates the cardano-node configuration directory, transaction generation
@@ -175,7 +177,8 @@ The configured processes are:
 - `5-amaru-downstream`
 - `6-prepare-wallet`
 - `7-submit-tx`
-- `8-telemetry` (disabled by default; start it manually from the TUI to open telemetry tabs with `cmd + R`)
+- `8-telemetry-setup`
+- `8-telemetry-open` (disabled by default; start it manually from the TUI to open telemetry tabs)
 - `9-watch`
 
 ## Telemetry
@@ -208,8 +211,7 @@ After the middle relay has synced a few blocks or accepted submitted transaction
 The trace tab populates when matching spans are emitted. The transaction trace and metrics view populate after
 `submit-tx` submits a transaction to the downstream node and the middle node pulls it into its mempool.
 
-The Process Compose TUI also lists a disabled `8-telemetry` process. It does not run during startup. Start or restart
-`8-telemetry` when you want to open the telemetry tabs during the live demo.
+Use `./process-compose.sh telemetry-open` or start `8-telemetry-open` when you want to open the telemetry tabs during the live demo.
 
 To stop the telemetry stack:
 

--- a/scripts/demos/relay-1/process-compose.sh
+++ b/scripts/demos/relay-1/process-compose.sh
@@ -127,6 +127,12 @@ validate_config() {
   require_configured_tx
 }
 
+validate_startup_config() {
+  [[ -n "$CARDANO_NODE_CONFIG_DIR" ]] || die "CARDANO_NODE_CONFIG_DIR must be set (directory with config.json, topology.json, etc.)"
+  [[ -d "$AMARU_DIR" ]] || die "AMARU_DIR does not exist: $AMARU_DIR"
+  require_configured_tx
+}
+
 initialize() {
   require_unscaled_process initialize
   require_runtime_processes_stopped initialize
@@ -233,13 +239,14 @@ telemetry-urls) telemetry_urls ;;
 run)
   case "${2:-}" in
   setup | 0-setup) setup ;;
+  telemetry-up | 8-telemetry-setup) telemetry_up ;;
   mithril-refresh | 1-mithril-refresh) run_mithril_refresh ;;
   initialize | 2-initialize) initialize ;;
   cardano-upstream | cardano-node | 3-cardano-node) run_cardano_upstream ;;
   amaru-middle | 4-amaru-middle) run_amaru_middle ;;
   amaru-downstream | 5-amaru-downstream) run_amaru_downstream ;;
   watch | 9-watch) run_watch ;;
-  telemetry-open | telemetry | 8-telemetry) open_telemetry ;;
+  telemetry-open | telemetry | 8-telemetry-open) open_telemetry ;;
   prepare-wallet | 6-prepare-wallet)
     run_prepare_wallet
     exit $?
@@ -252,7 +259,7 @@ run)
     run_submit_tx_batch "${3:-}"
     exit $?
     ;;
-  *) die "usage: $0 run {setup|mithril-refresh|initialize|cardano-upstream|amaru-middle|amaru-downstream|watch|telemetry-open|submit-tx|submit-tx-batch|prepare-wallet}" ;;
+  *) die "usage: $0 run {setup|telemetry-up|mithril-refresh|initialize|cardano-upstream|amaru-middle|amaru-downstream|watch|telemetry-open|submit-tx|submit-tx-batch|prepare-wallet}" ;;
   esac
   ;;
 ready)

--- a/scripts/demos/relay-1/process-compose.sh
+++ b/scripts/demos/relay-1/process-compose.sh
@@ -71,6 +71,7 @@ default_tx_query_source() {
 TX_QUERY_SOURCE="${TX_QUERY_SOURCE:-$(default_tx_query_source)}"
 START_TELEMETRY="${START_TELEMETRY:-true}"
 TELEMETRY_DIR="${TELEMETRY_DIR:-$AMARU_DIR/monitoring}"
+TELEMETRY_COMPOSE_OVERRIDE_FILE="${TELEMETRY_COMPOSE_OVERRIDE_FILE:-$SCRIPT_DIR/telemetry/docker-compose.yml}"
 TELEMETRY_PROFILES="${TELEMETRY_PROFILES:-prometheus grafana tempo}"
 TELEMETRY_GRAFANA_URL="${TELEMETRY_GRAFANA_URL:-http://localhost}"
 TELEMETRY_PROMETHEUS_URL="${TELEMETRY_PROMETHEUS_URL:-http://localhost:9090}"
@@ -216,7 +217,7 @@ run_prepare_wallet() {
 
 telemetry_urls() {
   grafana_trace_url "traces" '{ resource.service.name = "amaru-middle" && span:name = "roll_forward.process" } with (most_recent=true)'
-  grafana_mempool_dashboard_url
+  grafana_dashboard_url "amaru-relay-mempool"
 }
 
 case "${1:-up}" in

--- a/scripts/demos/relay-1/process-compose.yaml
+++ b/scripts/demos/relay-1/process-compose.yaml
@@ -121,7 +121,11 @@ processes:
       6-prepare-wallet:
         condition: process_completed_successfully
 
-  8-telemetry:
+  8-telemetry-setup:
+    description: Start Grafana, Tempo, Prometheus, and the OTLP collector.
+    command: ./process-compose.sh run telemetry-up
+
+  8-telemetry-open:
     description: Open Grafana Tempo traces and Prometheus metrics for Amaru in the browser.
     command: ./process-compose.sh run telemetry-open
     disabled: true

--- a/scripts/demos/relay-1/telemetry/dashboards.yml
+++ b/scripts/demos/relay-1/telemetry/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: Amaru
+    orgId: 1
+    folder: Amaru
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/scripts/demos/relay-1/telemetry/dashboards/amaru-relay-mempool.json
+++ b/scripts/demos/relay-1/telemetry/dashboards/amaru-relay-mempool.json
@@ -1,0 +1,703 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(sum by (exported_job, origin, result) (amaru_metrics_mempoolTxInsertionsNum_int{exported_job=~\"amaru-middle|amaru-downstream\"}), \"panel\", \"insertions\", \"exported_job\", \".*\")",
+          "legendFormat": "{{panel}} {{exported_job}} {{origin}} {{result}}",
+          "range": true,
+          "refId": "insertions"
+        }
+      ],
+      "title": "Mempool Insertions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "transactions",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 16,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(max_over_time(cardano_node_metrics_txsInMempool_int{exported_job=~\"amaru-middle|amaru-downstream\"}[30s]), \"panel\", \"in_mempool_30s_max\", \"exported_job\", \".*\")",
+          "legendFormat": "{{panel}} {{exported_job}}",
+          "range": true,
+          "refId": "in_mempool_30s_max"
+        }
+      ],
+      "title": "Transactions In Mempool (30s Max)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "bytes",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 16,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(max_over_time(cardano_node_metrics_mempoolBytes_int{exported_job=~\"amaru-middle|amaru-downstream\"}[30s]), \"panel\", \"mempool_bytes_30s_max\", \"exported_job\", \".*\")",
+          "legendFormat": "{{panel}} {{exported_job}}",
+          "range": true,
+          "refId": "mempool_bytes_30s_max"
+        }
+      ],
+      "title": "Mempool Byte Size (30s Max)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "transactions",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 38,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(sum by (exported_job) (increase(cardano_node_metrics_txsProcessedNum_int{exported_job=~\"amaru-middle|amaru-downstream\"}[1m])), \"panel\", \"processed_1m\", \"exported_job\", \".*\")",
+          "legendFormat": "{{panel}} {{exported_job}}",
+          "range": true,
+          "refId": "processed_1m"
+        }
+      ],
+      "title": "Transactions Processed In Last Minute",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "transactions",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 38,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(sum by (exported_job) (increase(cardano_node_metrics_txsProcessedNum_int{exported_job=~\"amaru-middle|amaru-downstream\"}[15m])), \"panel\", \"processed_15m\", \"exported_job\", \".*\")",
+          "legendFormat": "{{panel}} {{exported_job}}",
+          "range": true,
+          "refId": "processed_15m"
+        }
+      ],
+      "title": "Transactions Processed In Last 15 Minutes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "milliseconds",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(cardano_node_metrics_txsSyncDuration_int{exported_job=~\"amaru-middle|amaru-downstream\"}, \"panel\", \"revalidation_ms\", \"exported_job\", \".*\")",
+          "legendFormat": "{{panel}} {{exported_job}}",
+          "range": true,
+          "refId": "revalidation_ms"
+        }
+      ],
+      "title": "Latest Mempool Revalidation Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "milliseconds",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(cardano_node_metrics_txsSyncDurationTotal_int{exported_job=~\"amaru-middle|amaru-downstream\"}, \"panel\", \"revalidation_total_ms\", \"exported_job\", \".*\")",
+          "legendFormat": "{{panel}} {{exported_job}}",
+          "range": true,
+          "refId": "revalidation_total_ms"
+        }
+      ],
+      "title": "Cumulative Mempool Revalidation Duration",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 41,
+  "tags": [
+    "amaru",
+    "relay-1",
+    "mempool"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Amaru Relay Mempool",
+  "uid": "amaru-relay-mempool",
+  "version": 1,
+  "weekStart": ""
+}

--- a/scripts/demos/relay-1/telemetry/docker-compose.yml
+++ b/scripts/demos/relay-1/telemetry/docker-compose.yml
@@ -1,0 +1,18 @@
+# Demo-specific telemetry overlay: provisions the relay-1 Grafana dashboards on top of the
+# shared monitoring stack. Selected via TELEMETRY_COMPOSE_OVERRIDE_FILE; host paths are
+# anchored on TELEMETRY_COMPOSE_OVERRIDE_DIR because docker compose resolves relative paths
+# against the first compose file's directory, not this one.
+services:
+  grafana:
+    volumes:
+      - "${TELEMETRY_COMPOSE_OVERRIDE_DIR}/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yaml"
+      - "${TELEMETRY_COMPOSE_OVERRIDE_DIR}/dashboards:/var/lib/grafana/dashboards"
+
+  # Keep service.name for this multi-node demo (see ./otlp-collector.yml). Docker Compose
+  # replaces the command list rather than appending, so this restates the collector configs
+  # contributed by the active TELEMETRY_PROFILES (TELEMETRY_COLLECTOR_CONFIGS, exported by
+  # telemetry_compose()) and adds the demo layer last.
+  otlp-collector:
+    volumes:
+      - "${TELEMETRY_COMPOSE_OVERRIDE_DIR}/otlp-collector.yml:/etc/otlp-collector-demo.yml"
+    command: "${TELEMETRY_COLLECTOR_CONFIGS} --config=/etc/otlp-collector-demo.yml"

--- a/scripts/demos/relay-1/telemetry/otlp-collector.yml
+++ b/scripts/demos/relay-1/telemetry/otlp-collector.yml
@@ -1,0 +1,12 @@
+# Demo-only collector override, layered as the last --config after the shared configs.
+#
+# The relay-1 demo runs two Amaru nodes (amaru-middle and amaru-downstream) and plots them
+# side by side on the same Grafana dashboard. That requires keeping service.name, which the
+# shared monitoring config drops to limit Prometheus label cardinality. Redefining the
+# processor here replaces its attribute list (collector configs merge by replacing lists),
+# so only the per-instance id is dropped and service.name survives as the exported_job label.
+processors:
+  resource/drop_prometheus_labels:
+    attributes:
+      - key: service.instance.id
+        action: delete

--- a/scripts/refresh-from-mithril
+++ b/scripts/refresh-from-mithril
@@ -156,9 +156,9 @@ prepare_latest_bootstrap_config() {
   jq -s '
     map({
       epoch,
-      point: ((.slot | tostring) + "." + .hash),
-      url: ((.archive_path // "") | tostring),
-      parent_point: (.parent_point.Specific | ((.[0] | tostring) + "." + .[1]))
+      point,
+      parent_point,
+      url: ((.archive_path // "") | tostring)
     })
   ' \
     "$metadata_dir/$BOOTSTRAP_START_EPOCH.json" \


### PR DESCRIPTION
This PR packages a few fixes after trying to run the `relay-1` demo in a fresh environment:

 - The `mithril-refresh` job can override the `db-analyzer` version to get around the issue mentioned in issue [#2061](https://github.com/IntersectMBO/ouroboros-consensus/pull/2061). I will simplify this when there's a new `db-analyser` release.
 - I have added a dashboard that shows metrics data for the mempool of the two `amaru` nodes of the demo.
 - I noticed that the console output shows redundant tags for events. Those tags are only necessary for filtering when sent to an OpenTelemetry collector so they are now filtered out.

no-changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic retrieval of official Cardano node configuration assets for supported networks.
  * Added support for a telemetry Docker Compose override file, layered collector configs, and a new relay mempool Grafana dashboard.
  * Split telemetry startup and browser-opening into separate demo processes/commands.
* **Bug Fixes**
  * Improved Mithril-based database initialization/refresh reliability and verified `db-analyser --analyse-from` behavior before refresh.
  * Corrected snapshot manifest point handling.
  * Hid internal tag fields from compact console trace output.
* **Documentation**
  * Updated demo READMEs with the database workaround, telemetry override variables, and revised relay demo workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->