### PR TITLE
perf: skip the validation of already-stored headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Other guiding principles:
 - **amaru-ledger**: track account unregistrations to avoid O(n) scan on all accounts during epoch transition calculations.
 - **amaru-ledger**: add phase-one conformance coverage for `TooManyCollateralInputs`, `ScriptsNotPaidUTxO` and `IncorrectTotalCollateralField`, and move the fixture that was filed under `InsufficientCollateral` while expecting `ValueNotConservedUTxO` to the directory matching its predicate.
 - **amaru**: consolidate the monitoring stack.
+- **amaru-consensus**: skip the validation of headers whose evolved nonces are already stored, to avoid unnecessary rechecks when getting the same header from different peers. ([#1087][])
 
 ### Fixed
 
@@ -271,6 +272,7 @@ Other guiding principles:
 [#1060]: https://github.com/pragma-org/amaru/issues/1060
 [#1078]: https://github.com/pragma-org/amaru/issues/1078
 [#1082]: https://github.com/pragma-org/amaru/pull/1082
+[#1087]: https://github.com/pragma-org/amaru/pull/1087
 [#1095]: https://github.com/pragma-org/amaru/issues/1095
 [#1098]: https://github.com/pragma-org/amaru/pull/1098
 [#1101]: https://github.com/pragma-org/amaru/pull/1101

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Other guiding principles:
 
 ## v10.11.20260806 _[unreleased; planned for 2026-08-06]_
 
+### Changed
+
+- **amaru-consensus**: skip the validation of headers whose evolved nonces are already stored, to avoid unnecessary rechecks when getting the same header from different peers. ([#1087][])
+
 ### Removed
 
 - **amaru-kernel**: dependency on `pallas-*`

--- a/crates/amaru-consensus/src/effects/ledger_effects.rs
+++ b/crates/amaru-consensus/src/effects/ledger_effects.rs
@@ -18,7 +18,8 @@ use amaru_kernel::{BlockHeader, ConsensusParameters, EraHistory, Point, Tip, Tra
 use amaru_metrics::ledger::LedgerMetrics;
 use amaru_observability::TraceContext;
 use amaru_ouroboros_traits::{
-    BlockValidationError, CanValidateBlocks, CanValidateTxs, HasStakePools, PoolSummaries, TransactionValidationError,
+    BlockValidationError, CanValidateBlocks, CanValidateTxs, HasStakePools, Nonces, PoolSummaries,
+    TransactionValidationError,
 };
 use amaru_protocols::store_effects::ResourceHeaderStore;
 use amaru_pure_stage::{BoxFuture, Effects, ExternalEffect, ExternalEffectAPI, Resources, SendData, Void};
@@ -31,7 +32,9 @@ use crate::validate_header::ValidateHeaderError;
 pub trait LedgerOps: Send + Sync {
     fn validate_tx(&self, tx: &Transaction) -> BoxFuture<'_, Result<(), TransactionValidationError>>;
 
-    fn validate_header(&self, header: &BlockHeader) -> BoxFuture<'static, Result<(), ValidateHeaderError>>;
+    /// Validate a header and return its evolved nonces, which the caller is expected to store
+    /// atomically with the header itself.
+    fn validate_header(&self, header: &BlockHeader) -> BoxFuture<'static, Result<Nonces, ValidateHeaderError>>;
 
     fn validate_block(
         &self,
@@ -78,7 +81,7 @@ impl LedgerOps for Ledger {
         self.effects.external(ValidateTxEffect::new(tx))
     }
 
-    fn validate_header(&self, header: &BlockHeader) -> BoxFuture<'static, Result<(), ValidateHeaderError>> {
+    fn validate_header(&self, header: &BlockHeader) -> BoxFuture<'static, Result<Nonces, ValidateHeaderError>> {
         self.effects.external(ValidateHeaderEffect::new(header).with_trace_context(&self.trace_context))
     }
 
@@ -253,7 +256,7 @@ impl ExternalEffect for ValidateHeaderEffect {
 }
 
 impl ExternalEffectAPI for ValidateHeaderEffect {
-    type Response = Result<(), ValidateHeaderError>;
+    type Response = Result<Nonces, ValidateHeaderError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/crates/amaru-consensus/src/stages/select_chain/mod.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/mod.rs
@@ -224,7 +224,8 @@ impl SelectChain {
         };
 
         if let Some(valid) = valid {
-            // track_peers only sends a tip if the header was just stored, so it cannot be already validated
+            // track_peers only sends a tip if the header was just validated,
+            // so its block cannot be already validated.
             tracing::error!(tip = %tip.point(), %valid, "got tip from upstream that was already validated");
             return eff.terminate().await;
         } else {

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -25,6 +25,7 @@ use amaru_kernel::{
 use amaru_metrics::consensus::ConsensusMetrics;
 use amaru_observability::{TraceContext, debug, debug_record, debug_span, error};
 use amaru_ouroboros::ConnectionId;
+use amaru_ouroboros_traits::Nonces;
 use amaru_protocols::{
     chainsync::{self, ChainSyncInitiatorMsg, HeaderContent},
     metrics_effects::{Metrics, MetricsOps},
@@ -384,12 +385,13 @@ impl TrackPeers {
     ///
     /// The received `tip` is the highest advertised tip for the peer as part of the RollForward message.
     ///
-    /// If the store already holds evolved nonces for this header (this is the durable proof that it
-    /// went through full validation once before) the header is skipped and `None` is returned.
-    /// Otherwise the header is validated and the point of its parent is returned.
+    /// If the store already holds evolved nonces for this header, it went through full validation
+    /// before (nonces are only stored together with a validated header), so the header is skipped
+    /// and `None` is returned. Otherwise the header is validated and the point of its parent is
+    /// returned, together with the nonces to store alongside it.
     ///
-    /// Note: a header could already sits in the chain store, as is the case for headers imported
-    /// during bootstrap, but not carry a nonce yet.
+    /// Note: a header can already sit in the chain store without carrying any nonces, as is the
+    /// case for headers imported during bootstrap. Those still need to be validated.
     #[expect(clippy::too_many_arguments)]
     async fn validate_header(
         &mut self,
@@ -401,7 +403,7 @@ impl TrackPeers {
         ledger: &Ledger,
         store: &Store,
         current_time: Instant,
-    ) -> Result<Option<Point>, ConsensusError> {
+    ) -> Result<Option<(Point, Nonces)>, ConsensusError> {
         let era_name = self.era_history.slot_to_era_tag(header.slot())?;
         if era_name != variant {
             return Err(ConsensusError::EraNameMismatch { from_raw_header: variant, from_slot: era_name });
@@ -454,14 +456,16 @@ impl TrackPeers {
             return Err(ConsensusError::HeaderSlotInNearFuture(header.slot()));
         }
 
-        // The evolved nonces are the durable proof that a header was fully validated.
-        // Note that a header merely imported during bootstrap has no nonces yet and must still be
-        // validated.
+        // Stored nonces are the durable proof that a header was fully validated: they are only
+        // written together with the header they belong to, once it passed all the Praos checks.
         if store.get_nonces(&header.hash()).await.is_some() {
             return Ok(None);
         }
-        ledger.validate_header(header).await.map_err(|e| ConsensusError::InvalidHeader(header.point(), Box::new(e)))?;
-        Ok(Some(current.point()))
+        let nonces = ledger
+            .validate_header(header)
+            .await
+            .map_err(|e| ConsensusError::InvalidHeader(header.point(), Box::new(e)))?;
+        Ok(Some((current.point(), nonces)))
     }
 
     async fn roll_forward(&mut self, conn_id: ConnectionId, header: &BlockHeader, tip: Tip) {
@@ -620,8 +624,8 @@ impl TrackPeers {
         let store = Store::new(eff.clone()).with_trace_context(trace_context);
 
         let result = self.validate_header(peer, *conn_id, *variant, header, *tip, &ledger, &store, now).await;
-        let parent = match result {
-            Ok(parent) => parent,
+        let validated = match result {
+            Ok(validated) => validated,
             Err(error) => {
                 if let Some(dh) = self.try_defer_for_stake(&args, &error) {
                     return Err(dh);
@@ -642,14 +646,13 @@ impl TrackPeers {
                 return Ok(());
             }
         };
-        // at this point the evolved nonces have been stored and follow-up headers can be validated
         self.roll_forward(*conn_id, header, *tip).await;
 
         // now we can destructure to consume the pieces
         let RollForwardArgs { peer, header, tip, sent_request_next, handler, trace_context, received_at, .. } = args;
         let header_tip = header.tip();
         let current = header_tip.point();
-        match parent {
+        match validated {
             None => {
                 tracing::debug!(%peer, %current, highest = %tip.point(), "roll forward, header already stored");
                 debug!(
@@ -660,9 +663,11 @@ impl TrackPeers {
                 );
                 record_header_rejected(eff, PerfHeaderForwardOutcome::DuplicateHeader).await;
             }
-            Some(parent) => {
+            Some((parent, nonces)) => {
+                // the header and its nonces are stored atomically, so that stored nonces always
+                // denote a fully validated header, and follow-up headers can be validated
                 store
-                    .store_header(&header)
+                    .store_validated_header(&header, &nonces)
                     .or_terminate_with(eff, async |e| {
                         let error = ConsensusError::StoreHeaderFailed(header.hash(), e);
                         error!(

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -380,9 +380,16 @@ impl TrackPeers {
         });
     }
 
-    /// Validate an incoming header for protocol conformance and store it in the chain store.
+    /// Validate an incoming header for protocol conformance.
     ///
     /// The received `tip` is the highest advertised tip for the peer as part of the RollForward message.
+    ///
+    /// If the store already holds evolved nonces for this header (this is the durable proof that it
+    /// went through full validation once before) the header is skipped and `None` is returned.
+    /// Otherwise the header is validated and the point of its parent is returned.
+    ///
+    /// Note: a header could already sits in the chain store, as is the case for headers imported
+    /// during bootstrap, but not carry a nonce yet.
     #[expect(clippy::too_many_arguments)]
     async fn validate_header(
         &mut self,
@@ -392,8 +399,9 @@ impl TrackPeers {
         header: &BlockHeader,
         tip: Tip,
         ledger: &Ledger,
+        store: &Store,
         current_time: Instant,
-    ) -> Result<Point, ConsensusError> {
+    ) -> Result<Option<Point>, ConsensusError> {
         let era_name = self.era_history.slot_to_era_tag(header.slot())?;
         if era_name != variant {
             return Err(ConsensusError::EraNameMismatch { from_raw_header: variant, from_slot: era_name });
@@ -446,8 +454,14 @@ impl TrackPeers {
             return Err(ConsensusError::HeaderSlotInNearFuture(header.slot()));
         }
 
+        // The evolved nonces are the durable proof that a header was fully validated.
+        // Note that a header merely imported during bootstrap has no nonces yet and must still be
+        // validated.
+        if store.get_nonces(&header.hash()).await.is_some() {
+            return Ok(None);
+        }
         ledger.validate_header(header).await.map_err(|e| ConsensusError::InvalidHeader(header.point(), Box::new(e)))?;
-        Ok(current.point())
+        Ok(Some(current.point()))
     }
 
     async fn roll_forward(&mut self, conn_id: ConnectionId, header: &BlockHeader, tip: Tip) {
@@ -456,16 +470,6 @@ impl TrackPeers {
         };
         *current = header.tip();
         *highest = tip;
-    }
-
-    async fn maybe_store_header(&mut self, header: BlockHeader, store: &Store) -> Result<bool, ConsensusError> {
-        let hash = header.hash();
-        if store.has_header(&hash).await {
-            Ok(false)
-        } else {
-            store.store_header(&header).await.map_err(|e| ConsensusError::StoreHeaderFailed(hash, e))?;
-            Ok(true)
-        }
     }
 
     async fn roll_backward(
@@ -615,7 +619,7 @@ impl TrackPeers {
         let ledger = Ledger::new(eff.clone()).with_trace_context(trace_context);
         let store = Store::new(eff.clone()).with_trace_context(trace_context);
 
-        let result = self.validate_header(peer, *conn_id, *variant, header, *tip, &ledger, now).await;
+        let result = self.validate_header(peer, *conn_id, *variant, header, *tip, &ledger, &store, now).await;
         let parent = match result {
             Ok(parent) => parent,
             Err(error) => {
@@ -645,31 +649,35 @@ impl TrackPeers {
         let RollForwardArgs { peer, header, tip, sent_request_next, handler, trace_context, received_at, .. } = args;
         let header_tip = header.tip();
         let current = header_tip.point();
-        let new = self
-            .maybe_store_header(header, &store)
-            .or_terminate_with(eff, async |error| {
-                error!(
+        match parent {
+            None => {
+                tracing::debug!(%peer, %current, highest = %tip.point(), "roll forward, header already stored");
+                debug!(
                     consensus::perf::header::LIFECYCLE,
                     peer = peer.clone(),
                     header_hash = current.hash(),
-                    error = %error,
-                    outcome = PerfHeaderForwardOutcome::StoreHeaderError.as_str()
+                    outcome = PerfHeaderForwardOutcome::DuplicateHeader.as_str()
                 );
-                record_header_rejected(eff, PerfHeaderForwardOutcome::StoreHeaderError).await;
-            })
-            .await;
-        if new {
-            tracing::debug!(%peer, %current, highest = %tip.point(), "roll forward with new header");
-            eff.send(&self.downstream, NewTip { tip: header_tip, parent, trace_context, received_at }).await;
-        } else {
-            tracing::debug!(%peer, %current, highest = %tip.point(), "roll forward, header already stored");
-            debug!(
-                consensus::perf::header::LIFECYCLE,
-                peer = peer.clone(),
-                header_hash = current.hash(),
-                outcome = PerfHeaderForwardOutcome::DuplicateHeader.as_str()
-            );
-            record_header_rejected(eff, PerfHeaderForwardOutcome::DuplicateHeader).await;
+                record_header_rejected(eff, PerfHeaderForwardOutcome::DuplicateHeader).await;
+            }
+            Some(parent) => {
+                store
+                    .store_header(&header)
+                    .or_terminate_with(eff, async |e| {
+                        let error = ConsensusError::StoreHeaderFailed(header.hash(), e);
+                        error!(
+                            consensus::perf::header::LIFECYCLE,
+                            peer = peer.clone(),
+                            header_hash = current.hash(),
+                            error = %error,
+                            outcome = PerfHeaderForwardOutcome::StoreHeaderError.as_str()
+                        );
+                        record_header_rejected(eff, PerfHeaderForwardOutcome::StoreHeaderError).await;
+                    })
+                    .await;
+                tracing::debug!(%peer, %current, highest = %tip.point(), "roll forward with new header");
+                eff.send(&self.downstream, NewTip { tip: header_tip, parent, trace_context, received_at }).await;
+            }
         }
 
         if !sent_request_next {

--- a/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
@@ -15,8 +15,8 @@
 use std::{sync::Arc, time::Duration};
 
 use amaru_kernel::{
-    BlockHeader, ConsensusParameters, Epoch, EraHistory, Hash, HeaderHash, IsHeader, NetworkName, Point, Tip,
-    make_header, num::CheckedSub,
+    BlockHeader, ConsensusParameters, Epoch, EraHistory, HeaderHash, IsHeader, NetworkName, Point, Tip, make_header,
+    num::CheckedSub,
 };
 use amaru_ouroboros::ConnectionId;
 use amaru_ouroboros_traits::{
@@ -27,7 +27,8 @@ use amaru_protocols::{
     chainsync::{self, InitiatorMessage},
     manager::ManagerMessage,
     store_effects::{
-        GetNoncesEffect, HasHeaderEffect, LoadHeaderEffect, LoadTipEffect, ResourceHeaderStore, StoreHeaderEffect,
+        GetNoncesEffect, HasHeaderEffect, LoadHeaderEffect, LoadTipEffect, ResourceHeaderStore,
+        StoreValidatedHeaderEffect,
     },
 };
 use amaru_pure_stage::{
@@ -102,14 +103,9 @@ pub fn build_store(headers: &[BlockHeader]) -> Arc<InMemoryChainStore> {
 pub fn build_store_with_nonces(headers: &[BlockHeader]) -> Arc<InMemoryChainStore> {
     let store = build_store(headers);
     for header in headers {
-        store.put_nonces(&header.hash(), &dummy_nonces()).unwrap();
+        store.put_nonces(&header.hash(), &Nonces::for_tests()).unwrap();
     }
     store
-}
-
-fn dummy_nonces() -> Nonces {
-    let zero = Hash::from([0u8; 32]);
-    Nonces { active: zero, evolving: zero, candidate: zero, tail: zero, epoch: Epoch::from(0) }
 }
 
 /// Bundles state, runtime, handler, conn_id, and three linked headers for tests.
@@ -172,8 +168,11 @@ pub fn te_get_nonces(at_stage: &str, hash: HeaderHash) -> TraceEntry {
     TraceEntry::suspend(Effect::external(at_stage, Box::new(GetNoncesEffect::new(hash))))
 }
 
-pub fn te_store_header(at_stage: &str, header: BlockHeader) -> TraceEntry {
-    TraceEntry::suspend(Effect::external(at_stage, Box::new(StoreHeaderEffect::new(header))))
+pub fn te_store_validated_header(at_stage: &str, header: BlockHeader) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(
+        at_stage,
+        Box::new(StoreValidatedHeaderEffect::new(header, Nonces::for_tests())),
+    ))
 }
 
 pub fn te_clock_suspend(at_stage: &str) -> TraceEntry {
@@ -210,7 +209,7 @@ fn register_guards() -> DeserializerGuards {
         amaru_pure_stage::register_effect_deserializer::<LoadTipEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<HasHeaderEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<GetNoncesEffect>().boxed(),
-        amaru_pure_stage::register_effect_deserializer::<StoreHeaderEffect>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<StoreValidatedHeaderEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<ValidateHeaderEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<TipEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<VolatileTipEffect>().boxed(),
@@ -226,7 +225,9 @@ pub fn setup(
     store: Arc<InMemoryChainStore>,
 ) -> (SimulationRunning, DeserializerGuards, Logs) {
     setup_base(rt, state, [msg], store, |running| {
-        running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| OverrideResult::handled(Ok(())));
+        running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| {
+            OverrideResult::handled(Ok(Nonces::for_tests()))
+        });
     })
 }
 
@@ -241,7 +242,9 @@ pub fn setup_with_ledger_tip_until_sleeping(
     ledger_tip: Tip,
 ) -> (SimulationRunning, DeserializerGuards, Logs) {
     setup_base_until_sleeping(rt, state, msg, store, |running| {
-        running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| OverrideResult::handled(Ok(())));
+        running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| {
+            OverrideResult::handled(Ok(Nonces::for_tests()))
+        });
         running.override_external_effect::<VolatileTipEffect>(usize::MAX, {
             move |_| OverrideResult::handled(ledger_tip)
         });

--- a/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
@@ -15,18 +15,20 @@
 use std::{sync::Arc, time::Duration};
 
 use amaru_kernel::{
-    BlockHeader, ConsensusParameters, Epoch, EraHistory, HeaderHash, IsHeader, NetworkName, Point, Tip, make_header,
-    num::CheckedSub,
+    BlockHeader, ConsensusParameters, Epoch, EraHistory, Hash, HeaderHash, IsHeader, NetworkName, Point, Tip,
+    make_header, num::CheckedSub,
 };
 use amaru_ouroboros::ConnectionId;
 use amaru_ouroboros_traits::{
-    BaseReadChainStore, MockBlockValidator, PoolSummaries, WriteChainStore, has_stake_pools::MockHasStakePools,
+    BaseReadChainStore, MockBlockValidator, Nonces, PoolSummaries, WriteChainStore, has_stake_pools::MockHasStakePools,
     in_memory_chain_store::InMemoryChainStore,
 };
 use amaru_protocols::{
     chainsync::{self, InitiatorMessage},
     manager::ManagerMessage,
-    store_effects::{HasHeaderEffect, LoadHeaderEffect, LoadTipEffect, ResourceHeaderStore, StoreHeaderEffect},
+    store_effects::{
+        GetNoncesEffect, HasHeaderEffect, LoadHeaderEffect, LoadTipEffect, ResourceHeaderStore, StoreHeaderEffect,
+    },
 };
 use amaru_pure_stage::{
     DeserializerGuards, Effect, Instant, Name, ScheduleId, ScheduleIds, StageRef,
@@ -95,6 +97,21 @@ pub fn build_store(headers: &[BlockHeader]) -> Arc<InMemoryChainStore> {
     store
 }
 
+/// Like [`build_store`] but also persists nonces for each header, mimicking a header that has
+/// already been fully validated (as opposed to one merely imported during bootstrap).
+pub fn build_store_with_nonces(headers: &[BlockHeader]) -> Arc<InMemoryChainStore> {
+    let store = build_store(headers);
+    for header in headers {
+        store.put_nonces(&header.hash(), &dummy_nonces()).unwrap();
+    }
+    store
+}
+
+fn dummy_nonces() -> Nonces {
+    let zero = Hash::from([0u8; 32]);
+    Nonces { active: zero, evolving: zero, candidate: zero, tail: zero, epoch: Epoch::from(0) }
+}
+
 /// Bundles state, runtime, handler, conn_id, and three linked headers for tests.
 pub struct TestPrep {
     pub state: TrackPeers,
@@ -151,8 +168,8 @@ pub fn te_load_tip(at_stage: &str, hash: HeaderHash) -> TraceEntry {
     TraceEntry::suspend(Effect::external(at_stage, Box::new(LoadTipEffect::new(hash))))
 }
 
-pub fn te_has_header(at_stage: &str, hash: HeaderHash) -> TraceEntry {
-    TraceEntry::suspend(Effect::external(at_stage, Box::new(HasHeaderEffect::new(hash))))
+pub fn te_get_nonces(at_stage: &str, hash: HeaderHash) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(at_stage, Box::new(GetNoncesEffect::new(hash))))
 }
 
 pub fn te_store_header(at_stage: &str, header: BlockHeader) -> TraceEntry {
@@ -192,6 +209,7 @@ fn register_guards() -> DeserializerGuards {
         amaru_pure_stage::register_effect_deserializer::<LoadHeaderEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<LoadTipEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<HasHeaderEffect>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<GetNoncesEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<StoreHeaderEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<ValidateHeaderEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<TipEffect>().boxed(),

--- a/crates/amaru-consensus/src/stages/track_peers/tests.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/tests.rs
@@ -36,10 +36,10 @@ use crate::{
         track_peers::{
             TrackPeers, TrackPeersMsg,
             test_setup::{
-                HEIGHT_RECHECK_INTERVAL, build_store, height_recheck_schedule_id, make_block_header, new_tip,
-                schedule_id_at, setup, setup_base, setup_with_ledger_tip_until_sleeping, te_clock, te_clock_suspend,
-                te_has_header, te_load_tip, te_schedule, te_store_header, te_validate_header, test_prep,
-                test_prep_with_max_peer_lead, tm_volatile_tip,
+                HEIGHT_RECHECK_INTERVAL, build_store, build_store_with_nonces, height_recheck_schedule_id,
+                make_block_header, new_tip, schedule_id_at, setup, setup_base, setup_with_ledger_tip_until_sleeping,
+                te_clock, te_clock_suspend, te_get_nonces, te_load_tip, te_schedule, te_store_header,
+                te_validate_header, test_prep, test_prep_with_max_peer_lead, tm_volatile_tip,
             },
         },
     },
@@ -347,6 +347,51 @@ fn test_roll_forward_known_peer_header_already_stored() {
     expected.insert_peer(peer.clone(), prep.conn_id, header.tip(), header.tip());
 
     let (running, _guards, mut logs) =
+        setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store_with_nonces(slice::from_ref(header)));
+    assert_trace_match(
+        &running,
+        &[
+            te_state("tp-1", &state).into(),
+            te_input("tp-1", &msg).into(),
+            te_clock_suspend("tp-1").into(),
+            te_send("tp-1", &prep.handler, RequestNext).into(),
+            te_get_nonces("tp-1", header.hash()).into(),
+            te_header_rejected("duplicate header").into(),
+            te_state("tp-1", &expected).into(),
+        ],
+    );
+    logs.assert_and_remove(Level::DEBUG, &["roll forward", "already stored"]).assert_no_remaining_at([
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
+}
+
+/// A header imported during bootstrap is present in the chain store but has no evolved nonces.
+/// When re-received from a peer, its nonces must still be computed (via `validate_header`) so
+/// that descendant headers can be validated. Nonce absence means the header was never fully
+/// validated, so it is treated like a new header: stored (idempotent) and propagated downstream.
+#[test]
+fn test_roll_forward_stored_header_missing_nonces_revalidates() {
+    let prep = test_prep();
+    let peer = Peer::new("peer1");
+    let parent = &prep.headers[0];
+    let header = &prep.headers[1];
+    let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
+        peer: peer.clone(),
+        conn_id: prep.conn_id,
+        handler: prep.handler.clone(),
+        msg: chainsync::InitiatorResult::RollForward(HeaderContent::new(header, EraName::Conway), header.tip()),
+    });
+
+    let mut state = prep.state.clone();
+    state.insert_peer(peer.clone(), prep.conn_id, parent.tip(), parent.tip());
+
+    let mut expected = prep.state.clone();
+    expected.insert_peer(peer.clone(), prep.conn_id, header.tip(), header.tip());
+
+    // Header present but nonces absent, as after a bootstrap import.
+    let (running, _guards, mut logs) =
         setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(slice::from_ref(header)));
     assert_trace_match(
         &running,
@@ -355,13 +400,14 @@ fn test_roll_forward_known_peer_header_already_stored() {
             te_input("tp-1", &msg).into(),
             te_clock_suspend("tp-1").into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
+            te_get_nonces("tp-1", header.hash()).into(),
             te_validate_header("tp-1", header.clone()).into(),
-            te_has_header("tp-1", header.hash()).into(),
-            te_header_rejected("duplicate header").into(),
+            te_store_header("tp-1", header.clone()).into(),
+            te_send("tp-1", "downstream", new_tip(header.tip(), parent.point())).into(),
             te_state("tp-1", &expected).into(),
         ],
     );
-    logs.assert_and_remove(Level::DEBUG, &["roll forward", "already stored"]).assert_no_remaining_at([
+    logs.assert_and_remove(Level::DEBUG, &["roll forward", "new header"]).assert_no_remaining_at([
         Level::INFO,
         Level::WARN,
         Level::ERROR,
@@ -395,8 +441,8 @@ fn test_roll_forward_known_peer_new_header_forwards_tip() {
             te_input("tp-1", &msg).into(),
             te_clock_suspend("tp-1").into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
+            te_get_nonces("tp-1", header.hash()).into(),
             te_validate_header("tp-1", header.clone()).into(),
-            te_has_header("tp-1", header.hash()).into(),
             te_store_header("tp-1", header.clone()).into(),
             te_send("tp-1", "downstream", new_tip(header.tip(), parent.point())).into(),
             te_state("tp-1", &expected).into(),
@@ -625,6 +671,7 @@ fn test_roll_forward_header_validation_failure_removes_peer() {
             te_input("tp-1", &msg).into(),
             te_clock_suspend("tp-1").into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
+            te_get_nonces("tp-1", header.hash()).into(),
             te_validate_header("tp-1", header.clone()).into(),
             te_header_rejected("invalid header").into(),
             te_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer)).into(),
@@ -760,6 +807,7 @@ fn test_roll_forward_stake_dist_far_ahead_rejects() {
             te_input("tp-1", &msg).into(),
             te_clock_suspend("tp-1").into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
+            te_get_nonces("tp-1", header.hash()).into(),
             te_validate_header("tp-1", header.clone()).into(),
             te_header_rejected("invalid header").into(),
             te_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer)).into(),
@@ -1041,8 +1089,8 @@ fn test_height_defer_recheck_when_ledger_advances() {
             te_input("tp-1", &TrackPeersMsg::RecheckLedgerHeight).into(),
             tm_volatile_tip("tp-1"),
             te_clock_suspend("tp-1").into(),
+            te_get_nonces("tp-1", header.hash()).into(),
             te_validate_header("tp-1", header.clone()).into(),
-            te_has_header("tp-1", header.hash()).into(),
             te_store_header("tp-1", header.clone()).into(),
             te_send("tp-1", "downstream", new_tip(header.tip(), Point::Origin)).into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
@@ -1169,6 +1217,7 @@ fn test_pipelined_stake_defer_and_wake_sequence() {
             te_input("tp-1", &msg1).into(),
             te_clock_suspend("tp-1").into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
+            te_get_nonces("tp-1", h1.hash()).into(),
             te_validate_header("tp-1", h1.clone()).into(),
             tm_state::<TrackPeers>("tp-1", |s| s.deferred.len() == 1, "first stake deferred"),
             te_input("tp-1", &msg2).into(),
@@ -1177,12 +1226,12 @@ fn test_pipelined_stake_defer_and_wake_sequence() {
             te_input("tp-1", &wake).into(),
             tm_volatile_tip("tp-1"),
             te_clock_suspend("tp-1").into(),
+            te_get_nonces("tp-1", h1.hash()).into(),
             te_validate_header("tp-1", h1.clone()).into(),
-            te_has_header("tp-1", h1.hash()).into(),
             te_store_header("tp-1", h1.clone()).into(),
             te_send("tp-1", "downstream", new_tip(h1.tip(), parent.point())).into(),
+            te_get_nonces("tp-1", h2.hash()).into(),
             te_validate_header("tp-1", h2.clone()).into(),
-            te_has_header("tp-1", h2.hash()).into(),
             te_store_header("tp-1", h2.clone()).into(),
             te_send("tp-1", "downstream", new_tip(h2.tip(), h1.point())).into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),

--- a/crates/amaru-consensus/src/stages/track_peers/tests.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/tests.rs
@@ -17,7 +17,7 @@ use std::{self, slice, time::Duration};
 use amaru_kernel::{BlockHeight, Epoch, EraHistory, EraName, HeaderHash, IsHeader, Peer, Point, Tip, num::CheckedSub};
 use amaru_metrics::consensus::ConsensusMetrics;
 use amaru_ouroboros::ConnectionId;
-use amaru_ouroboros_traits::has_stake_distribution::GetPoolError;
+use amaru_ouroboros_traits::{Nonces, has_stake_distribution::GetPoolError};
 use amaru_protocols::chainsync::{
     self, ChainSyncInitiatorMsg, HeaderContent, InitiatorMessage, InitiatorMessage::RequestNext,
 };
@@ -38,7 +38,7 @@ use crate::{
             test_setup::{
                 HEIGHT_RECHECK_INTERVAL, build_store, build_store_with_nonces, height_recheck_schedule_id,
                 make_block_header, new_tip, schedule_id_at, setup, setup_base, setup_with_ledger_tip_until_sleeping,
-                te_clock, te_clock_suspend, te_get_nonces, te_load_tip, te_schedule, te_store_header,
+                te_clock, te_clock_suspend, te_get_nonces, te_load_tip, te_schedule, te_store_validated_header,
                 te_validate_header, test_prep, test_prep_with_max_peer_lead, tm_volatile_tip,
             },
         },
@@ -370,7 +370,8 @@ fn test_roll_forward_known_peer_header_already_stored() {
 /// A header imported during bootstrap is present in the chain store but has no evolved nonces.
 /// When re-received from a peer, its nonces must still be computed (via `validate_header`) so
 /// that descendant headers can be validated. Nonce absence means the header was never fully
-/// validated, so it is treated like a new header: stored (idempotent) and propagated downstream.
+/// validated, so it is treated like a new header: stored with its nonces and propagated
+/// downstream.
 #[test]
 fn test_roll_forward_stored_header_missing_nonces_revalidates() {
     let prep = test_prep();
@@ -402,7 +403,7 @@ fn test_roll_forward_stored_header_missing_nonces_revalidates() {
             te_send("tp-1", &prep.handler, RequestNext).into(),
             te_get_nonces("tp-1", header.hash()).into(),
             te_validate_header("tp-1", header.clone()).into(),
-            te_store_header("tp-1", header.clone()).into(),
+            te_store_validated_header("tp-1", header.clone()).into(),
             te_send("tp-1", "downstream", new_tip(header.tip(), parent.point())).into(),
             te_state("tp-1", &expected).into(),
         ],
@@ -443,7 +444,7 @@ fn test_roll_forward_known_peer_new_header_forwards_tip() {
             te_send("tp-1", &prep.handler, RequestNext).into(),
             te_get_nonces("tp-1", header.hash()).into(),
             te_validate_header("tp-1", header.clone()).into(),
-            te_store_header("tp-1", header.clone()).into(),
+            te_store_validated_header("tp-1", header.clone()).into(),
             te_send("tp-1", "downstream", new_tip(header.tip(), parent.point())).into(),
             te_state("tp-1", &expected).into(),
         ],
@@ -756,7 +757,7 @@ fn test_roll_forward_header_slot_near_future_defers() {
             tm_state::<TrackPeers>("tp-1", |s| s.deferred.len() == 1, "clock skew deferred"),
             te_input("tp-1", &TrackPeersMsg::RecheckLedgerHeight).into(),
             te_validate_header("tp-1", header.clone()).into(),
-            te_store_header("tp-1", header.clone()).into(),
+            te_store_validated_header("tp-1", header.clone()).into(),
             tm_state::<TrackPeers>("tp-1", |s| s.deferred.is_empty(), "processed after recheck"),
         ],
     );
@@ -1068,7 +1069,9 @@ fn test_height_defer_recheck_when_ledger_advances() {
                 // First call (defer decision) still at origin; recheck sees advanced height.
                 if n == 1 { OverrideResult::handled(Tip::origin()) } else { OverrideResult::handled(advanced_tip) }
             });
-            running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| OverrideResult::handled(Ok(())));
+            running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| {
+                OverrideResult::handled(Ok(Nonces::for_tests()))
+            });
         });
 
     logs.assert_and_remove(Level::DEBUG, &["track_peers.defer_request_next"])
@@ -1091,7 +1094,7 @@ fn test_height_defer_recheck_when_ledger_advances() {
             te_clock_suspend("tp-1").into(),
             te_get_nonces("tp-1", header.hash()).into(),
             te_validate_header("tp-1", header.clone()).into(),
-            te_store_header("tp-1", header.clone()).into(),
+            te_store_validated_header("tp-1", header.clone()).into(),
             te_send("tp-1", "downstream", new_tip(header.tip(), Point::Origin)).into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
             tm_state::<TrackPeers>(
@@ -1132,7 +1135,9 @@ fn test_pipelined_headers_after_slot_near_future_defer() {
 
     let (running, _guards, mut logs) =
         setup_base(&prep.rt_handle(), state.clone(), [msg1.clone(), msg2.clone()], build_store(&[]), |running| {
-            running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| OverrideResult::handled(Ok(())));
+            running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| {
+                OverrideResult::handled(Ok(Nonces::for_tests()))
+            });
         });
 
     logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
@@ -1198,7 +1203,7 @@ fn test_pipelined_stake_defer_and_wake_sequence() {
                         GetPoolError::StakeDistributionNotAvailable(slot1, Some(target_epoch)),
                     ))))
                 } else {
-                    OverrideResult::handled(Ok(()))
+                    OverrideResult::handled(Ok(Nonces::for_tests()))
                 }
             });
         },
@@ -1228,11 +1233,11 @@ fn test_pipelined_stake_defer_and_wake_sequence() {
             te_clock_suspend("tp-1").into(),
             te_get_nonces("tp-1", h1.hash()).into(),
             te_validate_header("tp-1", h1.clone()).into(),
-            te_store_header("tp-1", h1.clone()).into(),
+            te_store_validated_header("tp-1", h1.clone()).into(),
             te_send("tp-1", "downstream", new_tip(h1.tip(), parent.point())).into(),
             te_get_nonces("tp-1", h2.hash()).into(),
             te_validate_header("tp-1", h2.clone()).into(),
-            te_store_header("tp-1", h2.clone()).into(),
+            te_store_validated_header("tp-1", h2.clone()).into(),
             te_send("tp-1", "downstream", new_tip(h2.tip(), h1.point())).into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
             tm_state::<TrackPeers>(

--- a/crates/amaru-consensus/src/store.rs
+++ b/crates/amaru-consensus/src/store.rs
@@ -44,6 +44,8 @@ impl Praos<BlockHeader> for PraosChainStore {
     ///
     /// Once the stability window has been reached, the candidate is fixed for the epoch and will
     /// be used once crossing the epoch boundary to produce the next epoch nonce.
+    ///
+    /// Return the evolved nonces.
     fn evolve_nonce(&self, header: &BlockHeader) -> Result<Nonces, Self::Error> {
         let (epoch, is_within_stability_window) = nonce::randomness_stability_window(
             header,
@@ -52,58 +54,31 @@ impl Praos<BlockHeader> for PraosChainStore {
         )
         .map_err(NoncesError::EraHistoryError)?;
 
+        // Get the necessary data from the store
         let parent_hash = header.parent().unwrap_or((&Point::Origin).into());
-
         let parent_nonces = self
             .store
             .get_nonces(&parent_hash)
             .ok_or_else(|| NoncesError::UnknownParent { header: header.hash(), parent: parent_hash })?;
 
-        // Compute the new evolving nonce by combining it with the current one and the header's VRF
-        // output.
-        let evolving = nonce::evolve(header, &parent_nonces.evolving);
-
-        let nonces = Nonces {
-            epoch,
-            evolving,
-
-            // On epoch changes, compute the new active nonce by combining:
-            //   1. the (now stable) candidate; and
-            //   2. the previous epoch's last block's parent header hash.
-            //
-            // If the epoch hasn't changed, then our active nonce is unchanged.
-            active: if epoch > parent_nonces.epoch {
-                let tail = self
-                    .store
-                    .load_header(&parent_nonces.tail)
-                    .ok_or(NoncesError::UnknownHeader { header: parent_nonces.tail })?;
-                nonce::from_candidate(&tail, &parent_nonces.candidate)
-                    .ok_or(NoncesError::NoParentHeader { header: parent_nonces.tail })?
-            } else {
-                parent_nonces.active
-            },
-
-            // Unless we are within the randomness stability window, we also update the candidate. This
-            // means that outside of the stability window, we always have:
-            //
-            //   evolving == candidate
-            //
-            // They only diverge for the last blocks of each epoch; The candidate remains stable while
-            // the rolling nonce keeps evolving in preparation of the next epoch. Another way to look
-            // at it is to think that there's always an entire epoch length contributing to the nonce
-            // randomness, but it spans over two epochs.
-            candidate: if is_within_stability_window { evolving } else { parent_nonces.candidate },
-
-            // On epoch changes, the parent header is -- by definition -- the last header of the
-            // previous epoch.
-            //
-            // Otherwise, the tail remains unchanged.
-            tail: if epoch > parent_nonces.epoch { parent_hash } else { parent_nonces.tail },
+        // The last header of the previous epoch is only needed when crossing an epoch boundary.
+        let previous_epoch_tail_parent_hash = if epoch > parent_nonces.epoch {
+            self.store
+                .load_header(&parent_nonces.tail)
+                .ok_or(NoncesError::UnknownHeader { header: parent_nonces.tail })?
+                .parent_hash()
+        } else {
+            None
         };
 
-        self.store.put_nonces(&header.hash(), &nonces)?;
-
-        Ok(nonces)
+        // Evolve the nonces per se
+        Ok(nonce::evolve_nonces(
+            header,
+            &parent_nonces,
+            epoch,
+            is_within_stability_window,
+            previous_epoch_tail_parent_hash,
+        ))
     }
 }
 
@@ -114,9 +89,6 @@ pub enum NoncesError {
 
     #[error("unknown header: {header}")]
     UnknownHeader { header: HeaderHash },
-
-    #[error("no parent header for: {header} (where one is clearly expected)")]
-    NoParentHeader { header: HeaderHash },
 
     #[error("{0}")]
     StoreError(#[from] StoreError),
@@ -133,7 +105,7 @@ mod test {
         BlockHeader, Epoch, EraHistory, GlobalParameters, IsHeader, PREPROD_ERA_HISTORY, PREPROD_GLOBAL_PARAMETERS,
         from_cbor, hash, to_cbor,
     };
-    use amaru_ouroboros_traits::{BaseReadChainStore, WriteChainStore, in_memory_chain_store::InMemoryChainStore};
+    use amaru_ouroboros_traits::{WriteChainStore, in_memory_chain_store::InMemoryChainStore};
     use proptest::{prelude::*, prop_compose, proptest};
 
     use super::*;
@@ -188,7 +160,7 @@ mod test {
         current: &BlockHeader,
         era_history: &EraHistory,
         global_parameters: &GlobalParameters,
-    ) -> Option<Nonces> {
+    ) -> Nonces {
         let store = Arc::new(InMemoryChainStore::default());
         let consensus_parameters = Arc::new(ConsensusParameters::new(global_parameters.clone(), era_history));
 
@@ -198,10 +170,8 @@ mod test {
         // Have information about the direct parent.
         store.put_nonces(&parent.0.hash(), parent.1).expect("database failure");
 
-        // Evolve the current nonce so that 'get_nonces' can then return a result.
         let praos_store = PraosChainStore::new(consensus_parameters, store.clone());
-        praos_store.evolve_nonce(current).expect("evolve nonce failed");
-        store.get_nonces(&current.hash())
+        praos_store.evolve_nonce(current).expect("evolve nonce failed")
     }
 
     #[test]
@@ -213,9 +183,8 @@ mod test {
                 &PREPROD_HEADER_70070379,
                 &PREPROD_ERA_HISTORY,
                 &PREPROD_GLOBAL_PARAMETERS
-            )
-            .as_ref(),
-            Some(&*PREPROD_NONCES_70070379)
+            ),
+            *PREPROD_NONCES_70070379
         )
     }
 
@@ -228,9 +197,8 @@ mod test {
                 &PREPROD_HEADER_70070426,
                 &PREPROD_ERA_HISTORY,
                 &PREPROD_GLOBAL_PARAMETERS
-            )
-            .as_ref(),
-            Some(&*PREPROD_NONCES_70070426)
+            ),
+            *PREPROD_NONCES_70070426
         )
     }
 
@@ -243,9 +211,8 @@ mod test {
                 &PREPROD_HEADER_70070464,
                 &PREPROD_ERA_HISTORY,
                 &PREPROD_GLOBAL_PARAMETERS
-            )
-            .as_ref(),
-            Some(&*PREPROD_NONCES_70070464)
+            ),
+            *PREPROD_NONCES_70070464
         )
     }
 

--- a/crates/amaru-consensus/src/validate_header.rs
+++ b/crates/amaru-consensus/src/validate_header.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use amaru_kernel::{BlockHeader, ConsensusParameters, Epoch, EraHistory, IsHeader, to_cbor};
 use amaru_observability::debug_span;
 use amaru_ouroboros::praos::{self, header::AssertHeaderError};
-use amaru_ouroboros_traits::{ChainStore, PoolSummaries, Praos, has_stake_distribution::GetPoolError};
+use amaru_ouroboros_traits::{ChainStore, Nonces, PoolSummaries, Praos, has_stake_distribution::GetPoolError};
 
 use crate::{
     errors::ConsensusError,
@@ -45,11 +45,14 @@ impl ValidateHeaderError {
     }
 }
 
-/// Validate a block header.
+/// Validate a block header and return its evolved nonces.
 ///
 /// This is the core implementation, intended to be called from within an external effect
 /// (ValidateHeaderEffect) so that up-to-date resources (in particular PoolSummaries) can be
 /// obtained on each use.
+///
+/// Nothing is written to the store here. The returned nonces are meant to be stored atomically
+/// with the header itself, so that stored nonces always denote a fully validated header.
 #[allow(clippy::result_large_err)]
 pub fn validate_header(
     header: &BlockHeader,
@@ -57,13 +60,12 @@ pub fn validate_header(
     store: Arc<dyn ChainStore>,
     pool_summaries: Arc<PoolSummaries>,
     era_history: Arc<EraHistory>,
-) -> Result<(), ValidateHeaderError> {
+) -> Result<Nonces, ValidateHeaderError> {
     let _span = debug_span!(consensus::header::VALIDATE, header_hash = &header.hash()).entered();
     let _guard = _span.enter();
 
-    let epoch_nonce = debug_span!(consensus::header::EVOLVE_NONCE, header_hash = header.hash())
-        .in_scope(|| PraosChainStore::new(consensus_parameters.clone(), store.clone()).evolve_nonce(header))?
-        .active;
+    let nonces = debug_span!(consensus::header::EVOLVE_NONCE, header_hash = header.hash())
+        .in_scope(|| PraosChainStore::new(consensus_parameters.clone(), store.clone()).evolve_nonce(header))?;
 
     debug_span!(consensus::header::CHECK, issuer_key = &header.header_body().issuer_vkey).in_scope(|| {
         let pool_id = header.pool_id();
@@ -81,7 +83,7 @@ pub fn validate_header(
             to_cbor(&header.header_body()).as_slice(),
             last_opcert_sequence_number,
             &pool_summary,
-            &epoch_nonce,
+            &nonces.active,
         )
         .and_then(|assertions| {
             use rayon::prelude::*;
@@ -90,5 +92,56 @@ pub fn validate_header(
         .map_err(ValidateHeaderError::Assert)
     })?;
 
-    Ok(())
+    Ok(nonces)
+}
+
+#[cfg(test)]
+mod test {
+    use amaru_kernel::{Epoch, PREPROD_ERA_HISTORY, PREPROD_GLOBAL_PARAMETERS, hash};
+    use amaru_ouroboros_traits::{
+        BaseReadChainStore, Nonces, WriteChainStore, in_memory_chain_store::InMemoryChainStore,
+    };
+
+    use super::*;
+    use crate::test::include_header;
+
+    include_header!(PREPROD_HEADER_69638382, 69638382);
+    include_header!(PREPROD_HEADER_70070331, 70070331);
+    include_header!(PREPROD_HEADER_70070379, 70070379);
+
+    /// Nonces are only made durable by the caller, so a header failing the Praos checks leaves
+    /// nothing behind: stored nonces always denote a fully validated header.
+    #[test]
+    fn no_nonces_are_stored_for_an_invalid_header() {
+        let store = Arc::new(InMemoryChainStore::default());
+        store.store_header(&PREPROD_HEADER_69638382).expect("database failure");
+        store
+            .put_nonces(
+                &PREPROD_HEADER_70070331.hash(),
+                &Nonces {
+                    epoch: Epoch::from(165),
+                    active: hash!("a7c4477e9fcfd519bf7dcba0d4ffe35a399125534bc8c60fa89ff6b50a060a7a"),
+                    candidate: hash!("74fe03b10c4f52dd41105a16b5f6a11015ec890a001a5253db78a779fe43f6b6"),
+                    evolving: hash!("9b945f3c45b140f796f0d2ec81c48b50730044bf75eb7208c85f6195f68e9b8c"),
+                    tail: hash!("5da6ba37a4a07df015c4ea92c880e3600d7f098b97e73816f8df04bbb5fad3b7"),
+                },
+            )
+            .expect("database failure");
+
+        let header = &*PREPROD_HEADER_70070379;
+        let consensus_parameters =
+            Arc::new(ConsensusParameters::new(PREPROD_GLOBAL_PARAMETERS.clone(), &PREPROD_ERA_HISTORY));
+
+        // No stake distribution is available, so the header cannot be validated.
+        let result = validate_header(
+            header,
+            consensus_parameters,
+            store.clone(),
+            Arc::new(PoolSummaries::default()),
+            Arc::new(PREPROD_ERA_HISTORY.clone()),
+        );
+
+        assert!(result.is_err(), "the header should not validate");
+        assert_eq!(store.get_nonces(&header.hash()), None);
+    }
 }

--- a/crates/amaru-node/src/tests/setup.rs
+++ b/crates/amaru-node/src/tests/setup.rs
@@ -24,7 +24,7 @@ use amaru_consensus::{
 };
 use amaru_kernel::{BlockHeight, ConsensusParameters, IsHeader, NetworkName, NonEmptyVec, Tip, Transaction};
 use amaru_ouroboros::{
-    BaseReadChainStore, ConnectionsResource, DiagnosticChainStore, MockBlockValidator, MockCanValidateTxs,
+    BaseReadChainStore, ConnectionsResource, DiagnosticChainStore, MockBlockValidator, MockCanValidateTxs, Nonces,
     PoolSummaries, ResourceMempool, has_stake_pools::MockHasStakePools,
 };
 use amaru_protocols::{
@@ -67,7 +67,9 @@ pub fn create_nodes(rng: &mut RandStdRng, configs: Vec<NodeTestConfig>) -> anyho
 
         let mut running = stage_graph.run();
         // Don't validate the generated headers, we just want to check the mini-protocols communication.
-        running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| OverrideResult::handled(Ok(())));
+        running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| {
+            OverrideResult::handled(Ok(Nonces::for_tests()))
+        });
 
         nodes.push(Node::new(config, running, test_node_stages));
     }
@@ -160,7 +162,7 @@ async fn actions_stage(state: ActionsState, msg: Action, eff: Effects<Action>) -
         Action::RollForward { header, .. } => {
             tracing::info!(point = %header.point(), "rollforward");
             store
-                .store_header(header)
+                .store_validated_header(header, &Nonces::for_tests())
                 .or_terminate_with(&eff, |e| async move {
                     tracing::error!("Cannot store the header {}: {e:?}. The seed is {seed}", &header);
                 })

--- a/crates/amaru-ouroboros-traits/src/praos/nonces.rs
+++ b/crates/amaru-ouroboros-traits/src/praos/nonces.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{Epoch, HeaderHash, Nonce, cbor};
+use amaru_kernel::{Epoch, Hasher, HeaderHash, Nonce, cbor};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Nonces {
@@ -21,6 +21,21 @@ pub struct Nonces {
     pub candidate: Nonce,
     pub tail: HeaderHash,
     pub epoch: Epoch,
+}
+
+impl Nonces {
+    /// The active nonce for the epoch starting after these nonces, derived from the candidate
+    /// (stable by then) and the parent hash of the last header of the previous epoch.
+    pub fn next_active(&self, hash: HeaderHash) -> Nonce {
+        Hasher::<256>::hash(&[&self.candidate[..], &hash[..]].concat())
+    }
+
+    /// Zeroed nonces, for tests that need a `Nonces` value whose contents they never inspect.
+    #[cfg(feature = "test-utils")]
+    pub fn for_tests() -> Self {
+        let zero = Nonce::from([0u8; 32]);
+        Nonces { active: zero, evolving: zero, candidate: zero, tail: zero, epoch: Epoch::from(0) }
+    }
 }
 
 impl<C> cbor::encode::Encode<C> for Nonces {

--- a/crates/amaru-ouroboros-traits/src/stores/chain_store/in_memory_chain_store.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/chain_store/in_memory_chain_store.rs
@@ -75,6 +75,25 @@ impl InMemoryChainStoreInner {
             block_validity: BTreeMap::new(),
         }
     }
+
+    /// Record a header, its link to its parent, and the opcert sequence number it declares. Every
+    /// stored header must contribute to the opcert index, otherwise the sequence numbers observed
+    /// on the chain go stale and subsequent headers get rejected as being too far ahead.
+    fn put_header(&mut self, header: &BlockHeader) {
+        let hash = header.hash();
+        self.headers.insert(hash, header.clone());
+        let parent_hash = header.parent().unwrap_or(ORIGIN_HASH);
+        let children = self.parent_child_relationship.entry(parent_hash).or_default();
+        if !children.contains(&hash) {
+            children.push(hash);
+        };
+        self.opcert_sequence_numbers
+            .entry(header.pool_id())
+            .or_default()
+            .entry(header.slot())
+            .or_default()
+            .insert(hash, header.op_cert_seq());
+    }
 }
 
 impl BaseReadChainStore for InMemoryChainStore {
@@ -185,21 +204,16 @@ impl ReadChainStore for InMemoryChainStore {
 impl WriteChainStore for InMemoryChainStore {
     #[expect(clippy::unwrap_used)]
     fn store_header(&self, header: &BlockHeader) -> Result<(), StoreError> {
-        let hash = header.hash();
         let mut inner = self.inner.lock().unwrap();
-        inner.headers.insert(hash, header.clone());
-        let parent_hash = header.parent().unwrap_or(ORIGIN_HASH);
-        let children = inner.parent_child_relationship.entry(parent_hash).or_default();
-        if !children.contains(&hash) {
-            children.push(hash);
-        };
-        inner
-            .opcert_sequence_numbers
-            .entry(header.pool_id())
-            .or_default()
-            .entry(header.slot())
-            .or_default()
-            .insert(hash, header.op_cert_seq());
+        inner.put_header(header);
+        Ok(())
+    }
+
+    #[expect(clippy::unwrap_used)]
+    fn store_validated_header(&self, header: &BlockHeader, nonces: &Nonces) -> Result<(), StoreError> {
+        let mut inner = self.inner.lock().unwrap();
+        inner.put_header(header);
+        inner.nonces.insert(header.hash(), nonces.clone());
         Ok(())
     }
 

--- a/crates/amaru-ouroboros-traits/src/stores/chain_store/overriding_chain_store.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/chain_store/overriding_chain_store.rs
@@ -55,6 +55,8 @@ struct Overrides {
     >,
     has_header: Option<Box<dyn FnMut(&dyn BaseReadChainStore, &HeaderHash) -> bool + Send>>,
     store_header: Option<Box<dyn FnMut(&dyn ChainStore, &BlockHeader) -> Result<(), StoreError> + Send>>,
+    store_validated_header:
+        Option<Box<dyn FnMut(&dyn ChainStore, &BlockHeader, &Nonces) -> Result<(), StoreError> + Send>>,
     set_anchor_hash: Option<Box<dyn FnMut(&dyn ChainStore, &HeaderHash) -> Result<(), StoreError> + Send>>,
     set_best_chain_hash: Option<Box<dyn FnMut(&dyn ChainStore, &HeaderHash) -> Result<(), StoreError> + Send>>,
     store_block: Option<Box<dyn FnMut(&dyn ChainStore, &HeaderHash, &RawBlock) -> Result<(), StoreError> + Send>>,
@@ -187,6 +189,14 @@ impl OverridingChainStoreBuilder {
         F: FnMut(&dyn ChainStore, &BlockHeader) -> Result<(), StoreError> + Send + 'static,
     {
         self.overrides.store_header = Some(Box::new(f));
+        self
+    }
+
+    pub fn with_store_validated_header<F>(mut self, f: F) -> Self
+    where
+        F: FnMut(&dyn ChainStore, &BlockHeader, &Nonces) -> Result<(), StoreError> + Send + 'static,
+    {
+        self.overrides.store_validated_header = Some(Box::new(f));
         self
     }
 
@@ -475,6 +485,14 @@ impl WriteChainStore for OverridingChainStore {
         match &mut overrides.store_header {
             Some(f) => f(self.inner.as_ref(), header),
             None => self.inner.store_header(header),
+        }
+    }
+
+    fn store_validated_header(&self, header: &BlockHeader, nonces: &Nonces) -> Result<(), StoreError> {
+        let mut overrides = self.overrides.lock();
+        match &mut overrides.store_validated_header {
+            Some(f) => f(self.inner.as_ref(), header, nonces),
+            None => self.inner.store_validated_header(header, nonces),
         }
     }
 

--- a/crates/amaru-ouroboros-traits/src/stores/chain_store/write_chain_store.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/chain_store/write_chain_store.rs
@@ -20,6 +20,12 @@ use crate::{Nonces, OpcertSequenceNumbers, StoreError};
 pub trait WriteChainStore: Send + Sync {
     fn store_header(&self, header: &BlockHeader) -> Result<(), StoreError>;
 
+    /// Store a header together with its evolved nonces in a single store operation.
+    ///
+    /// Both are written atomically so that the presence of nonces for a header always means that
+    /// this header was fully validated.
+    fn store_validated_header(&self, header: &BlockHeader, nonces: &Nonces) -> Result<(), StoreError>;
+
     /// TODO: use a set_anchor_tip function instead
     fn set_anchor_hash(&self, hash: &HeaderHash) -> Result<(), StoreError>;
 

--- a/crates/amaru-ouroboros/src/praos/nonce.rs
+++ b/crates/amaru-ouroboros/src/praos/nonce.rs
@@ -12,17 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{Epoch, EraHistory, EraHistoryError, Hasher, IsHeader, Nonce};
+use amaru_kernel::{Epoch, EraHistory, EraHistoryError, Hasher, HeaderHash, IsHeader, Nonce, ORIGIN_HASH};
+use amaru_ouroboros_traits::Nonces;
 
 use crate::vrf;
 
-/// Obtain the final nonce at an epoch boundary for the epoch from the stable candidate and the
-/// last block (header) of the previous epoch.
-///
-/// Return `None` if header has no parent (i.e. which never happens because all our blocks have
-/// parents in Amaru).
-pub fn from_candidate<H: IsHeader>(header: &H, candidate: &Nonce) -> Option<Nonce> {
-    Some(Hasher::<256>::hash(&[&candidate[..], &header.parent()?[..]].concat()))
+/// Compute the nonces of a header from the nonces of its parent.
+pub fn evolve_nonces<H: IsHeader>(
+    header: &H,
+    parent_nonces: &Nonces,
+    epoch: Epoch,
+    is_within_stability_window: bool,
+    previous_epoch_tail_parent_hash: Option<HeaderHash>,
+) -> Nonces {
+    // Compute the new evolving nonce by combining it with the current one and the header's VRF
+    // output.
+    let evolving = evolve(header, &parent_nonces.evolving);
+
+    // Unless we are within the randomness stability window, we also update the candidate. This
+    // means that outside of the stability window, we always have:
+    //
+    //   evolving == candidate
+    //
+    // They only diverge for the last blocks of each epoch; The candidate remains stable while
+    // the rolling nonce keeps evolving in preparation of the next epoch. Another way to look
+    // at it is to think that there's always an entire epoch length contributing to the nonce
+    // randomness, but it spans over two epochs.
+    let candidate = if is_within_stability_window { evolving } else { parent_nonces.candidate };
+
+    // The active nonce is either:
+    //  1. the active parent nonce if there's no epoch change.
+    //  2. the combination of the stable candidate and the previous epoch's last block's parent header hash.
+    //
+    // The tail is either
+    //  1. the parent_nonce tail if there is no epoch change.
+    //  2. the parent hash of the current header (the last header hash of the previous epoch).
+    //
+    let (active, tail) = match previous_epoch_tail_parent_hash {
+        Some(previous_epoch_tail_parent_hash) => {
+            (parent_nonces.next_active(previous_epoch_tail_parent_hash), header.parent().unwrap_or(ORIGIN_HASH))
+        }
+        None => (parent_nonces.active, parent_nonces.tail),
+    };
+
+    Nonces { epoch, evolving, candidate, active, tail }
 }
 
 /// Evolve the current nonce by combining it with the current rolling nonce and the

--- a/crates/amaru-protocols/src/store_effects.rs
+++ b/crates/amaru-protocols/src/store_effects.rs
@@ -108,8 +108,12 @@ impl Store {
         self.effects.external(SetBestChainHashEffect::new(*hash))
     }
 
-    pub fn store_header(&self, header: &BlockHeader) -> BoxFuture<'static, Result<(), StoreError>> {
-        self.effects.external(StoreHeaderEffect::new(header.clone()))
+    pub fn store_validated_header(
+        &self,
+        header: &BlockHeader,
+        nonces: &Nonces,
+    ) -> BoxFuture<'static, Result<(), StoreError>> {
+        self.effects.external(StoreValidatedHeaderEffect::new(header.clone(), nonces.clone()))
     }
 
     pub fn store_block(&self, hash: &HeaderHash, block: &RawBlock) -> BoxFuture<'static, Result<(), StoreError>> {
@@ -187,7 +191,7 @@ pub type ResourceParameters = GlobalParameters;
 
 pub fn register_deserializers() -> DeserializerGuards {
     vec![
-        amaru_pure_stage::register_effect_deserializer::<StoreHeaderEffect>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<StoreValidatedHeaderEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<StoreBlockEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<SetAnchorHashEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<SetBestChainHashEffect>().boxed(),
@@ -221,28 +225,31 @@ pub fn register_deserializers() -> DeserializerGuards {
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct StoreHeaderEffect {
+pub struct StoreValidatedHeaderEffect {
     header: BlockHeader,
+    nonces: Nonces,
 }
 
-impl StoreHeaderEffect {
-    pub fn new(header: BlockHeader) -> Self {
-        Self { header }
+impl StoreValidatedHeaderEffect {
+    pub fn new(header: BlockHeader, nonces: Nonces) -> Self {
+        Self { header, nonces }
     }
 }
 
-impl ExternalEffect for StoreHeaderEffect {
+impl ExternalEffect for StoreValidatedHeaderEffect {
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
         Self::wrap_sync({
-            let store =
-                resources.get::<ResourceHeaderStore>().expect("StoreHeaderEffect requires a chain store").clone();
-            store.store_header(&self.header)
+            let store = resources
+                .get::<ResourceHeaderStore>()
+                .expect("StoreValidatedHeaderEffect requires a chain store")
+                .clone();
+            store.store_validated_header(&self.header, &self.nonces)
         })
     }
 }
 
-impl ExternalEffectAPI for StoreHeaderEffect {
+impl ExternalEffectAPI for StoreValidatedHeaderEffect {
     type Response = Result<(), StoreError>;
 }
 

--- a/crates/amaru-protocols/src/tests/chainsync_stage.rs
+++ b/crates/amaru-protocols/src/tests/chainsync_stage.rs
@@ -15,6 +15,7 @@
 use std::{collections::VecDeque, sync::Arc, time::Duration};
 
 use amaru_kernel::{BlockHeader, IsHeader, Point, cbor};
+use amaru_ouroboros_traits::Nonces;
 use amaru_pure_stage::{Effects, StageRef};
 use tokio::sync::Notify;
 
@@ -206,7 +207,7 @@ pub(super) async fn test_chainsync_stage(
             tracing::info!(%peer, hash = header_hash.to_string(), %tip, "roll forward");
 
             // store the header, update the best chain, fetch and store the block
-            store.store_header(&block_header).await.unwrap();
+            store.store_validated_header(&block_header, &Nonces::for_tests()).await.unwrap();
             store.roll_forward_chain(&point).await.unwrap();
             // We accumulate points to fetch and fetch them in batches of 3
             state.blocks_to_fetch.push(point);

--- a/crates/amaru-stores/src/rocksdb/consensus/tests.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/tests.rs
@@ -1231,6 +1231,32 @@ fn storing_a_header_records_its_opcert_sequence_number() {
 }
 
 #[test]
+fn storing_a_validated_header_records_its_opcert_sequence_number() {
+    with_db(|db| {
+        let header1 = make_block_header_with_op_cert_seq(1, 1, None, 3);
+        let header2 = make_block_header_with_op_cert_seq(2, 2, Some(header1.hash()), 4);
+        let header3 = make_block_header_with_op_cert_seq(3, 3, Some(header2.hash()), 5);
+        db.store_validated_header(&header1, &Nonces::for_tests()).unwrap();
+        db.roll_forward_chain(&header1.point()).unwrap();
+        db.set_anchor_hash(&header1.hash()).unwrap();
+        db.store_validated_header(&header2, &Nonces::for_tests()).unwrap();
+        db.store_validated_header(&header3, &Nonces::for_tests()).unwrap();
+        let pool_id = header1.pool_id();
+
+        assert_eq!(
+            db.get_latest_opcert_sequence_number(&pool_id, &header2).unwrap(),
+            Some(3),
+            "the opcert sequence number of its parent"
+        );
+        assert_eq!(
+            db.get_latest_opcert_sequence_number(&pool_id, &header3).unwrap(),
+            Some(4),
+            "the opcert sequence number of its parent"
+        );
+    })
+}
+
+#[test]
 fn pools_can_be_initialized_with_opcert_sequence_numbers() {
     with_db(|db| {
         // mirror bootstrap + first-start initialization (build_node.rs)

--- a/crates/amaru-stores/src/rocksdb/consensus/write_chain_store.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/write_chain_store.rs
@@ -15,7 +15,7 @@
 use amaru_kernel::{BlockHeader, HeaderHash, IsHeader, ORIGIN_HASH, Point, RawBlock, size::HEADER, to_cbor};
 use amaru_observability::debug_span;
 use amaru_ouroboros_traits::{Nonces, OpcertSequenceNumbers, StoreError, WriteChainStore};
-use rocksdb::{IteratorMode, PrefixRange, ReadOptions};
+use rocksdb::{IteratorMode, PrefixRange, ReadOptions, WriteBatch};
 
 use crate::rocksdb::consensus::{
     OPCERT_PREFIX, RocksDBStore,
@@ -28,13 +28,19 @@ impl WriteChainStore for RocksDBStore {
         let span = debug_span!(stores::consensus::header::STORE, hash = header.hash());
         let _guard = span.enter();
 
-        let hash = header.hash();
-        let parent_hash = header.parent().unwrap_or(ORIGIN_HASH);
+        self.with_batch(|batch| {
+            put_header(batch, header);
+            Ok(())
+        })
+    }
+
+    fn store_validated_header(&self, header: &BlockHeader, nonces: &Nonces) -> Result<(), StoreError> {
+        let span = debug_span!(stores::consensus::header::STORE, hash = header.hash());
+        let _guard = span.enter();
 
         self.with_batch(|batch| {
-            batch.put([&CHILD_PREFIX[..], &parent_hash[..], &hash[..]].concat(), []);
-            batch.put([&HEADER_PREFIX[..], &hash[..]].concat(), to_cbor(header));
-            batch.put(opcert_key(header), to_cbor(&header.op_cert_seq()));
+            put_header(batch, header);
+            batch.put([&NONCES_PREFIX[..], &header.hash()[..]].concat(), to_cbor(nonces));
             Ok(())
         })
     }
@@ -150,4 +156,16 @@ impl WriteChainStore for RocksDBStore {
             Ok(())
         })
     }
+}
+
+/// Record a header, its link to its parent, and the opcert sequence number it declares. Every
+/// stored header must contribute to the opcert index, otherwise the sequence numbers observed on
+/// the chain go stale and subsequent headers get rejected as being too far ahead.
+fn put_header(batch: &mut WriteBatch, header: &BlockHeader) {
+    let hash = header.hash();
+    let parent_hash = header.parent().unwrap_or(ORIGIN_HASH);
+
+    batch.put([&CHILD_PREFIX[..], &parent_hash[..], &hash[..]].concat(), []);
+    batch.put([&HEADER_PREFIX[..], &hash[..]].concat(), to_cbor(header));
+    batch.put(opcert_key(header), to_cbor(&header.op_cert_seq()));
 }

--- a/crates/amaru/src/bin/amaru/cmd/dev/ledger/sync.rs
+++ b/crates/amaru/src/bin/amaru/cmd/dev/ledger/sync.rs
@@ -166,9 +166,8 @@ async fn process_block(
     let network_block = NetworkBlock::try_from(raw_block)?;
     let block = network_block.decode_block()?;
     let block_header = BlockHeader::from(&block.header);
-    chain_store.store_header(&block_header)?;
     chain_store.store_block(&point.hash(), &network_block.raw_block())?;
-    let epoch_nonce = praos_chain_store.evolve_nonce(&block_header)?;
+    let nonces = praos_chain_store.evolve_nonce(&block_header)?;
 
     {
         let summaries = pool_summaries.read().unwrap();
@@ -183,10 +182,12 @@ async fn process_block(
             to_cbor(&block_header.header_body()).as_slice(),
             last_opcert_sequence_number,
             &pool_summary,
-            &epoch_nonce.active,
+            &nonces.active,
         )
         .and_then(|assertions| assertions.into_par_iter().try_for_each(|assert| assert()))?;
     }
+
+    chain_store.store_validated_header(&block_header, &nonces)?;
 
     // Verify block content
     block_validator


### PR DESCRIPTION
This PR skips the verification of a header when it has already been stored in the `ChainStore`.
This situation can happen when there are multiple upstream peers sending us the same headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced nonce-aware header validation so duplicate headers are handled more efficiently when evolved nonces are already stored.
  * Improved tip propagation by storing a newly validated header before forwarding downstream.
* **Bug Fixes**
  * Fixed scenarios where headers missing evolved nonces were not correctly revalidated and propagated after import/bootstrap.
  * Prevented duplicate-header reprocessing from triggering unnecessary storage or forwarding.
* **Tests**
  * Added nonce evolution and regression coverage, plus updated validation/tracing expectations for deferred and peer-related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->