### PR TITLE
scheduling messages within a pure-stage is reliable, update simulation accordingly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Other guiding principles:
 
 - **amaru**: no more `--force` flag on `node bootstrap`; if chain or ledger directories already exist, bootstrap aborts and asks the operator to remove them manually. ([#1062](https://github.com/pragma-org/amaru/pull/1062))
 
-
 ### Fixed
 
 - **amaru-ledger**: use effective collateral when collecting epoch fees for phase-2-invalid transactions. ([#1048][])
@@ -62,6 +61,7 @@ Other guiding principles:
 - **amaru**: bootstrap creates the chain DB at the current schema version instead of replaying migrations on an empty store (avoids a spurious migration warning). ([#1060](https://github.com/pragma-org/amaru/pull/1062))
 - **amaru-protocols**: delegate connection attempts to connector stage to avoid blocking the manager and allow up to 10 concurrent connections. ([#1058](https://github.com/pragma-org/amaru/pull/1058))
 - **amaru-consensus**: fix chainsync mini-protocol lifecycle handling in `track_peers` stage to properly clean up resources when stopping to sync from a peer. ([#1059](https://github.com/pragma-org/amaru/pull/1059))
+- **amaru-pure-stage**: simulation runtime now also guarantees delivery of scheduled messages; both runtimes enforce limit on priority messages in flight. ([#1066](https://github.com/pragma-org/amaru/pull/1066))
 
 ## [v10.11.20260716](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260716)
 

--- a/crates/amaru-pure-stage/README.md
+++ b/crates/amaru-pure-stage/README.md
@@ -7,6 +7,7 @@ Design goals:
 - executable on concurrent thread pool or using a deterministic simulator
 - fully back-pressured
 - ability for biased reading from inputs (which is necessary to avoid deadlocks with back-pressure)
+- scheduled self-messages (`schedule_at` / `schedule_after`) are control traffic: guaranteed delivery independent of bulk mailbox capacity, preferred over ordinary messages, with a configurable outstanding cap per stage (default `PRIORITY_MAILBOX_SIZE` = 10 via `with_priority_mailbox_size`; exceeding panics)
 - wiring code should be nicely readable
 
 ## Design elements

--- a/crates/amaru-pure-stage/src/effect.rs
+++ b/crates/amaru-pure-stage/src/effect.rs
@@ -232,12 +232,29 @@ impl<M> Effects<M> {
         )
     }
 
-    /// Schedule a message to be sent to the given stage at a specific instant in the future.
+    /// Schedule a message to be delivered to **this** stage at a specific instant in the future.
     ///
-    /// Returns a token that can be used to cancel the scheduled message using [`cancel_schedule`](Self::cancel_schedule).
+    /// Returns a token that can be used to cancel the scheduled message using
+    /// [`cancel_schedule`](Self::cancel_schedule).
     ///
-    /// The scheduled message will be sent at the specified `when` instant. If `when` is in the past,
-    /// the message will be sent immediately.
+    /// # Delivery guarantees
+    ///
+    /// Scheduled messages are **control traffic**: they do not compete with the stage's bulk
+    /// mailbox for capacity and are preferred over ordinary mailbox messages when both are
+    /// available. Unless cancelled or the stage terminates, a due scheduled message is
+    /// eventually presented as a normal transition input, even when the bulk mailbox is full.
+    ///
+    /// A stage may have only a limited number of undelivered scheduled messages outstanding
+    /// (armed timers plus due messages not yet received). The limit defaults to
+    /// [`PRIORITY_MAILBOX_SIZE`](crate::PRIORITY_MAILBOX_SIZE) and is configured per network via
+    /// the stage-graph builder (`with_priority_mailbox_size`). Exceeding that limit panics —
+    /// stages should coalesce control wakeups rather than arm many concurrent schedules.
+    ///
+    /// If `when` is in the past, the message is delivered as soon as the runtime can run this
+    /// stage again (still via the priority path, not the bulk mailbox).
+    ///
+    /// Ordering among due schedules is by [`ScheduleId`](crate::ScheduleId) (time, then sequence).
+    /// The schedule effect itself never waits on mailbox space.
     pub fn schedule_at(&self, msg: M, when: Instant) -> BoxFuture<'static, ScheduleId>
     where
         M: SendData,
@@ -249,11 +266,10 @@ impl<M> Effects<M> {
         })
     }
 
-    /// Schedule a message to be sent to the given stage after a delay.
+    /// Schedule a message to be delivered to **this** stage after a delay.
     ///
-    /// Returns a token that can be used to cancel the scheduled message using [`cancel_schedule`](Self::cancel_schedule).
-    ///
-    /// The scheduled message will be sent after the specified `delay` duration from now.
+    /// Equivalent to [`schedule_at`](Self::schedule_at) with `now + delay`. See that method for
+    /// delivery guarantees, priority over the bulk mailbox, and the outstanding-schedule cap.
     pub fn schedule_after(&self, msg: M, delay: Duration) -> BoxFuture<'static, ScheduleId>
     where
         M: SendData,
@@ -266,7 +282,9 @@ impl<M> Effects<M> {
     /// Cancel a previously scheduled message.
     ///
     /// Returns `true` if the scheduled message was found and cancelled, or `false` if it was
-    /// not found (e.g., it was already sent or already cancelled).
+    /// not found (e.g., it was already delivered into the stage's receive path or already
+    /// cancelled). Cancelling frees a slot under the stage's configured priority-mailbox
+    /// outstanding budget (default [`PRIORITY_MAILBOX_SIZE`](crate::PRIORITY_MAILBOX_SIZE)).
     pub fn cancel_schedule(&self, id: ScheduleId) -> BoxFuture<'static, bool> {
         airlock_effect(&self.effect, StageEffect::CancelSchedule(id), |eff| match eff {
             Some(StageResponse::CancelScheduleResponse(cancelled)) => Some(cancelled),

--- a/crates/amaru-pure-stage/src/lib.rs
+++ b/crates/amaru-pure-stage/src/lib.rs
@@ -53,5 +53,7 @@ pub use trace_match::{
     TraceMatch, assert_trace_contains, assert_trace_does_not_contain, assert_trace_match, tm_add_stage,
     tm_external_effect, tm_external_effect_match, tm_input, tm_send, tm_state, tm_terminate, tm_terminated,
 };
-pub use types::{BLACKHOLE_NAME, BoxFuture, Name, OrTerminateWith, SendData, TryInStage, Void, err, warn};
+pub use types::{
+    BLACKHOLE_NAME, BoxFuture, Name, OrTerminateWith, PRIORITY_MAILBOX_SIZE, SendData, TryInStage, Void, err, warn,
+};
 pub use typetag;

--- a/crates/amaru-pure-stage/src/simulation/replay.rs
+++ b/crates/amaru-pure-stage/src/simulation/replay.rs
@@ -236,11 +236,13 @@ impl Replay {
                     StageData {
                         name: name.clone(),
                         mailbox: VecDeque::new(),
+                        priority: VecDeque::new(),
                         tombstones: VecDeque::new(),
                         state: StageState::Idle(initial_state),
                         transition,
                         waiting: Some(StageEffect::Receive),
                         senders: VecDeque::new(),
+                        scheduled_pending: 0,
                         supervised_by: at_stage,
                         tombstone,
                     },

--- a/crates/amaru-pure-stage/src/simulation/running/mod.rs
+++ b/crates/amaru-pure-stage/src/simulation/running/mod.rs
@@ -81,6 +81,7 @@ pub struct SimulationRunning {
     runnable: VecDeque<(Name, StageResponse)>,
     scheduled: ScheduledRunnables,
     mailbox_size: usize,
+    priority_mailbox_size: usize,
     overrides: Vec<OverrideExternalEffect>,
     breakpoints: Vec<(Name, Box<dyn Fn(&Effect) -> bool + Send + 'static>)>,
     schedule_ids: ScheduleIds,
@@ -106,6 +107,7 @@ impl SimulationRunning {
         clock: Arc<dyn Clock + Send + Sync>,
         resources: Resources,
         mailbox_size: usize,
+        priority_mailbox_size: usize,
         schedule_ids: ScheduleIds,
         trace_buffer: Arc<Mutex<TraceBuffer>>,
         eval_strategy: Box<dyn EvalStrategy>,
@@ -123,6 +125,7 @@ impl SimulationRunning {
             runnable: VecDeque::new(),
             scheduled: ScheduledRunnables::new(),
             mailbox_size,
+            priority_mailbox_size,
             overrides: Vec::new(),
             breakpoints: Vec::new(),
             schedule_ids,
@@ -741,19 +744,24 @@ impl SimulationRunning {
             Effect::Schedule { at_stage, msg, id } => {
                 let data =
                     self.stages.get_mut(&at_stage).log_termination(&at_stage)?.assert_stage("which cannot schedule");
+                let limit = self.priority_mailbox_size;
+                if data.scheduled_pending >= limit {
+                    panic!(
+                        "stage `{}` exceeded priority mailbox size ({limit}): too many outstanding scheduled messages",
+                        data.name
+                    );
+                }
+                data.scheduled_pending += 1;
                 resume_schedule_internal(data, run, id).expect("schedule effect is always runnable");
-                // Now schedule the wakeup (after run is dropped)
                 let now = self.clock.now(self.global_epoch_offset);
                 if id.time() > now {
-                    // Schedule wakeup
                     self.schedule_wakeup(id, {
                         move |sim| {
-                            let _ = deliver_message(&mut sim.stages, sim.mailbox_size, at_stage, msg);
+                            deliver_priority(sim, at_stage, msg);
                         }
                     });
                 } else {
-                    // Send immediately
-                    let _ = deliver_message(&mut self.stages, self.mailbox_size, at_stage, msg);
+                    deliver_priority(self, at_stage, msg);
                 }
             }
             Effect::CancelSchedule { at_stage, id } => {
@@ -763,6 +771,9 @@ impl SimulationRunning {
                     .get_mut(&at_stage)
                     .log_termination(&at_stage)?
                     .assert_stage("which cannot cancel schedule");
+                if cancelled {
+                    data.scheduled_pending = data.scheduled_pending.saturating_sub(1);
+                }
                 resume_cancel_schedule_internal(data, run, cancelled)
                     .expect("cancel_schedule effect is always runnable");
             }
@@ -853,11 +864,13 @@ impl SimulationRunning {
                         StageOrAdapter::Stage(StageData {
                             name,
                             mailbox: VecDeque::new(),
+                            priority: VecDeque::new(),
                             tombstones: VecDeque::new(),
                             state: StageState::Idle(initial_state),
                             transition: (transition)(self.effect.clone()),
                             waiting: Some(StageEffect::Receive),
                             senders: VecDeque::new(),
+                            scheduled_pending: 0,
                             supervised_by: at_stage,
                             tombstone,
                         }),
@@ -1190,11 +1203,13 @@ impl SimulationRunning {
                 StageOrAdapter::Stage(StageData {
                     name,
                     mailbox: VecDeque::new(),
+                    priority: VecDeque::new(),
                     tombstones: VecDeque::new(),
                     state: StageState::Idle(initial_state),
                     transition: (transition)(self.effect.clone()),
                     waiting: Some(StageEffect::Receive),
                     senders: VecDeque::new(),
+                    scheduled_pending: 0,
                     supervised_by: at_stage.name().clone(),
                     tombstone,
                 }),
@@ -1504,6 +1519,26 @@ fn post_message(data: &mut StageData, mailbox_size: usize, msg: Box<dyn SendData
     }
     data.mailbox.push_back(msg);
     DeliverMessageResult::Delivered(data)
+}
+
+/// Deliver a due self-scheduled message into the stage's priority ingress.
+///
+/// Priority messages never compete with the bulk mailbox. The outstanding budget was
+/// already reserved when the schedule effect ran (`scheduled_pending`).
+fn deliver_priority(sim: &mut SimulationRunning, at_stage: Name, msg: Box<dyn SendData>) {
+    let limit = sim.priority_mailbox_size;
+    let Some(data) = sim.stages.get_mut(&at_stage) else {
+        tracing::warn!(name = %at_stage, "stage was terminated, skipping scheduled message delivery");
+        return;
+    };
+    let data = data.assert_stage("which cannot receive scheduled messages");
+    if data.priority.len() >= limit {
+        panic!("stage `{}` exceeded priority mailbox size ({limit}): too many due scheduled messages", data.name);
+    }
+    data.priority.push_back(msg);
+    let name = data.name.clone();
+    // Stage may already be waiting on Receive; wake it so the priority message is not stuck.
+    let _ = resume_receive_internal(sim, &name);
 }
 
 #[test]

--- a/crates/amaru-pure-stage/src/simulation/running/resume.rs
+++ b/crates/amaru-pure-stage/src/simulation/running/resume.rs
@@ -71,10 +71,16 @@ pub fn resume_receive_internal(simulation: &mut SimulationRunning, at_stage: &Na
             return Ok(false);
         }
         None => {
-            let Some(msg) = data.mailbox.pop_front() else {
-                return Ok(false);
-            };
-            msg
+            // Prefer due self-scheduled (priority) messages over bulk mailbox traffic.
+            if let Some(msg) = data.priority.pop_front() {
+                data.scheduled_pending = data.scheduled_pending.saturating_sub(1);
+                msg
+            } else {
+                let Some(msg) = data.mailbox.pop_front() else {
+                    return Ok(false);
+                };
+                msg
+            }
         }
     };
 

--- a/crates/amaru-pure-stage/src/simulation/simulation_builder.rs
+++ b/crates/amaru-pure-stage/src/simulation/simulation_builder.rs
@@ -137,7 +137,7 @@ impl SimulationBuilder {
 
     /// Set the maximum number of undelivered self-scheduled messages allowed per stage.
     ///
-    /// Defaults to [`PRIORITY_MAILBOX_SIZE`](crate::PRIORITY_MAILBOX_SIZE). Exceeding the limit
+    /// Defaults to [`PRIORITY_MAILBOX_SIZE`]. Exceeding the limit
     /// panics so schedule storms fail loudly.
     pub fn with_priority_mailbox_size(mut self, size: usize) -> Self {
         self.priority_mailbox_size = size;

--- a/crates/amaru-pure-stage/src/simulation/simulation_builder.rs
+++ b/crates/amaru-pure-stage/src/simulation/simulation_builder.rs
@@ -49,8 +49,8 @@ use rand::{SeedableRng, prelude::StdRng};
 use tokio::runtime::Builder;
 
 use crate::{
-    BLACKHOLE_NAME, Clock, EPOCH, Instant, Name, Resources, ScheduleIds, SendData, Sender, StageBuildRef, StageGraph,
-    StageRef,
+    BLACKHOLE_NAME, Clock, EPOCH, Instant, Name, PRIORITY_MAILBOX_SIZE, Resources, ScheduleIds, SendData, Sender,
+    StageBuildRef, StageGraph, StageRef,
     adapter::{Adapter, StageOrAdapter, find_recipient},
     effect::{Effects, StageEffect},
     effect_box::EffectBox,
@@ -123,6 +123,7 @@ pub struct SimulationBuilder {
     resources: Resources,
     schedule_ids: ScheduleIds,
     mailbox_size: usize,
+    priority_mailbox_size: usize,
     inputs: Inputs,
     trace_buffer: Arc<Mutex<TraceBuffer>>,
     eval_strategy: Box<dyn EvalStrategy>,
@@ -131,6 +132,15 @@ pub struct SimulationBuilder {
 impl SimulationBuilder {
     pub fn with_mailbox_size(mut self, size: usize) -> Self {
         self.mailbox_size = size;
+        self
+    }
+
+    /// Set the maximum number of undelivered self-scheduled messages allowed per stage.
+    ///
+    /// Defaults to [`PRIORITY_MAILBOX_SIZE`](crate::PRIORITY_MAILBOX_SIZE). Exceeding the limit
+    /// panics so schedule storms fail loudly.
+    pub fn with_priority_mailbox_size(mut self, size: usize) -> Self {
+        self.priority_mailbox_size = size;
         self
     }
 
@@ -190,11 +200,13 @@ impl SimulationBuilder {
                     StageData {
                         name,
                         mailbox: data.mailbox,
+                        priority: VecDeque::new(),
                         tombstones: VecDeque::new(),
                         state,
                         transition: data.transition,
                         waiting: Some(StageEffect::Receive),
                         senders: VecDeque::new(),
+                        scheduled_pending: 0,
                         supervised_by: BLACKHOLE_NAME.clone(),
                         tombstone: None,
                     },
@@ -213,6 +225,7 @@ impl SimulationBuilder {
             global_epoch_offset,
             resources,
             mailbox_size,
+            priority_mailbox_size,
             inputs,
             schedule_ids,
             trace_buffer,
@@ -242,11 +255,13 @@ impl SimulationBuilder {
             let data = StageOrAdapter::Stage(StageData {
                 name: name.clone(),
                 mailbox,
+                priority: VecDeque::new(),
                 tombstones: VecDeque::new(),
                 state,
                 transition,
                 waiting: Some(StageEffect::Receive),
                 senders: VecDeque::new(),
+                scheduled_pending: 0,
                 supervised_by: BLACKHOLE_NAME.clone(),
                 tombstone: None,
             });
@@ -259,6 +274,7 @@ impl SimulationBuilder {
             clock,
             resources,
             mailbox_size,
+            priority_mailbox_size,
             schedule_ids,
             trace_buffer,
             eval_strategy,
@@ -279,6 +295,7 @@ impl Default for SimulationBuilder {
             global_epoch_offset: Duration::ZERO,
             resources: Resources::default(),
             mailbox_size: 10,
+            priority_mailbox_size: PRIORITY_MAILBOX_SIZE,
             inputs: Inputs::new(10),
             schedule_ids: ScheduleIds::new(),
             // default is a TraceBuffer that drops all messages

--- a/crates/amaru-pure-stage/src/simulation/state.rs
+++ b/crates/amaru-pure-stage/src/simulation/state.rs
@@ -63,12 +63,20 @@ impl fmt::Debug for StageState {
 
 pub(crate) struct StageData {
     pub name: Name,
+    /// Bounded bulk ingress (subject to `mailbox_size` and back-pressure).
     pub mailbox: VecDeque<Box<dyn SendData>>,
+    /// Due self-scheduled messages, preferred over [`Self::mailbox`] on receive.
+    /// Capacity is governed by the network's configured `priority_mailbox_size` together with
+    /// armed timers via [`Self::scheduled_pending`].
+    pub priority: VecDeque<Box<dyn SendData>>,
     pub tombstones: VecDeque<Result<Box<dyn SendData>, Name>>,
     pub state: StageState,
     pub waiting: Option<StageEffect<()>>,
     pub transition: Transition,
     pub senders: VecDeque<(Name, Box<dyn SendData>)>,
+    /// Armed schedules not yet consumed by receive (including due entries still in
+    /// [`Self::priority`]). Must stay ≤ the network's configured `priority_mailbox_size`.
+    pub scheduled_pending: usize,
     pub supervised_by: Name,
     pub tombstone: Option<Box<dyn SendData>>,
 }

--- a/crates/amaru-pure-stage/src/tokio.rs
+++ b/crates/amaru-pure-stage/src/tokio.rs
@@ -165,7 +165,7 @@ impl TokioBuilder {
 
     /// Set the maximum number of undelivered self-scheduled messages allowed per stage.
     ///
-    /// Defaults to [`PRIORITY_MAILBOX_SIZE`](crate::PRIORITY_MAILBOX_SIZE). Exceeding the limit
+    /// Defaults to [`PRIORITY_MAILBOX_SIZE`]. Exceeding the limit
     /// panics so schedule storms fail loudly.
     pub fn with_priority_mailbox_size(mut self, size: usize) -> Self {
         self.inner.priority_mailbox_size = size;

--- a/crates/amaru-pure-stage/src/tokio.rs
+++ b/crates/amaru-pure-stage/src/tokio.rs
@@ -41,7 +41,8 @@ use tokio::{
 use tracing::trace_span;
 
 use crate::{
-    BoxFuture, Effects, Instant, Name, ScheduleId, ScheduleIds, SendData, Sender, StageBuildRef, StageGraph, StageRef,
+    BoxFuture, Effects, Instant, Name, PRIORITY_MAILBOX_SIZE, ScheduleId, ScheduleIds, SendData, Sender, StageBuildRef,
+    StageGraph, StageRef,
     adapter::{Adapter, StageOrAdapter, find_recipient},
     drop_guard::DropGuard,
     effect::{CallExtra, CallTimeout, CanSupervise, StageEffect, StageResponse, TransitionFactory},
@@ -71,6 +72,7 @@ struct TokioInner {
     resources: Resources,
     schedule_ids: ScheduleIds,
     mailbox_size: usize,
+    priority_mailbox_size: usize,
     stage_counter: Mutex<usize>,
     trace_buffer: Arc<Mutex<TraceBuffer>>,
 }
@@ -85,6 +87,7 @@ impl TokioInner {
             resources: Resources::default(),
             schedule_ids: ScheduleIds::default(),
             mailbox_size: 10,
+            priority_mailbox_size: PRIORITY_MAILBOX_SIZE,
             stage_counter: Mutex::new(0usize),
             trace_buffer: TraceBuffer::new_shared(0, 0),
         }
@@ -157,6 +160,15 @@ impl TokioBuilder {
 
     pub fn with_global_epoch_offset(mut self, offset: Duration) -> Self {
         self.inner.global_epoch_offset = offset;
+        self
+    }
+
+    /// Set the maximum number of undelivered self-scheduled messages allowed per stage.
+    ///
+    /// Defaults to [`PRIORITY_MAILBOX_SIZE`](crate::PRIORITY_MAILBOX_SIZE). Exceeding the limit
+    /// panics so schedule storms fail loudly.
+    pub fn with_priority_mailbox_size(mut self, size: usize) -> Self {
+        self.inner.priority_mailbox_size = size;
         self
     }
 }
@@ -262,6 +274,7 @@ impl StageGraph for TokioBuilder {
 }
 
 enum PriorityMessage {
+    /// Due self-scheduled message; bypasses the bulk mpsc mailbox.
     Scheduled(Box<dyn SendData>, ScheduleId, watch::Receiver<bool>),
     TimerCancelled(ScheduleId),
     Tombstone(Box<dyn SendData>),
@@ -283,6 +296,8 @@ async fn run_stage_boxed(
     // will terminate those spawned stages
     let mut timers = FuturesUnordered::<BoxFuture<'static, PriorityMessage>>::new();
     let mut cancel_senders = BTreeMap::<ScheduleId, watch::Sender<bool>>::new();
+    // Armed schedules not yet consumed by receive (matches simulation `scheduled_pending`).
+    let mut scheduled_pending: usize = 0;
 
     let tb = DropGuard::new(inner.trace_buffer.clone(), |tb| {
         // ensure that Aborted is traced when this Future is dropped
@@ -298,6 +313,7 @@ async fn run_stage_boxed(
         // if multiple timers have fired since the last poll, we need them all so that we can deliver them in order
         let mut timer_chunks = (&mut timers).ready_chunks(1000);
 
+        // Prefer due scheduled (priority) messages over bulk mailbox traffic.
         tokio::select! { biased;
             Some(res) = timer_chunks.next(), if poll_timers => {
                 let mut scheduled = Vec::new();
@@ -306,7 +322,10 @@ async fn run_stage_boxed(
                         PriorityMessage::Scheduled(msg, id, cancelation) => {
                             scheduled.push((id, msg, cancelation));
                         }
-                        PriorityMessage::TimerCancelled(_id) => {}
+                        PriorityMessage::TimerCancelled(_id) => {
+                            // Cancel won before the timer fired; free the outstanding budget.
+                            scheduled_pending = scheduled_pending.saturating_sub(1);
+                        }
                         PriorityMessage::Tombstone(msg) => msgs.push((msg, None)),
                     }
                 }
@@ -326,6 +345,7 @@ async fn run_stage_boxed(
         for (msg, cancelation) in msgs.drain(..) {
             if let Some((id, canceled)) = cancelation {
                 cancel_senders.remove(&id);
+                scheduled_pending = scheduled_pending.saturating_sub(1);
                 if *canceled.borrow() {
                     // cancellation happened after the timer fired but before the message was delivered
                     continue;
@@ -341,7 +361,9 @@ async fn run_stage_boxed(
             inner.trace_buffer.lock().push_input(&stage_name, &msg);
 
             let f = (transition)(state, msg);
-            let result = interpreter(&inner, &effect, &stage_name, &mut timers, &mut cancel_senders, f).await;
+            let result =
+                interpreter(&inner, &effect, &stage_name, &mut timers, &mut cancel_senders, &mut scheduled_pending, f)
+                    .await;
             match result {
                 Some(st) => state = st,
                 None => {
@@ -381,6 +403,7 @@ fn interpreter(
     name: &Name,
     timers: &mut FuturesUnordered<BoxFuture<'static, PriorityMessage>>,
     cancel_senders: &mut BTreeMap<ScheduleId, watch::Sender<bool>>,
+    scheduled_pending: &mut usize,
     mut stage: BoxFuture<'static, Box<dyn SendData>>,
 ) -> impl Future<Output = Option<Box<dyn SendData>>> + Send {
     // trying to write this as an async fn fails with inscrutable compile errors, it seems
@@ -511,10 +534,19 @@ fn interpreter(
                     StageResponse::ContramapResponse(name)
                 }
                 StageEffect::Schedule(msg, id) => {
+                    let limit = inner.priority_mailbox_size;
+                    #[expect(clippy::panic)]
+                    if *scheduled_pending >= limit {
+                        panic!(
+                            "stage `{name}` exceeded priority mailbox size ({limit}): too many outstanding scheduled messages"
+                        );
+                    }
+                    *scheduled_pending += 1;
                     let when = id.time();
                     let sleep = tokio::time::sleep_until(when.to_tokio());
                     let (tx, mut rx) = watch::channel(false);
                     cancel_senders.insert(id, tx);
+                    // Priority path: timers bypass the bounded mpsc bulk mailbox.
                     timers.push(Box::pin(async move {
                         let rx2 = rx.clone();
                         tokio::select! { biased;
@@ -527,6 +559,8 @@ fn interpreter(
                 StageEffect::CancelSchedule(id) => {
                     if let Some(tx) = cancel_senders.remove(&id) {
                         tx.send_replace(true);
+                        // Budget is released when TimerCancelled is observed (or when a
+                        // late-fired Scheduled is discarded after cancel).
                         StageResponse::CancelScheduleResponse(true)
                     } else {
                         StageResponse::CancelScheduleResponse(false)

--- a/crates/amaru-pure-stage/src/types.rs
+++ b/crates/amaru-pure-stage/src/types.rs
@@ -33,6 +33,15 @@ use crate::{
 
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
+/// Default maximum number of undelivered self-scheduled messages a stage may have outstanding.
+///
+/// This is the default for both [`SimulationBuilder::with_priority_mailbox_size`](crate::simulation::SimulationBuilder::with_priority_mailbox_size)
+/// and [`TokioBuilder::with_priority_mailbox_size`](crate::tokio::TokioBuilder::with_priority_mailbox_size).
+/// The bound covers armed timers that have not yet fired and due messages waiting in the
+/// stage's priority ingress. Exceeding the configured limit panics (schedule storms are a
+/// programming error and must fail loudly).
+pub const PRIORITY_MAILBOX_SIZE: usize = 10;
+
 /// Type constraint for messages, which must be self-contained and have a `Debug` instance.
 ///
 /// It is not possible to require an implementation of `PartialEq<Box<dyn Message>>`, but it

--- a/crates/amaru-pure-stage/tests/simulation.rs
+++ b/crates/amaru-pure-stage/tests/simulation.rs
@@ -24,8 +24,8 @@ use std::{
 };
 
 use amaru_pure_stage::{
-    Effect, ExternalEffect, Instant, Name, OrTerminateWith, OutputEffect, Receiver, Resources, SendData, StageGraph,
-    StageGraphRunning, StageRef, StageResponse, UnknownExternalEffect,
+    Effect, ExternalEffect, Instant, Name, OrTerminateWith, OutputEffect, PRIORITY_MAILBOX_SIZE, Receiver, Resources,
+    ScheduleId, SendData, StageGraph, StageGraphRunning, StageRef, StageResponse, UnknownExternalEffect,
     serde::SendDataValue,
     simulation::{RandStdRng, SimulationBuilder, running::OverrideResult},
     trace_buffer::{TraceBuffer, TraceEntry},
@@ -285,6 +285,118 @@ fn backpressure() {
     running.run_until_blocked().assert_idle();
 
     assert_eq!(*running.get_state(&pressure).unwrap(), 7);
+}
+
+/// Self-scheduled messages are delivered via the priority path even when the bulk mailbox is full,
+/// and are preferred over bulk messages when both are pending.
+#[test]
+fn schedule_delivered_despite_full_bulk_mailbox() {
+    tracing_subscriber::fmt().with_test_writer().with_env_filter(EnvFilter::from_default_env()).try_init().ok();
+
+    let mut network = SimulationBuilder::default().with_mailbox_size(1);
+
+    let stage = network.stage("stage", async |mut state: Vec<u32>, msg: u32, eff| {
+        if msg == 0 {
+            // Schedule control message immediately, then suspend so bulk can fill the mailbox.
+            eff.schedule_after(99, Duration::ZERO).await;
+            eff.clock().await;
+        }
+        state.push(msg);
+        state
+    });
+    let stage = network.wire_up(stage, Vec::<u32>::new());
+    let mut running = network.run();
+
+    running.enqueue_msg(&stage, [0u32]);
+    running.breakpoint("clock", {
+        let stage = stage.clone();
+        move |eff| matches!(eff, Effect::Clock { at_stage } if at_stage == stage.name())
+    });
+
+    // Run until schedule is registered and clock is hit; due schedule may already be in priority.
+    let clock_eff = running.run_until_blocked().assert_breakpoint("clock");
+
+    // Fill bulk mailbox while stage is suspended on clock.
+    running.enqueue_msg(&stage, [1u32]);
+    assert_eq!(running.mailbox_len(&stage), 1);
+
+    // Resume clock; stage finishes msg 0. Next receives must prefer priority (99) over bulk (1).
+    running.clear_breakpoint("clock");
+    running.handle_effect(clock_eff);
+    running.run_until_blocked().assert_idle();
+
+    let state = running.get_state(&stage).unwrap();
+    assert!(state.contains(&99), "scheduled control message must be delivered: {state:?}");
+    assert!(state.contains(&1), "bulk message must still be delivered: {state:?}");
+    // Control (priority) before remaining bulk.
+    let pos_ctrl = state.iter().position(|m| *m == 99).unwrap();
+    let pos_bulk = state.iter().position(|m| *m == 1).unwrap();
+    assert!(pos_ctrl < pos_bulk, "priority message must precede bulk: {state:?}");
+}
+
+#[test]
+fn schedule_cap_panics_at_limit_plus_one() {
+    tracing_subscriber::fmt().with_test_writer().with_env_filter(EnvFilter::from_default_env()).try_init().ok();
+
+    // Use an explicit limit (not the default) so the test documents configurability.
+    const LIMIT: usize = 3;
+    let mut network = SimulationBuilder::default().with_priority_mailbox_size(LIMIT);
+    let stage = network.stage("stage", async |state: (), msg: u32, eff| {
+        if msg == 0 {
+            for i in 0..=LIMIT as u32 {
+                // Future schedules so they stay outstanding without being received.
+                eff.schedule_after(i + 1, Duration::from_secs(10)).await;
+            }
+        }
+        state
+    });
+    let stage = network.wire_up(stage, ());
+    let mut running = network.run();
+
+    running.enqueue_msg(&stage, [0u32]);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        running.run_until_blocked();
+    }));
+    assert!(result.is_err(), "expected panic when exceeding configured priority mailbox size");
+}
+
+#[test]
+fn cancel_schedule_frees_priority_slot() {
+    tracing_subscriber::fmt().with_test_writer().with_env_filter(EnvFilter::from_default_env()).try_init().ok();
+
+    let mut network = SimulationBuilder::default().with_priority_mailbox_size(PRIORITY_MAILBOX_SIZE);
+    let stage = network.stage("stage", async |state: Option<ScheduleId>, msg: u32, eff| {
+        match msg {
+            0 => {
+                let mut last = None;
+                for i in 0..PRIORITY_MAILBOX_SIZE as u32 {
+                    // Far-future so they stay armed until we cancel (do not auto-advance into them).
+                    last = Some(eff.schedule_after(100 + i, Duration::from_secs(10)).await);
+                }
+                last
+            }
+            1 => {
+                let id = state.expect("id from previous message");
+                assert!(eff.cancel_schedule(id).await);
+                // Slot freed: one more schedule must succeed without exceeding the cap.
+                eff.schedule_after(200, Duration::from_secs(10)).await;
+                None
+            }
+            _ => state,
+        }
+    });
+    let stage = network.wire_up(stage, None);
+    let mut running = network.run();
+
+    running.enqueue_msg(&stage, [0u32]);
+    // Stop at Sleeping so far-future schedules are not delivered yet.
+    running.run_until_sleeping_or_blocked().assert_sleeping();
+    assert!(running.get_state(&stage).unwrap().is_some());
+
+    running.enqueue_msg(&stage, [1u32]);
+    running.run_until_sleeping_or_blocked().assert_sleeping();
+    // No panic and state cleared after successful cancel+reschedule.
+    assert!(running.get_state(&stage).unwrap().is_none());
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
This guarantee was already present in the Tokio runtime, this PR adds it for simulation and
documents it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled self-messages now flow through a priority delivery path, ensuring timely delivery even when bulk mailbox capacity is constrained.
  * Introduced `PRIORITY_MAILBOX_SIZE` (default: 10) to cap outstanding scheduled messages per stage.
  * Added `with_priority_mailbox_size(...)` configuration for both simulation and Tokio execution.
  * Canceling a scheduled message releases its reserved capacity.

* **Documentation**
  * Expanded scheduling API docs and Pure Stage README to clarify guarantees, ordering, cancellation, and cap/panic behavior.

* **Tests**
  * Added coverage for priority precedence, cap enforcement (panic), and cancellation freeing capacity.

* **Chores**
  * Cleaned up unreleased changelog formatting and updated runtime notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->