### PR TITLE
fix: do not defer header validation based on block height / max epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Other guiding principles:
 - **amaru-ledger**: reject pool retirement when the retirement epoch is out of range. ([#1036][])
 - **amaru-ledger**: validate stake pool exists when attempting to unregister ([#912][], [#1034][])
 - **amaru-consensus**: fix the recheck deferred headers loop ([#1078][], [#1082][])
+- **amaru-consensus**: do not defer header validation based on height or epoch; only rely on availability of the stake distributions.
 
 ## [v10.11.20260723](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260723)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ Other guiding principles:
 - **amaru-ledger**: reject pool retirement when the retirement epoch is out of range. ([#1036][])
 - **amaru-ledger**: validate stake pool exists when attempting to unregister ([#912][], [#1034][])
 - **amaru-consensus**: fix the recheck deferred headers loop ([#1078][], [#1082][])
-- **amaru-consensus**: do not defer header validation based on height or epoch; only rely on availability of the stake distributions.
+- **amaru-consensus**: do not defer header validation based on height or epoch; only rely on availability of the stake distributions. ([#1084][])
 
 ## [v10.11.20260723](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260723)
 
@@ -244,3 +244,4 @@ Other guiding principles:
 [#1060]: https://github.com/pragma-org/amaru/issues/1060
 [#1078]: https://github.com/pragma-org/amaru/issues/1078
 [#1082]: https://github.com/pragma-org/amaru/pull/1082
+[#1084]: https://github.com/pragma-org/amaru/pull/1084

--- a/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
@@ -32,6 +32,10 @@ use crate::stages::{
 // TODO make configurable
 const MAX_MISSING_BLOCKS_PER_BATCH: usize = 25;
 
+/// Upper bound on the number of points collected when computing the missing-blocks cursor.
+/// This only bounds memory: the cursor itself is consumed in batches of [`MAX_MISSING_BLOCKS_PER_BATCH`].
+const MAX_MISSING_BLOCKS_SCAN: usize = 100_000;
+
 /// Block fetch coordinator stage.
 ///
 /// This stage drives the retrieval of full blocks for headers that have been selected
@@ -46,13 +50,17 @@ const MAX_MISSING_BLOCKS_PER_BATCH: usize = 25;
 /// - Pure actor stage (see `stage()` fn) processing `FetchBlocksMsg`.
 /// - Collaborates with a dynamically ensured child stage (`cleanup_replies`) to safely
 ///   handle out-of-order or late block replies without clogging its own mailbox.
-/// - Uses bounded batches (MAX_MISSING_BLOCKS_PER_BATCH=25) for fetch requests.
+/// - Maintains a missing-blocks cursor that is consumed in bounded batches across successive fetch
+///   requests.
 /// - Timeout-driven retry (5s) with upstream signaling for continuation.
 ///
 /// ## Input messages and behaviour
-/// - `NewTip(tip, parent)`: Update tracked block_height, assert no outstanding missing,
-///   delegate to `request_missing_blocks` which queries store for gaps and (if any)
-///   sends `ManagerMessage::FetchBlocks` (with cr=child ref for replies) then schedules
+/// - `NewTip(tip, parent, chain_switched)`: Update tracked block_height, assert no outstanding request,
+///   delegate to `request_missing_blocks`. When the cursor still holds points and the best chain
+///   has not switched to another branch (`chain_switched` is false, as tracked by select_chain),
+///   the next batch is served straight from the cursor.
+///   Otherwise the cursor is recomputed via `find_missing_blocks`. If there is anything to fetch, sends
+///   `ManagerMessage::FetchBlocks` (with cr=child ref for replies) then schedules
 ///   a `Timeout(req_id)`.
 /// - `RecoverStoredBlocks(best_hash)`: Startup recovery only. If origin, signal upstream
 ///   immediately. Otherwise replay any unvalidated-but-stored blocks downstream for
@@ -61,10 +69,12 @@ const MAX_MISSING_BLOCKS_PER_BATCH: usize = 25;
 /// - `Block(peer, network_block)`: Decode + basic integrity (body_hash match → adversarial
 ///   on fail), ordering checks against current `missing` cursor (parent + first point;
 ///   stragglers logged and dropped). On match: store block, send `(Tip, parent_boundary, block_height)`
-///   downstream, `shift_one_block` on cursor; if now empty, clear state, cancel timeout,
-///   signal `FetchNextFrom` upstream.
-/// - `Timeout(req_id)`: If matches current, log error (unless paused for no peers), clear
-///   missing/timeout, signal `FetchNextFrom(boundary)` upstream to retry (no direct peer penalty here).
+///   downstream, `shift_one_block` on cursor; when the current request's last point
+///   (`requested_through`) arrives, cancel the timeout and signal `FetchNextFrom` upstream
+///   (the cursor keeps any remaining points for the next batch).
+/// - `Timeout(req_id)`: If matches current, log error (unless paused for no peers), clear the
+///   outstanding request/timeout (the cursor is kept: the unfetched remainder is still at its
+///   front), signal `FetchNextFrom(boundary)` upstream to retry (no direct peer penalty here).
 /// - `NoPeersAvailable(req_id)`: If matches current, log INFO that fetch is paused; leave the
 ///   5s timeout armed so retry is rate-limited without ERROR.
 ///
@@ -85,9 +95,12 @@ const MAX_MISSING_BLOCKS_PER_BATCH: usize = 25;
 /// ## Key state (missing blocks, requests, timeouts)
 /// - `downstream: StageRef<(Tip, Point, BlockHeight)>`: where validated-ready blocks go (contramapped in wiring).
 /// - `req_id: u64`: monotonic, incremented on each new FetchBlocks; used to pair timeouts and filter in child.
-/// - `missing: Option<MissingBlocks>`: cursor over current batch (from `find_missing_blocks`); supports
-///   `from_to()`, `first()`, `boundary()`, `shift_one_block()`, `is_empty()`, `nb_missing_blocks()`.
-///   Asserted None on NewTip/Recover entry; cleared on completion, timeout, or no-work cases.
+/// - `missing: Option<MissingBlocks>`: cursor over all known-missing blocks (from `find_missing_blocks`);
+///   supports `first()`, `nth()`, `boundary()`, `shift_one_block()`, `is_empty()`, `nb_missing_blocks()`.
+///   Persists across fetch requests and timeouts; cleared when exhausted or when the best chain
+///   switched to another branch (`chain_switched` on `NewTip`).
+/// - `requested_through: Option<Point>`: last point of the outstanding fetch request; asserted None on
+///   NewTip entry; cleared on completion or timeout.
 /// - `timeout: Option<ScheduleId>`: the pending 5s timeout for current req; taken/cancelled only on batch success.
 /// - `no_peers_pause: bool`: set when manager reports no initiating connections; suppresses ERROR on the following timeout.
 /// - `block_height: BlockHeight`: monotonic max over seen tips; passed with every downstream send (for both live and recovered blocks).
@@ -108,7 +121,12 @@ const MAX_MISSING_BLOCKS_PER_BATCH: usize = 25;
 pub struct FetchBlocks {
     downstream: StageRef<DownloadedBlock>,
     req_id: u64,
+    /// Cursor over the blocks that still need to be fetched, oldest first. It is computed with a
+    /// single (expensive) backward walk over unfetched headers and then consumed in batches of
+    /// [`MAX_MISSING_BLOCKS_PER_BATCH`] across successive fetch requests.
     missing: Option<MissingBlocks>,
+    /// The last point of the currently outstanding fetch request, if any.
+    requested_through: Option<Point>,
     upstream: StageRef<SelectChainMsg>,
     manager: StageRef<ManagerMessage>,
     block_source: StageRef<BlockSourceMsg>,
@@ -135,6 +153,7 @@ impl FetchBlocks {
             downstream,
             req_id: 0,
             missing: None,
+            requested_through: None,
             upstream,
             manager,
             block_source,
@@ -165,6 +184,7 @@ impl FetchBlocks {
         &mut self,
         tip: Tip,
         parent: Point,
+        chain_switched: bool,
         eff: Effects<FetchBlocksMsg>,
         parent_context: TraceContext,
     ) {
@@ -172,9 +192,9 @@ impl FetchBlocks {
 
         tracing::debug!(tip = %tip.point(), parent = %parent, "fetching blocks");
         assert!(
-            self.missing.is_none(),
-            "there shouldn't be any missing blocks when starting a new tip: {:?}",
-            self.missing
+            self.requested_through.is_none(),
+            "there shouldn't be an outstanding fetch request when starting a new tip: {:?}",
+            self.requested_through
         );
 
         let span = debug_span!(
@@ -185,7 +205,9 @@ impl FetchBlocks {
         );
         let stage_context = (&span).into();
 
-        self.request_missing_blocks(tip, parent, eff, parent_context, stage_context).instrument(span).await;
+        self.request_missing_blocks(tip, parent, chain_switched, eff, parent_context, stage_context)
+            .instrument(span)
+            .await;
     }
 
     /// Startup-only recovery: resubmit downloaded blocks whose validity was not
@@ -241,7 +263,8 @@ impl FetchBlocks {
                     parent = Some(tip.point());
                 }
                 Ok(false) => {
-                    self.request_missing_blocks(tip, block_parent, eff, trace_context.clone(), trace_context).await;
+                    self.request_missing_blocks(tip, block_parent, true, eff, trace_context.clone(), trace_context)
+                        .await;
                     return;
                 }
                 Err(error) => {
@@ -259,55 +282,52 @@ impl FetchBlocks {
         &mut self,
         tip: Tip,
         parent: Point,
+        chain_switched: bool,
         eff: Effects<FetchBlocksMsg>,
         parent_context: TraceContext,
         stage_context: TraceContext,
     ) {
         let store = Store::new(eff.clone()).with_trace_context(&stage_context);
-        match store.find_missing_blocks(tip.hash(), MAX_MISSING_BLOCKS_PER_BATCH).await {
-            Ok(MissingBlocksResult::StartHeaderNotFound) => {
-                tracing::error!("failed to load initial header");
-                return eff.terminate().await;
-            }
-            Ok(MissingBlocksResult::BoundaryNotFound) => {
-                tracing::debug!("no boundary for missing blocks found given the new tip");
-                self.missing = None;
-            }
-            Ok(MissingBlocksResult::Found(missing_blocks)) => {
-                self.missing = Some(missing_blocks);
-            }
-            Err(error) => {
-                tracing::error!(%error, "failed to find missing blocks");
-                return eff.terminate().await;
+
+        let reuse_cursor = !chain_switched && self.missing.as_ref().is_some_and(|missing| !missing.is_empty());
+        if !reuse_cursor {
+            self.missing = None;
+            match store.find_missing_blocks(tip.hash(), MAX_MISSING_BLOCKS_SCAN).await {
+                Ok(MissingBlocksResult::StartHeaderNotFound) => {
+                    tracing::error!("failed to load initial header");
+                    return eff.terminate().await;
+                }
+                Ok(MissingBlocksResult::BoundaryNotFound) => {
+                    tracing::debug!("no boundary for missing blocks found given the new tip");
+                }
+                Ok(MissingBlocksResult::Found(missing_blocks)) => {
+                    self.missing = Some(missing_blocks);
+                }
+                Err(error) => {
+                    tracing::error!(%error, "failed to find missing blocks");
+                    return eff.terminate().await;
+                }
             }
         }
         let Some(missing) = self.missing.as_ref() else {
             return;
         };
 
-        match missing.from_to() {
-            None => {
-                self.missing = None;
-                tracing::info!(tip = %tip.point(), parent = %parent, "no blocks to fetch");
-                self.fetch_next_from(eff, tip.point()).await;
-            }
-            Some((from, to)) => {
-                tracing::debug!(%from, %to, length = missing.nb_missing_blocks(), "requesting blocks");
+        let batch_size = missing.nb_missing_blocks().min(MAX_MISSING_BLOCKS_PER_BATCH);
+        match (missing.first(), missing.nth(batch_size.wrapping_sub(1))) {
+            (Some(from), Some(through)) => {
+                tracing::debug!(%from, %through, length = batch_size, remaining = missing.nb_missing_blocks(), "requesting blocks");
                 self.req_id += 1;
                 self.no_peers_pause = false;
+                self.requested_through = Some(through);
                 self.trace_context = Some(parent_context);
 
                 let now = eff.clock().await;
                 let requested: Vec<HeaderHash> =
-                    missing.missing_points().into_iter().map(|point| point.hash()).collect();
+                    missing.missing_points().into_iter().take(batch_size).map(|point| point.hash()).collect();
                 eff.send(
                     &self.manager,
-                    ManagerMessage::FetchBlocks {
-                        from: *from,
-                        through: *to,
-                        id: self.req_id,
-                        cr: self.cleanup_replies.clone(),
-                    },
+                    ManagerMessage::FetchBlocks { from, through, id: self.req_id, cr: self.cleanup_replies.clone() },
                 )
                 .await;
                 // Tell the select_chain stage when this block was received so it can record the
@@ -315,6 +335,11 @@ impl FetchBlocks {
                 eff.send(&self.upstream, SelectChainMsg::BlocksRequested(requested, now)).await;
                 let timeout = eff.schedule_after(FetchBlocksMsg::Timeout(self.req_id), Duration::from_secs(5)).await;
                 self.timeout = Some(timeout);
+            }
+            _ => {
+                self.missing = None;
+                tracing::info!(tip = %tip.point(), parent = %parent, "no blocks to fetch");
+                self.fetch_next_from(eff, tip.point()).await;
             }
         }
     }
@@ -377,6 +402,9 @@ impl FetchBlocks {
         missing.shift_one_block();
         if missing.is_empty() {
             self.missing = None;
+        }
+        if self.requested_through == Some(point) {
+            self.requested_through = None;
             self.no_peers_pause = false;
             if let Some(timeout) = self.timeout.take() {
                 eff.cancel_schedule(timeout).await;
@@ -386,7 +414,7 @@ impl FetchBlocks {
     }
 
     pub async fn no_peers_available(&mut self, req_id: u64, _eff: Effects<FetchBlocksMsg>) {
-        if req_id != self.req_id || self.missing.is_none() {
+        if req_id != self.req_id || self.requested_through.is_none() {
             return;
         }
 
@@ -408,7 +436,9 @@ impl FetchBlocks {
             None => (),
             Some(from) => {
                 self.timeout = None;
-                self.missing = None;
+                // keep `missing`: the unfetched remainder of the timed-out request is still at
+                // the front of the cursor and will be re-requested on the next tip
+                self.requested_through = None;
                 self.no_peers_pause = false;
                 self.fetch_next_from(eff, from).await;
             }
@@ -437,7 +467,7 @@ impl DownloadedBlock {
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum FetchBlocksMsg {
-    NewTip { tip: Tip, parent: Point, trace_context: TraceContext },
+    NewTip { tip: Tip, parent: Point, chain_switched: bool, trace_context: TraceContext },
     RecoverStoredBlocks(HeaderHash, TraceContext),
     Block(Peer, NetworkBlock),
     Timeout(u64),
@@ -446,7 +476,7 @@ pub enum FetchBlocksMsg {
 
 impl FetchBlocksMsg {
     pub fn new_tip(tip: Tip, parent: Point) -> Self {
-        Self::NewTip { tip, parent, trace_context: Default::default() }
+        Self::NewTip { tip, parent, chain_switched: false, trace_context: Default::default() }
     }
 
     pub fn recover_stored_blocks(best_hash: HeaderHash) -> Self {
@@ -460,7 +490,9 @@ pub async fn stage(mut state: FetchBlocks, msg: FetchBlocksMsg, eff: Effects<Fet
     })
     .await;
     match msg {
-        FetchBlocksMsg::NewTip { tip, parent, trace_context } => state.new_tip(tip, parent, eff, trace_context).await,
+        FetchBlocksMsg::NewTip { tip, parent, chain_switched, trace_context } => {
+            state.new_tip(tip, parent, chain_switched, eff, trace_context).await
+        }
         FetchBlocksMsg::RecoverStoredBlocks(best_hash, trace_context) => {
             state.trace_context = Some(trace_context);
             state.recover_stored_blocks(eff, best_hash).await

--- a/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
@@ -112,7 +112,8 @@ impl TestPrep {
     }
 
     pub fn state_with_request(&self, missing: MissingBlocks, req_id: u64, timeout: ScheduleId) -> FetchBlocks {
-        FetchBlocks { req_id, missing: Some(missing), timeout: Some(timeout), ..self.state.clone() }
+        let requested_through = missing.last();
+        FetchBlocks { req_id, missing: Some(missing), requested_through, timeout: Some(timeout), ..self.state.clone() }
     }
 
     pub fn state_with_block_height(&self, block_height: u64) -> FetchBlocks {

--- a/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
@@ -26,8 +26,8 @@ use tracing::Level;
 use super::*;
 use crate::stages::{
     fetch_blocks::test_setup::{
-        TestPrep, setup, te_cancel_schedule, te_clock, te_find_missing_blocks, te_has_block, te_load_header,
-        te_load_tip, te_schedule, te_store_block, te_unvalidated_ancestor_hashes, test_peer, test_prep,
+        TestPrep, make_block_header, setup, te_cancel_schedule, te_clock, te_find_missing_blocks, te_has_block,
+        te_load_header, te_load_tip, te_schedule, te_store_block, te_unvalidated_ancestor_hashes, test_peer, test_prep,
     },
     test_utils::{
         assert_trace, start_in_era, te_clock_read, te_input, te_send, te_state, te_terminate, te_terminated, tm_state,
@@ -48,7 +48,7 @@ fn test_new_tip_load_header_fails() {
         &[
             te_state("fb-1", &prep.state),
             te_input("fb-1", &msg),
-            te_find_missing_blocks("fb-1", tip.hash(), 25),
+            te_find_missing_blocks("fb-1", tip.hash(), MAX_MISSING_BLOCKS_SCAN),
             te_terminate("fb-1"),
             te_terminated("fb-1", TerminationReason::Voluntary),
         ],
@@ -72,14 +72,15 @@ fn test_new_tip_no_blocks_to_fetch() {
     let msg = FetchBlocksMsg::new_tip(tip, parent);
 
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    let expected = prep.state_with_block_height(3);
     assert_trace(
         &running,
         &[
             te_state("fb-1", &prep.state),
             te_input("fb-1", &msg),
-            te_find_missing_blocks("fb-1", tip.hash(), 25),
+            te_find_missing_blocks("fb-1", tip.hash(), MAX_MISSING_BLOCKS_SCAN),
             te_send("fb-1", "upstream", SelectChainMsg::fetch_next_from(tip.point())),
-            te_state("fb-1", &prep.state_with_block_height(3)),
+            te_state("fb-1", &expected),
         ],
     );
     logs.assert_and_remove(Level::INFO, &["no blocks to fetch"]).assert_no_remaining_at([
@@ -160,7 +161,7 @@ fn test_new_tip_blocks_to_fetch() {
     let requested_at = Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time);
     let state_after_timeout = {
         let mut state = state_with_timeout.clone();
-        state.missing = None;
+        state.requested_through = None;
         state.timeout = None;
         state.trace_context = None;
         state
@@ -170,7 +171,7 @@ fn test_new_tip_blocks_to_fetch() {
         &[
             te_state("fb-1", &prep.state),
             te_input("fb-1", &msg),
-            te_find_missing_blocks("fb-1", tip.hash(), 25),
+            te_find_missing_blocks("fb-1", tip.hash(), MAX_MISSING_BLOCKS_SCAN),
             te_clock_read("fb-1"),
             te_send(
                 "fb-1",
@@ -267,6 +268,7 @@ fn test_block2_received() {
     let expected = {
         let mut state = prep.state.clone();
         state.missing = None;
+        state.requested_through = None;
         state.timeout = None;
         state
     };
@@ -321,7 +323,7 @@ fn test_new_tip_find_missing_blocks_error() {
         &running,
         &[
             te_input("fb-1", &msg).into(),
-            te_find_missing_blocks("fb-1", tip.hash(), 25).into(),
+            te_find_missing_blocks("fb-1", tip.hash(), MAX_MISSING_BLOCKS_SCAN).into(),
             te_terminate("fb-1").into(),
             te_terminated("fb-1", TerminationReason::Voluntary).into(),
         ],
@@ -442,7 +444,7 @@ fn test_timeout_after_no_peers_pause_retries_without_error() {
 
     let state_after_timeout = {
         let mut state = prep.state.clone();
-        state.missing = None;
+        state.requested_through = None;
         state.timeout = None;
         state.no_peers_pause = false;
         state.trace_context = None;
@@ -481,6 +483,211 @@ fn test_no_peers_available_stale_is_ignored() {
     assert_trace(&running, &[te_state("fb-1", &prep.state), te_input("fb-1", &msg), te_state("fb-1", &prep.state)]);
 
     logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_new_tip_reuses_cursor_for_same_tip() {
+    let mut prep = test_prep();
+    prep.store_headers(&[&prep.headers.h0, &prep.headers.h1, &prep.headers.h2]);
+    prep.set_anchor(prep.headers.h0.hash());
+    // leftover cursor from a timed-out request for the same tip
+    prep.state.missing =
+        Some(MissingBlocks::new(prep.headers.h0.point(), vec![prep.headers.h1.point(), prep.headers.h2.point()]));
+    prep.state.req_id = 1;
+
+    let tip = prep.headers.h2.tip();
+    let msg = FetchBlocksMsg::new_tip(tip, prep.headers.h1.point());
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+
+    let timeout_at = Instant::at_offset(Duration::from_secs(10 + 5), start_in_era().relative_time);
+    let schedule_id = ScheduleIds::default().next_at(timeout_at);
+    let requested_at = Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time);
+    let expected = {
+        let mut state = prep.state.clone();
+        state.req_id = 2;
+        state.requested_through = Some(prep.headers.h2.point());
+        state.timeout = Some(schedule_id);
+        state.block_height = BlockHeight::from(3);
+        state.trace_context = Some(Default::default());
+        state
+    };
+    let state_after_timeout = {
+        let mut state = expected.clone();
+        state.requested_through = None;
+        state.timeout = None;
+        state.trace_context = None;
+        state
+    };
+    // the cursor is reused as-is: no find_missing_blocks
+    assert_trace(
+        &running,
+        &[
+            te_state("fb-1", &prep.state),
+            te_input("fb-1", &msg),
+            te_clock_read("fb-1"),
+            te_send(
+                "fb-1",
+                "manager",
+                ManagerMessage::FetchBlocks {
+                    from: prep.headers.h1.point(),
+                    through: prep.headers.h2.point(),
+                    id: 2,
+                    cr: prep.cleanup_replies.clone(),
+                },
+            ),
+            te_send(
+                "fb-1",
+                "upstream",
+                SelectChainMsg::BlocksRequested(vec![prep.headers.h1.hash(), prep.headers.h2.hash()], requested_at),
+            ),
+            te_schedule("fb-1", FetchBlocksMsg::Timeout(2), schedule_id),
+            te_state("fb-1", &expected),
+            te_clock(timeout_at),
+            te_input("fb-1", &FetchBlocksMsg::Timeout(2)),
+            te_send("fb-1", "upstream", SelectChainMsg::fetch_next_from(prep.headers.h0.point())),
+            te_state("fb-1", &state_after_timeout),
+        ],
+    );
+    logs.assert_and_remove(Level::DEBUG, &["requesting blocks"])
+        .assert_and_remove(Level::ERROR, &["timeout fetching blocks"])
+        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_new_tip_reuses_cursor_when_tip_extends_its_chain() {
+    let mut prep = test_prep();
+    prep.store_headers(&[&prep.headers.h0, &prep.headers.h1, &prep.headers.h2]);
+    prep.set_anchor(prep.headers.h0.hash());
+    // cursor computed when h1 was the tip; h2 now extends that chain
+    prep.state.missing = Some(MissingBlocks::new(prep.headers.h0.point(), vec![prep.headers.h1.point()]));
+    prep.state.req_id = 1;
+
+    let tip = prep.headers.h2.tip();
+    let msg = FetchBlocksMsg::new_tip(tip, prep.headers.h1.point());
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+
+    let timeout_at = Instant::at_offset(Duration::from_secs(10 + 5), start_in_era().relative_time);
+    let schedule_id = ScheduleIds::default().next_at(timeout_at);
+    let requested_at = Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time);
+    let expected = {
+        let mut state = prep.state.clone();
+        state.req_id = 2;
+        state.requested_through = Some(prep.headers.h1.point());
+        state.timeout = Some(schedule_id);
+        state.block_height = BlockHeight::from(3);
+        state.trace_context = Some(Default::default());
+        state
+    };
+    let state_after_timeout = {
+        let mut state = expected.clone();
+        state.requested_through = None;
+        state.timeout = None;
+        state.trace_context = None;
+        state
+    };
+    // the chain has not switched: the cursor is reused without any store access
+    assert_trace(
+        &running,
+        &[
+            te_state("fb-1", &prep.state),
+            te_input("fb-1", &msg),
+            te_clock_read("fb-1"),
+            te_send(
+                "fb-1",
+                "manager",
+                ManagerMessage::FetchBlocks {
+                    from: prep.headers.h1.point(),
+                    through: prep.headers.h1.point(),
+                    id: 2,
+                    cr: prep.cleanup_replies.clone(),
+                },
+            ),
+            te_send("fb-1", "upstream", SelectChainMsg::BlocksRequested(vec![prep.headers.h1.hash()], requested_at)),
+            te_schedule("fb-1", FetchBlocksMsg::Timeout(2), schedule_id),
+            te_state("fb-1", &expected),
+            te_clock(timeout_at),
+            te_input("fb-1", &FetchBlocksMsg::Timeout(2)),
+            te_send("fb-1", "upstream", SelectChainMsg::fetch_next_from(prep.headers.h0.point())),
+            te_state("fb-1", &state_after_timeout),
+        ],
+    );
+    logs.assert_and_remove(Level::DEBUG, &["requesting blocks"])
+        .assert_and_remove(Level::ERROR, &["timeout fetching blocks"])
+        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_new_tip_drops_cursor_on_fork_switch() {
+    let mut prep = test_prep();
+    // f2 is a sibling of h2: same parent h1, same height
+    let f2 = make_block_header(3, 4, Some(prep.headers.h1.hash()));
+    prep.store_headers(&[&prep.headers.h0, &prep.headers.h1, &prep.headers.h2, &f2]);
+    prep.store_block(&prep.headers.h0);
+    prep.store_block(&prep.headers.h1);
+    prep.set_anchor(prep.headers.h0.hash());
+    // cursor computed for the h2 branch
+    prep.state.missing = Some(MissingBlocks::new(prep.headers.h1.point(), vec![prep.headers.h2.point()]));
+    prep.state.req_id = 1;
+
+    let tip = f2.tip();
+    let msg = FetchBlocksMsg::NewTip {
+        tip,
+        parent: prep.headers.h1.point(),
+        chain_switched: true,
+        trace_context: Default::default(),
+    };
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+
+    let timeout_at = Instant::at_offset(Duration::from_secs(10 + 5), start_in_era().relative_time);
+    let schedule_id = ScheduleIds::default().next_at(timeout_at);
+    let requested_at = Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time);
+    let expected = {
+        let mut state = prep.state.clone();
+        state.missing = Some(MissingBlocks::new(prep.headers.h1.point(), vec![f2.point()]));
+        state.req_id = 2;
+        state.requested_through = Some(f2.point());
+        state.timeout = Some(schedule_id);
+        state.block_height = BlockHeight::from(3);
+        state.trace_context = Some(Default::default());
+        state
+    };
+    let state_after_timeout = {
+        let mut state = expected.clone();
+        state.requested_through = None;
+        state.timeout = None;
+        state.trace_context = None;
+        state
+    };
+    // the chain switched to the f2 branch: the cursor is recomputed
+    assert_trace(
+        &running,
+        &[
+            te_state("fb-1", &prep.state),
+            te_input("fb-1", &msg),
+            te_find_missing_blocks("fb-1", f2.hash(), MAX_MISSING_BLOCKS_SCAN),
+            te_clock_read("fb-1"),
+            te_send(
+                "fb-1",
+                "manager",
+                ManagerMessage::FetchBlocks {
+                    from: f2.point(),
+                    through: f2.point(),
+                    id: 2,
+                    cr: prep.cleanup_replies.clone(),
+                },
+            ),
+            te_send("fb-1", "upstream", SelectChainMsg::BlocksRequested(vec![f2.hash()], requested_at)),
+            te_schedule("fb-1", FetchBlocksMsg::Timeout(2), schedule_id),
+            te_state("fb-1", &expected),
+            te_clock(timeout_at),
+            te_input("fb-1", &FetchBlocksMsg::Timeout(2)),
+            te_send("fb-1", "upstream", SelectChainMsg::fetch_next_from(prep.headers.h1.point())),
+            te_state("fb-1", &state_after_timeout),
+        ],
+    );
+    logs.assert_and_remove(Level::DEBUG, &["requesting blocks"])
+        .assert_and_remove(Level::ERROR, &["timeout fetching blocks"])
+        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 
 #[test]

--- a/crates/amaru-consensus/src/stages/select_chain/mod.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/mod.rs
@@ -44,6 +44,8 @@ pub use headers_performance::PerfHeaderForwardOutcome;
 /// - `best_tip`: the current best `BlockHeader` (or `None`); updated only on strictly better candidates per `cmp_tip`.
 /// - `may_fetch_blocks`: "Whether the downstream stage has sent a FetchNextFrom message that has not yet been responded to."
 ///   Starts `false` (see `new()`); controls whether a newly superior tip triggers an immediate send.
+/// - `chain_switched`: whether the best tip moved to a different branch since the last `NewBestTip` send
+///   (set on forks and on best-tip invalidation); drained into the `chain_switched` field of the next send.
 ///
 /// This stage must be preloaded at graph construction time with `Initialize(...)` (current best from store); if there is
 /// no FetchBlocks stage connected (e.g. in tests) it also needs `FetchNextFrom(Point::Origin)` (to kick off fetching) —
@@ -102,6 +104,10 @@ pub struct SelectChain {
     best_tip: Option<BlockHeader>,
     /// Whether the downstream stage has sent a FetchNextFrom message that has not yet been responded to.
     may_fetch_blocks: bool,
+    /// Whether the best tip has moved to a different branch since the last `NewBestTip` sent
+    /// downstream. Carried on the next `NewBestTip` so that the fetch_blocks stage knows whether
+    /// its missing-blocks cursor still applies to the chain of the new tip.
+    chain_switched: bool,
     /// Performance tracking for headers. It emits one `perf.header.lifecycle` event per header and
     /// records the matching metrics when a header reaches a terminal state.
     headers_performance: HeadersPerformance,
@@ -114,6 +120,7 @@ impl SelectChain {
             best_tip: None,
             tips: BTreeMap::new(),
             may_fetch_blocks: false,
+            chain_switched: false,
             headers_performance: HeadersPerformance::new(),
         }
     }
@@ -261,12 +268,15 @@ impl SelectChain {
 
             // if we have a real fork, start recording the time it takes to switch to that fork
             if parent.hash() != best_tip.hash() {
+                self.chain_switched = true;
                 self.headers_performance.fork_started(&eff.erase(), tip, received_at).await;
             }
 
             if self.may_fetch_blocks {
                 self.may_fetch_blocks = false;
-                eff.send(&self.downstream, NewBestTip { tip, parent, trace_context: parent_context }).await;
+                let chain_switched = std::mem::take(&mut self.chain_switched);
+                eff.send(&self.downstream, NewBestTip { tip, parent, chain_switched, trace_context: parent_context })
+                    .await;
             }
             self.best_tip = Some(header);
         }
@@ -317,6 +327,7 @@ impl SelectChain {
             && !self.tips.contains_key(&best_tip.hash())
         {
             tracing::info!(%removed, "best tip candidate invalidated");
+            self.chain_switched = true;
             // need to pick new best tip
             match eff.external(FindBestCandidate).await {
                 Ok(new_best_tip) if new_best_tip != ORIGIN_HASH => {
@@ -330,7 +341,12 @@ impl SelectChain {
                     let parent = load_parent_point(&eff, &store, &new_best_tip).await;
                     if self.may_fetch_blocks {
                         self.may_fetch_blocks = false;
-                        eff.send(&self.downstream, NewBestTip { tip: new_best_tip.tip(), parent, trace_context }).await;
+                        let chain_switched = std::mem::take(&mut self.chain_switched);
+                        eff.send(
+                            &self.downstream,
+                            NewBestTip { tip: new_best_tip.tip(), parent, chain_switched, trace_context },
+                        )
+                        .await;
                     }
                     let (to_validate, _) = store.unvalidated_ancestor_hashes(new_best_tip.hash()).await;
                     self.tips.insert(new_best_tip.hash(), to_validate);
@@ -396,7 +412,8 @@ impl SelectChain {
                 Point::Origin
             };
             tracing::debug!(tip = %best_tip.point(), %parent, "resuming block fetching");
-            eff.send(&self.downstream, NewBestTip { tip: best_tip.tip(), parent, trace_context }).await;
+            let chain_switched = std::mem::take(&mut self.chain_switched);
+            eff.send(&self.downstream, NewBestTip { tip: best_tip.tip(), parent, chain_switched, trace_context }).await;
         } else {
             self.may_fetch_blocks = true;
         }
@@ -408,12 +425,14 @@ impl SelectChain {
 pub struct NewBestTip {
     pub tip: Tip,
     pub parent: Point,
+    /// Whether the best tip has moved to a different branch since the previous `NewBestTip`.
+    pub chain_switched: bool,
     pub trace_context: TraceContext,
 }
 
 impl NewBestTip {
     pub fn new(tip: Tip, parent: Point) -> Self {
-        NewBestTip { tip, parent, trace_context: Default::default() }
+        NewBestTip { tip, parent, chain_switched: false, trace_context: Default::default() }
     }
 }
 

--- a/crates/amaru-consensus/src/stages/select_chain/tests.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/tests.rs
@@ -180,7 +180,7 @@ fn test_tip_h3_extends_with_anchor_at_h2() {
             te_input("sc-1", &msg),
             te_load_header("sc-1", tip.hash(), true),
             te_unvalidated_ancestor_hashes("sc-1", parent.hash()),
-            te_send("sc-1", "downstream", NewBestTip::new(tip, parent)),
+            te_send("sc-1", "downstream", NewBestTip { chain_switched: true, ..NewBestTip::new(tip, parent) }),
             te_state("sc-1", &expected),
         ],
     );
@@ -224,7 +224,7 @@ fn test_tip_h3_extends_with_best_chain_h3a() {
             te_input("sc-1", &msg),
             te_load_header("sc-1", tip.hash(), true),
             te_unvalidated_ancestor_hashes("sc-1", parent.hash()),
-            te_send("sc-1", "downstream", NewBestTip::new(tip, parent)),
+            te_send("sc-1", "downstream", NewBestTip { chain_switched: true, ..NewBestTip::new(tip, parent) }),
             te_state("sc-1", &expected),
         ],
     );
@@ -303,7 +303,7 @@ fn test_tip_h3a_extends_with_best_chain_h2() {
             te_input("sc-1", &msg),
             te_load_header("sc-1", tip.hash(), true),
             te_unvalidated_ancestor_hashes("sc-1", parent.hash()),
-            te_send("sc-1", "downstream", NewBestTip::new(tip, parent)),
+            te_send("sc-1", "downstream", NewBestTip { chain_switched: true, ..NewBestTip::new(tip, parent) }),
             te_state("sc-1", &expected),
         ],
     );
@@ -418,7 +418,11 @@ fn test_block_validation_result_invalid_best_tip_invalidated() {
             te_find_best_candidate("sc-1"),
             te_load_header("sc-1", prep.headers.h1.hash(), false),
             te_load_tip("sc-1", prep.headers.h0.hash()),
-            te_send("sc-1", "downstream", NewBestTip::new(prep.headers.h1.tip(), prep.headers.h0.point())),
+            te_send(
+                "sc-1",
+                "downstream",
+                NewBestTip { chain_switched: true, ..NewBestTip::new(prep.headers.h1.tip(), prep.headers.h0.point()) },
+            ),
             te_unvalidated_ancestor_hashes("sc-1", prep.headers.h1.hash()),
             te_clock_read("sc-1"),
             te_state("sc-1", &expected),
@@ -465,7 +469,14 @@ fn test_block_validation_result_invalid_best_tip_invalidated_switch_fork() {
             te_find_best_candidate("sc-1"),
             te_load_header("sc-1", prep.headers.h3a.hash(), false),
             te_load_tip("sc-1", prep.headers.h2a.hash()),
-            te_send("sc-1", "downstream", NewBestTip::new(prep.headers.h3a.tip(), prep.headers.h2a.point())),
+            te_send(
+                "sc-1",
+                "downstream",
+                NewBestTip {
+                    chain_switched: true,
+                    ..NewBestTip::new(prep.headers.h3a.tip(), prep.headers.h2a.point())
+                },
+            ),
             te_unvalidated_ancestor_hashes("sc-1", prep.headers.h3a.hash()),
             te_clock_read("sc-1"),
             te_state("sc-1", &expected),
@@ -621,6 +632,43 @@ fn test_fetch_next_from_resumes_best_candidate() {
             te_load_header("sc-1", prep.headers.h3.hash(), false).into(),
             te_load_tip("sc-1", prep.headers.h2.hash()).into(),
             te_send("sc-1", "downstream", NewBestTip::new(prep.headers.h3.tip(), prep.headers.h2.point())).into(),
+        ],
+    );
+
+    logs.assert_and_remove(Level::DEBUG, &["resuming block fetching"]).assert_no_remaining_at([
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
+}
+
+#[test]
+fn test_fetch_next_from_carries_pending_chain_switch() {
+    let mut prep = test_prep();
+    prep.store_headers(&prep.headers.main());
+    prep.state.best_tip = Some(prep.headers.h3.clone());
+    prep.state.may_fetch_blocks = false;
+    // the best tip moved to another branch while the downstream stage was busy fetching
+    prep.state.chain_switched = true;
+
+    let msg = SelectChainMsg::fetch_next_from(prep.headers.h1.point());
+
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+
+    let expected = SelectChain { chain_switched: false, ..prep.state.clone() };
+    assert_trace(
+        &running,
+        &[
+            te_state("sc-1", &prep.state),
+            te_input("sc-1", &msg),
+            te_load_header("sc-1", prep.headers.h3.hash(), false),
+            te_load_tip("sc-1", prep.headers.h2.hash()),
+            te_send(
+                "sc-1",
+                "downstream",
+                NewBestTip { chain_switched: true, ..NewBestTip::new(prep.headers.h3.tip(), prep.headers.h2.point()) },
+            ),
+            te_state("sc-1", &expected),
         ],
     );
 

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -20,7 +20,7 @@ use std::{
 
 use amaru_kernel::{
     BlockHeader, BlockHeight, Epoch, EraHistory, EraName, IsHeader, ORIGIN_HASH, Peer, Point, Slot, Tip,
-    from_cbor_no_leftovers, num::CheckedSub,
+    from_cbor_no_leftovers,
 };
 use amaru_metrics::consensus::ConsensusMetrics;
 use amaru_observability::{TraceContext, debug, debug_record, debug_span, error};
@@ -41,9 +41,6 @@ use crate::{
     stages::select_chain::PerfHeaderForwardOutcome,
     validate_header::ValidateHeaderError,
 };
-
-/// Poll interval while headers are deferred on applied ledger height.
-pub const HEIGHT_RECHECK_INTERVAL: Duration = Duration::from_millis(200);
 
 /// Stage that tracks chainsync sessions from whom we receive headers.
 ///
@@ -90,9 +87,6 @@ pub const HEIGHT_RECHECK_INTERVAL: Duration = Duration::from_millis(200);
 ///
 /// Headers that cannot be finished yet are kept in `deferred` with a reason:
 ///
-/// - **LedgerHeight** — header height exceeds applied ledger by more than `max_peer_lead`.
-///   `RequestNext` is not sent until the ledger catches up. Arms a single coalesced
-///   `RecheckLedgerHeight` timer (poll interval [`HEIGHT_RECHECK_INTERVAL`]).
 /// - **StakeDistribution** — pool stake for the header's epoch is not yet known (at most one
 ///   epoch ahead of `max_epoch`). `RequestNext` may already have been pipelined before validation
 ///   failed. Woken by [`TrackPeersMsg::StakeDistUpdated`] (no self-timer).
@@ -135,10 +129,8 @@ pub struct TrackPeers {
     upstream: BTreeMap<ConnectionId, PerPeer>,
     peer_selection: StageRef<PeerSelectionMsg>,
     downstream: StageRef<NewTip>,
-    max_peer_lead: u64,
     ledger_applied_block_height: BlockHeight,
     ledger_last_checked_at: Instant,
-    max_epoch: Epoch,
     deferred: Vec<DeferredHeader>,
     /// Single outstanding self-schedule for height/clock deferred rechecks.
     recheck_timer: Option<ScheduleId>,
@@ -171,8 +163,6 @@ impl PerPeer {
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 enum DeferReason {
-    /// Wait until the ledger has reached at least this applied block height before asking the peer for more.
-    LedgerHeight { min_height: BlockHeight, header: BlockHeader, tip: Tip, variant: EraName },
     /// The header's validation requires a stake distribution that is not yet available; hold the
     /// data needed to re-validate and store once it arrives (via StakeDistUpdated).
     StakeDistribution { epoch: Epoch, header: BlockHeader, tip: Tip, variant: EraName, rn_sent: bool },
@@ -226,17 +216,6 @@ impl From<DeferredHeader> for RollForwardArgs {
     fn from(dh: DeferredHeader) -> RollForwardArgs {
         let DeferredHeader { peer, conn_id, handler, reason, trace_context, received_at } = dh;
         match reason {
-            DeferReason::LedgerHeight { header, tip, variant, .. } => RollForwardArgs {
-                peer,
-                conn_id,
-                sent_request_next: false,
-                handler,
-                variant,
-                header,
-                tip,
-                trace_context,
-                received_at,
-            },
             DeferReason::StakeDistribution { header, tip, variant, rn_sent, .. } => RollForwardArgs {
                 peer,
                 conn_id,
@@ -279,8 +258,8 @@ pub enum TrackPeersMsg {
     FromUpstream(ChainSyncInitiatorMsg),
     /// A new stake distribution is available; recheck any headers deferred for stake dist.
     StakeDistUpdated(Epoch),
-    /// Self-scheduled message to check if ledger height has advanced enough for deferred headers.
-    RecheckLedgerHeight,
+    /// Self-scheduled message to check headers that were deferred due to a slight clock skew.
+    RecheckClock,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -316,13 +295,12 @@ pub async fn stage(mut state: TrackPeers, msg: TrackPeersMsg, eff: Effects<Track
         TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg { peer, conn_id, handler, msg }) => {
             state.handle_from_upstream(peer, conn_id, handler, msg, eff).await;
         }
-        TrackPeersMsg::StakeDistUpdated(max_epoch) => {
-            state.max_epoch = max_epoch;
-            state.recheck_deferred(&eff).await;
+        TrackPeersMsg::StakeDistUpdated(epoch) => {
+            state.recheck_deferred(&eff, Some(epoch)).await;
         }
-        TrackPeersMsg::RecheckLedgerHeight => {
+        TrackPeersMsg::RecheckClock => {
             state.recheck_timer = None;
-            state.recheck_deferred(&eff).await;
+            state.recheck_deferred(&eff, None).await;
         }
     }
     state
@@ -333,19 +311,15 @@ impl TrackPeers {
         era_history: EraHistory,
         peer_selection: StageRef<PeerSelectionMsg>,
         downstream: StageRef<NewTip>,
-        max_peer_lead: u64,
-        max_epoch: Epoch,
     ) -> Self {
         Self {
             era_history,
             upstream: BTreeMap::new(),
             peer_selection,
             downstream,
-            max_peer_lead,
             deferred: Vec::new(),
             ledger_applied_block_height: BlockHeight::from(0),
             ledger_last_checked_at: Instant::at_offset(Duration::ZERO, Duration::ZERO),
-            max_epoch,
             recheck_timer: None,
         }
     }
@@ -507,11 +481,6 @@ impl TrackPeers {
             return None;
         };
 
-        // target more than one epoch ahead of known stake dists → adversarial; otherwise defer.
-        // Use checked_sub so target < max_epoch does not panic (treat as defer / retry).
-        if target.checked_sub(&self.max_epoch).is_some_and(|d| d > *Epoch::ONE) {
-            return None;
-        }
         Some(DeferredHeader {
             peer: args.peer.clone(),
             conn_id: args.conn_id,
@@ -561,42 +530,37 @@ impl TrackPeers {
     }
 
     /// Earliest instant at which height- or clock-deferred work should be rechecked.
-    fn next_recheck_at(&self, now: Instant) -> Option<Instant> {
+    fn next_recheck_at(&self) -> Option<Instant> {
         self.deferred
             .iter()
             .filter_map(|d| match &d.reason {
-                DeferReason::LedgerHeight { .. } => Some(now + HEIGHT_RECHECK_INTERVAL),
                 DeferReason::ClockSkew { min_time, .. } => Some(*min_time),
                 DeferReason::StakeDistribution { .. } | DeferReason::FollowUp { .. } => None,
             })
             .min()
     }
 
-    /// Ensure at most one outstanding `RecheckLedgerHeight` for time-based deferred work.
+    /// Ensure at most one outstanding `RecheckClock` for time-based deferred work.
     async fn ensure_recheck_armed(&mut self, eff: &Effects<TrackPeersMsg>) {
-        let needs_timer = self
-            .deferred
-            .iter()
-            .any(|d| matches!(d.reason, DeferReason::LedgerHeight { .. } | DeferReason::ClockSkew { .. }));
+        let needs_timer = self.deferred.iter().any(|d| matches!(d.reason, DeferReason::ClockSkew { .. }));
         if !needs_timer {
             if let Some(id) = self.recheck_timer.take() {
                 eff.cancel_schedule(id).await;
             }
             return;
         }
-        let now = eff.clock().await;
-        let Some(when) = self.next_recheck_at(now) else {
+        let Some(when) = self.next_recheck_at() else {
             return;
         };
         match self.recheck_timer {
             Some(id) if id.time() <= when => {}
             Some(id) => {
                 eff.cancel_schedule(id).await;
-                let id = eff.schedule_at(TrackPeersMsg::RecheckLedgerHeight, when).await;
+                let id = eff.schedule_at(TrackPeersMsg::RecheckClock, when).await;
                 self.recheck_timer = Some(id);
             }
             None => {
-                let id = eff.schedule_at(TrackPeersMsg::RecheckLedgerHeight, when).await;
+                let id = eff.schedule_at(TrackPeersMsg::RecheckClock, when).await;
                 self.recheck_timer = Some(id);
             }
         }
@@ -771,36 +735,7 @@ impl TrackPeers {
                         return;
                     }
 
-                    let header_height = header.block_height();
-                    let limit = header_height - self.max_peer_lead;
-                    // maybe update ledger applied block height (rate-limited to 500ms or initial)
-                    if limit > self.ledger_applied_block_height
-                        && (now.saturating_since(self.ledger_last_checked_at) > Duration::from_millis(500)
-                            || self.ledger_applied_block_height == BlockHeight::from(0))
-                    {
-                        self.ledger_last_checked_at = now;
-                        self.ledger_applied_block_height = eff.external(VolatileTipEffect).await.block_height();
-                    }
-
-                    let ledger_height = self.ledger_applied_block_height;
-                    if ledger_height < limit {
-                        tracing::debug!(%peer, %header_height, %ledger_height, %limit, "track_peers.defer_request_next");
-                        self.deferred.push(DeferredHeader {
-                            peer: peer.clone(),
-                            conn_id,
-                            handler: handler.clone(),
-                            reason: DeferReason::LedgerHeight {
-                                header: header.clone(),
-                                tip,
-                                variant,
-                                min_height: limit,
-                            },
-                            trace_context,
-                            received_at: now,
-                        });
-                        self.ensure_recheck_armed(&eff).await;
-                        return;
-                    }
+                    let now = eff.clock().await;
 
                     eff.send(&handler, chainsync::InitiatorMessage::RequestNext).await;
                     let args = RollForwardArgs {
@@ -850,7 +785,7 @@ impl TrackPeers {
         }
     }
 
-    async fn recheck_deferred(&mut self, eff: &Effects<TrackPeersMsg>) {
+    async fn recheck_deferred(&mut self, eff: &Effects<TrackPeersMsg>, max_epoch: Option<Epoch>) {
         let curr_height = eff.external(VolatileTipEffect).await.block_height();
         self.ledger_applied_block_height = curr_height;
 
@@ -868,8 +803,7 @@ impl TrackPeers {
             }
             let defer = blocked.contains(&conn_id)
                 || match &d.reason {
-                    DeferReason::LedgerHeight { min_height, .. } => curr_height < *min_height,
-                    DeferReason::StakeDistribution { epoch, .. } => self.max_epoch < *epoch,
+                    DeferReason::StakeDistribution { epoch, .. } => *epoch > max_epoch.unwrap_or_default(),
                     DeferReason::ClockSkew { min_time, .. } => current_time < *min_time,
                     DeferReason::FollowUp { .. } => false,
                 };

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -735,8 +735,6 @@ impl TrackPeers {
                         return;
                     }
 
-                    let now = eff.clock().await;
-
                     eff.send(&handler, chainsync::InitiatorMessage::RequestNext).await;
                     let args = RollForwardArgs {
                         peer,

--- a/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use amaru_kernel::{
-    BlockHeader, ConsensusParameters, Epoch, EraHistory, HeaderHash, IsHeader, NetworkName, Point, Tip, make_header,
-    num::CheckedSub,
+    BlockHeader, ConsensusParameters, EraHistory, HeaderHash, IsHeader, NetworkName, Point, Tip, make_header,
 };
 use amaru_ouroboros::ConnectionId;
 use amaru_ouroboros_traits::{
@@ -29,7 +28,7 @@ use amaru_protocols::{
     store_effects::{HasHeaderEffect, LoadHeaderEffect, LoadTipEffect, ResourceHeaderStore, StoreHeaderEffect},
 };
 use amaru_pure_stage::{
-    DeserializerGuards, Effect, Instant, Name, ScheduleId, ScheduleIds, StageRef,
+    DeserializerGuards, Effect, Name, StageRef,
     simulation::{SimulationRunning, running::OverrideResult},
     trace_buffer::TraceEntry,
 };
@@ -48,44 +47,6 @@ use crate::{
         },
     },
 };
-
-/// Matches `run_simulation` initial clock (+10s) for schedule id expectations.
-pub const SIM_INITIAL_CLOCK_SECS: u64 = 10;
-
-/// Height recheck poll interval used by the stage (`HEIGHT_RECHECK_INTERVAL`).
-pub const HEIGHT_RECHECK_INTERVAL: Duration = Duration::from_millis(200);
-
-pub fn height_recheck_schedule_id() -> ScheduleId {
-    let when = Instant::at_offset(
-        Duration::from_secs(SIM_INITIAL_CLOCK_SECS) + HEIGHT_RECHECK_INTERVAL,
-        start_in_era().relative_time,
-    );
-    ScheduleIds::default().next_at(when)
-}
-
-pub fn schedule_id_at(delay_from_sim_start: Duration) -> ScheduleId {
-    let when = Instant::at_offset(
-        Duration::from_secs(SIM_INITIAL_CLOCK_SECS) + delay_from_sim_start,
-        start_in_era().relative_time,
-    );
-    ScheduleIds::default().next_at(when)
-}
-
-pub fn te_schedule(
-    at_stage: impl AsRef<str>,
-    msg: impl amaru_pure_stage::SendData,
-    schedule_id: ScheduleId,
-) -> TraceEntry {
-    TraceEntry::suspend(Effect::Schedule {
-        at_stage: Name::from(at_stage.as_ref()),
-        msg: Box::new(msg),
-        id: schedule_id,
-    })
-}
-
-pub fn te_clock(instant: Instant) -> TraceEntry {
-    TraceEntry::Clock(instant)
-}
 
 pub fn build_store(headers: &[BlockHeader]) -> Arc<InMemoryChainStore> {
     let store = Arc::new(InMemoryChainStore::new());
@@ -114,11 +75,6 @@ impl TestPrep {
 
 /// Creates basic state, runtime, handler, conn_id, and three properly linked headers for tests.
 pub fn test_prep() -> TestPrep {
-    test_prep_with_max_peer_lead(10_000_000)
-}
-
-/// Creates a `TestPrep` with a configurable peer lead limit (for testing defer logic).
-pub fn test_prep_with_max_peer_lead(max_peer_lead: u64) -> TestPrep {
     let start_times = start_in_era();
     // EraHistory::default() matches synthetic headers at slots 1,2,3 used throughout these tests.
     // Clock-skew tests map simulation time through this same history (see tests).
@@ -126,8 +82,6 @@ pub fn test_prep_with_max_peer_lead(max_peer_lead: u64) -> TestPrep {
         EraHistory::default(),
         StageRef::named_for_tests("peer_selection"),
         StageRef::named_for_tests("downstream"),
-        max_peer_lead,
-        start_times.epoch.checked_sub(Epoch::TWO).unwrap(),
     );
     let rt = Builder::new_current_thread().build().unwrap();
     let handler = StageRef::<InitiatorMessage>::named_for_tests("handler");
@@ -212,25 +166,6 @@ pub fn setup(
     })
 }
 
-/// Forces a specific ledger-applied tip and stops when the sim first sleeps on a scheduled
-/// wakeup (does not auto-advance time). Safe for frozen-height defer tests that arm a recheck
-/// timer without running an infinite height-poll loop.
-pub fn setup_with_ledger_tip_until_sleeping(
-    rt: &Handle,
-    state: TrackPeers,
-    msg: impl IntoIterator<Item = TrackPeersMsg>,
-    store: Arc<InMemoryChainStore>,
-    ledger_tip: Tip,
-) -> (SimulationRunning, DeserializerGuards, Logs) {
-    setup_base_until_sleeping(rt, state, msg, store, |running| {
-        running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| OverrideResult::handled(Ok(())));
-        running.override_external_effect::<VolatileTipEffect>(usize::MAX, {
-            move |_| OverrideResult::handled(ledger_tip)
-        });
-        running.override_external_effect::<TipEffect>(usize::MAX, move |_| OverrideResult::handled(ledger_tip));
-    })
-}
-
 pub fn setup_base(
     rt: &Handle,
     state: TrackPeers,
@@ -239,16 +174,6 @@ pub fn setup_base(
     overrides: impl FnOnce(&mut SimulationRunning),
 ) -> (SimulationRunning, DeserializerGuards, Logs) {
     setup_inner(rt, state, msg, store, overrides, true)
-}
-
-fn setup_base_until_sleeping(
-    rt: &Handle,
-    state: TrackPeers,
-    msg: impl IntoIterator<Item = TrackPeersMsg>,
-    store: Arc<InMemoryChainStore>,
-    overrides: impl FnOnce(&mut SimulationRunning),
-) -> (SimulationRunning, DeserializerGuards, Logs) {
-    setup_inner(rt, state, msg, store, overrides, false)
 }
 
 fn setup_inner(

--- a/crates/amaru-consensus/src/stages/track_peers/tests.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/tests.rs
@@ -14,13 +14,11 @@
 
 use std::{self, slice, time::Duration};
 
-use amaru_kernel::{BlockHeight, Epoch, EraHistory, EraName, HeaderHash, IsHeader, Peer, Point, Tip, num::CheckedSub};
+use amaru_kernel::{num::CheckedSub, BlockHeight, Epoch, EraHistory, EraName, HeaderHash, IsHeader, Peer, Point, Tip};
 use amaru_metrics::consensus::ConsensusMetrics;
-use amaru_ouroboros::{ConnectionId, praos::header::AssertHeaderError};
+use amaru_ouroboros::{praos::header::AssertHeaderError, ConnectionId};
 use amaru_ouroboros_traits::has_stake_distribution::GetPoolError;
-use amaru_protocols::chainsync::{
-    self, ChainSyncInitiatorMsg, HeaderContent, InitiatorMessage, InitiatorMessage::RequestNext,
-};
+use amaru_protocols::chainsync::{self, ChainSyncInitiatorMsg, HeaderContent, InitiatorMessage::RequestNext};
 use amaru_pure_stage::{
     assert_trace_contains, assert_trace_does_not_contain, assert_trace_match, simulation::running::OverrideResult,
     tm_send, trace_buffer::TraceEntry,
@@ -28,18 +26,16 @@ use amaru_pure_stage::{
 use tracing::Level;
 
 use crate::{
-    effects::{ValidateHeaderEffect, VolatileTipEffect},
+    effects::ValidateHeaderEffect,
     stages::{
         peer_selection::PeerSelectionMsg,
         test_utils::{assert_trace, te_input, te_record_consensus_metrics, te_send, te_state, tm_state},
         track_peers::{
-            TrackPeers, TrackPeersMsg,
             test_setup::{
-                HEIGHT_RECHECK_INTERVAL, build_store, height_recheck_schedule_id, make_block_header, new_tip,
-                schedule_id_at, setup, setup_base, setup_with_ledger_tip_until_sleeping, te_clock, te_clock_suspend,
-                te_has_header, te_load_tip, te_schedule, te_store_header, te_validate_header, test_prep,
-                test_prep_with_max_peer_lead, tm_volatile_tip,
+                build_store, make_block_header, new_tip, setup, setup_base, te_clock_suspend, te_has_header,
+                te_load_tip, te_store_header, te_validate_header, test_prep, tm_volatile_tip,
             },
+            TrackPeers, TrackPeersMsg,
         },
     },
     store::NoncesError,
@@ -110,7 +106,7 @@ fn test_initialize_resets_established_session() {
 
 #[test]
 fn test_terminated_purges_upstream_and_deferred() {
-    let prep = test_prep_with_max_peer_lead(0);
+    let prep = test_prep();
     let peer = Peer::new("peer1");
     let parent = &prep.headers[0];
     let header = &prep.headers[1];
@@ -697,7 +693,7 @@ fn test_roll_forward_header_slot_near_future_defers() {
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
 
     logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
-    // Clock-skew defers, then sim advances and RecheckLedgerHeight processes the header.
+    // Clock-skew defers, then sim advances and RecheckClock processes the header.
     assert_trace_contains(
         &running,
         &[
@@ -706,7 +702,7 @@ fn test_roll_forward_header_slot_near_future_defers() {
             te_send("tp-1", &prep.handler, RequestNext).into(),
             te_clock_suspend("tp-1").into(),
             tm_state::<TrackPeers>("tp-1", |s| s.deferred.len() == 1, "clock skew deferred"),
-            te_input("tp-1", &TrackPeersMsg::RecheckLedgerHeight).into(),
+            te_input("tp-1", &TrackPeersMsg::RecheckClock).into(),
             te_validate_header("tp-1", header.clone()).into(),
             te_store_header("tp-1", header.clone()).into(),
             tm_state::<TrackPeers>("tp-1", |s| s.deferred.is_empty(), "processed after recheck"),
@@ -716,9 +712,9 @@ fn test_roll_forward_header_slot_near_future_defers() {
 }
 
 /// Tests that a header whose required stake distribution is more than 1 epoch ahead
-/// causes immediate adversarial rejection (no deferral).
+/// is also deferred.
 #[test]
-fn test_roll_forward_stake_dist_far_ahead_rejects() {
+fn test_roll_forward_stake_dist_far_ahead_defer() {
     let prep = test_prep();
     let peer = Peer::new("peer1");
     let parent = &prep.headers[0];
@@ -730,7 +726,6 @@ fn test_roll_forward_stake_dist_far_ahead_rejects() {
         msg: chainsync::InitiatorResult::RollForward(HeaderContent::new(header, EraName::Conway), header.tip()),
     });
 
-    let expected = prep.state.clone();
     let mut state = prep.state.clone();
     state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), header.tip());
 
@@ -752,7 +747,7 @@ fn test_roll_forward_stake_dist_far_ahead_rejects() {
         Level::WARN,
         Level::ERROR,
     ]);
-    assert_trace_match(
+    assert_trace_contains(
         &running,
         &[
             te_state("tp-1", &state).into(),
@@ -760,11 +755,10 @@ fn test_roll_forward_stake_dist_far_ahead_rejects() {
             te_clock_suspend("tp-1").into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
             te_validate_header("tp-1", header.clone()).into(),
-            te_header_rejected("invalid header").into(),
-            te_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer)).into(),
-            te_state("tp-1", &expected).into(),
+            tm_state::<TrackPeers>("tp-1", |s| s.deferred.len() == 1, "stake distr deferred"),
         ],
     );
+    assert_trace_does_not_contain(&running, &[tm_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer))]);
 }
 
 #[test]
@@ -978,7 +972,6 @@ fn test_pipelined_headers_after_height_defer() {
             te_schedule("tp-1", TrackPeersMsg::RecheckLedgerHeight, sid).into(),
             tm_state::<TrackPeers>("tp-1", |s| s.deferred.len() == 1, "first ledger-height deferred"),
             te_input("tp-1", &msg2).into(),
-            te_clock_suspend("tp-1").into(),
             tm_state::<TrackPeers>(
                 "tp-1",
                 |s| s.deferred.len() == 2 && s.recheck_timer == Some(sid),
@@ -1017,42 +1010,11 @@ fn test_height_defer_recheck_when_ledger_advances() {
             running.override_external_effect::<VolatileTipEffect>(usize::MAX, move |_| {
                 n += 1;
                 // First call (defer decision) still at origin; recheck sees advanced height.
-                if n == 1 { OverrideResult::handled(Tip::origin()) } else { OverrideResult::handled(advanced_tip) }
-            });
-            running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| OverrideResult::handled(Ok(())));
-        });
-
-    logs.assert_and_remove(Level::DEBUG, &["track_peers.defer_request_next"])
-        .assert_and_remove(Level::DEBUG, &["roll forward"])
-        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
-
-    assert_trace_match(
-        &running,
-        &[
-            te_state("tp-1", &state).into(),
-            te_input("tp-1", &msg).into(),
-            te_clock_suspend("tp-1").into(),
-            tm_volatile_tip("tp-1"),
-            te_clock_suspend("tp-1").into(),
-            te_schedule("tp-1", TrackPeersMsg::RecheckLedgerHeight, sid).into(),
-            tm_state::<TrackPeers>("tp-1", |s| s.deferred.len() == 1, "height deferred"),
-            te_clock(recheck_at).into(),
-            te_input("tp-1", &TrackPeersMsg::RecheckLedgerHeight).into(),
-            tm_volatile_tip("tp-1"),
-            te_clock_suspend("tp-1").into(),
-            te_validate_header("tp-1", header.clone()).into(),
-            te_has_header("tp-1", header.hash()).into(),
-            te_store_header("tp-1", header.clone()).into(),
-            te_send("tp-1", "downstream", new_tip(header.tip(), Point::Origin)).into(),
-            te_send("tp-1", &prep.handler, RequestNext).into(),
-            tm_state::<TrackPeers>(
-                "tp-1",
-                |s| s.deferred.is_empty() && s.recheck_timer.is_none(),
-                "processed after height advanced",
-            ),
-        ],
-    );
-}
+                if n == 1 {
+                    OverrideResult::handled(Tip::origin())
+                } else {
+                    OverrideResult::handled(advanced_tip)
+                }
 
 #[test]
 fn test_pipelined_headers_after_slot_near_future_defer() {
@@ -1217,7 +1179,7 @@ fn test_recheck_deferred_survives_purge_shrinking_the_list() {
     state.push_deferred_for_tests(peer.clone(), prep.conn_id, prep.handler.clone(), h1.clone(), h1.tip());
     state.push_deferred_for_tests(peer.clone(), prep.conn_id, prep.handler.clone(), h2.clone(), h2.tip());
 
-    let msg = TrackPeersMsg::RecheckLedgerHeight;
+    let msg = TrackPeersMsg::RecheckClock;
 
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
     assert_trace_match(

--- a/crates/amaru-consensus/src/stages/track_peers/tests.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/tests.rs
@@ -14,9 +14,9 @@
 
 use std::{self, slice, time::Duration};
 
-use amaru_kernel::{num::CheckedSub, BlockHeight, Epoch, EraHistory, EraName, HeaderHash, IsHeader, Peer, Point, Tip};
+use amaru_kernel::{BlockHeight, Epoch, EraHistory, EraName, HeaderHash, IsHeader, Peer, Point, Tip, num::CheckedSub};
 use amaru_metrics::consensus::ConsensusMetrics;
-use amaru_ouroboros::{praos::header::AssertHeaderError, ConnectionId};
+use amaru_ouroboros::{ConnectionId, praos::header::AssertHeaderError};
 use amaru_ouroboros_traits::has_stake_distribution::GetPoolError;
 use amaru_protocols::chainsync::{self, ChainSyncInitiatorMsg, HeaderContent, InitiatorMessage::RequestNext};
 use amaru_pure_stage::{
@@ -31,11 +31,11 @@ use crate::{
         peer_selection::PeerSelectionMsg,
         test_utils::{assert_trace, te_input, te_record_consensus_metrics, te_send, te_state, tm_state},
         track_peers::{
+            TrackPeers, TrackPeersMsg,
             test_setup::{
                 build_store, make_block_header, new_tip, setup, setup_base, te_clock_suspend, te_has_header,
                 te_load_tip, te_store_header, te_validate_header, test_prep, tm_volatile_tip,
             },
-            TrackPeers, TrackPeersMsg,
         },
     },
     store::NoncesError,
@@ -729,10 +729,10 @@ fn test_roll_forward_stake_dist_far_ahead_defer() {
     let mut state = prep.state.clone();
     state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), header.tip());
 
-    // More than one epoch beyond known max_epoch (start-2) → adversarial, not defer.
+    // More than one epoch beyond known max_epoch (start-2): the header is deferred, not rejected.
     let far_epoch = prep.start_times.epoch;
     let slot = header.slot();
-    // Override to simulate far-ahead stake dist not available (distance >1 -> reject)
+    // Override to simulate the required stake distribution not being available yet.
     let (running, _guards, mut logs) =
         setup_base(&prep.rt_handle(), state.clone(), [msg.clone()], build_store(&[]), |running| {
             running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, move |_| {
@@ -742,11 +742,7 @@ fn test_roll_forward_stake_dist_far_ahead_defer() {
             });
         });
 
-    logs.assert_and_remove(Level::ERROR, &["perf.header.lifecycle"]).assert_no_remaining_at([
-        Level::INFO,
-        Level::WARN,
-        Level::ERROR,
-    ]);
+    logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
     assert_trace_contains(
         &running,
         &[
@@ -865,156 +861,6 @@ fn test_roll_backward_unknown_point_removes_peer() {
         .assert_and_remove(Level::INFO, &["roll backward"])
         .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
-
-/// Tests that a RollForward whose header height requires a ledger height beyond what is currently
-/// applied defers RequestNext and arms a single coalesced height-recheck schedule.
-#[test]
-fn test_roll_forward_defers_request_next() {
-    // Use max_peer_lead = 0 so any header taller than the known ledger height triggers defer.
-    let prep = test_prep_with_max_peer_lead(0);
-    let peer = Peer::new("peer1");
-    let header = prep.headers[0].clone();
-    let tip = header.tip();
-
-    let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), prep.conn_id, Tip::origin(), tip);
-
-    let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
-        peer: peer.clone(),
-        conn_id: prep.conn_id,
-        handler: prep.handler.clone(),
-        msg: chainsync::InitiatorResult::RollForward(HeaderContent::new(&header, EraName::Conway), tip),
-    });
-
-    let store = build_store(&[]);
-    let sid = height_recheck_schedule_id();
-
-    // Frozen ledger tip would poll forever if wakeups auto-advanced; stop at first sleep.
-    let (running, _guards, mut logs) =
-        setup_with_ledger_tip_until_sleeping(&prep.rt_handle(), state.clone(), [msg.clone()], store, Tip::origin());
-
-    logs.assert_and_remove(Level::DEBUG, &["track_peers.defer_request_next"]).assert_no_remaining_at([
-        Level::ERROR,
-        Level::WARN,
-        Level::INFO,
-    ]);
-
-    assert_trace_match(
-        &running,
-        &[
-            te_state("tp-1", &state).into(),
-            te_input("tp-1", &msg).into(),
-            te_clock_suspend("tp-1").into(),
-            tm_volatile_tip("tp-1"),
-            te_clock_suspend("tp-1").into(),
-            te_schedule("tp-1", TrackPeersMsg::RecheckLedgerHeight, sid).into(),
-            tm_state::<TrackPeers>(
-                "tp-1",
-                |s| s.deferred.len() == 1 && s.recheck_timer == Some(sid),
-                "ledger height deferred with recheck armed",
-            ),
-        ],
-    );
-
-    // The handler must *not* have received an immediate RequestNext (that is the whole point of deferring).
-    assert_trace_does_not_contain(&running, &[tm_send("tp-1", "", InitiatorMessage::RequestNext)]);
-}
-
-#[test]
-fn test_pipelined_headers_after_height_defer() {
-    let prep = test_prep_with_max_peer_lead(0);
-    let peer = Peer::new("peer1");
-    let parent = &prep.headers[0];
-    let h1 = prep.headers[1].clone();
-    let h2 = make_block_header(3, h1.slot().as_u64() + 1, Some(h1.hash()));
-
-    let msg1 = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
-        peer: peer.clone(),
-        conn_id: prep.conn_id,
-        handler: prep.handler.clone(),
-        msg: chainsync::InitiatorResult::RollForward(HeaderContent::new(&h1, EraName::Conway), h1.tip()),
-    });
-    let msg2 = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
-        peer: peer.clone(),
-        conn_id: prep.conn_id,
-        handler: prep.handler.clone(),
-        msg: chainsync::InitiatorResult::RollForward(HeaderContent::new(&h2, EraName::Conway), h2.tip()),
-    });
-
-    let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), h2.tip());
-
-    let sid = height_recheck_schedule_id();
-
-    // Forced ledger tip = origin so height defers apply; second header is FollowUp while peer deferred.
-    // Stop at first sleep so the height-poll loop does not run forever under a frozen tip.
-    let (running, _guards, mut logs) = setup_with_ledger_tip_until_sleeping(
-        &prep.rt_handle(),
-        state.clone(),
-        [msg1.clone(), msg2.clone()],
-        build_store(&[]),
-        Tip::origin(),
-    );
-
-    logs.assert_and_remove(Level::DEBUG, &["track_peers.defer_request_next"]).assert_no_remaining_at([
-        Level::INFO,
-        Level::WARN,
-        Level::ERROR,
-    ]);
-    assert_trace_match(
-        &running,
-        &[
-            te_state("tp-1", &state).into(),
-            te_input("tp-1", &msg1).into(),
-            te_clock_suspend("tp-1").into(),
-            tm_volatile_tip("tp-1"),
-            te_clock_suspend("tp-1").into(),
-            te_schedule("tp-1", TrackPeersMsg::RecheckLedgerHeight, sid).into(),
-            tm_state::<TrackPeers>("tp-1", |s| s.deferred.len() == 1, "first ledger-height deferred"),
-            te_input("tp-1", &msg2).into(),
-            tm_state::<TrackPeers>(
-                "tp-1",
-                |s| s.deferred.len() == 2 && s.recheck_timer == Some(sid),
-                "follow-up queued while deferred; still one recheck timer",
-            ),
-        ],
-    );
-    assert_trace_does_not_contain(&running, &[tm_send("tp-1", "", InitiatorMessage::RequestNext)]);
-}
-
-/// Height defer is released when a later recheck sees the applied ledger height advance.
-#[test]
-fn test_height_defer_recheck_when_ledger_advances() {
-    let prep = test_prep_with_max_peer_lead(0);
-    let peer = Peer::new("peer1");
-    let header = prep.headers[0].clone();
-    let tip = header.tip();
-
-    let mut state = prep.state.clone();
-    state.insert_peer(peer.clone(), prep.conn_id, Tip::origin(), tip);
-
-    let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
-        peer: peer.clone(),
-        conn_id: prep.conn_id,
-        handler: prep.handler.clone(),
-        msg: chainsync::InitiatorResult::RollForward(HeaderContent::new(&header, EraName::Conway), tip),
-    });
-
-    let sid = height_recheck_schedule_id();
-    let recheck_at = schedule_id_at(HEIGHT_RECHECK_INTERVAL).time();
-    let advanced_tip = Tip::new(header.point(), header.block_height());
-
-    let (running, _guards, mut logs) =
-        setup_base(&prep.rt_handle(), state.clone(), [msg.clone()], build_store(&[]), |running| {
-            let mut n = 0u8;
-            running.override_external_effect::<VolatileTipEffect>(usize::MAX, move |_| {
-                n += 1;
-                // First call (defer decision) still at origin; recheck sees advanced height.
-                if n == 1 {
-                    OverrideResult::handled(Tip::origin())
-                } else {
-                    OverrideResult::handled(advanced_tip)
-                }
 
 #[test]
 fn test_pipelined_headers_after_slot_near_future_defer() {

--- a/crates/amaru-node/src/stages/build_node.rs
+++ b/crates/amaru-node/src/stages/build_node.rs
@@ -118,7 +118,6 @@ pub fn build_node(
     let chain_store = make_chain_store(config)?;
     let pool_summaries = state.pool_summaries();
     let block_validator = Arc::new(make_block_validator(&config.ledger_config, state, chain_store.clone())?);
-    let max_epoch = pool_summaries.max_epoch();
 
     // Make the chain store, either from the network resources if already set
     // or from the configuration.
@@ -149,8 +148,7 @@ pub fn build_node(
     let resources = stage_builder.resources().clone();
 
     // Build the stage graph and return a reference to the stages that can be connected from outside this function
-    let node_stages =
-        build_stage_graph(config, era_history, global_parameters, ledger_tip, best_hash, max_epoch, stage_builder);
+    let node_stages = build_stage_graph(config, era_history, global_parameters, ledger_tip, best_hash, stage_builder);
 
     let track_peers_sender = node_stages.track_peers_stake_dist_sender();
     block_validator.set_on_stake_dist_updated(Arc::new(move |summaries| {

--- a/crates/amaru-node/src/stages/build_stage_graph.rs
+++ b/crates/amaru-node/src/stages/build_stage_graph.rs
@@ -24,7 +24,7 @@ use amaru_consensus::stages::{
     track_peers::{self, TrackPeers, TrackPeersMsg},
     validate_block::{self, ValidateBlock, ValidateBlockMsg},
 };
-use amaru_kernel::{Epoch, EraHistory, GlobalParameters, HeaderHash, Peer, Tip};
+use amaru_kernel::{EraHistory, GlobalParameters, HeaderHash, Peer, Tip};
 use amaru_observability::debug_span;
 use amaru_ouroboros::MempoolMsg;
 use amaru_protocols::{
@@ -52,7 +52,6 @@ pub fn build_stage_graph(
     global_parameters: &GlobalParameters,
     ledger_tip: Tip,
     best_hash: HeaderHash,
-    max_epoch: Epoch,
     stage_graph: &mut impl StageGraph,
 ) -> NodeStages {
     let span = debug_span!(consensus::node::INITIALIZE);
@@ -98,11 +97,6 @@ pub fn build_stage_graph(
     let block_source_sender = block_source_stage.sender();
 
     let k = global_parameters.consensus_security_param;
-
-    // The number of headers fetched via chainsync ahead of the applied ledger tip.
-    // This value should be large enough to avoid stalling block fetches, but not much
-    // larger because those headers also consume resources.
-    let max_peer_lead = 1000;
 
     // Wire mempool (from main) — kept for its own use even if not passed to adopt_chain in this resolution
     let mempool_stage = stage_graph.wire_up(mempool_stage, MempoolStageState::default()).without_state();
@@ -163,10 +157,8 @@ pub fn build_stage_graph(
         SelectChainMsg::TipFromUpstream { tip, parent, trace_context, received_at }
     });
 
-    let track_peers_wired = stage_graph.wire_up(
-        track_peers,
-        TrackPeers::new(era_history.clone(), peer_selection_ref, select_chain_input, max_peer_lead, max_epoch),
-    );
+    let track_peers_wired =
+        stage_graph.wire_up(track_peers, TrackPeers::new(era_history.clone(), peer_selection_ref, select_chain_input));
     let track_peers_stake_dist_sender = stage_graph.input(&track_peers_wired);
     let track_peers_input = stage_graph.contramap(track_peers_wired, "track_peers_input", TrackPeersMsg::FromUpstream);
 

--- a/crates/amaru-node/src/stages/build_stage_graph.rs
+++ b/crates/amaru-node/src/stages/build_stage_graph.rs
@@ -143,8 +143,8 @@ pub fn build_stage_graph(
         .expect("fetch blocks recovery message must be preloaded");
 
     let fetch_blocks_input = stage_graph.contramap(fetch_blocks, "fetch_blocks_input", |msg| {
-        let select_chain::NewBestTip { tip, parent, trace_context } = msg;
-        FetchBlocksMsg::NewTip { tip, parent, trace_context }
+        let select_chain::NewBestTip { tip, parent, chain_switched, trace_context } = msg;
+        FetchBlocksMsg::NewTip { tip, parent, chain_switched, trace_context }
     });
 
     let select_chain = stage_graph.wire_up(select_chain, SelectChain::new(fetch_blocks_input));

--- a/crates/amaru-ouroboros-traits/src/stores/chain_store/types.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/chain_store/types.rs
@@ -96,6 +96,10 @@ impl MissingBlocks {
         self.missing.back().copied()
     }
 
+    pub fn nth(&self, n: usize) -> Option<Point> {
+        self.missing.get(n).copied()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.missing.is_empty()
     }


### PR DESCRIPTION
  This is wrong; since some of the Ouroboros properties aren't verified,
  we cannot actually guarantee that headers won't be extremely sparse.
  The only minimum we have is really one header every 3*k/f slots. Which
  means that headers could actually span over many many epochs.

  The real blocker is the stake distribution, so it makes sense to
  simply await it in the consensus whenever required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Header validation deferrals now depend on stake distribution availability (not ledger height/epoch).
  - Clock-skew–related deferred headers are rechecked using updated timing recheck flow.
  - Roll-forward and next-block requests proceed immediately when not deferred, reducing stalling.
  - Far-ahead header handling now defers for later processing instead of blocking peer selection.
  - Block fetching now improves missing-block cursor reuse, batching, and timeout/retry state handling.
- **New Features**
  - Added an accessor to retrieve the *n*th missing block point during block discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->