### PR TITLE
fix: fix the recheck of deferred headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Other guiding principles:
 
 - **amaru-ledger**: reject pool retirement when the retirement epoch is out of range. ([#1036][])
 - **amaru-ledger**: validate stake pool exists when attempting to unregister ([#912][], [#1034][])
+- **amaru-consensus**: fix the recheck deferred headers loop ([#1078][], [#1082][])
 
 ## [v10.11.20260723](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260723)
 
@@ -223,3 +224,5 @@ Other guiding principles:
 [#1055]: https://github.com/pragma-org/amaru/pull/1055
 [#1056]: https://github.com/pragma-org/amaru/pull/1056
 [#1060]: https://github.com/pragma-org/amaru/issues/1060
+[#1078]: https://github.com/pragma-org/amaru/issues/1078
+[#1082]: https://github.com/pragma-org/amaru/pull/1082

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -111,7 +111,8 @@ pub const HEIGHT_RECHECK_INTERVAL: Duration = Duration::from_millis(200);
 /// `TrackPeers::recheck_deferred` walks `deferred` in order. A peer stays blocked while any
 /// earlier deferred item for that peer is still blocked (so FollowUps wait on prior
 /// LedgerHeight / stake / clock items). When an item is ready, it is re-run through
-/// `TrackPeers::try_roll_forward`.
+/// `TrackPeers::try_roll_forward`. If re-running an item fails validation (adversarial), the
+/// connection is purged and its remaining deferred items are dropped.
 ///
 /// # Effects and sends
 ///
@@ -165,7 +166,7 @@ impl PerPeer {
     }
 }
 
-#[derive(Default, Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 enum DeferReason {
     /// Wait until the ledger has reached at least this applied block height before asking the peer for more.
     LedgerHeight { min_height: BlockHeight, header: BlockHeader, tip: Tip, variant: EraName },
@@ -177,8 +178,6 @@ enum DeferReason {
     ClockSkew { min_time: Instant, header: BlockHeader, tip: Tip, variant: EraName, rn_sent: bool },
     /// A follow-up header that was received after a previous header was deferred.
     FollowUp { header: BlockHeader, tip: Tip, variant: EraName },
-    #[default]
-    Placeholder,
 }
 
 /// A header (or request) that was deferred. The reason indicates what is blocking and what data
@@ -190,17 +189,6 @@ struct DeferredHeader {
     handler: StageRef<chainsync::InitiatorMessage>,
     reason: DeferReason,
     trace_context: TraceContext,
-}
-impl Default for DeferredHeader {
-    fn default() -> Self {
-        Self {
-            peer: Peer::new(""),
-            conn_id: ConnectionId::initial(),
-            handler: StageRef::blackhole(),
-            reason: DeferReason::default(),
-            trace_context: Default::default(),
-        }
-    }
 }
 
 struct RollForwardArgs {
@@ -217,7 +205,6 @@ struct RollForwardArgs {
 impl From<DeferredHeader> for RollForwardArgs {
     fn from(dh: DeferredHeader) -> RollForwardArgs {
         let DeferredHeader { peer, conn_id, handler, reason, trace_context } = dh;
-        #[expect(clippy::panic)]
         match reason {
             DeferReason::LedgerHeight { header, tip, variant, .. } => RollForwardArgs {
                 peer,
@@ -259,7 +246,6 @@ impl From<DeferredHeader> for RollForwardArgs {
                 tip,
                 trace_context,
             },
-            DeferReason::Placeholder => panic!("cannot convert Placeholder to RollForwardArgs"),
         }
     }
 }
@@ -533,7 +519,7 @@ impl TrackPeers {
             .filter_map(|d| match &d.reason {
                 DeferReason::LedgerHeight { .. } => Some(now + HEIGHT_RECHECK_INTERVAL),
                 DeferReason::ClockSkew { min_time, .. } => Some(*min_time),
-                DeferReason::StakeDistribution { .. } | DeferReason::FollowUp { .. } | DeferReason::Placeholder => None,
+                DeferReason::StakeDistribution { .. } | DeferReason::FollowUp { .. } => None,
             })
             .min()
     }
@@ -791,32 +777,35 @@ impl TrackPeers {
 
         let current_time = eff.clock().await;
 
+        // try_roll_forward may purge a connection, which removes its entries from
+        // self.deferred. Iterating over a taken copy keeps that reentrant mutation
+        // from invalidating the iteration; entries already taken out are beyond the
+        // purge's reach, so they are skipped explicitly.
         let mut blocked = BTreeSet::new();
-        let mut pos = 0;
-        for idx in 0..self.deferred.len() {
-            let d = take(&mut self.deferred[idx]);
+        for d in take(&mut self.deferred) {
             let conn_id = d.conn_id;
+            if !self.upstream.contains_key(&conn_id) {
+                continue;
+            }
             let defer = blocked.contains(&conn_id)
                 || match &d.reason {
                     DeferReason::LedgerHeight { min_height, .. } => curr_height < *min_height,
                     DeferReason::StakeDistribution { epoch, .. } => self.max_epoch < *epoch,
                     DeferReason::ClockSkew { min_time, .. } => current_time < *min_time,
                     DeferReason::FollowUp { .. } => false,
-                    DeferReason::Placeholder => false,
                 };
             if defer {
                 blocked.insert(conn_id);
-                self.deferred[pos] = d;
-                pos += 1;
+                self.deferred.push(d);
                 continue;
             }
 
             if let Err(dh) = self.try_roll_forward(d.into(), eff, current_time).await {
-                self.deferred[pos] = dh;
-                pos += 1;
+                // the connection must still be marked as blocked
+                blocked.insert(conn_id);
+                self.deferred.push(dh);
             }
         }
-        self.deferred.truncate(pos);
         self.ensure_recheck_armed(eff).await;
     }
 }

--- a/crates/amaru-consensus/src/stages/track_peers/tests.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/tests.rs
@@ -1161,3 +1161,110 @@ fn test_pipelined_stake_defer_and_wake_sequence() {
         ],
     );
 }
+
+/// Two headers deferred for the same connection; on recheck the first fails validation and
+/// purges the connection, which also drops the second entry from the deferred list.
+/// Regression: the recheck loop used to index past the shrunk list and panic.
+#[test]
+fn test_recheck_deferred_survives_purge_shrinking_the_list() {
+    let prep = test_prep();
+    let peer = Peer::new("peer1");
+    let parent = &prep.headers[0];
+    let wrong_parent = HeaderHash::from([9u8; 32]);
+    let h1 = make_block_header(2, 2, Some(wrong_parent));
+    let h2 = make_block_header(3, 3, Some(h1.hash()));
+
+    let mut state = prep.state.clone();
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), parent.tip());
+    state.push_deferred_for_tests(peer.clone(), prep.conn_id, prep.handler.clone(), h1.clone(), h1.tip());
+    state.push_deferred_for_tests(peer.clone(), prep.conn_id, prep.handler.clone(), h2.clone(), h2.tip());
+
+    let msg = TrackPeersMsg::RecheckLedgerHeight;
+
+    let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
+    assert_trace_match(
+        &running,
+        &[
+            te_state("tp-1", &state).into(),
+            te_input("tp-1", &msg).into(),
+            tm_volatile_tip("tp-1"),
+            te_clock_suspend("tp-1").into(),
+            te_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer)).into(),
+            tm_state::<TrackPeers>(
+                "tp-1",
+                |s| s.deferred.is_empty() && s.upstream.is_empty(),
+                "connection purged with all its deferred entries",
+            ),
+        ],
+    );
+    logs.assert_and_remove(Level::ERROR, &["chain_sync.validate_header.failed", "Invalid header parent"])
+        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+/// A deferred header that is still deferred on recheck must keep blocking its follow-ups.
+/// The peer tip has not advanced, so validating a follow-up would wrongly flag the peer as adversarial.
+#[test]
+fn test_redeferred_header_keeps_blocking_follow_ups() {
+    let prep = test_prep();
+    let peer = Peer::new("peer1");
+    let parent = &prep.headers[0];
+    let h1 = prep.headers[1].clone();
+    let h2 = make_block_header(3, h1.slot().as_u64() + 1, Some(h1.hash()));
+
+    let msg1 = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
+        peer: peer.clone(),
+        conn_id: prep.conn_id,
+        handler: prep.handler.clone(),
+        msg: chainsync::InitiatorResult::RollForward(HeaderContent::new(&h1, EraName::Conway), h1.tip()),
+    });
+    let msg2 = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
+        peer: peer.clone(),
+        conn_id: prep.conn_id,
+        handler: prep.handler.clone(),
+        msg: chainsync::InitiatorResult::RollForward(HeaderContent::new(&h2, EraName::Conway), h2.tip()),
+    });
+    // One epoch ahead of known max_epoch (start-2). We defer the header.
+    let first_target = prep.start_times.epoch.checked_sub(Epoch::ONE).unwrap();
+    // The stake distribution is updated but the header stays deferred.
+    let stake_distribution_update = TrackPeersMsg::StakeDistUpdated(first_target);
+    let second_target = prep.start_times.epoch;
+
+    let mut state = prep.state.clone();
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), h2.tip());
+
+    let slot1 = h1.slot();
+    let (running, _guards, mut logs) = setup_base(
+        &prep.rt_handle(),
+        state.clone(),
+        [msg1.clone(), msg2.clone(), stake_distribution_update.clone()],
+        build_store(&[]),
+        |running| {
+            let mut n = 0u8;
+            running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, move |_| {
+                n += 1;
+                let target = if n == 1 { first_target } else { second_target };
+                OverrideResult::handled(Err(ValidateHeaderError::Assert(AssertHeaderError::PoolError(
+                    GetPoolError::StakeDistributionNotAvailable(slot1, Some(target)),
+                ))))
+            });
+        },
+    );
+
+    logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+    assert_trace_contains(
+        &running,
+        &[
+            te_input("tp-1", &msg1).into(),
+            tm_state::<TrackPeers>("tp-1", |s| s.deferred.len() == 1, "first header deferred"),
+            te_input("tp-1", &msg2).into(),
+            tm_state::<TrackPeers>("tp-1", |s| s.deferred.len() == 2, "its follow-up is queued"),
+            te_input("tp-1", &stake_distribution_update).into(),
+            tm_state::<TrackPeers>(
+                "tp-1",
+                |s| s.deferred.len() == 2 && !s.upstream.is_empty(),
+                "both headers are still deferred after recheck. The connection is active",
+            ),
+        ],
+    );
+    assert_trace_does_not_contain(&running, &[tm_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer))]);
+}


### PR DESCRIPTION
This PR fixes the iteration for checking the deferred headers: #1078. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deferred-header rechecks to safely handle connection purges while preventing issues when pending items shrink.
  * Ensured deferred headers are only reprocessed once valid prerequisites are available, and re-deferred items continue to block dependent work.
* **Tests**
  * Added regression tests covering purge and redefer scenarios during recheck.
* **Documentation**
  * Updated the unreleased changelog with the deferred-headers recheck fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->