### PR TITLE
ProposalReturnAccountDoesNotExist logic and fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Other guiding principles:
 - **amaru-ledger**: when a leader changes it reward account, the rewards owed to the previous account must return to the treasury ([#1125](https://github.com/pragma-org/amaru/pull/1125)).
 - **amaru-consensus**: fix peer_selection to only schedule a single cool-down timer and thus properly bound priority mailbox usage. ([#1112](https://github.com/pragma-org/amaru/issues/1112))
 - **amaru-ledger**: validate provided treasury value matches actual treasury value (ConwayTreasuryValueMismatch) ([#1025][], [#888][])
+- **amaru-ledger**: reject governance proposals whose deposit return account is not registered. ([#928][])
 
 ## [v10.11.20260730](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260730)
 
@@ -255,6 +256,7 @@ Other guiding principles:
 [#909]: https://github.com/pragma-org/amaru/issues/909
 [#912]: https://github.com/pragma-org/amaru/issues/912
 [#915]: https://github.com/pragma-org/amaru/issues/915
+[#928]: https://github.com/pragma-org/amaru/issues/928
 [#929]: https://github.com/pragma-org/amaru/issues/929
 [#942]: https://github.com/pragma-org/amaru/pull/942
 [#951]: https://github.com/pragma-org/amaru/pull/951

--- a/crates/amaru-kernel/src/cardano/stake_credential.rs
+++ b/crates/amaru-kernel/src/cardano/stake_credential.rs
@@ -15,7 +15,7 @@
 use std::fmt;
 
 use crate::{
-    Address, HasOwnership, Hash, Network, cbor,
+    Address, HasOwnership, Hash, Network, StakePayload, cbor,
     size::{KEY, SCRIPT},
 };
 
@@ -91,6 +91,15 @@ pub fn parse_reward_account(bytes: &[u8]) -> Option<(StakeCredential, Network)> 
         Some((address.owner(), network))
     } else {
         None
+    }
+}
+
+impl From<StakePayload> for StakeCredential {
+    fn from(payload: StakePayload) -> Self {
+        match payload {
+            StakePayload::Key(hash) => Self::AddrKeyhash(hash),
+            StakePayload::Script(hash) => Self::ScriptHash(hash),
+        }
     }
 }
 

--- a/crates/amaru-ledger/src/rules.rs
+++ b/crates/amaru-ledger/src/rules.rs
@@ -92,6 +92,10 @@ fn prepare_votes<'a>(context: &mut impl PreparationContext<'a>, transaction: &'a
 }
 
 fn prepare_governance_action<'a>(context: &mut impl PreparationContext<'a>, proposal: &'a Proposal) {
+    if let Some((account, _)) = parse_reward_account(&proposal.reward_account) {
+        context.require_account(Cow::Owned(account));
+    }
+
     if let GovernanceAction::TreasuryWithdrawals(withdrawals, _) = &proposal.gov_action {
         withdrawals
             .iter()

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/fixture.rs
@@ -197,6 +197,7 @@ pub(super) enum Predicate {
     OutsideValidityIntervalUTxO,
     ScriptsNotPaidUTxO,
     TooManyCollateralInputs,
+    ProposalReturnAccountDoesNotExist,
     TreasuryWithdrawalReturnAccountsDoNotExist,
     DelegateeDRepNotRegistered,
     DelegateeStakePoolNotRegistered,
@@ -264,6 +265,9 @@ impl From<PhaseOneError> for Predicate {
             },
             PhaseOneError::Proposals(InvalidProposals::TreasuryWithdrawalReturnAccountsDoNotExist(_)) => {
                 Predicate::TreasuryWithdrawalReturnAccountsDoNotExist
+            }
+            PhaseOneError::Proposals(InvalidProposals::ProposalReturnAccountDoesNotExist(_)) => {
+                Predicate::ProposalReturnAccountDoesNotExist
             }
             PhaseOneError::ValueNotPreserved(_) => Predicate::ValueNotConservedUTxO,
             PhaseOneError::Certificates(InvalidCertificates::StakeCredentialInvalidPoolDelegation(ref e)) => match e {

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/proposals.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/proposals.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeSet;
 use amaru_kernel::{
     Address, Epoch, EraHistory, GovernanceAction, Hash, Lovelace, MemoizedDatum, Network, Proposal, ProposalId,
     ProposalPointer, ProtocolParamUpdate, ProtocolParameters, ProtocolVersion, RedeemerTag, RequiredScript,
-    StakeCredential, TransactionId, TransactionPointer, parse_reward_account, size::SCRIPT,
+    StakeCredential, TransactionId, TransactionPointer, size::SCRIPT,
 };
 use thiserror::Error;
 
@@ -33,6 +33,9 @@ pub enum InvalidProposals {
 
     #[error("proposal return address is malformed")]
     MalformedReturnAddress,
+
+    #[error("proposal return account does not exist: {0:?}")]
+    ProposalReturnAccountDoesNotExist(StakeCredential),
 
     #[error("treasury withdrawals total is zero")]
     ZeroTreasuryWithdrawals,
@@ -71,20 +74,8 @@ where
     C: ProposalsSlice + AccountsSlice + WitnessSlice + BalanceSlice,
 {
     for (proposal_index, proposal) in proposals.unwrap_or_default().into_iter().enumerate() {
-        validate_proposal(&proposal, network, protocol_parameters, era_history, transaction.1)?;
+        validate_proposal(context, &proposal, network, protocol_parameters, era_history, transaction.1)?;
 
-        if let GovernanceAction::TreasuryWithdrawals(ref wdrls, _) = proposal.gov_action {
-            let missing: BTreeSet<StakeCredential> = wdrls
-                .iter()
-                .filter_map(|(account, _)| {
-                    let (credential, _) = parse_reward_account(account)?;
-                    AccountsSlice::lookup(context, &credential).is_none().then_some(credential)
-                })
-                .collect();
-            if !missing.is_empty() {
-                return Err(InvalidProposals::TreasuryWithdrawalReturnAccountsDoNotExist(missing));
-            }
-        }
         if let Some(script_hash) = get_proposal_script_hash(&proposal) {
             context.require_script_witness(RequiredScript {
                 hash: script_hash,
@@ -119,13 +110,17 @@ pub(crate) fn count_lovelace<C>(
     context.produce_lovelace(protocol_parameters.gov_action_deposit * proposals.unwrap_or_default().len() as u64);
 }
 
-fn validate_proposal(
+fn validate_proposal<C>(
+    context: &C,
     proposal: &Proposal,
     network: Network,
     protocol_parameters: &ProtocolParameters,
     era_history: &EraHistory,
     pointer: TransactionPointer,
-) -> Result<(), InvalidProposals> {
+) -> Result<(), InvalidProposals>
+where
+    C: AccountsSlice,
+{
     if proposal.deposit != protocol_parameters.gov_action_deposit {
         return Err(InvalidProposals::IncorrectDeposit {
             provided: proposal.deposit,
@@ -136,6 +131,13 @@ fn validate_proposal(
     match Address::from_bytes(&proposal.reward_account[..]) {
         Some(Address::Stake(addr)) => {
             let actual = addr.network();
+
+            let credential = StakeCredential::from(*(addr.payload()));
+
+            if AccountsSlice::lookup(context, &credential).is_none() {
+                return Err(InvalidProposals::ProposalReturnAccountDoesNotExist(credential));
+            }
+
             if actual != network {
                 return Err(InvalidProposals::ReturnAddressWrongNetwork { expected: network, actual });
             }
@@ -145,19 +147,35 @@ fn validate_proposal(
 
     match &proposal.gov_action {
         GovernanceAction::TreasuryWithdrawals(wdrls, _) => {
-            for (account, _) in wdrls.iter() {
+            let mut any_positive = false;
+            let mut missing = BTreeSet::new();
+
+            for (account, coin) in wdrls.iter() {
                 match Address::from_bytes(&account[..]) {
                     Some(Address::Stake(addr)) => {
                         let actual = addr.network();
                         if actual != network {
                             return Err(InvalidProposals::TreasuryWithdrawalWrongNetwork { expected: network, actual });
                         }
+
+                        any_positive |= *coin > 0;
+
+                        let credential = StakeCredential::from(*(addr.payload()));
+
+                        if AccountsSlice::lookup(context, &credential).is_none() {
+                            missing.insert(credential);
+                        }
                     }
                     _ => return Err(InvalidProposals::MalformedReturnAddress),
                 }
             }
-            if !wdrls.iter().any(|(_, coin)| *coin > 0) {
+
+            if !any_positive {
                 return Err(InvalidProposals::ZeroTreasuryWithdrawals);
+            }
+
+            if !missing.is_empty() {
+                return Err(InvalidProposals::TreasuryWithdrawalReturnAccountsDoNotExist(missing));
             }
         }
 

--- a/crates/amaru-ledger/tests/data/phase-one/fail/ProposalReturnAccountDoesNotExist/0.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/ProposalReturnAccountDoesNotExist/0.json
@@ -1,0 +1,33 @@
+{
+  "title": "parameter change proposal with an unregistered return account",
+  "description": "A ParameterChange proposal whose return (deposit refund) account is not registered in the accounts state.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8400f6a1001864f6827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840ee54a69d13a9a37532cc28d8d76c30bb3796223d8c58cb81da876f84651ffe5c1398e83f6bb680860c748330c6557a5a7edc6a42d8304442970dea242be77a05f5f6",
+  "expected": {
+    "predicate": "ProposalReturnAccountDoesNotExist"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/fail/ProposalReturnAccountDoesNotExist/1.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/ProposalReturnAccountDoesNotExist/1.json
@@ -1,0 +1,33 @@
+{
+  "title": "hard fork initiation proposal with an unregistered return account",
+  "description": "A HardForkInitiation proposal whose return (deposit refund) account is not registered in the accounts state.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8301f6820b00827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840c9863c8a3b09ec751c391989f672fe6b4fe0c6e835ead0c3ca539a529fde8fc100a4a92165f71c3e3689c02721a9048b7dc7e038125c547f422cdd1046c7090cf5f6",
+  "expected": {
+    "predicate": "ProposalReturnAccountDoesNotExist"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/fail/ProposalReturnAccountDoesNotExist/2.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/ProposalReturnAccountDoesNotExist/2.json
@@ -1,0 +1,39 @@
+{
+  "title": "treasury withdrawals proposal with an unregistered return account",
+  "description": "A TreasuryWithdrawals proposal whose return (deposit refund) account is not registered. The withdrawal target account IS registered, so the only failure is the missing return account.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "pools": [],
+    "accounts": [
+      {
+        "credential": "8200581caaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8302a1581de0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1a000f4240f6827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840c6df443bdb9443e114af6ffeb60f7aca8afbcdfe1a5f3b1b6244cc045a1f20a6a137e119b922a5993e3cdf31191105ac141dd4a12956d7b01cc6e40d8a1d0800f5f6",
+  "expected": {
+    "predicate": "ProposalReturnAccountDoesNotExist"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/fail/ProposalReturnAccountDoesNotExist/3.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/ProposalReturnAccountDoesNotExist/3.json
@@ -1,0 +1,33 @@
+{
+  "title": "no confidence proposal with an unregistered return account",
+  "description": "A NoConfidence proposal whose return (deposit refund) account is not registered in the accounts state.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8203f6827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840c87502a35718eec5a091e6159b5385ec99f4551a7d0abc1b15e2dfdfcae5c8331f9fd91d3a965e6f40da63a56bcfb21be030888bd768f44b45f3a53563ed780ff5f6",
+  "expected": {
+    "predicate": "ProposalReturnAccountDoesNotExist"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/fail/ProposalReturnAccountDoesNotExist/4.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/ProposalReturnAccountDoesNotExist/4.json
@@ -1,0 +1,33 @@
+{
+  "title": "update committee proposal with an unregistered return account",
+  "description": "An UpdateCommittee proposal whose return (deposit refund) account is not registered in the accounts state.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8504f6d9010280a0d81e820102827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584096c0683da606dab9718b7ed13ecaf87ab7a701e9072995723f9f6043e90bfd3025d1ed2ffdb8113df5cd75b444a04b80f83f9912935d590e1436af5b4073ca04f5f6",
+  "expected": {
+    "predicate": "ProposalReturnAccountDoesNotExist"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/fail/ProposalReturnAccountDoesNotExist/5.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/ProposalReturnAccountDoesNotExist/5.json
@@ -1,0 +1,33 @@
+{
+  "title": "new constitution proposal with an unregistered return account",
+  "description": "A NewConstitution proposal whose return (deposit refund) account is not registered in the accounts state.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8305f682827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000f6827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258402ca1b2fd0fbcf0a3e1eb7fdd94c78cf241741a030a92a1700a2b390443af89daa9a47dbace7ed76e89874416e7d9029194705234afe5af1b8fba6936e3b44407f5f6",
+  "expected": {
+    "predicate": "ProposalReturnAccountDoesNotExist"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/fail/ProposalReturnAccountDoesNotExist/6.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/ProposalReturnAccountDoesNotExist/6.json
@@ -1,0 +1,33 @@
+{
+  "title": "information proposal with an unregistered return account",
+  "description": "An Information proposal whose return (deposit refund) account is not registered in the accounts state.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8106827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840e826224e52ce8f3ef0699b55be1df92d4dac4e5a5cb218e9b9441fd63ebee518052092b9243f746fe92fe52b04ea96ad073f5c48da2d95f70ec6214ac4c67906f5f6",
+  "expected": {
+    "predicate": "ProposalReturnAccountDoesNotExist"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/fail/TreasuryWithdrawalReturnAccountsDoNotExist/0.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/TreasuryWithdrawalReturnAccountsDoNotExist/0.json
@@ -16,7 +16,13 @@
       }
     ],
     "pools": [],
-    "accounts": [],
+    "accounts": [
+      {
+        "credential": "8200581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
     "dreps": [],
     "governanceActivity": {
       "consecutiveDormantEpochs": 0

--- a/crates/amaru-ledger/tests/data/phase-one/fail/TreasuryWithdrawalReturnAccountsDoNotExist/1.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/TreasuryWithdrawalReturnAccountsDoNotExist/1.json
@@ -16,7 +16,13 @@
       }
     ],
     "pools": [],
-    "accounts": [],
+    "accounts": [
+      {
+        "credential": "8200581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
     "dreps": [],
     "governanceActivity": {
       "consecutiveDormantEpochs": 0

--- a/crates/amaru-ledger/tests/data/phase-one/fail/TreasuryWithdrawalReturnAccountsDoNotExist/2.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/TreasuryWithdrawalReturnAccountsDoNotExist/2.json
@@ -21,6 +21,11 @@
         "credential": "8200581cdddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
         "deposit": 2000000,
         "rewards": 0
+      },
+      {
+        "credential": "8200581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec",
+        "deposit": 2000000,
+        "rewards": 0
       }
     ],
     "dreps": [],

--- a/crates/amaru-ledger/tests/data/phase-one/pass/proposal-return-account-hard-fork.json
+++ b/crates/amaru-ledger/tests/data/phase-one/pass/proposal-return-account-hard-fork.json
@@ -1,0 +1,37 @@
+{
+  "title": "hard fork initiation proposal with a registered return account",
+  "description": "A HardForkInitiation proposal whose return (deposit refund) account is registered.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "pools": [],
+    "accounts": [
+      {
+        "credential": "8200581cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8301f6820b00827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840c9863c8a3b09ec751c391989f672fe6b4fe0c6e835ead0c3ca539a529fde8fc100a4a92165f71c3e3689c02721a9048b7dc7e038125c547f422cdd1046c7090cf5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/phase-one/pass/proposal-return-account-information.json
+++ b/crates/amaru-ledger/tests/data/phase-one/pass/proposal-return-account-information.json
@@ -1,0 +1,37 @@
+{
+  "title": "information proposal with a registered return account",
+  "description": "An Information proposal whose return (deposit refund) account is registered.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "pools": [],
+    "accounts": [
+      {
+        "credential": "8200581cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8106827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840e826224e52ce8f3ef0699b55be1df92d4dac4e5a5cb218e9b9441fd63ebee518052092b9243f746fe92fe52b04ea96ad073f5c48da2d95f70ec6214ac4c67906f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/phase-one/pass/proposal-return-account-new-constitution.json
+++ b/crates/amaru-ledger/tests/data/phase-one/pass/proposal-return-account-new-constitution.json
@@ -1,0 +1,37 @@
+{
+  "title": "new constitution proposal with a registered return account",
+  "description": "A NewConstitution proposal whose return (deposit refund) account is registered.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "pools": [],
+    "accounts": [
+      {
+        "credential": "8200581cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8305f682827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000f6827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258402ca1b2fd0fbcf0a3e1eb7fdd94c78cf241741a030a92a1700a2b390443af89daa9a47dbace7ed76e89874416e7d9029194705234afe5af1b8fba6936e3b44407f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/phase-one/pass/proposal-return-account-no-confidence.json
+++ b/crates/amaru-ledger/tests/data/phase-one/pass/proposal-return-account-no-confidence.json
@@ -1,0 +1,37 @@
+{
+  "title": "no confidence proposal with a registered return account",
+  "description": "A NoConfidence proposal whose return (deposit refund) account is registered.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "pools": [],
+    "accounts": [
+      {
+        "credential": "8200581cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8203f6827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840c87502a35718eec5a091e6159b5385ec99f4551a7d0abc1b15e2dfdfcae5c8331f9fd91d3a965e6f40da63a56bcfb21be030888bd768f44b45f3a53563ed780ff5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/phase-one/pass/proposal-return-account-parameter-change.json
+++ b/crates/amaru-ledger/tests/data/phase-one/pass/proposal-return-account-parameter-change.json
@@ -1,0 +1,37 @@
+{
+  "title": "parameter change proposal with a registered return account",
+  "description": "A ParameterChange proposal whose return (deposit refund) account is registered.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "pools": [],
+    "accounts": [
+      {
+        "credential": "8200581cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8400f6a1001864f6827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840ee54a69d13a9a37532cc28d8d76c30bb3796223d8c58cb81da876f84651ffe5c1398e83f6bb680860c748330c6557a5a7edc6a42d8304442970dea242be77a05f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/phase-one/pass/proposal-return-account-treasury-withdrawals.json
+++ b/crates/amaru-ledger/tests/data/phase-one/pass/proposal-return-account-treasury-withdrawals.json
@@ -1,0 +1,42 @@
+{
+  "title": "treasury withdrawals proposal with a registered return account",
+  "description": "A TreasuryWithdrawals proposal whose return account and withdrawal target account are both registered.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "pools": [],
+    "accounts": [
+      {
+        "credential": "8200581cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "deposit": 2000000,
+        "rewards": 0
+      },
+      {
+        "credential": "8200581caaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8302a1581de0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1a000f4240f6827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840c6df443bdb9443e114af6ffeb60f7aca8afbcdfe1a5f3b1b6244cc045a1f20a6a137e119b922a5993e3cdf31191105ac141dd4a12956d7b01cc6e40d8a1d0800f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/phase-one/pass/proposal-return-account-update-committee.json
+++ b/crates/amaru-ledger/tests/data/phase-one/pass/proposal-return-account-update-committee.json
@@ -1,0 +1,37 @@
+{
+  "title": "update committee proposal with a registered return account",
+  "description": "An UpdateCommittee proposal whose return (deposit refund) account is registered.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "pools": [],
+    "accounts": [
+      {
+        "credential": "8200581cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8504f6d9010280a0d81e820102827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584096c0683da606dab9718b7ed13ecaf87ab7a701e9072995723f9f6043e90bfd3025d1ed2ffdb8113df5cd75b444a04b80f83f9912935d590e1436af5b4073ca04f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/rules-conformance.failures.toml
+++ b/crates/amaru-ledger/tests/data/rules-conformance.failures.toml
@@ -30,7 +30,6 @@
 "conway/fail-gov-invalid-index-in-govpurposeid/0" = "Expected failure, got success"
 "conway/fail-gov-non-existent-gov-actions/0" = "Expected failure, got success"
 "conway/fail-gov-policy-is-respected-by-proposals/0" = "Expected failure, got success"
-"conway/fail-gov-proposalreturnaccountdoesnotexist/0" = "Expected failure, got success"
 "conway/fail-gov-proposals-submitted-without-proper-parent-fail/0" = "Expected failure, got success"
 "conway/fail-gov-valid-govpurposeid-but-invalid-purpose/0" = "Expected failure, got success"
 "conway/fail-gov-votersdonotexist/0" = "Expected failure, got success"


### PR DESCRIPTION
Closes #928

This PR introduces validation logic to ensure a governance proposal's return account exists and fixtures for coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Governance proposals are now rejected when their deposit return account is not registered.
  * Return-account validation now applies consistently across all proposal types, including treasury withdrawals.
  * Valid proposals with registered return accounts continue to be accepted.

* **Tests**
  * Added coverage for invalid and valid return-account scenarios across governance proposal types.
  * Updated conformance expectations for previously failing proposal cases.

* **Documentation**
  * Updated the unreleased changelog with this fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->