### PR TITLE
chore: better make target name

### DIFF
--- a/.github/actions/bootstrap-db/action.yml
+++ b/.github/actions/bootstrap-db/action.yml
@@ -46,7 +46,7 @@ runs:
         if [[ -z "${AMARU_EPOCH}" ]]; then
           unset AMARU_EPOCH
         fi
-        make bootstrap
+        cargo run --profile test -- bootstrap
 
     - name: Save bootstrap DBs to cache
       if: steps.cache-restore.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main'

--- a/.github/actions/bootstrap-db/action.yml
+++ b/.github/actions/bootstrap-db/action.yml
@@ -46,7 +46,7 @@ runs:
         if [[ -z "${AMARU_EPOCH}" ]]; then
           unset AMARU_EPOCH
         fi
-        cargo run --profile test -- bootstrap
+        cargo run --profile test -- node bootstrap
 
     - name: Save bootstrap DBs to cache
       if: steps.cache-restore.outputs.cache-hit != 'true' && github.ref == 'refs/heads/main'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,14 +11,14 @@ This file provides instructions for agentic coding tools (e.g. opencode, Cursor 
 - `cargo fmt-amaru`: `fmt --all -- --check`
 - Use nightly toolchain: `nightly-2026-04-17` (see rust-toolchain.toml)
 
-### Makefile Targets (preferred for consistency)
+### Common Commands
 
-- `make build`: Build in release profile
-- `make start`: Build and run with defaults (uses AMARU_NETWORK=preprod)
+- `cargo build --release`: Build in release profile
+- `cargo run --release -- run`: Build and run with defaults
 - `make all-ci-checks`: Runs fmt, clippy, tests, examples, coverage
-- `make test-e2e`: End-to-end snapshot tests (`cargo test -p amaru -- --ignored`)
-- `make coverage-html`: Generate HTML coverage report (requires cargo-llvm-cov)
-- `make coverage-lconv`: LCOV for Codecov
+- `cargo test --release -p amaru -- --ignored`: End-to-end snapshot tests
+- `make coverage-html`: Generate HTML coverage (requires cargo-llvm-cov)
+- `make coverage-lconv`: Generate LCOV for Codecov
 
 ### Testing Commands
 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ else
 TRACE_SUMMARY_OUTPUT_ENABLED := 0
 endif
 
-.PHONY: help bootstrap create-snapshots publish-bootstrap-snapshots start download-haskell-config coverage-html coverage-lconv check-llvm-cov check-rust-toolchain-version dev generate-traces-doc run-until compare-trace-contract update-trace-contract generate-traces-doc serve-traces-doc validate-trace-schemas clean-dist cli-assets dist tarball zip zipball homebrew nix-flake winget deb rpm msi check-zip check-cargo-deb check-cargo-generate-rpm check-cargo-wix sync-from-mithril refresh
+.PHONY: help bootstrap create-snapshots publish-bootstrap-snapshots start download-haskell-config coverage-html coverage-lconv check-llvm-cov check-rust-toolchain-version run generate-traces-doc run-until compare-trace-contract update-trace-contract generate-traces-doc serve-traces-doc validate-trace-schemas clean-dist cli-assets dist tarball zip zipball homebrew nix-flake winget deb rpm msi check-zip check-cargo-deb check-cargo-generate-rpm check-cargo-wix sync-from-mithril refresh
 
 help:
 	@echo "\033[1;4mGetting Started:\033[00m"
@@ -149,8 +149,8 @@ validate-trace-schemas: ## &test Validate generated trace schemas against docs/t
 		exit 1; \
 	fi
 
-dev: start # 'backward-compatibility'; might remove after a while.
-start: ## &build Compile and run for $BUILD_PROFILE with default options
+start: run # 'backward-compatibility'; might remove after a while.
+run: ## &build Compile and run for $BUILD_PROFILE with default options
 	cargo run --profile $(BUILD_PROFILE) -- $(COMMON_ARGS) run $(ARGS)
 
 run-until: ## &test Synchronize Amaru until a target epoch $RUN_UNTIL_TARGET_EPOCH

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 export AMARU_NETWORK ?= preprod
 export AMARU_PEER_ADDRESS ?= 127.0.0.1:3001
 AWS_DEFAULT_REGION ?= auto
-BOOTSTRAP_TARGET_EPOCH ?=
 BOOTSTRAP_SNAPSHOT_EPOCH ?=
 BUCKET_NAME ?=
 ENDPOINT ?=
@@ -56,7 +55,7 @@ else
 TRACE_SUMMARY_OUTPUT_ENABLED := 0
 endif
 
-.PHONY: help bootstrap create-snapshots publish-bootstrap-snapshots start download-haskell-config coverage-html coverage-lconv check-llvm-cov check-rust-toolchain-version run generate-traces-doc run-until compare-trace-contract update-trace-contract generate-traces-doc serve-traces-doc validate-trace-schemas clean-dist cli-assets dist tarball zip zipball homebrew nix-flake winget deb rpm msi check-zip check-cargo-deb check-cargo-generate-rpm check-cargo-wix sync-from-mithril refresh
+.PHONY: help publish-bootstrap-snapshots download-haskell-config coverage-html coverage-lconv check-llvm-cov check-rust-toolchain-version generate-traces-doc run-until compare-trace-contract update-trace-contract generate-traces-doc serve-traces-doc validate-trace-schemas clean-dist cli-assets dist tarball zip zipball homebrew nix-flake winget deb rpm msi check-zip check-cargo-deb check-cargo-generate-rpm check-cargo-wix sync-from-mithril refresh
 
 help:
 	@echo "\033[1;4mGetting Started:\033[00m"
@@ -73,12 +72,6 @@ help:
 	@echo ""
 	@echo "\033[1;4mConfiguration:\033[00m"
 	@grep -E '^[a-zA-Z0-9_]+ \?= '  Makefile | sort | while read -r l; do printf "  \033[36m%s\033[00m=%s\n" "$$(echo $$l | cut -f 1 -d'=')" "$$(echo $$l | cut -f 2- -d'=')"; done
-
-bootstrap: ## &start Bootstrap Amaru from scratch (snapshots + headers + ledger-state + nonces)
-	cargo run --profile $(BUILD_PROFILE) -- $(COMMON_ARGS) bootstrap $(ARGS)
-
-create-snapshots: ## &start Create a three-epoch bootstrap snapshots (set BOOTSTRAP_TARGET_EPOCH to override auto epoch)
-	cargo run --profile $(BUILD_PROFILE) -- $(COMMON_ARGS) create-snapshots $(if $(BOOTSTRAP_TARGET_EPOCH),--epoch $(BOOTSTRAP_TARGET_EPOCH),) $(ARGS)
 
 publish-bootstrap-snapshots: ## &start Upload and publish the three existing bootstrap snapshots starting at $BOOTSTRAP_SNAPSHOT_EPOCH
 	@set -euo pipefail; \
@@ -105,9 +98,6 @@ download-haskell-config: ## &start Download Haskell node configuration files for
 	curl -fsSL -O --output-dir "$(HASKELL_NODE_CONFIG_DIR)" "$(HASKELL_NODE_CONFIG_REPOSITORY)/$(CARDANO_NODE_CONFIG_COMMIT)/$(HASKELL_NODE_CONFIG_DIRECTORY)/$(AMARU_NETWORK)/peer-snapshot.json"
 	curl -fsSL -O --output-dir "$(HASKELL_NODE_CONFIG_DIR)" "$(HASKELL_NODE_CONFIG_REPOSITORY)/$(CARDANO_NODE_CONFIG_COMMIT)/$(HASKELL_NODE_CONFIG_DIRECTORY)/$(AMARU_NETWORK)/shelley-genesis.json"
 	curl -fsSL -O --output-dir "$(HASKELL_NODE_CONFIG_DIR)" "$(HASKELL_NODE_CONFIG_REPOSITORY)/$(CARDANO_NODE_CONFIG_COMMIT)/$(HASKELL_NODE_CONFIG_DIRECTORY)/$(AMARU_NETWORK)/topology.json"
-
-build: ## &build Compile for $BUILD_PROFILE
-	cargo build --profile $(BUILD_PROFILE) $(ARGS)
 
 sync-from-mithril: ## &build Fast synchronization from a Mithril snapshot, for $BUILD_PROFILE
 	@cargo run --profile $(BUILD_PROFILE) --bin amaru-ledger $(COMMON_ARGS) mithril
@@ -148,10 +138,6 @@ validate-trace-schemas: ## &test Validate generated trace schemas against docs/t
 		} >> "$${GITHUB_STEP_SUMMARY:-/dev/null}"; \
 		exit 1; \
 	fi
-
-start: run # 'backward-compatibility'; might remove after a while.
-run: ## &build Compile and run for $BUILD_PROFILE with default options
-	cargo run --profile $(BUILD_PROFILE) -- $(COMMON_ARGS) run $(ARGS)
 
 run-until: ## &test Synchronize Amaru until a target epoch $RUN_UNTIL_TARGET_EPOCH
 	@set -e; \
@@ -214,9 +200,6 @@ ledger-conformance-known-failures: ## &test Update the set of 'known conformance
 
 regenerate-cbor-fixtures: ## &test Regenerate cuddle/antigen CBOR fixtures (requires GHC + cabal)
 	@./scripts/regenerate-cbor-fixtures
-
-test-e2e: ## &test Run snapshot tests, assuming snapshots are available
-	cargo test --profile $(BUILD_PROFILE) -p amaru -- --ignored
 
 check-llvm-cov: ## &test Check if cargo-llvm-cov is installed, install if not
 	@if ! cargo llvm-cov --version >/dev/null 2>&1; then \

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See either:
 #### Building from sources
 
 ```console
-make build
+cargo build --release
 ```
 
 > [!TIP]
@@ -110,7 +110,7 @@ on the selected network (e.g. [preprod](https://book.world.dev.cardano.org/env-p
 1. Bootstrap the node:
 
 ```bash
-make AMARU_NETWORK=preprod bootstrap
+AMARU_NETWORK=preprod cargo run --release -- bootstrap
 ```
 
 2. _(Optional)_ Setup observability backends:
@@ -122,14 +122,14 @@ docker compose -f monitoring/profiles/jaeger/docker-compose.yml up
 3. Run Amaru:
 
 ```console
-make AMARU_NETWORK=preprod start
+AMARU_NETWORK=preprod cargo run --release -- run
 ```
 
 > [!TIP]
 > To ensure logs are forwarded to an OpenTelemetry backend, set `AMARU_WITH_OPEN_TELEMETRY=true`:
 >
 > ```console
-> make AMARU_NETWORK=preprod AMARU_WITH_OPEN_TELEMETRY=true start
+> AMARU_NETWORK=preprod AMARU_WITH_OPEN_TELEMETRY=true cargo run --release -- run
 > ```
 
 ### Monitoring

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ on the selected network (e.g. [preprod](https://book.world.dev.cardano.org/env-p
 1. Bootstrap the node:
 
 ```bash
-AMARU_NETWORK=preprod cargo run --release -- bootstrap
+amaru node bootstrap --network=preprod
 ```
 
 2. _(Optional)_ Setup observability backends:
@@ -122,14 +122,14 @@ docker compose -f monitoring/profiles/jaeger/docker-compose.yml up
 3. Run Amaru:
 
 ```console
-AMARU_NETWORK=preprod cargo run --release -- run
+amaru node run --network=preprod
 ```
 
 > [!TIP]
 > To ensure logs are forwarded to an OpenTelemetry backend, set `AMARU_WITH_OPEN_TELEMETRY=true`:
 >
 > ```console
-> AMARU_NETWORK=preprod AMARU_WITH_OPEN_TELEMETRY=true cargo run --release -- run
+> amaru --with-open-telemetry node run --network=preprod
 > ```
 
 ### Monitoring

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -64,7 +64,7 @@ Note that this requires a trace severity of at least INFO since the detection of
 
 The previous command will run Amaru and preserve ledger snapshots. Those snapshots can then be used to produce epoch test snapshots which can be compared with golden test vectors, generated from the Haskell node. This ensure a bit-by-bit comparison of the ledger states between the two nodes:
 
-`make test-e2e`
+`cargo test --release -p amaru -- --ignored`
 
 Note that the test are network-specific and dependent on the `AMARU_NETWORK` environment variable.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -64,7 +64,7 @@ Note that this requires a trace severity of at least INFO since the detection of
 
 The previous command will run Amaru and preserve ledger snapshots. Those snapshots can then be used to produce epoch test snapshots which can be compared with golden test vectors, generated from the Haskell node. This ensure a bit-by-bit comparison of the ledger states between the two nodes:
 
-`cargo test --release -p amaru -- --ignored`
+`cargo test -p amaru -- --ignored`
 
 Note that the test are network-specific and dependent on the `AMARU_NETWORK` environment variable.
 


### PR DESCRIPTION
Removed superfluous make targets that just delegate to cargo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI/bootstrap workflow to bootstrap via direct Rust execution instead of a Makefile command.
  * Removed several Makefile entrypoints and related advertised variables, simplifying the command surface.
* **Documentation**
  * Updated setup and run instructions to use `cargo build` / `cargo run`, including bootstrap and running examples.
  * Refreshed common commands to prefer cargo-based workflows.
* **Tests**
  * Updated end-to-end (ignored) test instructions to run with `cargo test` in release mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->