### PR TITLE
feat: header lifecycle event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Other guiding principles:
 
 - **amaru-ledger**: reject treasury withdrawal proposals that reference unregistered reward accounts.  ([#1032][], [#929][])
 - **amaru-ledger**: introduce `StakePoolCostTooLowPOOL` coverage. ([#1037][], [#909][])
+- **amaru-consensus**: add events and metrics to track the performance of headers processing. ([#1005][])
 
 ### Changed
 
@@ -216,6 +217,7 @@ Other guiding principles:
 [#988]: https://github.com/pragma-org/amaru/pull/988
 [#996]: https://github.com/pragma-org/amaru/pull/996
 [#1000]: https://github.com/pragma-org/amaru/pull/1000
+[#1005]: https://github.com/pragma-org/amaru/pull/1005
 [#1009]: https://github.com/pragma-org/amaru/pull/1009
 [#1010]: https://github.com/pragma-org/amaru/pull/1010
 [#1013]: https://github.com/pragma-org/amaru/pull/1013

--- a/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
@@ -296,6 +296,10 @@ impl FetchBlocks {
                 self.req_id += 1;
                 self.no_peers_pause = false;
                 self.trace_context = Some(parent_context);
+
+                let now = eff.clock().await;
+                let requested: Vec<HeaderHash> =
+                    missing.missing_points().into_iter().map(|point| point.hash()).collect();
                 eff.send(
                     &self.manager,
                     ManagerMessage::FetchBlocks {
@@ -306,6 +310,9 @@ impl FetchBlocks {
                     },
                 )
                 .await;
+                // Tell the select_chain stage when this block was received so it can record the
+                // block_fetch_wait point of its lifecycle.
+                eff.send(&self.upstream, SelectChainMsg::BlocksRequested(requested, now)).await;
                 let timeout = eff.schedule_after(FetchBlocksMsg::Timeout(self.req_id), Duration::from_secs(5)).await;
                 self.timeout = Some(timeout);
             }
@@ -327,9 +334,8 @@ impl FetchBlocks {
 
         // check that body belongs to header
         if header.header().header_body.block_body_hash != block.body_hash() {
-            let trace_context =
-                debug_span!(consensus::block::MISMATCHED_HASH, peer = peer.clone(), header_hash = point.hash()).into();
-            eff.send(&self.peer_selection, PeerSelectionMsg::Adversarial(peer, trace_context)).await;
+            let span = debug_span!(consensus::block::MISMATCHED_HASH, peer = peer.clone(), header_hash = point.hash());
+            eff.send(&self.peer_selection, PeerSelectionMsg::Adversarial(peer, (&span).into())).await;
             tracing::warn!(expected = %header.header().header_body.block_body_hash, actual = %block.body_hash(), "block body hash mismatch");
             return;
         }
@@ -347,6 +353,11 @@ impl FetchBlocks {
             tracing::warn!(%expected, actual = ?point, "block point mismatch");
             return;
         }
+
+        // Tell the select_chain stage when this block was received so it can record the
+        // block_downloaded point of its lifecycle.
+        let now = eff.clock().await;
+        eff.send(&self.upstream, SelectChainMsg::BlockDownloaded(point.hash(), now)).await;
 
         store
             .store_block(&point.hash(), &network_block.raw_block())

--- a/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
@@ -29,7 +29,9 @@ use crate::stages::{
         TestPrep, setup, te_cancel_schedule, te_clock, te_find_missing_blocks, te_has_block, te_load_header,
         te_load_tip, te_schedule, te_store_block, te_unvalidated_ancestor_hashes, test_peer, test_prep,
     },
-    test_utils::{assert_trace, start_in_era, te_input, te_send, te_state, te_terminate, te_terminated, tm_state},
+    test_utils::{
+        assert_trace, start_in_era, te_clock_read, te_input, te_send, te_state, te_terminate, te_terminated, tm_state,
+    },
 };
 
 #[test]
@@ -155,6 +157,7 @@ fn test_new_tip_blocks_to_fetch() {
     );
     state_with_timeout.block_height = BlockHeight::from(3);
     state_with_timeout.trace_context = Some(Default::default());
+    let requested_at = Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time);
     let state_after_timeout = {
         let mut state = state_with_timeout.clone();
         state.missing = None;
@@ -168,6 +171,7 @@ fn test_new_tip_blocks_to_fetch() {
             te_state("fb-1", &prep.state),
             te_input("fb-1", &msg),
             te_find_missing_blocks("fb-1", tip.hash(), 25),
+            te_clock_read("fb-1"),
             te_send(
                 "fb-1",
                 "manager",
@@ -177,6 +181,11 @@ fn test_new_tip_blocks_to_fetch() {
                     id: 1,
                     cr: prep.cleanup_replies.clone(),
                 },
+            ),
+            te_send(
+                "fb-1",
+                "upstream",
+                SelectChainMsg::BlocksRequested(vec![prep.headers.h1.hash(), prep.headers.h2.hash()], requested_at),
             ),
             te_schedule("fb-1", FetchBlocksMsg::Timeout(1), schedule_id),
             te_state("fb-1", &state_with_timeout),
@@ -215,6 +224,15 @@ fn test_block_received() {
         &[
             te_state("fb-1", &prep.state),
             te_input("fb-1", &msg),
+            te_clock_read("fb-1"),
+            te_send(
+                "fb-1",
+                "upstream",
+                SelectChainMsg::BlockDownloaded(
+                    prep.headers.h1.hash(),
+                    Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time),
+                ),
+            ),
             te_store_block("fb-1", prep.headers.h1.hash(), TestPrep::raw_block(&prep.headers.h1)),
             te_send(
                 "fb-1",
@@ -257,6 +275,15 @@ fn test_block2_received() {
         &[
             te_state("fb-1", &prep.state),
             te_input("fb-1", &msg),
+            te_clock_read("fb-1"),
+            te_send(
+                "fb-1",
+                "upstream",
+                SelectChainMsg::BlockDownloaded(
+                    prep.headers.h2.hash(),
+                    Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time),
+                ),
+            ),
             te_store_block("fb-1", prep.headers.h2.hash(), TestPrep::raw_block(&prep.headers.h2)),
             te_send(
                 "fb-1",

--- a/crates/amaru-consensus/src/stages/select_chain/headers_performance.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/headers_performance.rs
@@ -1,0 +1,302 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use amaru_kernel::{HeaderHash, Tip};
+use amaru_metrics::consensus::ConsensusMetrics;
+use amaru_observability::debug;
+use amaru_protocols::metrics_effects::{Metrics, MetricsOps};
+use amaru_pure_stage::{Effects, Instant, Void};
+use serde::{Deserialize, Serialize};
+
+/// Tracks the processing of headers to emit a single `perf.header.lifecycle` event per header when
+/// its block reaches a terminal state (adopted, invalidated or abandoned). The event covers the four
+/// network-health processing points of a header's lifecycle and carries the intervals between them:
+///
+/// - `block_fetch_wait_micros`: from the header's reception to the request of its block.
+/// - `block_fetch_micros`: from the request of the block to its reception.
+/// - `forward_micros`: from the header's reception to the adoption of its block.
+///
+/// Fork switches are tracked independently and emitted as `perf.fork.switch`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HeadersPerformance {
+    /// The lifecycle timestamps of each header whose block has not yet reached a terminal state.
+    lifecycles: BTreeMap<HeaderHash, HeaderLifecycle>,
+    /// An in-progress fork switch, if any.
+    fork_switch: Option<ForkSwitch>,
+}
+
+/// The processing timestamps accumulated for a header until its block reaches a terminal state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct HeaderLifecycle {
+    /// Time when the header was first received from an upstream peer.
+    received_at: Instant,
+    /// Time when its block was first requested, if it was requested.
+    requested_at: Option<Instant>,
+    /// Time when its block was first received, if it was received.
+    downloaded_at: Option<Instant>,
+}
+
+impl HeaderLifecycle {
+    fn new(received_at: Instant) -> Self {
+        Self { received_at, requested_at: None, downloaded_at: None }
+    }
+}
+
+/// The in-progress switch to a new fork, with the hash of its expected new best tip and the
+/// time it was detected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ForkSwitch {
+    hash: HeaderHash,
+    started_at: Instant,
+}
+
+impl HeadersPerformance {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A header has been accepted from upstream: start tracking its lifecycle from `received_at`.
+    pub fn header_received(&mut self, tip: Tip, received_at: Instant) {
+        self.lifecycles.entry(tip.hash()).or_insert_with(|| HeaderLifecycle::new(received_at));
+    }
+
+    /// The fetch_blocks stage requested the blocks for these headers: record their request time.
+    pub fn blocks_requested(&mut self, hashes: &[HeaderHash], requested_at: Instant) {
+        for hash in hashes {
+            if let Some(lifecycle) = self.lifecycles.get_mut(hash) {
+                lifecycle.requested_at.get_or_insert(requested_at);
+            }
+        }
+    }
+
+    /// The fetch_blocks stage received a block for this header: record the reception time.
+    pub fn block_downloaded(&mut self, hash: &HeaderHash, downloaded_at: Instant) {
+        if let Some(lifecycle) = self.lifecycles.get_mut(hash) {
+            lifecycle.downloaded_at.get_or_insert(downloaded_at);
+        }
+    }
+
+    /// A received header that is abandoned because its block depends on an invalid block.
+    pub async fn header_abandoned(&mut self, eff: &Effects<Void>, hash: &HeaderHash, now: Instant) {
+        self.emit_lifecycle(eff, hash, PerfHeaderForwardOutcome::AbandonedBlock, now).await;
+    }
+
+    /// A fork has been detected: start tracking the time it takes to switch to it. If a previous
+    /// fork switch is still in progress, record it as superseded.
+    pub async fn fork_started(&mut self, eff: &Effects<Void>, tip: Tip, started_at: Instant) {
+        if let Some(previous) = self.fork_switch.take() {
+            let ops = Metrics::new(eff);
+            ops.record(
+                emit_fork_switch(&previous.hash, PerfForkSwitchOutcome::Superseded, started_at, previous.started_at)
+                    .into(),
+            )
+            .await;
+        }
+        self.fork_switch = Some(ForkSwitch { hash: tip.hash(), started_at });
+    }
+
+    /// The block for a header has been validated and adopted: emit its lifecycle event and the
+    /// fork-switch event if it was waiting on this header.
+    pub async fn block_valid(&mut self, eff: &Effects<Void>, hash: &HeaderHash, now: Instant) {
+        self.emit_lifecycle(eff, hash, PerfHeaderForwardOutcome::ValidBlock, now).await;
+        self.close_fork(eff, hash, PerfForkSwitchOutcome::ValidBlock, now).await;
+    }
+
+    /// A header has been pruned after a block validation.
+    /// `invalid == true` means that the block that was found invalid
+    /// Otherwise this header/block has been abandoned because a better chain is available.
+    pub async fn block_pruned(&mut self, eff: &Effects<Void>, hash: &HeaderHash, invalid: bool, now: Instant) {
+        let (header_outcome, fork_outcome) = if invalid {
+            (PerfHeaderForwardOutcome::InvalidBlock, PerfForkSwitchOutcome::InvalidBlock)
+        } else {
+            (PerfHeaderForwardOutcome::AbandonedBlock, PerfForkSwitchOutcome::AbandonedBlock)
+        };
+        self.emit_lifecycle(eff, hash, header_outcome, now).await;
+        self.close_fork(eff, hash, fork_outcome, now).await;
+    }
+
+    /// Emit a `perf.header.lifecycle` event for a header reaching a terminal state.
+    /// Record the corresponding metric, and drop its tracking record.
+    async fn emit_lifecycle(
+        &mut self,
+        eff: &Effects<Void>,
+        hash: &HeaderHash,
+        outcome: PerfHeaderForwardOutcome,
+        now: Instant,
+    ) {
+        let Some(lifecycle) = self.lifecycles.remove(hash) else {
+            return;
+        };
+
+        let block_fetch_wait_micros =
+            lifecycle.requested_at.map(|requested_at| duration_micros(lifecycle.received_at, requested_at));
+        let block_fetch_micros = lifecycle
+            .requested_at
+            .zip(lifecycle.downloaded_at)
+            .map(|(requested_at, downloaded_at)| duration_micros(requested_at, downloaded_at));
+        let forward_micros = duration_micros(lifecycle.received_at, now);
+
+        debug!(
+            consensus::perf::header::LIFECYCLE,
+            header_hash = hash,
+            outcome = outcome.as_str(),
+            block_fetch_wait_micros = @block_fetch_wait_micros,
+            block_fetch_micros = @block_fetch_micros,
+            forward_micros = @forward_micros
+        );
+
+        let ops = Metrics::new(eff);
+        ops.record(
+            ConsensusMetrics::HeaderLifecycle {
+                outcome: outcome.as_str().to_string(),
+                block_fetch_wait_micros,
+                block_fetch_micros,
+                forward_micros: Some(forward_micros),
+            }
+            .into(),
+        )
+        .await;
+    }
+
+    async fn close_fork(
+        &mut self,
+        eff: &Effects<Void>,
+        hash: &HeaderHash,
+        outcome: PerfForkSwitchOutcome,
+        now: Instant,
+    ) {
+        if self.fork_switch.as_ref().is_some_and(|fork| &fork.hash == hash)
+            && let Some(fork) = self.fork_switch.take()
+        {
+            let ops = Metrics::new(eff);
+            ops.record(emit_fork_switch(&fork.hash, outcome, now, fork.started_at).into()).await
+        }
+    }
+}
+
+impl PartialEq for HeadersPerformance {
+    fn eq(&self, other: &Self) -> bool {
+        // The recorded times are wall-clock values used only to compute durations on close, so
+        // equality compares only which headers are tracked, keeping it independent of timing.
+        self.lifecycles.keys().eq(other.lifecycles.keys())
+            && self.fork_switch.as_ref().map(|fork| fork.hash) == other.fork_switch.as_ref().map(|fork| fork.hash)
+    }
+}
+
+/// Number of microseconds elapsed between `started` and `now` (0 if `now` precedes `started`).
+fn duration_micros(started: Instant, now: Instant) -> u64 {
+    now.saturating_since(started).as_micros() as u64
+}
+
+/// Emit a `perf.fork.switch` event for a fork switch that started at `started_at` and ended now,
+/// and return the matching metric.
+fn emit_fork_switch(
+    hash: &HeaderHash,
+    outcome: PerfForkSwitchOutcome,
+    now: Instant,
+    started_at: Instant,
+) -> ConsensusMetrics {
+    let duration = duration_micros(started_at, now);
+    debug!(consensus::perf::fork::SWITCH, header_hash = hash, outcome = outcome.as_str(), duration_micros = @duration);
+    ConsensusMetrics::ForkSwitch { outcome: outcome.as_str().to_string(), duration_micros: duration }
+}
+
+/// Local enum modelling the outcome of a header's lifecycle
+#[derive(Debug, Clone, Copy)]
+pub enum PerfHeaderForwardOutcome {
+    /// We stopped trying to get the validity of a block (it might still have been downloaded in the
+    /// meantime).
+    AbandonedBlock,
+    /// The block was retrieved but validation failed.
+    InvalidBlock,
+    /// The block was retrieved and validated.
+    ValidBlock,
+    /// The header for a given block has already been received
+    DuplicateHeader,
+    /// The header cannot be decoded
+    UndecodableHeader,
+    /// The header is invalid
+    InvalidHeader,
+    /// The header for that block could not be stored
+    StoreHeaderError,
+}
+
+impl PerfHeaderForwardOutcome {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::AbandonedBlock => "abandoned",
+            Self::InvalidBlock => "invalid",
+            Self::ValidBlock => "valid",
+            Self::DuplicateHeader => "duplicate header",
+            Self::InvalidHeader => "invalid header",
+            Self::UndecodableHeader => "undecodable header",
+            Self::StoreHeaderError => "store header error",
+        }
+    }
+}
+
+/// Local enum modelling the outcome of the perf.fork.switch event
+#[derive(Debug, Clone, Copy)]
+pub enum PerfForkSwitchOutcome {
+    /// We stopped trying to get the validity of a block (it might still have been downloaded in the
+    /// meantime).
+    AbandonedBlock,
+    /// The block was retrieved but validation failed.
+    InvalidBlock,
+    /// The block was retrieved and validated.
+    ValidBlock,
+    /// This fork has been superseded by a better one.
+    Superseded,
+}
+
+impl PerfForkSwitchOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::AbandonedBlock => "abandoned",
+            Self::InvalidBlock => "invalid",
+            Self::ValidBlock => "valid",
+            Self::Superseded => "superseded fork",
+        }
+    }
+}
+
+#[cfg(test)]
+impl HeadersPerformance {
+    /// Track the given hashes as lifecycles started at time zero (test helper).
+    pub(crate) fn with_lifecycles(mut self, hashes: impl IntoIterator<Item = HeaderHash>) -> Self {
+        for hash in hashes {
+            self.lifecycles.insert(
+                hash,
+                HeaderLifecycle::new(Instant::at_offset(std::time::Duration::ZERO, std::time::Duration::ZERO)),
+            );
+        }
+        self
+    }
+
+    /// Track an in-progress fork switch for the given header hash (test helper).
+    pub(crate) fn with_fork_switch(mut self, hash: HeaderHash) -> Self {
+        self.fork_switch = Some(ForkSwitch {
+            hash,
+            started_at: Instant::at_offset(std::time::Duration::ZERO, std::time::Duration::ZERO),
+        });
+        self
+    }
+
+    pub(crate) fn with_fork_switch_at(mut self, hash: HeaderHash, started_at: std::time::Duration) -> Self {
+        self.fork_switch = Some(ForkSwitch { hash, started_at: Instant::at_offset(started_at, started_at) });
+        self
+    }
+}

--- a/crates/amaru-consensus/src/stages/select_chain/mod.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/mod.rs
@@ -12,15 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{cmp::Ordering, collections::BTreeMap};
+use std::{cmp::Ordering, collections::BTreeMap, time::Duration};
 
 use amaru_kernel::{BlockHeader, HeaderHash, IsHeader, ORIGIN_HASH, Point, Tip};
 use amaru_observability::{TraceContext, debug_span};
 use amaru_protocols::store_effects::Store;
-use amaru_pure_stage::{Effects, OrTerminateWith, StageRef};
+use amaru_pure_stage::{Effects, Instant, OrTerminateWith, StageRef};
 use tracing::Instrument;
 
 use crate::effects::FindBestCandidate;
+
+mod headers_performance;
+use headers_performance::HeadersPerformance;
+pub use headers_performance::PerfHeaderForwardOutcome;
 
 /// Chain selection / fork choice stage.
 ///
@@ -98,32 +102,47 @@ pub struct SelectChain {
     best_tip: Option<BlockHeader>,
     /// Whether the downstream stage has sent a FetchNextFrom message that has not yet been responded to.
     may_fetch_blocks: bool,
+    /// Performance tracking for headers. It emits one `perf.header.lifecycle` event per header and
+    /// records the matching metrics when a header reaches a terminal state.
+    headers_performance: HeadersPerformance,
 }
 
 impl SelectChain {
     pub fn new(downstream: StageRef<NewBestTip>) -> Self {
-        Self { downstream, best_tip: None, tips: BTreeMap::new(), may_fetch_blocks: false }
+        Self {
+            downstream,
+            best_tip: None,
+            tips: BTreeMap::new(),
+            may_fetch_blocks: false,
+            headers_performance: HeadersPerformance::new(),
+        }
     }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum SelectChainMsg {
     Initialize(HeaderHash),
-    TipFromUpstream {
-        tip: Tip,
-        parent: Point,
-        #[serde(skip, default)]
-        trace_context: TraceContext,
-    },
+    TipFromUpstream { tip: Tip, parent: Point, trace_context: TraceContext, received_at: Instant },
     BlockValidationResult(Tip, bool),
     // This message must also be preloaded upon startup to get the block-fetching
     // and validation processes started. Should then contain Point::Origin.
     FetchNextFrom(Point, TraceContext),
+    // Sent by the fetch_blocks stage at the moment it requests the blocks for these headers, with
+    // the request time. Used to record the block_fetch_wait point of the header lifecycle.
+    BlocksRequested(Vec<HeaderHash>, Instant),
+    // Sent by the fetch_blocks stage when it receives the block for a header, with the reception
+    // time. Used to record the block_downloaded point of the header lifecycle.
+    BlockDownloaded(HeaderHash, Instant),
 }
 
 impl SelectChainMsg {
     pub fn tip_from_upstream(tip: Tip, parent: Point) -> Self {
-        SelectChainMsg::TipFromUpstream { tip, parent, trace_context: Default::default() }
+        SelectChainMsg::TipFromUpstream {
+            tip,
+            parent,
+            trace_context: Default::default(),
+            received_at: Instant::at_offset(Duration::ZERO, Duration::ZERO),
+        }
     }
 
     pub fn fetch_next_from(point: Point) -> Self {
@@ -142,7 +161,7 @@ pub async fn stage(mut state: SelectChain, msg: SelectChainMsg, eff: Effects<Sel
                 state.tips.insert(best_hash, to_validate);
             }
         }
-        SelectChainMsg::TipFromUpstream { tip, parent, trace_context } => {
+        SelectChainMsg::TipFromUpstream { tip, parent, trace_context, received_at } => {
             let span = debug_span!(
                 parent_context: &trace_context,
                 consensus::chain::SELECT_FROM_TIP,
@@ -150,7 +169,10 @@ pub async fn stage(mut state: SelectChain, msg: SelectChainMsg, eff: Effects<Sel
                 header_hash = tip.hash(),
             );
             let child_trace_context = (&span).into();
-            state.handle_tip_from_upstream(tip, parent, eff, trace_context, child_trace_context).instrument(span).await;
+            state
+                .handle_tip_from_upstream(tip, parent, eff, trace_context, child_trace_context, received_at)
+                .instrument(span)
+                .await;
         }
         SelectChainMsg::BlockValidationResult(point, valid) => {
             let span = debug_span!(
@@ -166,6 +188,12 @@ pub async fn stage(mut state: SelectChain, msg: SelectChainMsg, eff: Effects<Sel
             let span = debug_span!(parent_context: trace_context, consensus::chain::FETCH_NEXT, point = point, header_hash = point.hash(),);
             let trace_context = (&span).into();
             state.handle_fetch_next_from(point, eff, trace_context).instrument(span).await;
+        }
+        SelectChainMsg::BlocksRequested(hashes, requested_at) => {
+            state.headers_performance.blocks_requested(&hashes, requested_at);
+        }
+        SelectChainMsg::BlockDownloaded(hash, downloaded_at) => {
+            state.headers_performance.block_downloaded(&hash, downloaded_at);
         }
     }
     state
@@ -183,7 +211,10 @@ impl SelectChain {
         eff: Effects<SelectChainMsg>,
         parent_context: TraceContext,
         stage_context: TraceContext,
+        received_at: Instant,
     ) {
+        self.headers_performance.header_received(tip, received_at);
+
         let store = Store::new(eff.clone()).with_trace_context(&stage_context);
 
         let Some((header, valid)) = store.load_header_with_validity(&tip.hash()).await else {
@@ -219,12 +250,20 @@ impl SelectChain {
                 self.tips.insert(tip.hash(), ancestors);
             } else {
                 tracing::info!(%parent, %tip, "upstream tip depends on invalid block");
+                let now = eff.clock().await;
+                self.headers_performance.header_abandoned(&eff.erase(), &tip.hash(), now).await;
             }
         }
 
         if self.tips.contains_key(&tip.hash()) && cmp_tip(Some(&header), self.best_tip.as_ref()) == Ordering::Greater {
             let best_tip = self.best_tip.take().map(|h| h.point()).unwrap_or(Point::Origin);
             tracing::debug!(tip = %tip.point(), height = %tip.block_height(), previous = %best_tip, "new best tip candidate");
+
+            // if we have a real fork, start recording the time it takes to switch to that fork
+            if parent.hash() != best_tip.hash() {
+                self.headers_performance.fork_started(&eff.erase(), tip, received_at).await;
+            }
+
             if self.may_fetch_blocks {
                 self.may_fetch_blocks = false;
                 eff.send(&self.downstream, NewBestTip { tip, parent, trace_context: parent_context }).await;
@@ -260,6 +299,8 @@ impl SelectChain {
                     v.drain(0..=idx);
                 }
             });
+            let now = eff.clock().await;
+            self.headers_performance.block_valid(&eff.erase(), &h, now).await;
             return;
         }
         // INVALID CASE
@@ -267,9 +308,11 @@ impl SelectChain {
         // remove all tips depending on the invalid block
         // (if a peer sends further headers on this chain, we will ignore them)
         let prev_tips = self.tips.len();
-        self.tips.extract_if(.., |_k, v| v.first() == Some(&tip.hash())).for_each(drop);
+        let pruned: Vec<HeaderHash> =
+            self.tips.extract_if(.., |_k, v| v.first() == Some(&tip.hash())).flat_map(|(_, v)| v).collect();
         let removed = prev_tips - self.tips.len();
 
+        let mut switched_to = None;
         if let Some(best_tip) = &self.best_tip
             && !self.tips.contains_key(&best_tip.hash())
         {
@@ -291,6 +334,7 @@ impl SelectChain {
                     }
                     let (to_validate, _) = store.unvalidated_ancestor_hashes(new_best_tip.hash()).await;
                     self.tips.insert(new_best_tip.hash(), to_validate);
+                    switched_to = Some(new_best_tip.tip());
                     self.best_tip = Some(new_best_tip);
                 }
                 Ok(_) => {
@@ -304,6 +348,18 @@ impl SelectChain {
             }
         } else if removed > 0 {
             tracing::warn!(%removed, "chain fork(s) removed due to invalid block");
+        }
+
+        // end the performance tracking for blocks that could not be successfully validated and that
+        // we dropped because a better chain is available
+        let now = eff.clock().await;
+        for hash in &pruned {
+            self.headers_performance.block_pruned(&eff.erase(), hash, hash == &tip.hash(), now).await;
+        }
+
+        // switching away from the invalidated best tip to another candidate is a fork switch
+        if let Some(new_tip) = switched_to {
+            self.headers_performance.fork_started(&eff.erase(), new_tip, now).await;
         }
     }
 

--- a/crates/amaru-consensus/src/stages/select_chain/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/test_setup.rs
@@ -15,11 +15,15 @@
 use std::sync::Arc;
 
 use amaru_kernel::{BlockHeader, HeaderHash, Tip, make_header, make_header_with_op_cert_seq};
+use amaru_metrics::{MetricsEvent, consensus::ConsensusMetrics};
 use amaru_ouroboros_traits::{ChainStore, in_memory_chain_store::InMemoryChainStore};
-use amaru_protocols::store_effects::{
-    GetAnchorHashEffect, GetBestChainHashEffect, GetChildrenEffect, HasHeaderEffect, LoadHeaderEffect,
-    LoadHeaderWithValidityEffect, LoadTipEffect, ResourceHeaderStore, SetBlockValidEffect,
-    UnvalidatedAncestorHashesEffect,
+use amaru_protocols::{
+    metrics_effects::RecordMetricsEffect,
+    store_effects::{
+        GetAnchorHashEffect, GetBestChainHashEffect, GetChildrenEffect, HasHeaderEffect, LoadHeaderEffect,
+        LoadHeaderWithValidityEffect, LoadTipEffect, ResourceHeaderStore, SetBlockValidEffect,
+        UnvalidatedAncestorHashesEffect,
+    },
 };
 use amaru_pure_stage::{
     DeserializerGuards, Effect, StageGraph, StageRef, simulation::SimulationRunning, trace_buffer::TraceEntry,
@@ -129,6 +133,7 @@ pub fn register_guards() -> DeserializerGuards {
         amaru_pure_stage::register_effect_deserializer::<HasHeaderEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<UnvalidatedAncestorHashesEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<FindBestCandidate>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<RecordMetricsEffect>().boxed(),
         amaru_pure_stage::register_data_deserializer::<(Vec<HeaderHash>, bool)>().boxed(),
     ]
 }
@@ -195,4 +200,11 @@ pub fn te_set_block_valid(at_stage: &str, hash: HeaderHash, valid: bool) -> Trac
 
 pub fn te_unvalidated_ancestor_hashes(at_stage: &str, start: HeaderHash) -> TraceEntry {
     TraceEntry::suspend(Effect::external(at_stage, Box::new(UnvalidatedAncestorHashesEffect::new(start))))
+}
+
+pub fn te_record_metrics(at_stage: &str, metrics: ConsensusMetrics) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(
+        at_stage,
+        Box::new(RecordMetricsEffect::new(MetricsEvent::ConsensusMetrics(metrics))),
+    ))
 }

--- a/crates/amaru-consensus/src/stages/select_chain/tests.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/tests.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use amaru_kernel::{BlockHeight, HeaderHash, Point, Slot};
+use amaru_metrics::consensus::ConsensusMetrics;
 use amaru_ouroboros_traits::{StoreError, overriding_chain_store::OverridingChainStore};
 use amaru_pure_stage::{
     assert_trace_contains,
@@ -25,17 +26,11 @@ use tracing::Level;
 use super::*;
 use crate::stages::{
     select_chain::test_setup::{
-        setup, te_find_best_candidate, te_has_header, te_load_header, te_load_tip, te_set_block_valid,
-        te_unvalidated_ancestor_hashes, test_prep,
+        setup, te_find_best_candidate, te_has_header, te_load_header, te_load_tip, te_record_metrics,
+        te_set_block_valid, te_unvalidated_ancestor_hashes, test_prep,
     },
-    test_utils::{assert_trace, te_input, te_send, te_state, te_terminate, te_terminated},
+    test_utils::{assert_trace, start_in_era, te_clock_read, te_input, te_send, te_state, te_terminate, te_terminated},
 };
-
-/// Expected message for a tip that was just received: it carries the trace context
-/// tracking the wait for the corresponding block.
-fn new_best_tip(tip: Tip, parent: Point) -> NewBestTip {
-    NewBestTip { tip, parent, trace_context: Default::default() }
-}
 
 #[test]
 fn test_tip_not_found() {
@@ -101,6 +96,7 @@ fn test_tip_extends_from_origin() {
         best_tip: Some(prep.header(tip.hash())),
         tips: BTreeMap::from_iter([(tip.hash(), vec![tip.hash()])]),
         may_fetch_blocks: false,
+        headers_performance: HeadersPerformance::default().with_lifecycles([tip.hash()]),
         ..prep.state.clone()
     };
 
@@ -111,7 +107,7 @@ fn test_tip_extends_from_origin() {
             te_state("sc-1", &prep.state),
             te_input("sc-1", &msg),
             te_load_header("sc-1", tip.hash(), true),
-            te_send("sc-1", "downstream", new_best_tip(tip, parent)),
+            te_send("sc-1", "downstream", NewBestTip::new(tip, parent)),
             te_state("sc-1", &expected),
         ],
     );
@@ -137,6 +133,7 @@ fn test_tip_extends_from_h1() {
             vec![prep.headers.h0.hash(), prep.headers.h1.hash(), prep.headers.h2.hash()],
         )]),
         may_fetch_blocks: false,
+        headers_performance: HeadersPerformance::default().with_lifecycles([tip.hash()]),
         ..prep.state.clone()
     };
 
@@ -148,7 +145,7 @@ fn test_tip_extends_from_h1() {
             te_input("sc-1", &msg),
             te_load_header("sc-1", tip.hash(), true),
             te_unvalidated_ancestor_hashes("sc-1", parent.hash()),
-            te_send("sc-1", "downstream", new_best_tip(tip, parent)),
+            te_send("sc-1", "downstream", NewBestTip::new(tip, parent)),
             te_state("sc-1", &expected),
         ],
     );
@@ -171,6 +168,7 @@ fn test_tip_h3_extends_with_anchor_at_h2() {
         best_tip: Some(prep.header(tip.hash())),
         tips: BTreeMap::from_iter([(tip.hash(), vec![prep.headers.h2.hash(), tip.hash()])]),
         may_fetch_blocks: false,
+        headers_performance: HeadersPerformance::default().with_lifecycles([tip.hash()]).with_fork_switch(tip.hash()),
         ..prep.state.clone()
     };
 
@@ -182,7 +180,7 @@ fn test_tip_h3_extends_with_anchor_at_h2() {
             te_input("sc-1", &msg),
             te_load_header("sc-1", tip.hash(), true),
             te_unvalidated_ancestor_hashes("sc-1", parent.hash()),
-            te_send("sc-1", "downstream", new_best_tip(tip, parent)),
+            te_send("sc-1", "downstream", NewBestTip::new(tip, parent)),
             te_state("sc-1", &expected),
         ],
     );
@@ -214,6 +212,7 @@ fn test_tip_h3_extends_with_best_chain_h3a() {
             (prep.headers.h3a.hash(), vec![prep.headers.h2a.hash(), prep.headers.h3a.hash()]),
         ]),
         may_fetch_blocks: false,
+        headers_performance: HeadersPerformance::default().with_lifecycles([tip.hash()]).with_fork_switch(tip.hash()),
         ..prep.state.clone()
     };
 
@@ -225,7 +224,7 @@ fn test_tip_h3_extends_with_best_chain_h3a() {
             te_input("sc-1", &msg),
             te_load_header("sc-1", tip.hash(), true),
             te_unvalidated_ancestor_hashes("sc-1", parent.hash()),
-            te_send("sc-1", "downstream", new_best_tip(tip, parent)),
+            te_send("sc-1", "downstream", NewBestTip::new(tip, parent)),
             te_state("sc-1", &expected),
         ],
     );
@@ -253,6 +252,7 @@ fn test_tip_h3a_extends_with_best_chain_h3() {
             (prep.headers.h3.hash(), vec![prep.headers.h2.hash(), prep.headers.h3.hash()]),
             (tip.hash(), vec![prep.headers.h2a.hash(), prep.headers.h3a.hash()]),
         ]),
+        headers_performance: HeadersPerformance::default().with_lifecycles([tip.hash()]),
         ..prep.state.clone()
     };
 
@@ -291,6 +291,7 @@ fn test_tip_h3a_extends_with_best_chain_h2() {
             (prep.headers.h2.hash(), vec![prep.headers.h1.hash(), prep.headers.h2.hash()]),
         ]),
         may_fetch_blocks: false,
+        headers_performance: HeadersPerformance::default().with_lifecycles([tip.hash()]).with_fork_switch(tip.hash()),
         ..prep.state.clone()
     };
 
@@ -302,7 +303,7 @@ fn test_tip_h3a_extends_with_best_chain_h2() {
             te_input("sc-1", &msg),
             te_load_header("sc-1", tip.hash(), true),
             te_unvalidated_ancestor_hashes("sc-1", parent.hash()),
-            te_send("sc-1", "downstream", new_best_tip(tip, parent)),
+            te_send("sc-1", "downstream", NewBestTip::new(tip, parent)),
             te_state("sc-1", &expected),
         ],
     );
@@ -320,7 +321,10 @@ fn test_upstream_tip_depends_on_invalid_block() {
     prep.set_anchor(prep.headers.h0.hash());
     let tip = prep.headers.h3.tip();
     let parent = prep.headers.h2.point();
-    let msg = SelectChainMsg::tip_from_upstream(tip, parent);
+    // Use the simulation clock as the reception time so the forward duration measured at
+    // abandonment (which reads the same clock) is zero.
+    let received_at = Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time);
+    let msg = SelectChainMsg::TipFromUpstream { tip, parent, trace_context: Default::default(), received_at };
 
     // Invalid chains are ignored: no send, best_tip stays Origin.
     let mut expected = SelectChain::new(prep.downstream.clone());
@@ -333,6 +337,16 @@ fn test_upstream_tip_depends_on_invalid_block() {
             te_input("sc-1", &msg),
             te_load_header("sc-1", tip.hash(), true),
             te_unvalidated_ancestor_hashes("sc-1", parent.hash()),
+            te_clock_read("sc-1"),
+            te_record_metrics(
+                "sc-1",
+                ConsensusMetrics::HeaderLifecycle {
+                    outcome: "abandoned".into(),
+                    block_fetch_wait_micros: None,
+                    block_fetch_micros: None,
+                    forward_micros: Some(0),
+                },
+            ),
             te_state("sc-1", &expected),
         ],
     );
@@ -363,6 +377,7 @@ fn test_block_validation_result_valid() {
             te_input("sc-1", &msg),
             te_has_header("sc-1", tip.hash()),
             te_set_block_valid("sc-1", tip.hash(), true),
+            te_clock_read("sc-1"),
             te_state("sc-1", &expected),
         ],
     );
@@ -388,6 +403,8 @@ fn test_block_validation_result_invalid_best_tip_invalidated() {
         best_tip: Some(prep.headers.h1.clone()),
         tips: BTreeMap::from_iter([(prep.headers.h1.hash(), vec![])]),
         may_fetch_blocks: false,
+        headers_performance: HeadersPerformance::default()
+            .with_fork_switch_at(prep.headers.h1.hash(), Duration::from_secs(10)),
         ..prep.state.clone()
     };
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
@@ -403,6 +420,7 @@ fn test_block_validation_result_invalid_best_tip_invalidated() {
             te_load_tip("sc-1", prep.headers.h0.hash()),
             te_send("sc-1", "downstream", NewBestTip::new(prep.headers.h1.tip(), prep.headers.h0.point())),
             te_unvalidated_ancestor_hashes("sc-1", prep.headers.h1.hash()),
+            te_clock_read("sc-1"),
             te_state("sc-1", &expected),
         ],
     );
@@ -432,6 +450,8 @@ fn test_block_validation_result_invalid_best_tip_invalidated_switch_fork() {
         best_tip: Some(prep.headers.h3a.clone()),
         tips: BTreeMap::from_iter([(prep.headers.h3a.hash(), vec![prep.headers.h2a.hash(), prep.headers.h3a.hash()])]),
         may_fetch_blocks: false,
+        headers_performance: HeadersPerformance::default()
+            .with_fork_switch_at(prep.headers.h3a.hash(), Duration::from_secs(10)),
         ..prep.state.clone()
     };
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
@@ -447,6 +467,7 @@ fn test_block_validation_result_invalid_best_tip_invalidated_switch_fork() {
             te_load_tip("sc-1", prep.headers.h2a.hash()),
             te_send("sc-1", "downstream", NewBestTip::new(prep.headers.h3a.tip(), prep.headers.h2a.point())),
             te_unvalidated_ancestor_hashes("sc-1", prep.headers.h3a.hash()),
+            te_clock_read("sc-1"),
             te_state("sc-1", &expected),
         ],
     );
@@ -481,6 +502,7 @@ fn test_block_validation_result_invalid_removes_tips() {
             te_input("sc-1", &msg),
             te_has_header("sc-1", tip.hash()),
             te_set_block_valid("sc-1", tip.hash(), false),
+            te_clock_read("sc-1"),
             te_state("sc-1", &expected),
         ],
     );
@@ -664,6 +686,29 @@ fn test_last_best_tip_invalidated_falls_back_to_origin() {
     );
 
     logs.assert_and_remove(Level::INFO, &["best tip candidate invalidated"]).assert_no_remaining_at([Level::ERROR]);
+}
+
+#[test]
+fn test_blocks_requested_records_request_time() {
+    let mut prep = test_prep();
+    let h1 = prep.headers.h1.hash();
+    let h2 = prep.headers.h2.hash();
+    let h3 = prep.headers.h3.hash();
+    prep.state.headers_performance = HeadersPerformance::default().with_lifecycles([h1, h2, h3]);
+
+    // The fetch_blocks stage reports that the h1 and h2 blocks were requested at this time. This
+    // only records the request point of their lifecycle: no event is emitted until they reach a
+    // terminal state, and all headers remain tracked.
+    let requested_at = Instant::at_offset(Duration::from_secs(0), Duration::ZERO);
+    let msg = SelectChainMsg::BlocksRequested(vec![h1, h2], requested_at);
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+
+    let expected = SelectChain {
+        headers_performance: HeadersPerformance::default().with_lifecycles([h1, h2, h3]),
+        ..prep.state.clone()
+    };
+    assert_trace(&running, &[te_state("sc-1", &prep.state), te_input("sc-1", &msg), te_state("sc-1", &expected)]);
+    logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 
 #[cfg(test)]

--- a/crates/amaru-consensus/src/stages/test_utils.rs
+++ b/crates/amaru-consensus/src/stages/test_utils.rs
@@ -176,6 +176,22 @@ pub fn te_terminate(at_stage: impl AsRef<str>) -> TraceEntry {
     TraceEntry::suspend(Effect::Terminate { at_stage: Name::from(at_stage.as_ref()) })
 }
 
+pub fn te_clock_read(at_stage: impl AsRef<str>) -> TraceEntry {
+    TraceEntry::suspend(Effect::clock(at_stage))
+}
+
+pub fn te_record_consensus_metrics(
+    at_stage: impl AsRef<str>,
+    metrics: amaru_metrics::consensus::ConsensusMetrics,
+) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(
+        at_stage.as_ref(),
+        Box::new(amaru_protocols::metrics_effects::RecordMetricsEffect::new(
+            amaru_metrics::MetricsEvent::ConsensusMetrics(metrics),
+        )),
+    ))
+}
+
 pub fn te_terminated(at_stage: impl AsRef<str>, reason: TerminationReason) -> TraceEntry {
     TraceEntry::Terminated { stage: Name::from(at_stage.as_ref()), reason }
 }

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -22,11 +22,13 @@ use amaru_kernel::{
     BlockHeader, BlockHeight, Epoch, EraHistory, EraName, IsHeader, ORIGIN_HASH, Peer, Point, Slot, Tip,
     from_cbor_no_leftovers, num::CheckedSub,
 };
-use amaru_observability::{TraceContext, debug_record, debug_span};
+use amaru_metrics::consensus::ConsensusMetrics;
+use amaru_observability::{TraceContext, debug, debug_record, debug_span, error};
 use amaru_ouroboros::{ConnectionId, praos::header::AssertHeaderError};
 use amaru_ouroboros_traits::has_stake_distribution::GetPoolError;
 use amaru_protocols::{
     chainsync::{self, ChainSyncInitiatorMsg, HeaderContent},
+    metrics_effects::{Metrics, MetricsOps},
     store_effects::Store,
 };
 use amaru_pure_stage::{Effects, Instant, OrTerminateWith, ScheduleId, StageRef};
@@ -36,6 +38,7 @@ use super::peer_selection::PeerSelectionMsg;
 use crate::{
     effects::{Ledger, LedgerOps, VolatileTipEffect},
     errors::{ConsensusError, InvalidHeaderParentData, InvalidHeaderPoint},
+    stages::select_chain::PerfHeaderForwardOutcome,
     validate_header::ValidateHeaderError,
 };
 
@@ -182,13 +185,28 @@ enum DeferReason {
 
 /// A header (or request) that was deferred. The reason indicates what is blocking and what data
 /// (if any) must be retained to resume.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct DeferredHeader {
     peer: Peer,
     conn_id: ConnectionId,
     handler: StageRef<chainsync::InitiatorMessage>,
     reason: DeferReason,
     trace_context: TraceContext,
+    /// When the header was first received from upstream, retained across deferrals so the forward
+    /// duration downstream is measured from the original ingress time.
+    received_at: Instant,
+}
+
+impl PartialEq for DeferredHeader {
+    fn eq(&self, other: &Self) -> bool {
+        // `received_at` is a performance timestamp used only to measure durations downstream; it does
+        // not define the identity of the deferred header, so it is excluded from equality.
+        self.peer == other.peer
+            && self.conn_id == other.conn_id
+            && self.handler == other.handler
+            && self.reason == other.reason
+            && self.trace_context == other.trace_context
+    }
 }
 
 struct RollForwardArgs {
@@ -200,11 +218,13 @@ struct RollForwardArgs {
     header: BlockHeader,
     tip: Tip,
     trace_context: TraceContext,
+    /// When the header was first received from upstream.
+    received_at: Instant,
 }
 
 impl From<DeferredHeader> for RollForwardArgs {
     fn from(dh: DeferredHeader) -> RollForwardArgs {
-        let DeferredHeader { peer, conn_id, handler, reason, trace_context } = dh;
+        let DeferredHeader { peer, conn_id, handler, reason, trace_context, received_at } = dh;
         match reason {
             DeferReason::LedgerHeight { header, tip, variant, .. } => RollForwardArgs {
                 peer,
@@ -215,6 +235,7 @@ impl From<DeferredHeader> for RollForwardArgs {
                 header,
                 tip,
                 trace_context,
+                received_at,
             },
             DeferReason::StakeDistribution { header, tip, variant, rn_sent, .. } => RollForwardArgs {
                 peer,
@@ -225,6 +246,7 @@ impl From<DeferredHeader> for RollForwardArgs {
                 header,
                 tip,
                 trace_context,
+                received_at,
             },
             DeferReason::ClockSkew { header, tip, variant, rn_sent, .. } => RollForwardArgs {
                 peer,
@@ -235,6 +257,7 @@ impl From<DeferredHeader> for RollForwardArgs {
                 header,
                 tip,
                 trace_context,
+                received_at,
             },
             DeferReason::FollowUp { header, tip, variant } => RollForwardArgs {
                 peer,
@@ -245,6 +268,7 @@ impl From<DeferredHeader> for RollForwardArgs {
                 header,
                 tip,
                 trace_context,
+                received_at,
             },
         }
     }
@@ -259,11 +283,32 @@ pub enum TrackPeersMsg {
     RecheckLedgerHeight,
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct NewTip {
     pub tip: Tip,
     pub parent: Point,
     pub trace_context: TraceContext,
+    /// When this header was received, so the downstream stage can measure the forward duration.
+    pub received_at: Instant,
+}
+
+impl PartialEq for NewTip {
+    fn eq(&self, other: &Self) -> bool {
+        // `received_at` is a performance timestamp used only to measure durations downstream; it does
+        // not define the identity of the message, so it is excluded from equality.
+        self.tip == other.tip && self.parent == other.parent && self.trace_context == other.trace_context
+    }
+}
+
+impl NewTip {
+    pub fn new(tip: Tip, parent: Point) -> Self {
+        NewTip {
+            tip,
+            parent,
+            trace_context: Default::default(),
+            received_at: Instant::at_offset(Duration::ZERO, Duration::ZERO),
+        }
+    }
 }
 
 pub async fn stage(mut state: TrackPeers, msg: TrackPeersMsg, eff: Effects<TrackPeersMsg>) -> TrackPeers {
@@ -333,6 +378,7 @@ impl TrackPeers {
             handler,
             reason: DeferReason::FollowUp { header, tip, variant: EraName::Conway },
             trace_context: TraceContext::default(),
+            received_at: Instant::at_offset(Duration::ZERO, Duration::ZERO),
         });
     }
 
@@ -478,6 +524,7 @@ impl TrackPeers {
                 rn_sent: args.sent_request_next,
             },
             trace_context: args.trace_context.clone(),
+            received_at: args.received_at,
         })
     }
 
@@ -509,6 +556,7 @@ impl TrackPeers {
                 rn_sent: args.sent_request_next,
             },
             trace_context: args.trace_context.clone(),
+            received_at: args.received_at,
         })
     }
 
@@ -582,7 +630,15 @@ impl TrackPeers {
                 } else if let Some(dh) = self.try_defer_for_clock_skew(&args, &error, eff).await {
                     return Err(dh);
                 }
-                tracing::error!(%error, %peer, "chain_sync.validate_header.failed");
+                error!(
+                    consensus::perf::header::LIFECYCLE,
+                    peer = peer.clone(),
+                    header_hash = header.hash(),
+                    error = %error,
+                    outcome = PerfHeaderForwardOutcome::InvalidHeader.as_str()
+                );
+                record_header_rejected(eff, PerfHeaderForwardOutcome::InvalidHeader).await;
+
                 self.purge_connection(*conn_id);
                 eff.send(&self.peer_selection, PeerSelectionMsg::Adversarial(args.peer, args.trace_context)).await;
                 return Ok(());
@@ -592,20 +648,34 @@ impl TrackPeers {
         self.roll_forward(*conn_id, header, *tip).await;
 
         // now we can destructure to consume the pieces
-        let RollForwardArgs { peer, header, tip, sent_request_next, handler, trace_context, .. } = args;
+        let RollForwardArgs { peer, header, tip, sent_request_next, handler, trace_context, received_at, .. } = args;
         let header_tip = header.tip();
         let current = header_tip.point();
         let new = self
             .maybe_store_header(header, &store)
             .or_terminate_with(eff, async |error| {
-                tracing::error!(%error, %peer, "chain_sync.store_header.failed");
+                error!(
+                    consensus::perf::header::LIFECYCLE,
+                    peer = peer.clone(),
+                    header_hash = current.hash(),
+                    error = %error,
+                    outcome = PerfHeaderForwardOutcome::StoreHeaderError.as_str()
+                );
+                record_header_rejected(eff, PerfHeaderForwardOutcome::StoreHeaderError).await;
             })
             .await;
         if new {
             tracing::debug!(%peer, %current, highest = %tip.point(), "roll forward with new header");
-            eff.send(&self.downstream, NewTip { tip: header_tip, parent, trace_context }).await;
+            eff.send(&self.downstream, NewTip { tip: header_tip, parent, trace_context, received_at }).await;
         } else {
             tracing::debug!(%peer, %current, highest = %tip.point(), "roll forward, header already stored");
+            debug!(
+                consensus::perf::header::LIFECYCLE,
+                peer = peer.clone(),
+                header_hash = current.hash(),
+                outcome = PerfHeaderForwardOutcome::DuplicateHeader.as_str()
+            );
+            record_header_rejected(eff, PerfHeaderForwardOutcome::DuplicateHeader).await;
         }
 
         if !sent_request_next {
@@ -669,8 +739,14 @@ impl TrackPeers {
                     let header = match probe {
                         Ok(h) => h,
                         Err(error) => {
-                            tracing::error!(%error, %peer, "chain_sync.decode_header.failed");
                             self.purge_connection(conn_id);
+                            error!(
+                                consensus::perf::header::LIFECYCLE,
+                                peer = peer.clone(),
+                                error = %error,
+                                outcome = PerfHeaderForwardOutcome::UndecodableHeader.as_str()
+                            );
+                            record_header_rejected(&eff, PerfHeaderForwardOutcome::UndecodableHeader).await;
                             eff.send(
                                 &self.peer_selection,
                                 PeerSelectionMsg::Adversarial(peer, trace_context.clone()),
@@ -681,6 +757,8 @@ impl TrackPeers {
                     };
                     debug_record!(consensus::roll_forward::PROCESS, header_hash = header.hash());
 
+                    let now = eff.clock().await;
+
                     if self.is_deferred(conn_id) {
                         self.deferred.push(DeferredHeader {
                             peer,
@@ -688,11 +766,10 @@ impl TrackPeers {
                             handler,
                             reason: DeferReason::FollowUp { header, tip, variant },
                             trace_context,
+                            received_at: now,
                         });
                         return;
                     }
-
-                    let now = eff.clock().await;
 
                     let header_height = header.block_height();
                     let limit = header_height - self.max_peer_lead;
@@ -719,6 +796,7 @@ impl TrackPeers {
                                 min_height: limit,
                             },
                             trace_context,
+                            received_at: now,
                         });
                         self.ensure_recheck_armed(&eff).await;
                         return;
@@ -734,6 +812,7 @@ impl TrackPeers {
                         header,
                         tip,
                         trace_context,
+                        received_at: now,
                     };
                     if let Err(dh) = self.try_roll_forward(args, &eff, now).await {
                         self.deferred.push(dh);
@@ -819,6 +898,25 @@ pub fn decode_header(raw_header: HeaderContent, peer: &Peer) -> Result<BlockHead
     }
     from_cbor_no_leftovers(&raw_header.cbor)
         .map_err(|reason| ConsensusError::CannotDecodeHeader { header: raw_header.cbor, reason: reason.to_string() })
+}
+
+/// Record the `header_lifecycle` metric for a header rejected on reception.
+/// Such a header carries no lifecycle durations, only its `outcome`.
+async fn record_header_rejected<T: amaru_pure_stage::SendData + Sync>(
+    eff: &Effects<T>,
+    outcome: PerfHeaderForwardOutcome,
+) {
+    Metrics::new(eff)
+        .record(
+            ConsensusMetrics::HeaderLifecycle {
+                outcome: outcome.as_str().to_string(),
+                block_fetch_wait_micros: None,
+                block_fetch_micros: None,
+                forward_micros: None,
+            }
+            .into(),
+        )
+        .await;
 }
 
 #[cfg(test)]

--- a/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
@@ -168,7 +168,12 @@ pub fn tm_volatile_tip(at_stage: &str) -> TraceMatch<'static> {
 }
 
 pub fn new_tip(tip: Tip, parent: Point) -> NewTip {
-    NewTip { tip, parent, trace_context: Default::default() }
+    NewTip {
+        tip,
+        parent,
+        trace_context: Default::default(),
+        received_at: amaru_pure_stage::Instant::at_offset(std::time::Duration::ZERO, std::time::Duration::ZERO),
+    }
 }
 
 fn register_guards() -> DeserializerGuards {
@@ -191,6 +196,8 @@ fn register_guards() -> DeserializerGuards {
         amaru_pure_stage::register_effect_deserializer::<ValidateHeaderEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<TipEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<VolatileTipEffect>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<amaru_protocols::metrics_effects::RecordMetricsEffect>()
+            .boxed(),
     ]
 }
 

--- a/crates/amaru-consensus/src/stages/track_peers/tests.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/tests.rs
@@ -15,6 +15,7 @@
 use std::{self, slice, time::Duration};
 
 use amaru_kernel::{BlockHeight, Epoch, EraHistory, EraName, HeaderHash, IsHeader, Peer, Point, Tip, num::CheckedSub};
+use amaru_metrics::consensus::ConsensusMetrics;
 use amaru_ouroboros::{ConnectionId, praos::header::AssertHeaderError};
 use amaru_ouroboros_traits::has_stake_distribution::GetPoolError;
 use amaru_protocols::chainsync::{
@@ -22,7 +23,7 @@ use amaru_protocols::chainsync::{
 };
 use amaru_pure_stage::{
     assert_trace_contains, assert_trace_does_not_contain, assert_trace_match, simulation::running::OverrideResult,
-    tm_send,
+    tm_send, trace_buffer::TraceEntry,
 };
 use tracing::Level;
 
@@ -30,7 +31,7 @@ use crate::{
     effects::{ValidateHeaderEffect, VolatileTipEffect},
     stages::{
         peer_selection::PeerSelectionMsg,
-        test_utils::{assert_trace, te_input, te_send, te_state, tm_state},
+        test_utils::{assert_trace, te_input, te_record_consensus_metrics, te_send, te_state, tm_state},
         track_peers::{
             TrackPeers, TrackPeersMsg,
             test_setup::{
@@ -44,6 +45,19 @@ use crate::{
     store::NoncesError,
     validate_header::ValidateHeaderError,
 };
+
+/// The metric recorded for a header rejected on reception: only its terminal outcome, no durations.
+fn te_header_rejected(outcome: &str) -> TraceEntry {
+    te_record_consensus_metrics(
+        "tp-1",
+        ConsensusMetrics::HeaderLifecycle {
+            outcome: outcome.into(),
+            block_fetch_wait_micros: None,
+            block_fetch_micros: None,
+            forward_micros: None,
+        },
+    )
+}
 
 #[test]
 fn test_new_peer() {
@@ -300,12 +314,16 @@ fn test_roll_forward_unknown_peer_removes_peer() {
             te_input("tp-1", &msg).into(),
             te_clock_suspend("tp-1").into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
+            te_header_rejected("invalid header").into(),
             te_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer)).into(),
             te_state("tp-1", &state).into(),
         ],
     );
-    logs.assert_and_remove(Level::ERROR, &["chain_sync.validate_header.failed", "Unknown peer"])
-        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+    logs.assert_and_remove(Level::ERROR, &["perf.header.lifecycle", "Unknown peer"]).assert_no_remaining_at([
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
 }
 
 #[test]
@@ -338,6 +356,7 @@ fn test_roll_forward_known_peer_header_already_stored() {
             te_send("tp-1", &prep.handler, RequestNext).into(),
             te_validate_header("tp-1", header.clone()).into(),
             te_has_header("tp-1", header.hash()).into(),
+            te_header_rejected("duplicate header").into(),
             te_state("tp-1", &expected).into(),
         ],
     );
@@ -411,11 +430,12 @@ fn test_roll_forward_invalid_variant_removes_peer() {
         &[
             te_state("tp-1", &state),
             te_input("tp-1", &msg),
+            te_header_rejected("undecodable header"),
             te_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer)),
             te_state("tp-1", &expected),
         ],
     );
-    logs.assert_and_remove(Level::ERROR, &["chain_sync.decode_header.failed", "Invalid header variant"])
+    logs.assert_and_remove(Level::ERROR, &["perf.header.lifecycle", "Invalid header variant"])
         .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 
@@ -444,11 +464,12 @@ fn test_roll_forward_invalid_cbor_removes_peer() {
         &[
             te_state("tp-1", &state),
             te_input("tp-1", &msg),
+            te_header_rejected("undecodable header"),
             te_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer)),
             te_state("tp-1", &expected),
         ],
     );
-    logs.assert_and_remove(Level::ERROR, &["chain_sync.decode_header.failed", "Failed to decode header"])
+    logs.assert_and_remove(Level::ERROR, &["perf.header.lifecycle", "Failed to decode header"])
         .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 
@@ -478,12 +499,16 @@ fn test_roll_forward_invalid_parent_removes_peer() {
             te_input("tp-1", &msg).into(),
             te_clock_suspend("tp-1").into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
+            te_header_rejected("invalid header").into(),
             te_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer)).into(),
             te_state("tp-1", &expected).into(),
         ],
     );
-    logs.assert_and_remove(Level::ERROR, &["chain_sync.validate_header.failed", "Invalid header parent"])
-        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+    logs.assert_and_remove(Level::ERROR, &["perf.header.lifecycle", "Invalid header parent"]).assert_no_remaining_at([
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
 }
 
 #[test]
@@ -511,12 +536,16 @@ fn test_roll_forward_invalid_height_removes_peer() {
             te_input("tp-1", &msg).into(),
             te_clock_suspend("tp-1").into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
+            te_header_rejected("invalid header").into(),
             te_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer)).into(),
             te_state("tp-1", &expected).into(),
         ],
     );
-    logs.assert_and_remove(Level::ERROR, &["chain_sync.validate_header.failed", "Invalid header height"])
-        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+    logs.assert_and_remove(Level::ERROR, &["perf.header.lifecycle", "Invalid header height"]).assert_no_remaining_at([
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
 }
 
 #[test]
@@ -544,12 +573,16 @@ fn test_roll_forward_invalid_point_removes_peer() {
             te_input("tp-1", &msg).into(),
             te_clock_suspend("tp-1").into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
+            te_header_rejected("invalid header").into(),
             te_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer)).into(),
             te_state("tp-1", &expected).into(),
         ],
     );
-    logs.assert_and_remove(Level::ERROR, &["chain_sync.validate_header.failed", "Invalid header point"])
-        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+    logs.assert_and_remove(Level::ERROR, &["perf.header.lifecycle", "Invalid header point"]).assert_no_remaining_at([
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
 }
 
 #[test]
@@ -579,7 +612,7 @@ fn test_roll_forward_header_validation_failure_removes_peer() {
             });
         });
 
-    logs.assert_and_remove(Level::ERROR, &["chain_sync.validate_header.failed"]).assert_no_remaining_at([
+    logs.assert_and_remove(Level::ERROR, &["perf.header.lifecycle"]).assert_no_remaining_at([
         Level::INFO,
         Level::WARN,
         Level::ERROR,
@@ -592,6 +625,7 @@ fn test_roll_forward_header_validation_failure_removes_peer() {
             te_clock_suspend("tp-1").into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
             te_validate_header("tp-1", header.clone()).into(),
+            te_header_rejected("invalid header").into(),
             te_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer)).into(),
             te_state("tp-1", &expected).into(),
         ],
@@ -621,7 +655,7 @@ fn test_roll_forward_header_slot_too_far_future_adversarial() {
 
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
 
-    logs.assert_and_remove(Level::ERROR, &["chain_sync.validate_header.failed"]).assert_no_remaining_at([
+    logs.assert_and_remove(Level::ERROR, &["perf.header.lifecycle"]).assert_no_remaining_at([
         Level::INFO,
         Level::WARN,
         Level::ERROR,
@@ -633,6 +667,7 @@ fn test_roll_forward_header_slot_too_far_future_adversarial() {
             te_input("tp-1", &msg).into(),
             te_clock_suspend("tp-1").into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
+            te_header_rejected("invalid header").into(),
             te_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer)).into(),
             te_state("tp-1", &expected).into(),
         ],
@@ -712,7 +747,7 @@ fn test_roll_forward_stake_dist_far_ahead_rejects() {
             });
         });
 
-    logs.assert_and_remove(Level::ERROR, &["chain_sync.validate_header.failed"]).assert_no_remaining_at([
+    logs.assert_and_remove(Level::ERROR, &["perf.header.lifecycle"]).assert_no_remaining_at([
         Level::INFO,
         Level::WARN,
         Level::ERROR,
@@ -725,6 +760,7 @@ fn test_roll_forward_stake_dist_far_ahead_rejects() {
             te_clock_suspend("tp-1").into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
             te_validate_header("tp-1", header.clone()).into(),
+            te_header_rejected("invalid header").into(),
             te_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer)).into(),
             te_state("tp-1", &expected).into(),
         ],
@@ -942,6 +978,7 @@ fn test_pipelined_headers_after_height_defer() {
             te_schedule("tp-1", TrackPeersMsg::RecheckLedgerHeight, sid).into(),
             tm_state::<TrackPeers>("tp-1", |s| s.deferred.len() == 1, "first ledger-height deferred"),
             te_input("tp-1", &msg2).into(),
+            te_clock_suspend("tp-1").into(),
             tm_state::<TrackPeers>(
                 "tp-1",
                 |s| s.deferred.len() == 2 && s.recheck_timer == Some(sid),
@@ -1134,6 +1171,7 @@ fn test_pipelined_stake_defer_and_wake_sequence() {
             te_validate_header("tp-1", h1.clone()).into(),
             tm_state::<TrackPeers>("tp-1", |s| s.deferred.len() == 1, "first stake deferred"),
             te_input("tp-1", &msg2).into(),
+            te_clock_suspend("tp-1").into(),
             tm_state::<TrackPeers>("tp-1", |s| s.deferred.len() == 2, "follow-up queued"),
             te_input("tp-1", &wake).into(),
             tm_volatile_tip("tp-1"),
@@ -1189,6 +1227,7 @@ fn test_recheck_deferred_survives_purge_shrinking_the_list() {
             te_input("tp-1", &msg).into(),
             tm_volatile_tip("tp-1"),
             te_clock_suspend("tp-1").into(),
+            te_header_rejected("invalid header").into(),
             te_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer)).into(),
             tm_state::<TrackPeers>(
                 "tp-1",
@@ -1197,8 +1236,11 @@ fn test_recheck_deferred_survives_purge_shrinking_the_list() {
             ),
         ],
     );
-    logs.assert_and_remove(Level::ERROR, &["chain_sync.validate_header.failed", "Invalid header parent"])
-        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+    logs.assert_and_remove(Level::ERROR, &["perf.header.lifecycle", "Invalid header parent"]).assert_no_remaining_at([
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
 }
 
 /// A deferred header that is still deferred on recheck must keep blocking its follow-ups.

--- a/crates/amaru-metrics/src/consensus.rs
+++ b/crates/amaru-metrics/src/consensus.rs
@@ -1,0 +1,167 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::OnceLock;
+
+#[cfg(not(target_arch = "wasm32"))]
+use opentelemetry::KeyValue;
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::{Counter, Histogram};
+use crate::{Meter, MetricRecorder, MetricsEvent};
+
+/// Performance measurements emitted by the select_chain stage, computed from `perf.*` events
+/// but aggregatable as OpenTelemetry metrics (a duration histogram plus an outcome-labelled
+/// counter per measurement kind).
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum ConsensusMetrics {
+    /// A header reached a terminal state. The optional durations are the intervals between the four
+    /// processing points of a header's lifecycle; they are absent when the corresponding point was
+    /// never reached (e.g. a header rejected on reception carries none of them).
+    HeaderLifecycle {
+        outcome: String,
+        /// Time from a header's reception to the request (or abandonment) of its block.
+        block_fetch_wait_micros: Option<u64>,
+        /// Time from a block's request to its reception.
+        block_fetch_micros: Option<u64>,
+        /// Time from a header's reception to the adoption/invalidation/abandonment of its block.
+        forward_micros: Option<u64>,
+    },
+    /// Time from the detection of a fork to its application/abandonment.
+    ForkSwitch { outcome: String, duration_micros: u64 },
+}
+
+#[cfg(target_arch = "wasm32")]
+impl MetricRecorder for ConsensusMetrics {
+    fn record_to_meter(&self, _meter: &Meter) {}
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl MetricRecorder for ConsensusMetrics {
+    fn record_to_meter(&self, meter: &Meter) {
+        static HEADER_TOTAL: OnceLock<Counter<u64>> = OnceLock::new();
+        static HEADER_FORWARD_DURATION: OnceLock<Histogram<u64>> = OnceLock::new();
+        static BLOCK_FETCH_WAIT_DURATION: OnceLock<Histogram<u64>> = OnceLock::new();
+        static BLOCK_FETCH_DURATION: OnceLock<Histogram<u64>> = OnceLock::new();
+        static FORK_SWITCH_DURATION: OnceLock<Histogram<u64>> = OnceLock::new();
+        static FORK_SWITCH_TOTAL: OnceLock<Counter<u64>> = OnceLock::new();
+
+        match self {
+            ConsensusMetrics::HeaderLifecycle {
+                outcome,
+                block_fetch_wait_micros,
+                block_fetch_micros,
+                forward_micros,
+            } => {
+                let attributes = &[KeyValue::new("outcome", outcome.to_string())];
+
+                // Census of every header outcome, whether or not it reached the end of the lifecycle.
+                let total = HEADER_TOTAL.get_or_init(|| {
+                    meter
+                        .u64_counter("amaru_consensus_header_total")
+                        .with_description("number of headers that reached a terminal state, labelled by outcome")
+                        .build()
+                });
+                total.add(1, attributes);
+
+                // Each interval is recorded only when the corresponding processing point was reached.
+                record_optional_duration(
+                    meter,
+                    &BLOCK_FETCH_WAIT_DURATION,
+                    "amaru_consensus_block_fetch_wait_duration_microseconds",
+                    "time from a header's reception to its block being requested or the wait abandoned",
+                    attributes,
+                    *block_fetch_wait_micros,
+                );
+                record_optional_duration(
+                    meter,
+                    &BLOCK_FETCH_DURATION,
+                    "amaru_consensus_block_fetch_duration_microseconds",
+                    "time from a block being requested to its reception",
+                    attributes,
+                    *block_fetch_micros,
+                );
+                record_optional_duration(
+                    meter,
+                    &HEADER_FORWARD_DURATION,
+                    "amaru_consensus_header_forward_duration_microseconds",
+                    "time from a header's reception to its block being adopted, invalidated or abandoned",
+                    attributes,
+                    *forward_micros,
+                );
+            }
+            ConsensusMetrics::ForkSwitch { outcome, duration_micros } => record_duration(
+                meter,
+                &FORK_SWITCH_DURATION,
+                &FORK_SWITCH_TOTAL,
+                "amaru_consensus_fork_switch_duration_microseconds",
+                "time from the detection of a fork to its application or abandonment",
+                "amaru_consensus_fork_switch_total",
+                "number of fork switches that ended, labelled by outcome",
+                outcome,
+                *duration_micros,
+            ),
+        }
+    }
+}
+
+/// Record a duration to its histogram, if present, without touching any counter.
+#[cfg(not(target_arch = "wasm32"))]
+fn record_optional_duration(
+    meter: &Meter,
+    duration: &'static OnceLock<Histogram<u64>>,
+    duration_name: &'static str,
+    duration_description: &'static str,
+    attributes: &[KeyValue],
+    duration_micros: Option<u64>,
+) {
+    let Some(duration_micros) = duration_micros else {
+        return;
+    };
+    let duration = duration.get_or_init(|| {
+        meter.u64_histogram(duration_name).with_description(duration_description).with_unit("us").build()
+    });
+    duration.record(duration_micros, attributes);
+}
+
+/// Record a duration measurement to its histogram and bump the matching outcome-labelled counter.
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(clippy::too_many_arguments)]
+fn record_duration(
+    meter: &Meter,
+    duration: &'static OnceLock<Histogram<u64>>,
+    total: &'static OnceLock<Counter<u64>>,
+    duration_name: &'static str,
+    duration_description: &'static str,
+    total_name: &'static str,
+    total_description: &'static str,
+    outcome: &str,
+    duration_micros: u64,
+) {
+    let duration = duration.get_or_init(|| {
+        meter.u64_histogram(duration_name).with_description(duration_description).with_unit("us").build()
+    });
+    let total = total.get_or_init(|| meter.u64_counter(total_name).with_description(total_description).build());
+
+    let attributes = &[KeyValue::new("outcome", outcome.to_string())];
+    duration.record(duration_micros, attributes);
+    total.add(1, attributes);
+}
+
+impl From<ConsensusMetrics> for MetricsEvent {
+    fn from(value: ConsensusMetrics) -> Self {
+        MetricsEvent::ConsensusMetrics(value)
+    }
+}

--- a/crates/amaru-metrics/src/lib.rs
+++ b/crates/amaru-metrics/src/lib.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use crate::metrics::{Counter, Gauge, Meter};
-use crate::{ledger::LedgerMetrics, mempool::MempoolMetrics, protocol::ProtocolMetrics};
+pub use crate::metrics::{Counter, Gauge, Histogram, Meter};
+use crate::{consensus::ConsensusMetrics, ledger::LedgerMetrics, mempool::MempoolMetrics, protocol::ProtocolMetrics};
+pub mod consensus;
 pub mod ledger;
 pub mod mempool;
 pub mod metrics;
@@ -26,6 +27,7 @@ pub enum MetricsEvent {
     LedgerMetrics(LedgerMetrics),
     MempoolMetrics(MempoolMetrics),
     ProtocolMetrics(ProtocolMetrics),
+    ConsensusMetrics(ConsensusMetrics),
 }
 
 pub trait MetricRecorder {
@@ -38,6 +40,7 @@ impl MetricRecorder for MetricsEvent {
             MetricsEvent::LedgerMetrics(ledger_metrics) => ledger_metrics.record_to_meter(meter),
             MetricsEvent::MempoolMetrics(mempool_metrics) => mempool_metrics.record_to_meter(meter),
             MetricsEvent::ProtocolMetrics(protocol_metrics) => protocol_metrics.record_to_meter(meter),
+            MetricsEvent::ConsensusMetrics(consensus_metrics) => consensus_metrics.record_to_meter(meter),
         }
     }
 }

--- a/crates/amaru-metrics/src/metrics.rs
+++ b/crates/amaru-metrics/src/metrics.rs
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use opentelemetry::metrics::{Counter, Gauge, Meter};
+pub use opentelemetry::metrics::{Counter, Gauge, Histogram, Meter};
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     pub type Meter = ();
     pub type Gauge = ();
     pub type Counter = ();
+    pub type Histogram = ();
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/amaru-node/src/stages/build_stage_graph.rs
+++ b/crates/amaru-node/src/stages/build_stage_graph.rs
@@ -159,8 +159,8 @@ pub fn build_stage_graph(
         .preload(&select_chain, [SelectChainMsg::Initialize(best_hash)])
         .expect("initialization message must be preloaded");
     let select_chain_input = stage_graph.contramap(select_chain, "select_chain_input", |msg| {
-        let track_peers::NewTip { tip, parent, trace_context } = msg;
-        SelectChainMsg::TipFromUpstream { tip, parent, trace_context }
+        let track_peers::NewTip { tip, parent, trace_context, received_at } = msg;
+        SelectChainMsg::TipFromUpstream { tip, parent, trace_context, received_at }
     });
 
     let track_peers_wired = stage_graph.wire_up(

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -151,6 +151,37 @@ define_schemas! {
                     required peer: amaru_kernel::Peer
                 }
             }
+            perf {
+                header {
+                    /// Event recorded once per header, when its processing reaches a terminal state.
+                    /// It covers the four network-health processing points of a header's lifecycle:
+                    /// reception of the header, request of its block, reception of its block and
+                    /// local adoption of the block. `outcome` describes the terminal state (including
+                    /// headers rejected on reception, which carry no durations). The optional
+                    /// durations are the intervals between those points:
+                    /// - `block_fetch_wait_micros`: reception of the header to the request of its block
+                    /// - `block_fetch_micros`: request of the block to its reception
+                    /// - `forward_micros`: reception of the header to the adoption of its block
+                    public LIFECYCLE {
+                        optional peer: amaru_kernel::Peer
+                        optional header_hash: amaru_kernel::HeaderHash
+                        optional outcome: String
+                        optional error: String
+                        optional block_fetch_wait_micros: u64
+                        optional block_fetch_micros: u64
+                        optional forward_micros: u64
+                    }
+                }
+                fork {
+                    /// Event recorded when a fork switch ends. `duration_micros` measures the time
+                    /// from the detection of the fork to its application (or abandonment).
+                    public SWITCH {
+                        required header_hash: amaru_kernel::HeaderHash
+                        optional outcome: String
+                        optional duration_micros: u64
+                    }
+                }
+            }
         }
         ledger {
             tags: cpu

--- a/crates/amaru-observability/src/trace_context.rs
+++ b/crates/amaru-observability/src/trace_context.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{fmt::Display, str::FromStr};
+use std::str::FromStr;
 
 use opentelemetry::{
     Context, ContextGuard,
@@ -21,18 +21,13 @@ use opentelemetry::{
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-/// Parent context for spans that must cross stage boundaries.
-/// It encapsulates an OpenTelemetry `SpanContext` to provide a few helper functions.
+/// Parent context for spans that must cross stage boundaries:
 ///
-/// Serialization carries the `SpanContext` and whether a live span was attached: the
-/// `tracing::Span` handle itself cannot be serialized, so deserialization substitutes a
-/// disabled placeholder span (`tracing::Span::none()`). A deserialized `TraceContext` thus
-/// keeps the same shape and can still parent new spans, but `record` and `close` have no
-/// observable effect.
+/// - It can be created from a regular `tracing::Span` (with `(&span).into()`)
+/// - It can be used as a parent via [`context`](Self::context) / [`attach`](Self::attach),
+///   or with the `parent_context:` argument of the span macros.
 #[derive(Clone, Debug)]
 pub struct TraceContext {
-    /// We keep the span as an option in order to drop it when it's closed
-    span: Option<tracing::Span>,
     span_context: SpanContext,
 }
 
@@ -46,7 +41,7 @@ impl Eq for TraceContext {}
 
 impl TraceContext {
     pub fn none() -> Self {
-        Self { span: None, span_context: SpanContext::empty_context() }
+        Self { span_context: SpanContext::empty_context() }
     }
 
     pub fn context(&self) -> Context {
@@ -60,33 +55,11 @@ impl TraceContext {
     pub fn attach(&self) -> ContextGuard {
         self.context().attach()
     }
-
-    /// Close the corresponding span
-    pub fn close(&mut self) {
-        if let Some(span) = self.span.take() {
-            drop(span)
-        }
-    }
-
-    /// Append a field to the corresponding span
-    pub fn record(&self, name: &'static str, value: &dyn Display) {
-        if let Some(span) = &self.span {
-            span.record(name, tracing::field::display(value));
-        }
-    }
-}
-
-impl From<tracing::Span> for TraceContext {
-    fn from(span: tracing::Span) -> Self {
-        let span_context = span.context().span().span_context().clone();
-        Self { span: Some(span), span_context }
-    }
 }
 
 impl From<&tracing::Span> for TraceContext {
     fn from(span: &tracing::Span) -> Self {
-        let span_context = span.context().span().span_context().clone();
-        Self { span: None, span_context }
+        Self { span_context: span.context().span().span_context().clone() }
     }
 }
 
@@ -96,11 +69,9 @@ impl Default for TraceContext {
     }
 }
 
-/// Serializable representation of a `TraceContext`: the OpenTelemetry `SpanContext` fields
-/// plus whether a live span was attached.
+/// Serializable representation of a `TraceContext`.
 #[derive(Serialize, Deserialize)]
 struct SerializedTraceContext {
-    has_span: bool,
     trace_id: String,
     span_id: String,
     trace_flags: u8,
@@ -112,7 +83,6 @@ impl From<&TraceContext> for SerializedTraceContext {
     fn from(trace_context: &TraceContext) -> Self {
         let span_context = &trace_context.span_context;
         Self {
-            has_span: trace_context.span.is_some(),
             trace_id: span_context.trace_id().to_string(),
             span_id: span_context.span_id().to_string(),
             trace_flags: span_context.trace_flags().to_u8(),
@@ -133,7 +103,7 @@ impl TryFrom<SerializedTraceContext> for TraceContext {
             serialized.is_remote,
             TraceState::from_str(&serialized.trace_state).map_err(|e| format!("invalid trace state: {e}"))?,
         );
-        Ok(Self { span: serialized.has_span.then(tracing::Span::none), span_context })
+        Ok(Self { span_context })
     }
 }
 
@@ -163,25 +133,12 @@ mod tests {
             true,
             TraceState::from_key_value(vec![("foo", "bar")]).unwrap(),
         );
-        let trace_context = TraceContext { span: None, span_context };
+        let trace_context = TraceContext { span_context };
 
         let serialized = serde_json::to_string(&trace_context).unwrap();
         let deserialized: TraceContext = serde_json::from_str(&serialized).unwrap();
 
         assert_eq!(deserialized, trace_context);
-        assert!(deserialized.span.is_none());
-    }
-
-    #[test]
-    fn serialization_round_trip_preserves_the_presence_of_a_span() {
-        let trace_context =
-            TraceContext { span: Some(tracing::Span::none()), span_context: SpanContext::empty_context() };
-
-        let serialized = serde_json::to_string(&trace_context).unwrap();
-        let deserialized: TraceContext = serde_json::from_str(&serialized).unwrap();
-
-        assert_eq!(deserialized, trace_context);
-        assert!(deserialized.span.is_some());
     }
 
     #[test]

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -606,6 +606,42 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 </details>
 
+## target: `amaru::consensus::perf::fork`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `switch` | `TRACE` | public | Event recorded when a fork switch ends. \`duration_micros\` measures the time from the detection of the fork to its application (or abandonment). | header_hash | outcome, duration_micros |
+
+<details><summary>span: `switch`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `header_hash` | `string` | ✓ |
+| `outcome` | `string` |  |
+| `duration_micros` | `integer` |  |
+
+</details>
+
+## target: `amaru::consensus::perf::header`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `lifecycle` | `TRACE` | public | Event recorded once per header, when its processing reaches a terminal state. It covers the four network-health processing points of a header's lifecycle: reception of the header, request of its block, reception of its block and local adoption of the block. \`outcome\` describes the terminal state (including headers rejected on reception, which carry no durations). The optional durations are the intervals between those points: - \`block_fetch_wait_micros\`: reception of the header to the request of its block - \`block_fetch_micros\`: request of the block to its reception - \`forward_micros\`: reception of the header to the adoption of its block | peer, header_hash, outcome, error, block_fetch_wait_micros, block_fetch_micros, forward_micros |  |
+
+<details><summary>span: `lifecycle`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `peer` | `string` |  |
+| `header_hash` | `string` |  |
+| `outcome` | `string` |  |
+| `error` | `string` |  |
+| `block_fetch_wait_micros` | `integer` |  |
+| `block_fetch_micros` | `integer` |  |
+| `forward_micros` | `integer` |  |
+
+</details>
+
 ## target: `amaru::ledger::account`
 
 | name | level | public | description | required fields | optional fields |

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -1045,6 +1045,78 @@
       "description": "Snapshot archive already packaged; skipping",
       "public": true
     },
+    "amaru::consensus::perf::fork::SWITCH": {
+      "type": "object",
+      "properties": {
+        "header_hash": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::HeaderHash"
+        },
+        "outcome": {
+          "type": "string"
+        },
+        "duration_micros": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "header_hash"
+      ],
+      "optional": [
+        "outcome",
+        "duration_micros"
+      ],
+      "additionalProperties": false,
+      "name": "switch",
+      "level": "TRACE",
+      "target": "amaru::consensus::perf::fork",
+      "description": "Event recorded when a fork switch ends. `duration_micros` measures the time from the detection of the fork to its application (or abandonment).",
+      "public": true
+    },
+    "amaru::consensus::perf::header::LIFECYCLE": {
+      "type": "object",
+      "properties": {
+        "peer": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Peer"
+        },
+        "header_hash": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::HeaderHash"
+        },
+        "outcome": {
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        },
+        "block_fetch_wait_micros": {
+          "type": "integer"
+        },
+        "block_fetch_micros": {
+          "type": "integer"
+        },
+        "forward_micros": {
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "optional": [
+        "peer",
+        "header_hash",
+        "outcome",
+        "error",
+        "block_fetch_wait_micros",
+        "block_fetch_micros",
+        "forward_micros"
+      ],
+      "additionalProperties": false,
+      "name": "lifecycle",
+      "level": "TRACE",
+      "target": "amaru::consensus::perf::header",
+      "description": "Event recorded once per header, when its processing reaches a terminal state. It covers the four network-health processing points of a header's lifecycle: reception of the header, request of its block, reception of its block and local adoption of the block. `outcome` describes the terminal state (including headers rejected on reception, which carry no durations). The optional durations are the intervals between those points: - `block_fetch_wait_micros`: reception of the header to the request of its block - `block_fetch_micros`: request of the block to its reception - `forward_micros`: reception of the header to the adoption of its block",
+      "public": true
+    },
     "amaru::ledger::account::PAY_OR_REFUND": {
       "type": "object",
       "properties": {

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   otlp-collector:
-    image: otel/opentelemetry-collector-contrib:latest
+    image: otel/opentelemetry-collector-contrib:0.133.0
     environment:
       - NO_PROXY=localhost,127.0.0.1
       - no_proxy=localhost,127.0.0.1

--- a/monitoring/otlp-collector.yml
+++ b/monitoring/otlp-collector.yml
@@ -20,7 +20,6 @@ exporters:
   prometheus:
     endpoint: "0.0.0.0:8889"
     add_metric_suffixes: false
-    without_scope_info: true
 
 service:
   pipelines:

--- a/monitoring/profiles/jaeger/docker-compose.yml
+++ b/monitoring/profiles/jaeger/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "16686:16686"
 
   otlp-collector:
-    image: otel/opentelemetry-collector-contrib:latest
+    image: otel/opentelemetry-collector-contrib:0.133.0
     volumes:
       - "./otlp-collector.yml:/etc/otlp-collector.yml"
     command: ["--config", "/etc/otlp-collector.yml"]

--- a/monitoring/profiles/prometheus/otlp-collector.yml
+++ b/monitoring/profiles/prometheus/otlp-collector.yml
@@ -1,7 +1,19 @@
-# Prometheus-specific overrides: update metrics pipeline to export to prometheus
+# Prometheus-specific overrides: update metrics pipeline to export to prometheus.
+#
+# The prometheus exporter derives otel_scope_name/otel_scope_version/otel_scope_schema_url
+# labels from every metric's OpenTelemetry instrumentation scope. Those labels add nothing to
+# the Prometheus series here, so we blank the scope on the way out.
+processors:
+  transform/drop_scope:
+    metric_statements:
+      - context: scope
+        statements:
+          - set(name, "")
+          - set(version, "")
+
 service:
   pipelines:
     metrics:
       receivers: [otlp]
-      processors: [resource/drop_prometheus_labels]
+      processors: [resource/drop_prometheus_labels, transform/drop_scope]
       exporters: [prometheus]

--- a/scripts/demos/common/telemetry.sh
+++ b/scripts/demos/common/telemetry.sh
@@ -130,6 +130,10 @@ grafana_dashboard_url() {
   printf '%s/d/%s?orgId=1&refresh=5s\n' "$TELEMETRY_GRAFANA_URL" "$1"
 }
 
+grafana_dashboard_panel_url() {
+  printf '%s/d/%s?orgId=1&refresh=5s&viewPanel=%s\n' "$TELEMETRY_GRAFANA_URL" "$1" "$2"
+}
+
 open_telemetry() {
   local url
   if have open; then

--- a/scripts/demos/relay-1/process-compose.sh
+++ b/scripts/demos/relay-1/process-compose.sh
@@ -75,12 +75,13 @@ TELEMETRY_COMPOSE_OVERRIDE_FILE="${TELEMETRY_COMPOSE_OVERRIDE_FILE:-$SCRIPT_DIR/
 TELEMETRY_PROFILES="${TELEMETRY_PROFILES:-prometheus grafana tempo}"
 TELEMETRY_GRAFANA_URL="${TELEMETRY_GRAFANA_URL:-http://localhost}"
 TELEMETRY_PROMETHEUS_URL="${TELEMETRY_PROMETHEUS_URL:-http://localhost:9090}"
+export AMARU_RELAY_LOGDIR="$LOGDIR"
 OTEL_EXPORTER_OTLP_ENDPOINT="${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:4317}"
 OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="${OTEL_EXPORTER_OTLP_METRICS_ENDPOINT:-http://localhost:4318/v1/metrics}"
 AMARU_MIDDLE_WITH_OPEN_TELEMETRY="${AMARU_MIDDLE_WITH_OPEN_TELEMETRY:-true}"
 AMARU_DOWNSTREAM_WITH_OPEN_TELEMETRY="${AMARU_DOWNSTREAM_WITH_OPEN_TELEMETRY:-true}"
-AMARU_MIDDLE_WITH_JSON_TRACES="${AMARU_MIDDLE_WITH_JSON_TRACES:-false}"
-AMARU_DOWNSTREAM_WITH_JSON_TRACES="${AMARU_DOWNSTREAM_WITH_JSON_TRACES:-false}"
+AMARU_MIDDLE_WITH_JSON_TRACES="${AMARU_MIDDLE_WITH_JSON_TRACES:-true}"
+AMARU_DOWNSTREAM_WITH_JSON_TRACES="${AMARU_DOWNSTREAM_WITH_JSON_TRACES:-true}"
 AMARU_TRACE_EMIT_PRIVATE="${AMARU_TRACE_EMIT_PRIVATE:-true}"
 AMARU_MIDDLE_LOG="${AMARU_MIDDLE_LOG:-info,amaru::ledger::state=trace}"
 AMARU_DOWNSTREAM_LOG="${AMARU_DOWNSTREAM_LOG:-info,amaru::ledger::state=trace}"
@@ -217,7 +218,9 @@ run_prepare_wallet() {
 
 telemetry_urls() {
   grafana_trace_url "traces" '{ resource.service.name = "amaru-middle" && span:name = "roll_forward.process" } with (most_recent=true)'
+  grafana_dashboard_panel_url "amaru-relay-consensus-perf" 7
   grafana_dashboard_url "amaru-relay-mempool"
+  grafana_dashboard_url "amaru-relay-consensus-perf"
 }
 
 case "${1:-up}" in

--- a/scripts/demos/relay-1/process-compose.yaml
+++ b/scripts/demos/relay-1/process-compose.yaml
@@ -62,6 +62,8 @@ processes:
         condition: process_completed_successfully
       3-cardano-node:
         condition: process_healthy
+      8-telemetry-setup:
+        condition: process_completed
 
   5-amaru-downstream:
     description: Run the downstream Amaru relay, connected to amaru-middle and exposing the local submit API.
@@ -81,6 +83,8 @@ processes:
         condition: process_completed_successfully
       4-amaru-middle:
         condition: process_healthy
+      8-telemetry-setup:
+        condition: process_completed
 
   6-prepare-wallet:
     description: Ensure the demo payment wallet has clean UTxOs for concurrent submit-tx runs.

--- a/scripts/demos/relay-1/telemetry/dashboards/amaru-relay-consensus-performance.json
+++ b/scripts/demos/relay-1/telemetry/dashboards/amaru-relay-consensus-performance.json
@@ -1,0 +1,825 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "headers/sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 38,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*_micros"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "µs"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(sum by (exported_job, outcome) (rate(amaru_consensus_header_total{exported_job=\"amaru-middle\"}[$__rate_interval])), \"panel\", \"header_outcomes\", \"exported_job\", \".*\")",
+          "legendFormat": "{{panel}} {{exported_job}} {{outcome}}",
+          "range": true,
+          "refId": "header_outcomes"
+        }
+      ],
+      "title": "Header Outcomes (per second, by outcome)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "duration",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "µs"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, exported_job) (rate(amaru_consensus_block_fetch_wait_duration_microseconds_bucket{exported_job=\"amaru-middle\"}[$__rate_interval])))",
+          "legendFormat": "{{exported_job}} p50",
+          "range": true,
+          "refId": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, exported_job) (rate(amaru_consensus_block_fetch_wait_duration_microseconds_bucket{exported_job=\"amaru-middle\"}[$__rate_interval])))",
+          "legendFormat": "{{exported_job}} p95",
+          "range": true,
+          "refId": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, exported_job) (rate(amaru_consensus_block_fetch_wait_duration_microseconds_bucket{exported_job=\"amaru-middle\"}[$__rate_interval])))",
+          "legendFormat": "{{exported_job}} p99",
+          "range": true,
+          "refId": "p99"
+        }
+      ],
+      "title": "Block Fetch Wait (header received → block requested)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "duration",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "µs"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, exported_job) (rate(amaru_consensus_block_fetch_duration_microseconds_bucket{exported_job=\"amaru-middle\"}[$__rate_interval])))",
+          "legendFormat": "{{exported_job}} p50",
+          "range": true,
+          "refId": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, exported_job) (rate(amaru_consensus_block_fetch_duration_microseconds_bucket{exported_job=\"amaru-middle\"}[$__rate_interval])))",
+          "legendFormat": "{{exported_job}} p95",
+          "range": true,
+          "refId": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, exported_job) (rate(amaru_consensus_block_fetch_duration_microseconds_bucket{exported_job=\"amaru-middle\"}[$__rate_interval])))",
+          "legendFormat": "{{exported_job}} p99",
+          "range": true,
+          "refId": "p99"
+        }
+      ],
+      "title": "Block Fetch (block requested → block received)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "duration",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "µs"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, exported_job) (rate(amaru_consensus_header_forward_duration_microseconds_bucket{exported_job=\"amaru-middle\"}[$__rate_interval])))",
+          "legendFormat": "{{exported_job}} p50",
+          "range": true,
+          "refId": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, exported_job) (rate(amaru_consensus_header_forward_duration_microseconds_bucket{exported_job=\"amaru-middle\"}[$__rate_interval])))",
+          "legendFormat": "{{exported_job}} p95",
+          "range": true,
+          "refId": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, exported_job) (rate(amaru_consensus_header_forward_duration_microseconds_bucket{exported_job=\"amaru-middle\"}[$__rate_interval])))",
+          "legendFormat": "{{exported_job}} p99",
+          "range": true,
+          "refId": "p99"
+        }
+      ],
+      "title": "Header Forward (header received → block adopted)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "duration",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "µs"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le, exported_job) (rate(amaru_consensus_fork_switch_duration_microseconds_bucket{exported_job=\"amaru-middle\"}[$__rate_interval])))",
+          "legendFormat": "{{exported_job}} p50",
+          "range": true,
+          "refId": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, exported_job) (rate(amaru_consensus_fork_switch_duration_microseconds_bucket{exported_job=\"amaru-middle\"}[$__rate_interval])))",
+          "legendFormat": "{{exported_job}} p95",
+          "range": true,
+          "refId": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, exported_job) (rate(amaru_consensus_fork_switch_duration_microseconds_bucket{exported_job=\"amaru-middle\"}[$__rate_interval])))",
+          "legendFormat": "{{exported_job}} p99",
+          "range": true,
+          "refId": "p99"
+        }
+      ],
+      "title": "Fork Switch (fork detected → applied or abandoned)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "fork switches/sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 38,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(sum by (exported_job, outcome) (rate(amaru_consensus_fork_switch_total{exported_job=\"amaru-middle\"}[$__rate_interval])), \"panel\", \"fork_switches\", \"exported_job\", \".*\")",
+          "legendFormat": "{{panel}} {{exported_job}} {{outcome}}",
+          "range": true,
+          "refId": "fork_switches"
+        }
+      ],
+      "title": "Fork Switches (per second, by outcome)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*_micros"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "µs"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 7,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "direction": "backward",
+          "editorMode": "builder",
+          "expr": "{job=\"amaru-relay-1\", service_name=\"amaru-middle\"} | json event=\"fields.message\", peer=\"fields.peer\", header_hash=\"fields.header_hash\", outcome=\"fields.outcome\", error=\"fields.error\", block_fetch_wait_micros=\"fields.block_fetch_wait_micros\", block_fetch_micros=\"fields.block_fetch_micros\", forward_micros=\"fields.forward_micros\" | event = \"perf.header.lifecycle\" | line_format \"{\\\"service\\\":\\\"{{.service_name}}\\\",\\\"peer\\\":\\\"{{.peer}}\\\",\\\"header_hash\\\":\\\"{{.header_hash}}\\\",\\\"outcome\\\":\\\"{{.outcome}}\\\",\\\"error\\\":\\\"{{.error}}\\\",\\\"block_fetch_wait_micros\\\":{{if .block_fetch_wait_micros}}{{.block_fetch_wait_micros}}{{else}}null{{end}},\\\"block_fetch_micros\\\":{{if .block_fetch_micros}}{{.block_fetch_micros}}{{else}}null{{end}},\\\"forward_micros\\\":{{if .forward_micros}}{{.forward_micros}}{{else}}null{{end}}}\"",
+          "queryType": "range",
+          "refId": "header_lifecycle_events"
+        }
+      ],
+      "title": "Header Lifecycle Events",
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "json",
+            "replace": false,
+            "source": "Line"
+          }
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "Time",
+                "service",
+                "peer",
+                "header_hash",
+                "outcome",
+                "error",
+                "block_fetch_wait_micros",
+                "block_fetch_micros",
+                "forward_micros"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "refresh": "5s",
+  "schemaVersion": 41,
+  "tags": [
+    "amaru",
+    "relay-1",
+    "consensus",
+    "performance"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Amaru Relay Consensus Performance",
+  "uid": "amaru-relay-consensus-perf",
+  "version": 1,
+  "weekStart": ""
+}

--- a/scripts/demos/relay-1/telemetry/docker-compose.yml
+++ b/scripts/demos/relay-1/telemetry/docker-compose.yml
@@ -5,8 +5,24 @@
 services:
   grafana:
     volumes:
+      - "${TELEMETRY_COMPOSE_OVERRIDE_DIR}/loki-datasource.yml:/etc/grafana/provisioning/datasources/loki.yaml"
       - "${TELEMETRY_COMPOSE_OVERRIDE_DIR}/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yaml"
       - "${TELEMETRY_COMPOSE_OVERRIDE_DIR}/dashboards:/var/lib/grafana/dashboards"
+
+  loki:
+    image: grafana/loki:latest
+    command: -config.file=/etc/loki/local-config.yaml
+    ports:
+      - "3100:3100"
+
+  promtail:
+    image: grafana/promtail:latest
+    volumes:
+      - "${TELEMETRY_COMPOSE_OVERRIDE_DIR}/promtail.yml:/etc/promtail/config.yml"
+      - "${AMARU_RELAY_LOGDIR}:/var/log/amaru:ro"
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      - loki
 
   # Keep service.name for this multi-node demo (see ./otlp-collector.yml). Docker Compose
   # replaces the command list rather than appending, so this restates the collector configs

--- a/scripts/demos/relay-1/telemetry/loki-datasource.yml
+++ b/scripts/demos/relay-1/telemetry/loki-datasource.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    uid: loki
+    access: proxy
+    orgId: 1
+    url: http://loki:3100
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: false

--- a/scripts/demos/relay-1/telemetry/promtail.yml
+++ b/scripts/demos/relay-1/telemetry/promtail.yml
@@ -1,0 +1,25 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: amaru-relay-1
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: amaru-relay-1
+          service_name: amaru-middle
+          __path__: /var/log/amaru/amaru-middle.log
+      - targets:
+          - localhost
+        labels:
+          job: amaru-relay-1
+          service_name: amaru-downstream
+          __path__: /var/log/amaru/amaru-downstream.log


### PR DESCRIPTION
This PR produces an event describing the lifecycle of a header to track significant times in the processing of a given header/block as described in [EDR-27](https://github.com/pragma-org/amaru/blob/main/engineering-decision-records/026-tracing-span-design.md#cardano-health-monitoring):

 - Header forward time (from reception to forwarding if it becomes adopted on the best chain).
 - Header "wait before block download" time.
 - Block download time.
 - Fork switch time (if the reception of a header triggers a switch to a fork).

These events can be queried directly via Grafana/Loki. Here is an example of query (added to the `relay-1` demo):
<img width="2926" height="196" alt="image" src="https://github.com/user-attachments/assets/881b0527-9a6c-4f18-ad83-d25dc6c0315c" />

Metrics are also emitted to aggregate time measurements and can be displayed on a Grafana dashboard (also added to the `relay-1` demo):
<img width="1784" height="329" alt="image" src="https://github.com/user-attachments/assets/4db4064f-4f55-4aa2-848c-4c675dc7de7a" />

Notes:

 - I pinned the version of the Otel collector. The `latest` version broke the demo because the `without_scope_info` does not exist anymore on the collector config. Pinning the version avoids future surprises of that sort.
 - Since the reason for that setting to exist was to remove useless Prometheus labels, I implemented a work-around with a `transform/drop_scope` processor.
 - The `TraceContext` used to parent spans between stages became simple again since it doesn't need to transport an optional `Span`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consensus performance metrics for header lifecycle and fork switching (including timing for fetch/wait/forward).
  * Emitted new tracing events for header lifecycle and fork-switch completion.
  * Added/updated Grafana dashboards and added deeper per-panel dashboard linking for consensus performance.
* **Documentation**
  * Documented the new tracing events and added their schema definitions.
* **Chores**
  * Pinned OpenTelemetry Collector versions and refined Prometheus metric naming/scope handling.
  * Updated demo telemetry setup (telemetry readiness ordering, default JSON trace output, and added Loki/Promtail for logs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->