### PR TITLE
fix: incorrect default logs

### DIFF
--- a/crates/amaru/src/observability.rs
+++ b/crates/amaru/src/observability.rs
@@ -43,11 +43,11 @@ use tracing_subscriber::{
 
 const AMARU_LOG_VAR: &str = "AMARU_LOG";
 
-const DEFAULT_AMARU_LOG_FILTER: &str = "info,amaru::consensus=debug,amaru::ledger=debug,amaru_pure_stage=warn";
+const DEFAULT_AMARU_LOG_FILTER: &str = "error,amaru=info";
 
 const AMARU_TRACE_VAR: &str = "AMARU_TRACE";
 
-const DEFAULT_AMARU_TRACE_FILTER: &str = "amaru=trace,amaru_pure_stage=trace,amaru_protocols=warn,amaru_consensus=info";
+const DEFAULT_AMARU_TRACE_FILTER: &str = "error,amaru=debug";
 
 const OTEL_ERROR_THROTTLE_MS: u64 = 5_000;
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -21,8 +21,8 @@ Any event (trace, span or metric) can be filtered by target and severity using t
 > [!TIP]
 > Both environment variable are optional.
 >
-> - When omitted, `AMARU_TRACE` defaults to all **amaru** and **pure-stage** targets above the **trace** level;
-> - When omitted, `AMARU_LOG` defaults to all **errors**, **amaru** targets above the **debug** level, and **pure-stage** above the **warn** level;
+> - When omitted, `AMARU_TRACE` defaults to all **errors** and **amaru** targets at or above the **info** level;
+> - When omitted, `AMARU_LOG` defaults to all **errors** and **amaru** targets at or above the **info** level;
 
 ### By target
 


### PR DESCRIPTION
Skip-Changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Improvements**
  * Reduced default logging verbosity when `AMARU_LOG` / `AMARU_TRACE` are not set, focusing on errors and `amaru` at info level or higher.
  * Simplified default trace filtering to reduce low-level detail (while still capturing more critical events).
  * Updates tracing subscriber initialization behavior, including JSON trace output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->