### PR TITLE
fix: properly encode a negative integer in CBOR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Other guiding principles:
 - **amaru-protocols**: delegate connection attempts to connector stage to avoid blocking the manager and allow up to 10 concurrent connections. ([#1058](https://github.com/pragma-org/amaru/pull/1058))
 - **amaru-consensus**: fix chainsync mini-protocol lifecycle handling in `track_peers` stage to properly clean up resources when stopping to sync from a peer. ([#1059](https://github.com/pragma-org/amaru/pull/1059))
 - **amaru-pure-stage**: simulation runtime now also guarantees delivery of scheduled messages; both runtimes enforce limit on priority messages in flight. ([#1066](https://github.com/pragma-org/amaru/pull/1066))
+- **amaru-uplc**: fixed the CBOR encoding of `-2^64`.
 
 ## [v10.11.20260716](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260716)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,7 +378,10 @@ name = "amaru-minicbor-extra"
 version = "0.1.2"
 dependencies = [
  "amaru-deps",
+ "hex",
  "minicbor",
+ "num",
+ "num-bigint",
  "tracing",
 ]
 
@@ -681,6 +684,7 @@ version = "0.4.0"
 dependencies = [
  "amaru-deps",
  "amaru-kernel",
+ "amaru-minicbor-extra",
  "append-only-vec",
  "blst",
  "bumpalo",

--- a/crates/amaru-deps/Cargo.toml
+++ b/crates/amaru-deps/Cargo.toml
@@ -119,7 +119,6 @@ itertools = { version = "0.13" }
 libc = { version = "0.2" }
 log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }
-num-bigint = { version = "0.4" }
 num-integer = { version = "0.1", features = ["i128"] }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
 percent-encoding = { version = "2" }
@@ -186,7 +185,6 @@ itertools = { version = "0.13" }
 libc = { version = "0.2" }
 log = { version = "0.4", default-features = false, features = ["std"] }
 memchr = { version = "2" }
-num-bigint = { version = "0.4" }
 num-integer = { version = "0.1", features = ["i128"] }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
 percent-encoding = { version = "2" }
@@ -231,6 +229,7 @@ hyper-util = { version = "0.1", default-features = false, features = ["client-pr
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
+num-bigint = { version = "0.4" }
 num-complex = { version = "0.4", default-features = false, features = ["libm"] }
 num-rational = { version = "0.4" }
 rustix = { version = "1", features = ["fs", "termios"] }
@@ -245,6 +244,7 @@ hyper-util = { version = "0.1", default-features = false, features = ["client-pr
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
+num-bigint = { version = "0.4" }
 num-complex = { version = "0.4", default-features = false, features = ["libm"] }
 num-rational = { version = "0.4" }
 rustix = { version = "1", features = ["fs", "termios"] }
@@ -259,6 +259,7 @@ hyper-util = { version = "0.1", default-features = false, features = ["client-pr
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
+num-bigint = { version = "0.4" }
 num-complex = { version = "0.4", default-features = false, features = ["libm"] }
 num-rational = { version = "0.4" }
 rustix = { version = "1", features = ["fs", "termios"] }
@@ -273,6 +274,7 @@ hyper-util = { version = "0.1", default-features = false, features = ["client-pr
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
+num-bigint = { version = "0.4" }
 num-complex = { version = "0.4", default-features = false, features = ["libm"] }
 num-rational = { version = "0.4" }
 rustix = { version = "1", features = ["fs", "termios"] }
@@ -287,6 +289,7 @@ hyper-util = { version = "0.1", default-features = false, features = ["client-pr
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
+num-bigint = { version = "0.4" }
 num-complex = { version = "0.4", default-features = false, features = ["libm"] }
 num-rational = { version = "0.4" }
 rustix = { version = "1", features = ["fs", "termios"] }
@@ -301,6 +304,7 @@ hyper-util = { version = "0.1", default-features = false, features = ["client-pr
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
+num-bigint = { version = "0.4" }
 num-complex = { version = "0.4", default-features = false, features = ["libm"] }
 num-rational = { version = "0.4" }
 rustix = { version = "1", features = ["fs", "termios"] }
@@ -315,6 +319,7 @@ hyper-util = { version = "0.1", default-features = false, features = ["client-pr
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
+num-bigint = { version = "0.4" }
 num-complex = { version = "0.4", default-features = false, features = ["libm"] }
 num-rational = { version = "0.4" }
 rustix = { version = "1", features = ["fs", "termios"] }
@@ -329,6 +334,7 @@ hyper-util = { version = "0.1", default-features = false, features = ["client-pr
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
+num-bigint = { version = "0.4" }
 num-complex = { version = "0.4", default-features = false, features = ["libm"] }
 num-rational = { version = "0.4" }
 rustix = { version = "1", features = ["fs", "termios"] }
@@ -343,6 +349,7 @@ hyper-util = { version = "0.1", default-features = false, features = ["client-pr
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
+num-bigint = { version = "0.4" }
 num-complex = { version = "0.4", default-features = false, features = ["libm"] }
 num-rational = { version = "0.4" }
 rustix = { version = "1", features = ["fs", "termios"] }
@@ -357,6 +364,7 @@ hyper-util = { version = "0.1", default-features = false, features = ["client-pr
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
+num-bigint = { version = "0.4" }
 num-complex = { version = "0.4", default-features = false, features = ["libm"] }
 num-rational = { version = "0.4" }
 rustix = { version = "1", features = ["fs", "termios"] }
@@ -368,6 +376,7 @@ uuid = { version = "1", features = ["v4"] }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1", default-features = false, features = ["client-proxy", "client-proxy-system", "http2"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
+num-bigint = { version = "0.4" }
 num-complex = { version = "0.4", default-features = false, features = ["libm"] }
 num-rational = { version = "0.4" }
 tower = { version = "0.5", default-features = false, features = ["retry", "timeout"] }
@@ -378,6 +387,7 @@ windows-sys = { version = "0.61", features = ["Wdk_Foundation", "Wdk_Storage_Fil
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper-util = { version = "0.1", default-features = false, features = ["client-proxy", "client-proxy-system", "http2"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
+num-bigint = { version = "0.4" }
 num-complex = { version = "0.4", default-features = false, features = ["libm"] }
 num-rational = { version = "0.4" }
 tower = { version = "0.5", default-features = false, features = ["retry", "timeout"] }
@@ -389,6 +399,7 @@ bumpalo = { version = "3", features = ["collections"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "std"] }
 js-sys = { version = "0.3" }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
+num-bigint = { version = "0.4" }
 num-complex = { version = "0.4", default-features = false, features = ["libm"] }
 num-rational = { version = "0.4" }
 once_cell = { version = "1" }
@@ -400,6 +411,7 @@ bumpalo = { version = "3", features = ["collections"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "std"] }
 js-sys = { version = "0.3" }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
+num-bigint = { version = "0.4" }
 num-complex = { version = "0.4", default-features = false, features = ["libm"] }
 num-rational = { version = "0.4" }
 once_cell = { version = "1" }
@@ -413,6 +425,7 @@ hyper-util = { version = "0.1", default-features = false, features = ["client-pr
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
+num-bigint = { version = "0.4" }
 num-complex = { version = "0.4", default-features = false, features = ["libm"] }
 num-rational = { version = "0.4" }
 rustix = { version = "1", features = ["fs", "termios"] }
@@ -427,6 +440,7 @@ hyper-util = { version = "0.1", default-features = false, features = ["client-pr
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "libm"] }
+num-bigint = { version = "0.4" }
 num-complex = { version = "0.4", default-features = false, features = ["libm"] }
 num-rational = { version = "0.4" }
 rustix = { version = "1", features = ["fs", "termios"] }

--- a/crates/amaru-minicbor-extra/Cargo.toml
+++ b/crates/amaru-minicbor-extra/Cargo.toml
@@ -21,7 +21,12 @@ tracing = ["dep:tracing"]
 
 [dependencies]
 minicbor.workspace = true
+num-bigint.workspace = true
+num.workspace = true
 tracing = { workspace = true, optional = true }
+
+[dev-dependencies]
+hex.workspace = true
 
 [target.'cfg(all(not(target_family="wasm"), not(target_arch="riscv32")))'.dependencies]
 amaru-deps.workspace = true

--- a/crates/amaru-minicbor-extra/src/decode.rs
+++ b/crates/amaru-minicbor-extra/src/decode.rs
@@ -14,7 +14,12 @@
 
 use std::fmt::Display;
 
-use minicbor::{data::Type, decode};
+use minicbor::{
+    data::{IanaTag, Type},
+    decode,
+};
+use num::One;
+use num_bigint::BigInt;
 
 use crate::cbor;
 
@@ -22,6 +27,29 @@ pub mod lazy;
 
 mod with_size;
 pub use with_size::*;
+
+/// Decode an arbitrary-precision integer, accepting both CBOR native integers and the tagged
+/// bignum forms (tag 2 for positive, tag 3 for negative).
+pub fn decode_bigint(d: &mut cbor::Decoder<'_>) -> Result<BigInt, cbor::decode::Error> {
+    if d.datatype()? == Type::Tag {
+        let tag = d.tag()?;
+        return match tag.try_into() {
+            Ok(iana @ (IanaTag::PosBignum | IanaTag::NegBignum)) => {
+                let mut bytes = Vec::new();
+                for chunk in d.bytes_iter()? {
+                    bytes.extend_from_slice(chunk?);
+                }
+
+                let magnitude = BigInt::from_bytes_be(num_bigint::Sign::Plus, &bytes);
+                Ok(if iana == IanaTag::PosBignum { magnitude } else { -magnitude - BigInt::one() })
+            }
+            _ => Err(cbor::decode::Error::message(format!("unexpected tag for bignum: {tag}"))),
+        };
+    }
+
+    let i: i128 = d.int()?.into();
+    Ok(BigInt::from(i))
+}
 
 // Misc
 // ----------------------------------------------------------------------------

--- a/crates/amaru-minicbor-extra/src/encode.rs
+++ b/crates/amaru-minicbor-extra/src/encode.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use minicbor::{self as cbor};
+use minicbor as cbor;
+use minicbor::{Encoder, data::Tag};
+use num::One;
+use num_bigint::BigInt;
 
 /// Encode a field with an optional value.
 pub fn encode_optional<C, T, W>(
@@ -30,4 +33,120 @@ where
     }
 
     Ok(())
+}
+
+pub fn encode_bigint<W: cbor::encode::Write>(
+    e: &mut Encoder<W>,
+    i: &BigInt,
+) -> Result<(), cbor::encode::Error<W::Error>> {
+    let (header, tag, bytes) = match i.sign() {
+        num_bigint::Sign::NoSign => {
+            e.u8(0)?;
+            return Ok(());
+        }
+        num_bigint::Sign::Plus => (0x00, 2, i.to_bytes_be().1),
+        num_bigint::Sign::Minus => (0x20, 3, ((-i) - BigInt::one()).to_bytes_be().1),
+    };
+
+    match bytes.len() {
+        1 if bytes[0] <= 0x17 => {
+            put(e, &[header | bytes[0]])?;
+        }
+        len @ 1..=8 => {
+            let width = len.next_power_of_two();
+            put(e, &[header | (24 + width.trailing_zeros() as u8)])?;
+            let mut buf = [0u8; 8];
+            buf[width - len..width].copy_from_slice(&bytes);
+            put(e, &buf[..width])?;
+        }
+        _ => {
+            e.tag(Tag::new(tag))?;
+            encode_bytestring(e, &bytes)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn put<W: minicbor::encode::Write>(e: &mut Encoder<W>, bytes: &[u8]) -> Result<(), minicbor::encode::Error<W::Error>> {
+    e.writer_mut().write_all(bytes).map_err(minicbor::encode::Error::write)
+}
+
+pub fn encode_bytestring<'a, W: minicbor::encode::Write>(
+    e: &'a mut Encoder<W>,
+    bs: &[u8],
+) -> Result<&'a mut Encoder<W>, minicbor::encode::Error<W::Error>> {
+    const CHUNK_SIZE: usize = 64;
+
+    if bs.len() <= 64 {
+        e.bytes(bs)?;
+    } else {
+        e.begin_bytes()?;
+
+        for b in bs.chunks(CHUNK_SIZE) {
+            e.bytes(b)?;
+        }
+
+        e.end()?;
+    }
+    Ok(e)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decode_bigint;
+
+    #[test]
+    fn encode_bigint_cases() {
+        for (value, expected) in cases() {
+            assert_eq!(encoded(value.clone()), expected, "encoding {value}");
+        }
+    }
+
+    #[test]
+    fn roundtrip_bigint_cases() {
+        for (value, _) in cases() {
+            assert_eq!(decoded(&encoded(value.clone())), value, "roundtrip {value}");
+        }
+    }
+
+    // HELPERS
+
+    /// Interesting values to exercise the encoder: zero, the small-integer boundary (±23),
+    /// the native-integer boundary (±2^64), and arbitrary-precision bignums in both directions.
+    /// Each value is paired with its expected canonical CBOR encoding.
+    fn cases() -> Vec<(BigInt, &'static str)> {
+        let two_64: BigInt = BigInt::from(1u8) << 64;
+        vec![
+            (BigInt::from(0), "00"),
+            (BigInt::from(23), "17"),
+            (BigInt::from(65536u32), "1a00010000"),
+            (BigInt::from(-65537i32), "3a00010000"),
+            (BigInt::from(4294967296u64), "1b0000000100000000"),
+            (BigInt::from(281474976710656u64), "1b0001000000000000"),
+            (&two_64 - BigInt::one(), "1bffffffffffffffff"),
+            (two_64.clone(), "c249010000000000000000"),
+            (big(), "c24c033b2e3c9fd0803ce7ffffff"),
+            (-big(), "c34c033b2e3c9fd0803ce7fffffe"),
+            (-two_64, "3bffffffffffffffff"),
+            (BigInt::from(-23), "36"),
+        ]
+    }
+
+    /// A very large BigInt: 999999999999999999999999999
+    fn big() -> BigInt {
+        BigInt::from_bytes_be(num_bigint::Sign::Plus, &hex::decode("033b2e3c9fd0803ce7ffffff").unwrap())
+    }
+
+    fn encoded(i: BigInt) -> String {
+        let mut e = Encoder::new(Vec::new());
+        encode_bigint(&mut e, &i).expect("failed to encode bigint");
+        hex::encode(e.into_writer())
+    }
+
+    fn decoded(hex_str: &str) -> BigInt {
+        let bytes = hex::decode(hex_str).unwrap();
+        decode_bigint(&mut cbor::Decoder::new(&bytes)).expect("failed to decode bigint")
+    }
 }

--- a/crates/amaru-uplc/Cargo.toml
+++ b/crates/amaru-uplc/Cargo.toml
@@ -16,7 +16,6 @@ indoc.workspace = true
 walkdir.workspace = true
 
 [dependencies]
-amaru-kernel.workspace = true
 append-only-vec.workspace = true
 blst.workspace = true
 bumpalo = { workspace = true, features = ["collections"] }
@@ -30,6 +29,10 @@ num.workspace = true
 once_cell.workspace = true
 secp256k1.workspace = true
 thiserror.workspace = true
+
+# Internal dependencies ───────────────────────────────────────────────────────┐
+amaru-kernel.workspace = true
+amaru-minicbor-extra.workspace = true
 
 [target.'cfg(all(not(target_family="wasm"), not(target_arch="riscv32")))'.dependencies]
 amaru-deps.workspace = true

--- a/crates/amaru-uplc/src/flat/data.rs
+++ b/crates/amaru-uplc/src/flat/data.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use amaru_minicbor_extra::{decode_bigint, encode_bigint, encode_bytestring};
 use bumpalo::collections::Vec as BumpVec;
 use minicbor::data::{IanaTag, Tag};
 
@@ -97,18 +98,8 @@ impl<'a, 'b> minicbor::decode::Decode<'b, SimpleCtx<'a>> for &'a PlutusData<'a> 
                 }
 
                 match tag.try_into() {
-                    Ok(x @ IanaTag::PosBignum | x @ IanaTag::NegBignum) => {
-                        let _ = decoder.tag()?;
-                        let mut bytes = BumpVec::new_in(ctx.arena.as_bump());
-
-                        for chunk in decoder.bytes_iter()? {
-                            let chunk = chunk?;
-
-                            bytes.extend_from_slice(chunk);
-                        }
-
-                        let n = num::BigInt::from_bytes_be(num_bigint::Sign::Plus, &bytes);
-                        let integer = ctx.arena.alloc_integer(if x == IanaTag::PosBignum { n } else { -n - 1 });
+                    Ok(IanaTag::PosBignum | IanaTag::NegBignum) => {
+                        let integer = ctx.arena.alloc_integer(decode_bigint(decoder)?);
 
                         Ok(PlutusData::integer(ctx.arena, integer))
                     }
@@ -166,9 +157,9 @@ impl<'a, 'b> minicbor::decode::Decode<'b, SimpleCtx<'a>> for &'a PlutusData<'a> 
             | minicbor::data::Type::I32
             | minicbor::data::Type::I64
             | minicbor::data::Type::Int => {
-                let i: i128 = decoder.int()?.into();
+                let integer = ctx.arena.alloc_integer(decode_bigint(decoder)?);
 
-                Ok(PlutusData::integer_from(ctx.arena, i))
+                Ok(PlutusData::integer(ctx.arena, integer))
             }
             any => {
                 let e = minicbor::decode::Error::message(format!("bad cbor data type ({any:?}) for plutus data"));
@@ -177,26 +168,6 @@ impl<'a, 'b> minicbor::decode::Decode<'b, SimpleCtx<'a>> for &'a PlutusData<'a> 
             }
         }
     }
-}
-
-fn encode_bytestring<'a, W: minicbor::encode::Write>(
-    e: &'a mut minicbor::Encoder<W>,
-    bs: &[u8],
-) -> Result<&'a mut minicbor::Encoder<W>, minicbor::encode::Error<W::Error>> {
-    const CHUNK_SIZE: usize = 64;
-
-    if bs.len() <= 64 {
-        e.bytes(bs)?;
-    } else {
-        e.begin_bytes()?;
-
-        for b in bs.chunks(CHUNK_SIZE) {
-            e.bytes(b)?;
-        }
-
-        e.end()?;
-    }
-    Ok(e)
 }
 
 impl<C> minicbor::encode::Encode<C> for PlutusData<'_> {
@@ -247,32 +218,7 @@ impl<C> minicbor::encode::Encode<C> for PlutusData<'_> {
                 }
             }
             PlutusData::Integer(n) => {
-                let (sign, digits) = n.to_u64_digits();
-                match sign {
-                    num_bigint::Sign::Plus => {
-                        if digits.len() == 1 {
-                            e.u64(digits[0])?;
-                        } else {
-                            e.tag(Tag::new(2))?;
-                            let (_sign, bytes) = n.to_bytes_be();
-                            encode_bytestring(e, &bytes)?;
-                        }
-                    }
-                    num_bigint::Sign::Minus => {
-                        if digits.len() == 1 {
-                            let integer = minicbor::data::Int::try_from(-(digits[0] as i128)).unwrap();
-                            e.int(integer)?;
-                        } else {
-                            e.tag(Tag::new(3))?;
-                            let abs_minus_one = (-*n) - num::BigInt::from(1);
-                            let (_sign, bytes) = abs_minus_one.to_bytes_be();
-                            encode_bytestring(e, &bytes)?;
-                        }
-                    }
-                    num_bigint::Sign::NoSign => {
-                        e.u8(0)?;
-                    }
-                }
+                encode_bigint(e, n)?;
             }
             // we match the haskell implementation by encoding bytestrings longer than 64
             // bytes as indefinite lists of bytes
@@ -369,6 +315,35 @@ mod tests {
         assert_eq!(decoded, &PlutusData::Integer(&n));
     }
 
+    /// Test that the encoding is correct at both 2^64 - 1 and -2^64
+    #[test]
+    fn encode_integer_word_boundaries() {
+        let one = num::BigInt::from(1);
+        let two_64: num::BigInt = num::BigInt::from(1) << 64;
+        let two_64_minus_one: num::BigInt = &two_64 - &one;
+
+        // Largest values still encoded as native CBOR integers.
+        assert_eq!(encode_integer_hex(&two_64_minus_one), "1bffffffffffffffff");
+        assert_eq!(encode_integer_hex(&-two_64_minus_one.clone()), "3bfffffffffffffffe");
+
+        // -2^64 is the smallest native negative integer (arg = 2^64 - 1 fits a word).
+        assert_eq!(encode_integer_hex(&-two_64.clone()), "3bffffffffffffffff");
+
+        // Just past the boundary, both directions switch to a bignum.
+        assert_eq!(encode_integer_hex(&two_64), "c249010000000000000000");
+        assert_eq!(encode_integer_hex(&(-two_64.clone() - &one)), "c349010000000000000000");
+    }
+
+    #[test]
+    fn roundtrip_integer_min_native() {
+        let two_64: num::BigInt = num::BigInt::from(1) << 64;
+        let n = -two_64;
+        let encoded = minicbor::to_vec(PlutusData::Integer(&n)).expect("encode failed");
+        let arena = Arena::new();
+        let decoded = PlutusData::from_cbor(&arena, &encoded).expect("decode failed");
+        assert_eq!(decoded, &PlutusData::Integer(&n));
+    }
+
     #[test]
     fn encode_cbor_data_list() {
         let zero = num::BigInt::from(0);
@@ -378,5 +353,14 @@ mod tests {
         let mut v = vec![];
         minicbor::encode(d, &mut v).expect("invalid PlutusData");
         assert_eq!(hex::encode(v), "d8799f9f0001ffff");
+    }
+
+    // HELPERS
+
+    /// Encode a BigInt as hex-encoded CBOR
+    fn encode_integer_hex(n: &num::BigInt) -> String {
+        let mut v = vec![];
+        minicbor::encode(PlutusData::Integer(n), &mut v).expect("invalid PlutusData");
+        hex::encode(v)
     }
 }


### PR DESCRIPTION
This PR fixes an edge case with the CBOR encoding of `-2^64`. Because of a off-by-one error that value was encoded as a bytestring, even though it fits into a native negative CBOR int.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CBOR encoding and decoding for large positive and negative integers, including the `-2^64` boundary.
  * Improved handling of native integer and bignum representations.
  * Ensured byte strings are encoded consistently, including larger values.

* **Tests**
  * Added coverage for integer boundary values, canonical encodings, and encode/decode round trips.

* **Documentation**
  * Updated the changelog with the CBOR encoding fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->