### PR TITLE
fix: do not export otel values

### DIFF
--- a/monitoring/otlp-collector.yml
+++ b/monitoring/otlp-collector.yml
@@ -20,6 +20,7 @@ exporters:
   prometheus:
     endpoint: "0.0.0.0:8889"
     add_metric_suffixes: false
+    without_scope_info: true
 
 service:
   pipelines:


### PR DESCRIPTION
Make sure prometheus only exports what is expected. `gliveview` breaks otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Prometheus metrics export to omit scope information, improving compatibility and simplifying exported metric data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->