### PR TITLE
Track account unregistrations to avoid O(n) scan on all accounts during epoch transition calculations.

### DIFF
--- a/.github/actions/bootstrap-db/action.yml
+++ b/.github/actions/bootstrap-db/action.yml
@@ -16,7 +16,7 @@ inputs:
   cache-version:
     description: Cache key version
     required: false
-    default: "v15"
+    default: "v16"
 
 runs:
   using: composite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Other guiding principles:
 ### Changed
 
 - **amaru**: use `zst` compression for all individual stake distribution snapshots.
+- **amaru-ledger**: track account unregistrations to avoid O(n) scan on all accounts during epoch transition calculations.
 
 ### Fixed
 

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -108,6 +108,7 @@ fn decode_initial_snapshot_prefix(
 pub fn import_initial_snapshot(
     db: &impl Store,
     reader: &mut dyn Read,
+    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
     point: &Point,
     era_history: &EraHistory,
     network: NetworkName,
@@ -239,7 +240,7 @@ pub fn import_initial_snapshot(
         d.array()?;
         Ok(())
     })?;
-    decoder.skip()?; // Epoch State / Snapshots / Mark
+    let mark_snapshot = decoder.with_decoder(|d| Ok(decode_stake_snapshot(d)?))?;
     decoder.skip()?; // Epoch State / Snapshots / Set
     decoder.skip()?; // Epoch State / Snapshots / Go
     decoder.skip()?; // Epoch State / Snapshots / Fee
@@ -277,7 +278,17 @@ pub fn import_initial_snapshot(
         (0_i64, 0_i64, BTreeMap::new(), 0_i64)
     };
 
-    import_accounts(db, &with_progress, point, era_history, &protocol_parameters, accounts, &mut rewards)?;
+    import_accounts(
+        db,
+        &with_progress,
+        point,
+        era_history,
+        &protocol_parameters,
+        accounts,
+        &mut rewards,
+        recently_unregistered_accounts,
+        mark_snapshot,
+    )?;
 
     let unclaimed_rewards = rewards
         .into_iter()
@@ -602,6 +613,7 @@ fn import_pots(db: &impl Store, pots: Pots) -> Result<(), Box<dyn std::error::Er
     Ok(())
 }
 
+#[expect(clippy::too_many_arguments)]
 fn import_accounts(
     db: &impl Store,
     with_progress: impl Fn(usize, &str) -> Box<dyn ProgressBar>,
@@ -610,6 +622,8 @@ fn import_accounts(
     protocol_parameters: &ProtocolParameters,
     accounts: BTreeMap<StakeCredential, Account>,
     rewards_updates: &mut BTreeMap<StakeCredential, Set<Reward>>,
+    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
+    mut mark_snapshot: BTreeSet<StakeCredential>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if db.iter_accounts()?.next().is_some() {
         warn!(bootstrap::accounts::IS_NOT_EMPTY);
@@ -620,6 +634,13 @@ fn import_accounts(
     let mut credentials = accounts
         .into_iter()
         .map(|(credential, Account { rewards_and_deposit, pool, drep, .. })| {
+            // Remove from the mark snapshot any account that is seen, to only keep those that are
+            // not present anymore.
+            mark_snapshot.remove(&credential);
+            // Prune the recently unregistered set from account we see, which indicates they have
+            // re-registered.
+            recently_unregistered_accounts.remove(&credential);
+
             let (rewards, deposit) = Option::<(Lovelace, Lovelace)>::from(rewards_and_deposit)
                 .unwrap_or((0, protocol_parameters.stake_credential_deposit));
 
@@ -689,7 +710,10 @@ fn import_accounts(
         progress.tick(n);
     }
 
-    if !rewards_updates.is_empty() {
+    // Retain accounts that have unregistered recently, i.e. those that were present in the mark
+    // snapshots but not present in the account set anymore.
+    recently_unregistered_accounts.append(&mut mark_snapshot);
+    if !recently_unregistered_accounts.is_empty() {
         transaction.save(
             era_history,
             protocol_parameters,
@@ -697,12 +721,10 @@ fn import_accounts(
             point,
             None,
             Default::default(),
-            // Mark unclaimed rewards as 'recently unregistered accounts' so that our internal invariants
-            // align with the snapshot import.
             store::Columns {
                 utxo: iter::empty(),
                 pools: iter::empty(),
-                accounts: rewards_updates.keys().cloned(),
+                accounts: recently_unregistered_accounts.iter().cloned(),
                 dreps: iter::empty(),
                 cc_members: iter::empty(),
                 proposals: iter::empty(),
@@ -917,6 +939,24 @@ fn import_votes(
     transaction.commit()?;
 
     Ok(())
+}
+
+pub fn decode_stake_snapshot(d: &mut cbor::Decoder<'_>) -> Result<BTreeSet<StakeCredential>, cbor::decode::Error> {
+    d.array()?;
+
+    struct Stake;
+    impl<'d, C> cbor::decode::Decode<'d, C> for Stake {
+        fn decode(d: &mut cbor::Decoder<'d>, _ctx: &mut C) -> Result<Self, cbor::decode::Error> {
+            d.skip()?;
+            Ok(Stake)
+        }
+    }
+
+    let accounts: BTreeMap<StakeCredential, Stake> = d.decode()?;
+
+    d.skip()?;
+
+    Ok(accounts.into_keys().collect())
 }
 
 // TODO: Move to Pallas

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -689,6 +689,29 @@ fn import_accounts(
         progress.tick(n);
     }
 
+    if !rewards_updates.is_empty() {
+        transaction.save(
+            era_history,
+            protocol_parameters,
+            GovernanceActivity::default(),
+            point,
+            None,
+            Default::default(),
+            // Mark unclaimed rewards as 'recently unregistered accounts' so that our internal invariants
+            // align with the snapshot import.
+            store::Columns {
+                utxo: iter::empty(),
+                pools: iter::empty(),
+                accounts: rewards_updates.keys().cloned(),
+                dreps: iter::empty(),
+                cc_members: iter::empty(),
+                proposals: iter::empty(),
+                votes: iter::empty(),
+            },
+            iter::empty(),
+        )?;
+    }
+
     transaction.commit()?;
     progress.clear();
 

--- a/crates/amaru-ledger/src/epoch_transition/rewards_state.rs
+++ b/crates/amaru-ledger/src/epoch_transition/rewards_state.rs
@@ -143,6 +143,9 @@ pub struct Rewards<STEP: KnownRewardState + Clone> {
     /// Amount to be paid to the treasury
     delta_treasury: Lovelace,
 
+    /// Total rewards across all accounts, including potentially unclaimed ones.
+    total_rewards: Lovelace,
+
     /// Per-account rewards, determined from their relative stake and their delegatee. This holds
     /// *every* account with a reward, whether or not it is still registered; the `Effective` step
     /// carves out the unclaimed ones through `unclaimed`. It is behind an `Arc` so that converting
@@ -162,9 +165,17 @@ impl Rewards<Computed> {
     pub fn new(
         delta_reserves: Lovelace,
         delta_treasury: Lovelace,
+        total_rewards: Lovelace,
         accounts: BTreeMap<StakeCredential, Lovelace>,
     ) -> Self {
-        Self { delta_reserves, delta_treasury, accounts: Arc::new(accounts), unclaimed: (), step: PhantomData }
+        Self {
+            delta_reserves,
+            delta_treasury,
+            total_rewards,
+            accounts: Arc::new(accounts),
+            unclaimed: (),
+            step: PhantomData,
+        }
     }
 }
 
@@ -175,16 +186,14 @@ impl Rewards<Effective> {
     /// have a reward but were no longer registered at the epoch boundary. Their amounts stay in the
     /// shared map (they are folded back into the treasury via [`Self::delta_treasury`]) but they are
     /// never paid out to the account.
-    pub fn new(computed_rewards: Rewards<Computed>, unregistered: &BTreeSet<StakeCredential>) -> Self {
-        let unclaimed: BTreeSet<StakeCredential> =
-            computed_rewards.accounts.keys().filter(|account| unregistered.contains(account)).cloned().collect();
-
+    pub fn new(computed_rewards: Rewards<Computed>, unregistered: BTreeSet<StakeCredential>) -> Self {
         Self {
             step: PhantomData,
             delta_reserves: computed_rewards.delta_reserves,
             delta_treasury: computed_rewards.delta_treasury,
+            total_rewards: computed_rewards.total_rewards,
             accounts: computed_rewards.accounts,
-            unclaimed: Arc::new(unclaimed),
+            unclaimed: Arc::new(unregistered),
         }
     }
 
@@ -194,11 +203,15 @@ impl Rewards<Effective> {
         if self.unclaimed.contains(account) { 0 } else { self.accounts.get(account).copied().unwrap_or(0) }
     }
 
-    /// The number of accounts that should receive a (non-zero) reward payout. Every account in the
-    /// map earns a reward, so the payable ones are simply those not flagged as unclaimed (`unclaimed`
-    /// is always a subset of the map's keys).
-    pub fn payable_accounts(&self) -> usize {
-        self.accounts.len() - self.unclaimed.len()
+    /// Total amount of rewards that couldn't be paid to accounts because they unregistered between
+    /// the moment the rewards were calculated and the moment they needed to be paid out.
+    pub fn unclaimed_rewards(&self) -> Lovelace {
+        self.unclaimed.iter().filter_map(|account| self.accounts.get(account)).sum()
+    }
+
+    /// Total rewards of ALL accounts, including unclaimed ones.
+    pub fn total_rewards(&self) -> Lovelace {
+        self.total_rewards
     }
 
     /// Amount to be paid to the reserves
@@ -209,8 +222,7 @@ impl Rewards<Effective> {
     /// Amount to be paid to the treasury, including the rewards left unclaimed by accounts that
     /// unregistered during the epoch.
     pub fn delta_treasury(&self) -> Lovelace {
-        let unclaimed: Lovelace = self.unclaimed.iter().filter_map(|account| self.accounts.get(account)).sum();
-        self.delta_treasury + unclaimed
+        self.delta_treasury + self.unclaimed_rewards()
     }
 
     /// Roll an effective rewards summary back to a computed one by dropping the unclaimed markers.
@@ -220,6 +232,7 @@ impl Rewards<Effective> {
             step: PhantomData,
             delta_reserves: self.delta_reserves,
             delta_treasury: self.delta_treasury,
+            total_rewards: self.total_rewards,
             accounts: self.accounts,
             unclaimed: (),
         }
@@ -249,15 +262,15 @@ mod test {
 
         let delta_reserves = 1_000;
         let delta_treasury = 7;
-        let computed_rewards = Rewards::<Computed>::new(delta_reserves, delta_treasury, accounts);
+        let computed_rewards =
+            Rewards::<Computed>::new(delta_reserves, delta_treasury, accounts.values().sum(), accounts);
         let effective_rewards =
-            Rewards::<Effective>::new(computed_rewards.clone(), &BTreeSet::from([unregistered.clone()]));
+            Rewards::<Effective>::new(computed_rewards.clone(), BTreeSet::from([unregistered.clone()]));
 
         // The still-registered account is paid its reward; the unregistered one is not (its reward
         // is folded back into the treasury instead).
         assert_eq!(effective_rewards.reward_of(&registered), 100);
         assert_eq!(effective_rewards.reward_of(&unregistered), 0);
-        assert_eq!(effective_rewards.payable_accounts(), 1);
         assert_eq!(effective_rewards.delta_reserves(), delta_reserves);
         assert_eq!(effective_rewards.delta_treasury(), delta_treasury + 42);
 

--- a/crates/amaru-ledger/src/epoch_transition/rewards_state.rs
+++ b/crates/amaru-ledger/src/epoch_transition/rewards_state.rs
@@ -175,31 +175,9 @@ impl Rewards<Effective> {
     /// have a reward but were no longer registered at the epoch boundary. Their amounts stay in the
     /// shared map (they are folded back into the treasury via [`Self::delta_treasury`]) but they are
     /// never paid out to the account.
-    ///
-    /// TODO: retain unregistered accounts for epoch transition instead of searching for them
-    //
-    //   We have to prune accounts from that have been unregistered in this epoch and can no longer
-    //   receive rewards. The number of accounts doing so is usually limited compared to the total
-    //   number of accounts (~1.5M on Mainnet). So instead of iterating through all accounts to see
-    //   which have disappeared, we could simply remember which accounts have unregistered in the
-    //   epoch and prune them here rapidly.
-    //
-    //   With interning of the account key, each account weights ~8 bytes; so even if all accounts
-    //   were to unregister in the epoch (end of Cardano?), that'd still be ~11MB of resident memory.
-    //   So very negligeable.
-    pub fn new(computed_rewards: Rewards<Computed>, accounts: impl Iterator<Item = StakeCredential>) -> Self {
-        // The set of accounts still registered at the boundary, used to tell claimed from unclaimed.
-        let registered: BTreeSet<StakeCredential> = accounts.collect();
-
-        let unclaimed: BTreeSet<StakeCredential> = computed_rewards
-            .accounts
-            .iter()
-            .filter(|(account, reward)| {
-                debug_assert!(**reward > 0, "the account {account:?} doesn't have a strictly positive reward");
-                !registered.contains(account)
-            })
-            .map(|(account, _)| account.clone())
-            .collect();
+    pub fn new(computed_rewards: Rewards<Computed>, unregistered: &BTreeSet<StakeCredential>) -> Self {
+        let unclaimed: BTreeSet<StakeCredential> =
+            computed_rewards.accounts.keys().filter(|account| unregistered.contains(account)).cloned().collect();
 
         Self {
             step: PhantomData,
@@ -272,9 +250,8 @@ mod test {
         let delta_reserves = 1_000;
         let delta_treasury = 7;
         let computed_rewards = Rewards::<Computed>::new(delta_reserves, delta_treasury, accounts);
-
-        // `unregistered` unregistered during the epoch, so its rewards can no longer be paid out.
-        let effective_rewards = Rewards::<Effective>::new(computed_rewards.clone(), [registered.clone()].into_iter());
+        let effective_rewards =
+            Rewards::<Effective>::new(computed_rewards.clone(), &BTreeSet::from([unregistered.clone()]));
 
         // The still-registered account is paid its reward; the unregistered one is not (its reward
         // is folded back into the treasury instead).

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -440,7 +440,7 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
                     // have some rewards summary being available. There's no way to continue progressing
                     // the ledger if we don't.
                     computed_rewards.ok_or(StateError::RewardsSummaryNotReady)?,
-                    &volatile_view.iter_unregistered_accounts()?.collect(),
+                    volatile_view.iter_unregistered_accounts()?.collect(),
                 );
 
                 (db.pots()?.treasury + effective_rewards.delta_treasury(), Some(effective_rewards))

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -440,7 +440,7 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
                     // have some rewards summary being available. There's no way to continue progressing
                     // the ledger if we don't.
                     computed_rewards.ok_or(StateError::RewardsSummaryNotReady)?,
-                    volatile_view.iter_accounts()?,
+                    &volatile_view.iter_unregistered_accounts()?.collect(),
                 );
 
                 (db.pots()?.treasury + effective_rewards.delta_treasury(), Some(effective_rewards))

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -1121,8 +1121,9 @@ mod tests {
     #[test]
     fn reward_balance_folds_in_the_pending_overlay_credit_during_the_straddle() {
         let mut db = VolatileDB::default();
-        let computed = Rewards::<Computed>::new(0, 0, BTreeMap::from([(cred(1), 5_000_000)]));
-        let effective = Rewards::<Effective>::new(computed, &BTreeSet::new());
+        let accounts = BTreeMap::from([(cred(1), 5_000_000)]);
+        let computed = Rewards::<Computed>::new(0, 0, accounts.values().sum(), accounts);
+        let effective = Rewards::<Effective>::new(computed, BTreeSet::new());
 
         // The pending boundary credit is added on top of the stable base.
         assert_eq!(db.resolve_account(&cred(1)).1, RewardsAtTip::Add(0));
@@ -1160,8 +1161,8 @@ mod tests {
     #[test_case(None, None => Existence::Unknown; "untouched everywhere defers to the stable store")]
     fn resolve_committee_precedence(draining: Option<CommitteeAct>, current: Option<CommitteeAct>) -> Existence<bool> {
         let mut db = VolatileDB::default();
-        let computed = Rewards::<Computed>::new(0, 0, BTreeMap::new());
-        let effective = Rewards::<Effective>::new(computed, &BTreeSet::new());
+        let computed = Rewards::<Computed>::new(0, 0, 0, BTreeMap::new());
+        let effective = Rewards::<Effective>::new(computed, BTreeSet::new());
         if let Some(act) = draining {
             db.push_back(committee_block(10, act));
         }
@@ -1253,8 +1254,8 @@ mod tests {
     /// Effective boundary rewards crediting a single account, to give the overlay non-trivial,
     /// observable state (its pending reward credit surfaces through `resolve_account`).
     fn effective_reward(credential: StakeCredential, amount: u64) -> Rewards<Effective> {
-        let computed = Rewards::<Computed>::new(0, 0, BTreeMap::from([(credential.clone(), amount)]));
-        Rewards::<Effective>::new(computed, &BTreeSet::new())
+        let computed = Rewards::<Computed>::new(0, 0, amount, BTreeMap::from([(credential.clone(), amount)]));
+        Rewards::<Effective>::new(computed, BTreeSet::new())
     }
 
     fn account_block(slot: u64, act: Act) -> AnchoredVolatileFragment {

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -1122,7 +1122,7 @@ mod tests {
     fn reward_balance_folds_in_the_pending_overlay_credit_during_the_straddle() {
         let mut db = VolatileDB::default();
         let computed = Rewards::<Computed>::new(0, 0, BTreeMap::from([(cred(1), 5_000_000)]));
-        let effective = Rewards::<Effective>::new(computed, std::iter::once(cred(1)));
+        let effective = Rewards::<Effective>::new(computed, &BTreeSet::new());
 
         // The pending boundary credit is added on top of the stable base.
         assert_eq!(db.resolve_account(&cred(1)).1, RewardsAtTip::Add(0));
@@ -1161,7 +1161,7 @@ mod tests {
     fn resolve_committee_precedence(draining: Option<CommitteeAct>, current: Option<CommitteeAct>) -> Existence<bool> {
         let mut db = VolatileDB::default();
         let computed = Rewards::<Computed>::new(0, 0, BTreeMap::new());
-        let effective = Rewards::<Effective>::new(computed, std::iter::empty());
+        let effective = Rewards::<Effective>::new(computed, &BTreeSet::new());
         if let Some(act) = draining {
             db.push_back(committee_block(10, act));
         }
@@ -1254,7 +1254,7 @@ mod tests {
     /// observable state (its pending reward credit surfaces through `resolve_account`).
     fn effective_reward(credential: StakeCredential, amount: u64) -> Rewards<Effective> {
         let computed = Rewards::<Computed>::new(0, 0, BTreeMap::from([(credential.clone(), amount)]));
-        Rewards::<Effective>::new(computed, std::iter::once(credential))
+        Rewards::<Effective>::new(computed, &BTreeSet::new())
     }
 
     fn account_block(slot: u64, act: Act) -> AnchoredVolatileFragment {

--- a/crates/amaru-ledger/src/state/volatile/overlay.rs
+++ b/crates/amaru-ledger/src/state/volatile/overlay.rs
@@ -201,8 +201,8 @@ impl StateOverlay {
                 Span::current().record("should_begin_epoch", should_begin_epoch);
 
                 let updated = if should_begin_epoch {
+                    batch.clear_recently_unregistered_accounts()?;
                     reset_blocks_count(batch)?;
-
                     reset_fees_and_donations(batch)?;
 
                     if let Some(pools_updates) = mem::take(&mut self.pools_updates) {
@@ -343,7 +343,7 @@ impl StateOverlay {
 
 #[cfg(test)]
 mod test {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
 
     use amaru_kernel::{Hash, PREPROD_DEFAULT_PROTOCOL_PARAMETERS, ProposalsRoots};
 
@@ -392,7 +392,7 @@ mod test {
     /// the epoch, so its rewards are unclaimed and returned to the treasury.
     fn effective_rewards() -> Rewards<Effective> {
         let computed = Rewards::<Computed>::new(1_000, 7, BTreeMap::from([(credential(1), 100), (credential(2), 42)]));
-        Rewards::<Effective>::new(computed, std::iter::once(credential(1)))
+        Rewards::<Effective>::new(computed, &BTreeSet::from([credential(2)]))
     }
 
     fn governance_updates() -> GovernanceUpdates {

--- a/crates/amaru-ledger/src/state/volatile/overlay.rs
+++ b/crates/amaru-ledger/src/state/volatile/overlay.rs
@@ -201,7 +201,7 @@ impl StateOverlay {
                 Span::current().record("should_begin_epoch", should_begin_epoch);
 
                 let updated = if should_begin_epoch {
-                    batch.clear_recently_unregistered_accounts()?;
+                    batch.prune_recently_unregistered_accounts(self.epoch)?;
                     reset_blocks_count(batch)?;
                     reset_fees_and_donations(batch)?;
 
@@ -391,8 +391,9 @@ mod test {
     /// Effective rewards where `credential(1)` is still registered while `credential(2)` unregistered during
     /// the epoch, so its rewards are unclaimed and returned to the treasury.
     fn effective_rewards() -> Rewards<Effective> {
-        let computed = Rewards::<Computed>::new(1_000, 7, BTreeMap::from([(credential(1), 100), (credential(2), 42)]));
-        Rewards::<Effective>::new(computed, &BTreeSet::from([credential(2)]))
+        let computed =
+            Rewards::<Computed>::new(1_000, 7, 142, BTreeMap::from([(credential(1), 100), (credential(2), 42)]));
+        Rewards::<Effective>::new(computed, BTreeSet::from([credential(2)]))
     }
 
     fn governance_updates() -> GovernanceUpdates {

--- a/crates/amaru-ledger/src/state/volatile/view.rs
+++ b/crates/amaru-ledger/src/state/volatile/view.rs
@@ -36,8 +36,8 @@ use crate::{
     },
 };
 
-mod iter_accounts;
 mod iter_pools;
+mod iter_unregistered_accounts;
 
 // ------------------------------------------------------------------------------------ VolatileView
 
@@ -127,15 +127,15 @@ impl<'volatile, 'db, DB: ReadStore> VolatileView<'volatile, 'db, DB> {
     /// registration or deregistration from the aggregated volatile state.
     ///
     /// IMPORTANT: Yields accounts in no particular order.
-    pub fn iter_accounts(&mut self) -> Result<impl Iterator<Item = StakeCredential>, StoreError> {
+    pub fn iter_unregistered_accounts(&mut self) -> Result<impl Iterator<Item = StakeCredential>, StoreError> {
         match mem::take(&mut self.accounts) {
             None => {
                 // Just being careful here. There's no reason to ever call this twice; but if it
                 // ever happens, this line might save us from hours of debugging.
-                unreachable!(".iter_accounts() called twice on the same VolatileView! Don't do that.")
+                unreachable!(".iter_unregistered_accounts() called twice on the same VolatileView! Don't do that.")
             }
-            Some(mut accounts) => Ok(iter_accounts::IterAccounts::new(
-                self.db.iter_accounts()?,
+            Some(mut accounts) => Ok(iter_unregistered_accounts::IterUnregisteredAccounts::new(
+                self.db.iter_recently_unregistered_accounts()?,
                 &mut accounts.registered,
                 &mut accounts.unregistered,
             )),

--- a/crates/amaru-ledger/src/state/volatile/view/iter_unregistered_accounts.rs
+++ b/crates/amaru-ledger/src/state/volatile/view/iter_unregistered_accounts.rs
@@ -16,18 +16,16 @@ use std::{collections::BTreeSet, mem};
 
 use amaru_kernel::StakeCredential;
 
-use crate::store::columns::accounts::Row as Account;
-
-/// Similar to [`crate::state::volatile::IterPools`], but for accounts; It provides an
-/// unordered iterator over accounts that patches a read-only stable store with pending updates
-/// such as registrations or de-registrations.
-pub(crate) struct IterAccounts<'volatile, DBIter: Iterator<Item = (StakeCredential, Account)>> {
+/// Similar to [`crate::state::volatile::IterPools`], but for accounts; It provides an unordered
+/// iterator over recently unregistered accounts in an epoch that patches a read-only stable store
+/// with pending updates such as registrations or de-registrations.
+pub(crate) struct IterUnregisteredAccounts<'volatile, DBIter: Iterator<Item = StakeCredential>> {
     db_iterator: DBIter,
     registrations: BTreeSet<&'volatile StakeCredential>,
     deregistrations: BTreeSet<&'volatile StakeCredential>,
 }
 
-impl<'volatile, DBIter: Iterator<Item = (StakeCredential, Account)>> IterAccounts<'volatile, DBIter> {
+impl<'volatile, DBIter: Iterator<Item = StakeCredential>> IterUnregisteredAccounts<'volatile, DBIter> {
     pub fn new(
         db_iterator: DBIter,
         registrations: &mut BTreeSet<&'volatile StakeCredential>,
@@ -37,19 +35,19 @@ impl<'volatile, DBIter: Iterator<Item = (StakeCredential, Account)>> IterAccount
     }
 }
 
-impl<'volatile, DBIter: Iterator<Item = (StakeCredential, Account)>> Iterator for IterAccounts<'volatile, DBIter> {
+impl<'volatile, DBIter: Iterator<Item = StakeCredential>> Iterator for IterUnregisteredAccounts<'volatile, DBIter> {
     type Item = StakeCredential;
 
     fn next(&mut self) -> Option<Self::Item> {
-        for (credential, _) in &mut self.db_iterator {
-            if self.deregistrations.contains(&credential) {
+        for credential in &mut self.db_iterator {
+            if self.registrations.contains(&credential) {
                 continue;
             }
 
             return Some(credential);
         }
 
-        if let Some(credential) = self.registrations.pop_first() {
+        if let Some(credential) = self.deregistrations.pop_first() {
             return Some(credential.clone());
         }
 

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -725,13 +725,14 @@ pub trait TransactionalContext<'a>: ReadStore {
         unimplemented!("TransactionalContext.remove_proposals({:?})", proposals.collect::<Vec<_>>());
     }
 
-    /// Clear all recently unregistered accounts from the database
+    /// Prune all recently unregistered accounts from the database that are no longer required to
+    /// keep around.
     #[cfg(not(any(test, feature = "test-utils")))]
-    fn clear_recently_unregistered_accounts(&self) -> Result<()>;
+    fn prune_recently_unregistered_accounts(&self, epoch: Epoch) -> Result<()>;
 
     #[cfg(any(test, feature = "test-utils"))]
-    fn clear_recently_unregistered_accounts(&self) -> Result<()> {
-        unimplemented!("TransactionalContext.clear_recently_unregistered_accounts()");
+    fn prune_recently_unregistered_accounts(&self, epoch: Epoch) -> Result<()> {
+        unimplemented!("TransactionalContext.prune_recently_unregistered_accounts({epoch})");
     }
 
     /// Get current values of the treasury and reserves accounts, and possibly modify them.

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -400,6 +400,17 @@ pub trait ReadStore {
         ))
     }
 
+    /// Get details about all recently unregistered accounts
+    #[cfg(not(any(test, feature = "test-utils")))]
+    fn iter_recently_unregistered_accounts(&self) -> Result<impl Iterator<Item = recently_unregistered_accounts::Key>>;
+
+    #[cfg(any(test, feature = "test-utils"))]
+    fn iter_recently_unregistered_accounts(&self) -> Result<impl Iterator<Item = recently_unregistered_accounts::Key>> {
+        Err::<std::iter::Empty<recently_unregistered_accounts::Key>, _>(default_read_store_error(
+            "ReadStore.iter_recently_unregistered_accounts()",
+        ))
+    }
+
     /// Get details about all dreps
     #[cfg(not(any(test, feature = "test-utils")))]
     fn iter_dreps(&self) -> Result<impl Iterator<Item = (dreps::Key, dreps::Row)>>;
@@ -712,6 +723,15 @@ pub trait TransactionalContext<'a>: ReadStore {
         Id: Deref<Target = ProposalId> + std::fmt::Debug + 'iter,
     {
         unimplemented!("TransactionalContext.remove_proposals({:?})", proposals.collect::<Vec<_>>());
+    }
+
+    /// Clear all recently unregistered accounts from the database
+    #[cfg(not(any(test, feature = "test-utils")))]
+    fn clear_recently_unregistered_accounts(&self) -> Result<()>;
+
+    #[cfg(any(test, feature = "test-utils"))]
+    fn clear_recently_unregistered_accounts(&self) -> Result<()> {
+        unimplemented!("TransactionalContext.clear_recently_unregistered_accounts()");
     }
 
     /// Get current values of the treasury and reserves accounts, and possibly modify them.

--- a/crates/amaru-ledger/src/store/columns/recently_unregistered_accounts.rs
+++ b/crates/amaru-ledger/src/store/columns/recently_unregistered_accounts.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 PRAGMA
+// Copyright 2026 PRAGMA
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,24 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use amaru_kernel::StakeCredential;
 
-use amaru_kernel::cbor;
-
-pub mod accounts;
-pub mod cc_members;
-pub mod dreps;
-pub mod pools;
-pub mod pots;
-pub mod proposals;
-pub mod recently_pruned_proposals;
-pub mod recently_unregistered_accounts;
-pub mod slots;
-pub mod utxo;
-pub mod votes;
-
-#[expect(clippy::panic)]
-pub fn unsafe_decode<T: for<'d> cbor::Decode<'d, ()>>(bytes: &[u8]) -> T {
-    cbor::decode(bytes).unwrap_or_else(|e| {
-        panic!("unable to decode {} from CBOR ({}): {e:?}", std::any::type_name::<T>(), hex::encode(bytes))
-    })
-}
+pub type Key = StakeCredential;
+pub type Value = ();

--- a/crates/amaru-ledger/src/store/columns/recently_unregistered_accounts.rs
+++ b/crates/amaru-ledger/src/store/columns/recently_unregistered_accounts.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use amaru_kernel::StakeCredential;
+use amaru_kernel::{Epoch, StakeCredential};
 
 pub type Key = StakeCredential;
-pub type Value = ();
+pub type Value = Epoch;

--- a/crates/amaru-ledger/src/store/epoch_transition.rs
+++ b/crates/amaru-ledger/src/store/epoch_transition.rs
@@ -41,18 +41,16 @@ pub fn pay_rewards<'store>(
     effective_rewards: &Rewards<Effective>,
 ) -> Result<(), StoreError> {
     debug_span!(stores::ledger::overlay::PAY_REWARDS).in_scope(|| {
+
         // Pay rewards out to every account
-        let mut seen_reward_accounts: usize = 0;
         db.with_accounts(|iterator| {
             let mut rewards_paid: u64 = 0;
             let mut accounts_paid: u64 = 0;
 
-            for (account, mut row) in iterator {
-                let rewards = effective_rewards.reward_of(&account);
+            for (credential, mut row) in iterator {
+                let rewards = effective_rewards.reward_of(&credential);
 
                 if rewards > 0 {
-                    seen_reward_accounts += 1;
-
                     // The condition avoids the mutable borrow when not needed,
                     // which will incur a db operation.
                     if let Some(account) = row.borrow_mut() {
@@ -63,20 +61,21 @@ pub fn pay_rewards<'store>(
                 }
             }
 
+            let expected_total_rewards = effective_rewards.total_rewards();
+            let actual_total_rewards = rewards_paid + effective_rewards.unclaimed_rewards();
+
+            // Technically, if we did everything *right*, there should be no accounts with rewards that
+            // cannot be paid out (i.e. accounts that no longer exists). This has been taken care of during
+            // the epoch transition calculations already. So at this point, this invariant must hold: every
+            // payable reward account was found while iterating the stored accounts.
+            assert!(
+                actual_total_rewards == expected_total_rewards,
+                "discrepancy between expected total rewards (={expected_total_rewards}) and actual total rewards (={actual_total_rewards})",
+            );
+
             Span::current().record("accounts_paid", accounts_paid);
             Span::current().record("rewards_paid", rewards_paid);
         })?;
-        let seen = seen_reward_accounts;
-
-        // Technically, if we did everything *right*, there should be no accounts with rewards that
-        // cannot be paid out (i.e. accounts that no longer exists). This has been taken care of during
-        // the epoch transition calculations already. So at this point, this invariant must hold: every
-        // payable reward account was found while iterating the stored accounts.
-        assert!(
-            seen == effective_rewards.payable_accounts(),
-            "unclaimed rewards when applying overlay: saw {seen} of {} payable reward accounts",
-            effective_rewards.payable_accounts(),
-        );
 
         // Adjust treasury and reserves accordingly.
         db.with_pots(|mut row| {

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -557,6 +557,11 @@ impl RewardsSummary {
 
 impl From<RewardsSummary> for Rewards<Computed> {
     fn from(summary: RewardsSummary) -> Self {
-        Rewards::<Computed>::new(summary.delta_reserves(), summary.delta_treasury(), summary.accounts)
+        Rewards::<Computed>::new(
+            summary.delta_reserves(),
+            summary.delta_treasury(),
+            summary.effective_rewards,
+            summary.accounts,
+        )
     }
 }

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -1067,8 +1067,10 @@ define_schemas! {
                     public INSERT {}
                     /// Remove a recently unregistered account
                     public REMOVE {}
-                    /// Clear all recently unregistered accounts
-                    public CLEAR {}
+                    /// Prune recently unregistered accounts
+                    public PRUNE {
+                        required epoch: Epoch
+                    }
                 }
                 dreps {
                     /// Point-read a DRep entry

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -735,6 +735,11 @@ define_schemas! {
                 public DETECT {
                     required count: usize
                 }
+                /// Failed to read or parse a local snapshot
+                public FAIL_TO_READ {
+                    required file: String,
+                    required hint: anyhow::Error,
+                }
             }
             nonces {
                 /// Import initial nonces into the chain store

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -1057,6 +1057,14 @@ define_schemas! {
                         optional reason: String
                     }
                 }
+                recently_unregistered_accounts {
+                    /// Insert a recently unregistered account
+                    public INSERT {}
+                    /// Remove a recently unregistered account
+                    public REMOVE {}
+                    /// Clear all recently unregistered accounts
+                    public CLEAR {}
+                }
                 dreps {
                     /// Point-read a DRep entry
                     public GET {}

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/accounts.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/accounts.rs
@@ -23,7 +23,10 @@ use amaru_ledger::store::{
 use amaru_observability::{debug, error, trace_span};
 use rocksdb::{DBPinnableSlice, Transaction};
 
-use crate::rocksdb::common::{PREFIX_LEN, as_key, as_value};
+use crate::rocksdb::{
+    common::{PREFIX_LEN, as_key, as_value},
+    recently_unregistered_accounts,
+};
 
 /// Name prefixed used for storing Account entries. UTF-8 encoding for "acct"
 pub const PREFIX: [u8; PREFIX_LEN] = [0x61, 0x63, 0x63, 0x74];
@@ -42,6 +45,9 @@ pub fn add<DB>(db: &Transaction<'_, DB>, rows: impl Iterator<Item = (Key, Value)
                     let mut row = Row { deposit, pool: None, drep: None, rewards };
                     pool.set_or_reset(&mut row.pool);
                     drep.set_or_reset(&mut row.drep);
+
+                    recently_unregistered_accounts::remove(db, &credential)?;
+
                     row
                 }
 
@@ -129,6 +135,7 @@ pub fn set_rewards<DB>(
 pub fn remove<DB>(db: &Transaction<'_, DB>, rows: impl Iterator<Item = Key>) -> Result<(), StoreError> {
     trace_span!(stores::ledger::accounts::REMOVE).in_scope(|| {
         for credential in rows {
+            recently_unregistered_accounts::insert(db, &credential)?;
             db.delete(as_key(&PREFIX, &credential)).map_err(|err| StoreError::Internal(err.into()))?;
         }
 

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/accounts.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/accounts.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{AsHash, Lovelace, StakeCredentialKind};
+use amaru_kernel::{AsHash, Epoch, Lovelace, StakeCredentialKind};
 use amaru_ledger::store::{
     StoreError,
     columns::{
@@ -132,10 +132,10 @@ pub fn set_rewards<DB>(
 }
 
 /// Clear a stake credential registration.
-pub fn remove<DB>(db: &Transaction<'_, DB>, rows: impl Iterator<Item = Key>) -> Result<(), StoreError> {
+pub fn remove<DB>(db: &Transaction<'_, DB>, rows: impl Iterator<Item = Key>, epoch: Epoch) -> Result<(), StoreError> {
     trace_span!(stores::ledger::accounts::REMOVE).in_scope(|| {
         for credential in rows {
-            recently_unregistered_accounts::insert(db, &credential)?;
+            recently_unregistered_accounts::insert(db, &credential, epoch)?;
             db.delete(as_key(&PREFIX, &credential)).map_err(|err| StoreError::Internal(err.into()))?;
         }
 

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/mod.rs
@@ -19,6 +19,7 @@ pub mod pools;
 pub mod pots;
 pub mod proposals;
 pub mod recently_pruned_proposals;
+pub mod recently_unregistered_accounts;
 pub mod slots;
 pub mod utxo;
 pub mod votes;

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/recently_unregistered_accounts.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/recently_unregistered_accounts.rs
@@ -1,0 +1,59 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub use amaru_ledger::store::{
+    StoreError,
+    columns::recently_unregistered_accounts::{Key, Value},
+};
+use amaru_observability::trace_span;
+use rocksdb::Transaction;
+
+use crate::rocksdb::{
+    as_value,
+    common::{PREFIX_LEN, as_key},
+    with_prefix_iterator,
+};
+
+/// Name prefixed used for storing recently unregistered accounts.
+pub const PREFIX: [u8; PREFIX_LEN] = *b"ruac";
+pub const COLLECTION_NAME: &str = "recently_unregistered_accounts";
+
+/// Insert a single entry
+pub fn insert<DB>(db: &Transaction<'_, DB>, key: &Key) -> Result<(), StoreError> {
+    trace_span!(stores::ledger::recently_unregistered_accounts::INSERT).in_scope(|| {
+        db.put(as_key(&PREFIX, key), as_value(())).map_err(|err| StoreError::Internal(err.into()))?;
+        Ok(())
+    })
+}
+
+/// Remove one entry, for example, when accounts are being re-registered.
+pub fn remove<DB>(db: &Transaction<'_, DB>, key: &Key) -> Result<(), StoreError> {
+    trace_span!(stores::ledger::recently_unregistered_accounts::REMOVE).in_scope(|| {
+        db.delete(as_key(&PREFIX, key)).map_err(|err| StoreError::Internal(err.into()))?;
+        Ok(())
+    })
+}
+
+/// Remove all entries, typically at an epoch transition.
+pub fn clear<DB>(db: &Transaction<'_, DB>) -> Result<(), StoreError> {
+    trace_span!(stores::ledger::recently_unregistered_accounts::CLEAR).in_scope(|| {
+        with_prefix_iterator::<Key, Value, DB>(db, PREFIX, COLLECTION_NAME, |iterator| {
+            for (_, mut row) in iterator {
+                *row.borrow_mut() = None;
+            }
+        })?;
+
+        Ok(())
+    })
+}

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/recently_unregistered_accounts.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/recently_unregistered_accounts.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use amaru_ledger::store::{
+use amaru_kernel::Epoch;
+use amaru_ledger::store::{
     StoreError,
     columns::recently_unregistered_accounts::{Key, Value},
 };
@@ -30,9 +31,9 @@ pub const PREFIX: [u8; PREFIX_LEN] = *b"ruac";
 pub const COLLECTION_NAME: &str = "recently_unregistered_accounts";
 
 /// Insert a single entry
-pub fn insert<DB>(db: &Transaction<'_, DB>, key: &Key) -> Result<(), StoreError> {
+pub fn insert<DB>(db: &Transaction<'_, DB>, key: &Key, value: Value) -> Result<(), StoreError> {
     trace_span!(stores::ledger::recently_unregistered_accounts::INSERT).in_scope(|| {
-        db.put(as_key(&PREFIX, key), as_value(())).map_err(|err| StoreError::Internal(err.into()))?;
+        db.put(as_key(&PREFIX, key), as_value(value)).map_err(|err| StoreError::Internal(err.into()))?;
         Ok(())
     })
 }
@@ -45,12 +46,25 @@ pub fn remove<DB>(db: &Transaction<'_, DB>, key: &Key) -> Result<(), StoreError>
     })
 }
 
-/// Remove all entries, typically at an epoch transition.
-pub fn clear<DB>(db: &Transaction<'_, DB>) -> Result<(), StoreError> {
-    trace_span!(stores::ledger::recently_unregistered_accounts::CLEAR).in_scope(|| {
+/// Remove all entries older than a certain epoch. We only need to remember recently pruned accounts
+/// for a few epochs and can prune old de-registrations once they're no longer relevant to rewards
+/// application. Consider the following:
+///
+/// - in epoch `e`, rewards are calculated using the stake distribution from the end of `e-3`
+/// - in the transition from `e` to `e+1`, we need to know which accounts have since unregistered
+///   and cannot receive rewards.
+/// - at the beginning of `e+1`, call this method and prune old data.
+///
+/// So any de-registration from `e-2`, `e-1` or `e` must survive until the end of `e`. Then, `e+2`
+/// can be cleared at the start of the next epoch `e+1`.
+pub fn prune<DB>(db: &Transaction<'_, DB>, epoch: Epoch) -> Result<(), StoreError> {
+    trace_span!(stores::ledger::recently_unregistered_accounts::PRUNE, epoch = epoch).in_scope(|| {
         with_prefix_iterator::<Key, Value, DB>(db, PREFIX, COLLECTION_NAME, |iterator| {
             for (_, mut row) in iterator {
-                *row.borrow_mut() = None;
+                let value = row.borrow_mut();
+                if value.is_some_and(|unregistered_at| unregistered_at + 3 <= epoch) {
+                    *value = None;
+                }
             }
         })?;
 

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -483,6 +483,16 @@ macro_rules! impl_ReadStore_body {
                 )
             }
 
+            fn iter_recently_unregistered_accounts(
+                &self,
+            ) -> Result<impl Iterator<Item = scolumns::recently_unregistered_accounts::Key>, StoreError>
+            {
+                iter(
+                    |mode, opts| self.db.iterator_opt(mode, opts),
+                    recently_unregistered_accounts::PREFIX,
+                ).map(|iterator| iterator.map(|(k, ())| k))
+            }
+
             fn iter_block_issuers(
                 &self,
             ) -> Result<impl Iterator<Item = (scolumns::slots::Key, scolumns::slots::Value)>, StoreError>
@@ -700,6 +710,11 @@ impl TransactionalContext<'_> for RocksDBTransactionalContext<'_> {
         Id: Deref<Target = ProposalId> + 'iter,
     {
         proposals::remove(&self.db, proposals.into_iter())
+    }
+
+    /// Clear all recently unregistered accounts from the database
+    fn clear_recently_unregistered_accounts(&self) -> Result<(), StoreError> {
+        recently_unregistered_accounts::clear(&self.db)
     }
 
     fn save(

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -487,10 +487,10 @@ macro_rules! impl_ReadStore_body {
                 &self,
             ) -> Result<impl Iterator<Item = scolumns::recently_unregistered_accounts::Key>, StoreError>
             {
-                iter(
+                iter::<_, scolumns::recently_unregistered_accounts::Value, _, _>(
                     |mode, opts| self.db.iterator_opt(mode, opts),
                     recently_unregistered_accounts::PREFIX,
-                ).map(|iterator| iterator.map(|(k, ())| k))
+                ).map(|iterator| iterator.map(|(k, _)| k))
             }
 
             fn iter_block_issuers(
@@ -712,9 +712,9 @@ impl TransactionalContext<'_> for RocksDBTransactionalContext<'_> {
         proposals::remove(&self.db, proposals.into_iter())
     }
 
-    /// Clear all recently unregistered accounts from the database
-    fn clear_recently_unregistered_accounts(&self) -> Result<(), StoreError> {
-        recently_unregistered_accounts::clear(&self.db)
+    /// Prune recently unregistered accounts from the database that are no longer required.
+    fn prune_recently_unregistered_accounts(&self, epoch: Epoch) -> Result<(), StoreError> {
+        recently_unregistered_accounts::prune(&self.db, epoch)
     }
 
     fn save(
@@ -782,7 +782,7 @@ impl TransactionalContext<'_> for RocksDBTransactionalContext<'_> {
 
                 utxo::remove(&self.db, remove.utxo)?;
                 pools::remove(&self.db, remove.pools)?;
-                accounts::remove(&self.db, remove.accounts)?;
+                accounts::remove(&self.db, remove.accounts, current_epoch)?;
                 dreps::remove(&self.db, remove.dreps)?;
 
                 // When a proposal is seen during a dormant period, we flush the current dormant

--- a/crates/amaru/src/bootstrap/mod.rs
+++ b/crates/amaru/src/bootstrap/mod.rs
@@ -15,7 +15,7 @@
 mod chain_sync_client;
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     error::Error,
     io,
     path::{Path, PathBuf},
@@ -24,7 +24,7 @@ use std::{
 
 use amaru_kernel::{
     BlockHeader, Epoch, EraHistory, GlobalParameters, Hash, HeaderHash, IsHeader, NetworkName, Nonce, Peer, Point,
-    from_cbor, num::CheckedSub, utils::path::relative_path,
+    StakeCredential, from_cbor, num::CheckedSub, utils::path::relative_path,
 };
 use amaru_ledger::{
     bootstrap::import_initial_snapshot,
@@ -545,14 +545,27 @@ pub async fn bootstrap(
         BootstrapError::MissingSnapshotDirectory(snapshot_directory_path(&snapshots_dir, third_snapshot))
     })?;
 
-    import_snapshot(network, global_parameters, &first_snapshot_path, &ledger_dir).await?;
-    import_snapshot(network, global_parameters, &second_snapshot_path, &ledger_dir).await?;
+    let mut recently_unregistered_accounts = BTreeSet::new();
+
+    import_snapshot(network, global_parameters, &first_snapshot_path, &ledger_dir, &mut recently_unregistered_accounts)
+        .await?;
+
+    import_snapshot(
+        network,
+        global_parameters,
+        &second_snapshot_path,
+        &ledger_dir,
+        &mut recently_unregistered_accounts,
+    )
+    .await?;
+
     let imported_third_snapshot = import_snapshot_with_optional_nonces(
         network,
         global_parameters,
         &third_snapshot_path,
         &ledger_dir,
         Some(second_snapshot.point.hash()),
+        &mut recently_unregistered_accounts,
     )
     .await?;
 
@@ -685,8 +698,9 @@ pub async fn import_snapshots(
     ledger_dir: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     info!(bootstrap::snapshots::IMPORT, count = snapshots.len());
+    let mut recently_unregistered_accounts: BTreeSet<StakeCredential> = BTreeSet::new();
     for snapshot in snapshots {
-        import_snapshot(network, global_parameters, snapshot, ledger_dir).await?;
+        import_snapshot(network, global_parameters, snapshot, ledger_dir, &mut recently_unregistered_accounts).await?;
     }
     Ok(())
 }
@@ -713,8 +727,17 @@ async fn import_snapshot(
     global_parameters: &GlobalParameters,
     snapshot: &Path,
     ledger_dir: &Path,
+    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    import_snapshot_with_optional_nonces(network, global_parameters, snapshot, ledger_dir, None).await?;
+    import_snapshot_with_optional_nonces(
+        network,
+        global_parameters,
+        snapshot,
+        ledger_dir,
+        None,
+        recently_unregistered_accounts,
+    )
+    .await?;
     Ok(())
 }
 
@@ -724,13 +747,31 @@ async fn import_snapshot_with_optional_nonces(
     snapshot: &Path,
     ledger_dir: &Path,
     nonce_tail: Option<HeaderHash>,
+    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
 ) -> Result<ImportedSnapshot, Box<dyn std::error::Error>> {
     if let Some(paths) = node_snapshot_paths(snapshot) {
-        return import_node_snapshot_dir(network, global_parameters, snapshot, &paths, ledger_dir, nonce_tail).await;
+        return import_node_snapshot_dir(
+            network,
+            global_parameters,
+            snapshot,
+            &paths,
+            ledger_dir,
+            nonce_tail,
+            recently_unregistered_accounts,
+        )
+        .await;
     }
 
     if is_cbor_snapshot_file(snapshot) {
-        return import_cbor_snapshot_file(network, global_parameters, snapshot, ledger_dir, nonce_tail).await;
+        return import_cbor_snapshot_file(
+            network,
+            global_parameters,
+            snapshot,
+            ledger_dir,
+            nonce_tail,
+            recently_unregistered_accounts,
+        )
+        .await;
     }
 
     Err(Box::new(ImportError::UnsupportedSnapshotPath(snapshot.to_path_buf())))
@@ -743,6 +784,7 @@ async fn import_cbor_snapshot_file(
     snapshot: &Path,
     ledger_dir: &Path,
     nonce_tail: Option<HeaderHash>,
+    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
 ) -> Result<ImportedSnapshot, Box<dyn std::error::Error>> {
     info!(bootstrap::snapshot::IMPORT_FILE, path = %relative_path(snapshot)?.display());
 
@@ -769,17 +811,22 @@ async fn import_cbor_snapshot_file(
     let mut file = std::fs::File::open(snapshot)?;
 
     let builder = std::thread::Builder::new().stack_size(10_000_000);
-    let (db, epoch) = builder
+
+    let mut accounts = recently_unregistered_accounts.clone();
+
+    let (db, epoch, accounts) = builder
         .spawn(move || {
-            import_initial_snapshot(&db, &mut file, &point, &era_history, network, |size, template| {
+            import_initial_snapshot(&db, &mut file, &mut accounts, &point, &era_history, network, |size, template| {
                 TerminalProgressBar::new(size as u64, template).boxed()
             })
             .map_err(|e| e.to_string())
-            .map(|epoch| (db, epoch))
+            .map(|epoch| (db, epoch, accounts))
         })
         .unwrap()
         .join()
         .unwrap()?;
+
+    *recently_unregistered_accounts = accounts;
 
     db.next_snapshot(epoch)?;
 
@@ -796,6 +843,7 @@ async fn import_node_snapshot_dir(
     paths: &NodeSnapshotPaths,
     ledger_dir: &Path,
     nonce_tail: Option<HeaderHash>,
+    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
 ) -> Result<ImportedSnapshot, Box<dyn std::error::Error>> {
     info!(bootstrap::snapshot::IMPORT_DIR, path = %relative_path(snapshot_dir)?.display());
 
@@ -811,7 +859,9 @@ async fn import_node_snapshot_dir(
 
     let global_parameters = global_parameters.clone();
     let builder = std::thread::Builder::new().stack_size(10_000_000);
-    let (db, epoch, initial_nonces) = builder
+    let mut accounts = recently_unregistered_accounts.clone();
+
+    let (db, epoch, initial_nonces, accounts) = builder
         .spawn(move || {
             import_snapshot_from_tvar(
                 &db,
@@ -820,14 +870,17 @@ async fn import_node_snapshot_dir(
                 network,
                 &global_parameters,
                 nonce_tail,
+                &mut accounts,
                 |size, template| TerminalProgressBar::new(size as u64, template).boxed(),
             )
             .map_err(|e| e.to_string())
-            .map(|(epoch, _point, initial_nonces)| (db, epoch, initial_nonces))
+            .map(|(epoch, _point, initial_nonces)| (db, epoch, initial_nonces, accounts))
         })
         .unwrap()
         .join()
         .unwrap()?;
+
+    *recently_unregistered_accounts = accounts;
 
     db.next_snapshot(epoch)?;
 

--- a/crates/amaru/src/bootstrap/mod.rs
+++ b/crates/amaru/src/bootstrap/mod.rs
@@ -30,7 +30,7 @@ use amaru_ledger::{
     bootstrap::import_initial_snapshot,
     store::{EpochTransitionProgress, Store, TransactionalContext},
 };
-use amaru_observability::{error, info};
+use amaru_observability::{error, info, warn};
 use amaru_ouroboros::{ChainStore, Nonces, WriteChainStore};
 use amaru_progress_bar::{ProgressBar, TerminalProgressBar};
 use amaru_stores::rocksdb::{RocksDB, RocksDbConfig, consensus::RocksDBStore};
@@ -67,7 +67,6 @@ struct Snapshot {
     parent_point: Point,
 
     /// The URL to retrieve snapshot from.
-    #[serde(default)]
     url: String,
 }
 
@@ -149,8 +148,25 @@ fn load_local_epoch_snapshots(network: NetworkName) -> Vec<Snapshot> {
     entries
         .flatten()
         .filter(|entry| entry.path().extension().and_then(|e| e.to_str()) == Some("json"))
-        .filter_map(|entry| std::fs::read(entry.path()).ok())
-        .filter_map(|bytes| serde_json::from_slice::<Snapshot>(&bytes).ok())
+        .filter_map(|entry| {
+            let bytes = std::fs::read(entry.path()).map_err(|e| anyhow!("failed to read file: {e}"));
+            let json = bytes.and_then(|bytes| {
+                serde_json::from_slice::<Snapshot>(&bytes).map_err(|e| anyhow!("failed to decode from JSON: {e}"))
+            });
+            match json {
+                Err(hint) => {
+                    warn!(
+                        bootstrap::local_snapshots::FAIL_TO_READ,
+                        file = relative_path(&entry.path())
+                            .map(|path| path.display().to_string())
+                            .unwrap_or_else(|_| entry.path().display().to_string()),
+                        hint,
+                    );
+                    None
+                }
+                Ok(snapshot) => Some(snapshot),
+            }
+        })
         .collect()
 }
 

--- a/crates/amaru/src/cardano_node/tvar.rs
+++ b/crates/amaru/src/cardano_node/tvar.rs
@@ -20,14 +20,14 @@
 //! - <https://github.com/IntersectMBO/ouroboros-consensus/blob/main/ouroboros-consensus-cardano/src/unstable-snapshot-conversion/Ouroboros/Consensus/Cardano/StreamingLedgerTables.hs>
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     io::{Read, Seek, SeekFrom},
     iter,
 };
 
 use amaru_kernel::{
     Epoch, EraHistory, GlobalParameters, Hash, HeaderHash, MemoizedTransactionOutput, NetworkName, Point,
-    TransactionInput, cbor, cbor::lazy::LazyDecoder,
+    StakeCredential, TransactionInput, cbor, cbor::lazy::LazyDecoder,
 };
 use amaru_ledger::{
     bootstrap::import_initial_snapshot,
@@ -40,6 +40,7 @@ use amaru_progress_bar::ProgressBar;
 use super::{mempack, parse_state_snapshot, parse_state_snapshot_with_nonces};
 use crate::bootstrap::InitialNonces;
 
+#[expect(clippy::too_many_arguments)]
 pub fn import_snapshot_from_tvar<S, F>(
     db: &S,
     state_file: &mut std::fs::File,
@@ -47,6 +48,7 @@ pub fn import_snapshot_from_tvar<S, F>(
     network: NetworkName,
     global_parameters: &GlobalParameters,
     nonce_tail: Option<HeaderHash>,
+    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
     with_progress: F,
 ) -> Result<(Epoch, Point, Option<InitialNonces>), Box<dyn std::error::Error>>
 where
@@ -69,7 +71,15 @@ where
 
     state_file.seek(SeekFrom::Start(new_epoch_state_offset as u64))?;
 
-    let epoch = import_initial_snapshot(db, state_file, &point, &parsed_snapshot.era_history, network, with_progress)?;
+    let epoch = import_initial_snapshot(
+        db,
+        state_file,
+        recently_unregistered_accounts,
+        &point,
+        &parsed_snapshot.era_history,
+        network,
+        with_progress,
+    )?;
 
     import_utxo_from_tvar(utxo_file, db, with_progress, &point, &parsed_snapshot.era_history, network)?;
 

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -157,12 +157,22 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
 | `detect` | `TRACE` | public | Detect locally-created snapshots from create-snapshots | count |  |
+| `fail_to_read` | `TRACE` | public | Failed to read or parse a local snapshot | file, hint |  |
 
 <details><summary>span: `detect`</summary>
 
 | field | type | required |
 | --- | --- | --- |
 | `count` | `integer` | ✓ |
+
+</details>
+
+<details><summary>span: `fail_to_read`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `file` | `string` | ✓ |
+| `hint` | `string` | ✓ |
 
 </details>
 

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -1887,6 +1887,14 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | --- | --- | --- | --- | --- | --- |
 | `replace_all` | `TRACE` | public | Inserting recently pruned proposals |  |  |
 
+## target: `amaru::stores::ledger::recently_unregistered_accounts`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `clear` | `TRACE` | public | Clear all recently unregistered accounts |  |  |
+| `insert` | `TRACE` | public | Insert a recently unregistered account |  |  |
+| `remove` | `TRACE` | public | Remove a recently unregistered account |  |  |
+
 ## target: `amaru::stores::ledger::slots`
 
 | name | level | public | description | required fields | optional fields |

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -1901,9 +1901,17 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `clear` | `TRACE` | public | Clear all recently unregistered accounts |  |  |
 | `insert` | `TRACE` | public | Insert a recently unregistered account |  |  |
+| `prune` | `TRACE` | public | Prune recently unregistered accounts | epoch |  |
 | `remove` | `TRACE` | public | Remove a recently unregistered account |  |  |
+
+<details><summary>span: `prune`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `epoch` | `string` | ✓ |
+
+</details>
 
 ## target: `amaru::stores::ledger::slots`
 

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -4004,6 +4004,42 @@
       "description": "Inserting recently pruned proposals",
       "public": true
     },
+    "amaru::stores::ledger::recently_unregistered_accounts::CLEAR": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "clear",
+      "level": "TRACE",
+      "target": "amaru::stores::ledger::recently_unregistered_accounts",
+      "description": "Clear all recently unregistered accounts",
+      "public": true
+    },
+    "amaru::stores::ledger::recently_unregistered_accounts::INSERT": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "insert",
+      "level": "TRACE",
+      "target": "amaru::stores::ledger::recently_unregistered_accounts",
+      "description": "Insert a recently unregistered account",
+      "public": true
+    },
+    "amaru::stores::ledger::recently_unregistered_accounts::REMOVE": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "remove",
+      "level": "TRACE",
+      "target": "amaru::stores::ledger::recently_unregistered_accounts",
+      "description": "Remove a recently unregistered account",
+      "public": true
+    },
     "amaru::stores::ledger::slots::GET": {
       "type": "object",
       "properties": {},

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -4027,18 +4027,6 @@
       "description": "Inserting recently pruned proposals",
       "public": true
     },
-    "amaru::stores::ledger::recently_unregistered_accounts::CLEAR": {
-      "type": "object",
-      "properties": {},
-      "required": [],
-      "optional": [],
-      "additionalProperties": false,
-      "name": "clear",
-      "level": "TRACE",
-      "target": "amaru::stores::ledger::recently_unregistered_accounts",
-      "description": "Clear all recently unregistered accounts",
-      "public": true
-    },
     "amaru::stores::ledger::recently_unregistered_accounts::INSERT": {
       "type": "object",
       "properties": {},
@@ -4049,6 +4037,25 @@
       "level": "TRACE",
       "target": "amaru::stores::ledger::recently_unregistered_accounts",
       "description": "Insert a recently unregistered account",
+      "public": true
+    },
+    "amaru::stores::ledger::recently_unregistered_accounts::PRUNE": {
+      "type": "object",
+      "properties": {
+        "epoch": {
+          "type": "string",
+          "description": "Custom type: Epoch"
+        }
+      },
+      "required": [
+        "epoch"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "prune",
+      "level": "TRACE",
+      "target": "amaru::stores::ledger::recently_unregistered_accounts",
+      "description": "Prune recently unregistered accounts",
       "public": true
     },
     "amaru::stores::ledger::recently_unregistered_accounts::REMOVE": {

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -244,6 +244,29 @@
       "description": "Detect locally-created snapshots from create-snapshots",
       "public": true
     },
+    "amaru::bootstrap::local_snapshots::FAIL_TO_READ": {
+      "type": "object",
+      "properties": {
+        "file": {
+          "type": "string"
+        },
+        "hint": {
+          "type": "string",
+          "description": "Custom type: anyhow::Error"
+        }
+      },
+      "required": [
+        "file",
+        "hint"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "fail_to_read",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::local_snapshots",
+      "description": "Failed to read or parse a local snapshot",
+      "public": true
+    },
     "amaru::bootstrap::nonces::IMPORT": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
@etorreborre my take on #1038; I figured that instead of keeping something in-memory (which may grow unbounded...) we may as well just put it in the store. It also simplifies the management of it, in particular around epoch transitions, quite a lot IMO. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved epoch transition reward calculations by focusing on recently unregistered accounts instead of scanning all accounts.
* **Bug Fixes**
  * Fixed effective reward accounting for accounts unregistered during the current epoch.
  * Recently unregistered account tracking is now persisted, pruned at epoch boundaries, and kept in sync with account add/remove.
* **Observability**
  * Added trace events for recently unregistered account record insert, remove, and prune.
  * Added a bootstrap trace event when local snapshot reads fail.
* **Chores**
  * Updated the default database bootstrap cache version when not explicitly set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->