### PR TITLE
fix: rollback in the future

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -47,18 +47,19 @@
     {
       "attr_path": "autoconf",
       "broken": false,
-      "derivation": "/nix/store/qzqqfiki3a3n678xx6xmlxgr2vs1li52-autoconf-2.73.drv",
+      "derivation": "/nix/store/mykf9gs1bg9k2y0745gymwvnymsbwfil-autoconf-2.73.drv",
       "description": "Part of the GNU Build System",
       "install_id": "autoconf",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "autoconf-2.73",
       "pname": "autoconf",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:13:13.588748Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:12:54.824053Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -67,8 +68,8 @@
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/gby6jfsjzmjwxwgswlxdx75i57zl2nb7-autoconf-2.73-doc",
-        "out": "/nix/store/z81cjs7gbr38jza8a9rslfb9x0nyywn1-autoconf-2.73"
+        "doc": "/nix/store/maz4kkn46fs0qdp1d7hf2sp4argija1r-autoconf-2.73-doc",
+        "out": "/nix/store/95l6ii3wvf2jb18qsv6c68zrh0icy124-autoconf-2.73"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -77,18 +78,19 @@
     {
       "attr_path": "autoconf",
       "broken": false,
-      "derivation": "/nix/store/b7q716v4qlk8n72k2h347y2afbdid9fa-autoconf-2.73.drv",
+      "derivation": "/nix/store/kc7a824d6jxkvl42kj30zdxjl4a99n52-autoconf-2.73.drv",
       "description": "Part of the GNU Build System",
       "install_id": "autoconf",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "autoconf-2.73",
       "pname": "autoconf",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:44:07.888732Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:41:21.337860Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -97,8 +99,8 @@
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/0bfq3980sll24xkk7i414gsxyw22jl42-autoconf-2.73-doc",
-        "out": "/nix/store/d8dbw6kvqzfmdnjv722yriflrx4rlykb-autoconf-2.73"
+        "doc": "/nix/store/1z7qbp9f9798p272kk86xiy2kmc22z25-autoconf-2.73-doc",
+        "out": "/nix/store/nm5rd8a2hwcr7hpmj3k9ycw8dfgkfflf-autoconf-2.73"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -107,18 +109,19 @@
     {
       "attr_path": "autoconf",
       "broken": false,
-      "derivation": "/nix/store/w4x1bajlysc9zsdh707wpwa4xvf2fsyp-autoconf-2.73.drv",
+      "derivation": "/nix/store/bia2waqhxwbfc6zkza67v18rj2xa1qc1-autoconf-2.73.drv",
       "description": "Part of the GNU Build System",
       "install_id": "autoconf",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "autoconf-2.73",
       "pname": "autoconf",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:13:05.842538Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:09:00.104573Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -127,8 +130,8 @@
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/sp3v3qb440px74xdilwmzlq2mdsdg91j-autoconf-2.73-doc",
-        "out": "/nix/store/5lpllx2pbgclzs2zdrss9hfcbwrdwnmb-autoconf-2.73"
+        "doc": "/nix/store/xcn9y4jclcmrny3v5p3fa09x2sdwmbr0-autoconf-2.73-doc",
+        "out": "/nix/store/fk6643wnsh9bp2ihcsshw13nawn4iqb6-autoconf-2.73"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -137,18 +140,19 @@
     {
       "attr_path": "autoconf",
       "broken": false,
-      "derivation": "/nix/store/31ziv3nbs6zfwwl0n48v7cp04hn2zq82-autoconf-2.73.drv",
+      "derivation": "/nix/store/nbvvyd2hwj5w97dfdj1dn6zq7qxgdbf2-autoconf-2.73.drv",
       "description": "Part of the GNU Build System",
       "install_id": "autoconf",
       "license": "GPL-3.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "autoconf-2.73",
       "pname": "autoconf",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:47:03.872766Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:40:23.943227Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -157,8 +161,8 @@
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/jvf8qvsfkmgqi83cg1fkb3clfwhq4lsg-autoconf-2.73-doc",
-        "out": "/nix/store/c3g361js93jz2xx8lx6mnmqg76lghxxh-autoconf-2.73"
+        "doc": "/nix/store/z7lc5ii3ygpndqc6k0w71rah3jxjnrw9-autoconf-2.73-doc",
+        "out": "/nix/store/l68kasv0m46dx3lf1972i21jsvwhxa03-autoconf-2.73"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -167,18 +171,19 @@
     {
       "attr_path": "blst",
       "broken": false,
-      "derivation": "/nix/store/a81wp06blzw9177n8h2gzhrfdbvx4zpp-blst-0.3.16.drv",
+      "derivation": "/nix/store/qn8hkxk9lzvsxk06dv5fhr8a3jll7g3h-blst-0.3.16.drv",
       "description": "Multilingual BLS12-381 signature library",
       "install_id": "blst",
       "license": "ISC",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "blst-0.3.16",
       "pname": "blst",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:13:13.684437Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:12:54.919780Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -187,7 +192,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/5n9iiqf7k4j9xvikinca13zjp0n9f4xh-blst-0.3.16"
+        "out": "/nix/store/ys0vjdwjiqzia83ysm20yz2xbcw9w2a3-blst-0.3.16"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -196,18 +201,19 @@
     {
       "attr_path": "blst",
       "broken": false,
-      "derivation": "/nix/store/9chcc1mp4zy54xlrqax72b5pvgvbl17a-blst-0.3.16.drv",
+      "derivation": "/nix/store/8vgghaxm9gdy7aa2vp18fw8yjqvgcl96-blst-0.3.16.drv",
       "description": "Multilingual BLS12-381 signature library",
       "install_id": "blst",
       "license": "ISC",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "blst-0.3.16",
       "pname": "blst",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:44:08.010569Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:41:21.462464Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -216,7 +222,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/mzdcbayg1xajics9k0d1m7gmf4cvpj63-blst-0.3.16"
+        "out": "/nix/store/l16sbiqw3rh8cjc373jaydr5bqk3skmz-blst-0.3.16"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -225,18 +231,19 @@
     {
       "attr_path": "blst",
       "broken": false,
-      "derivation": "/nix/store/z5n7p2lksdzpl50wac031fg88f3yrknq-blst-0.3.16.drv",
+      "derivation": "/nix/store/dz39kq5kwmzrpfbspl8fbnwncs01svrc-blst-0.3.16.drv",
       "description": "Multilingual BLS12-381 signature library",
       "install_id": "blst",
       "license": "ISC",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "blst-0.3.16",
       "pname": "blst",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:13:05.942352Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:09:00.223041Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -245,7 +252,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/c1g6slahxp2byqvlymdbzvx1nplqk6dd-blst-0.3.16"
+        "out": "/nix/store/i11d5z1yngs3kiian0qfy2j4ikizk8qk-blst-0.3.16"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -254,18 +261,19 @@
     {
       "attr_path": "blst",
       "broken": false,
-      "derivation": "/nix/store/qbazjhqp8i5xq02g0mnfc66jdr62fbi8-blst-0.3.16.drv",
+      "derivation": "/nix/store/3l1f1h1mjamfkcdy8p8zavp82gb56x0c-blst-0.3.16.drv",
       "description": "Multilingual BLS12-381 signature library",
       "install_id": "blst",
       "license": "ISC",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "blst-0.3.16",
       "pname": "blst",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:47:04.017833Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:40:24.080566Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -274,7 +282,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/km1c2fzvy8lp5zn19d3ap4jql1cqqsk6-blst-0.3.16"
+        "out": "/nix/store/q41jg3p588kjxlqsyvf1pnac34gy13xm-blst-0.3.16"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -283,18 +291,19 @@
     {
       "attr_path": "cabal-install",
       "broken": false,
-      "derivation": "/nix/store/si1f5a7mrp24kxfxj9dfigpjhf9d4xl4-cabal-install-3.16.1.0.drv",
+      "derivation": "/nix/store/hk1hhksl67mnlkhiw19c1scmc8w6pna8-cabal-install-3.16.1.0.drv",
       "description": "The command-line interface for Cabal and Hackage",
       "install_id": "cabal-install",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "cabal-install-3.16.1.0",
       "pname": "cabal-install",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:13:13.722485Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:12:54.958135Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -303,7 +312,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/i807ld6lmmwagy2nxjv1b5h4dlkfmbh8-cabal-install-3.16.1.0"
+        "out": "/nix/store/x5lhhs6zy187zli1xcikxzx9215zcpn8-cabal-install-3.16.1.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -312,18 +321,19 @@
     {
       "attr_path": "cabal-install",
       "broken": false,
-      "derivation": "/nix/store/cnmhk72msfj888p8axl00ws23grwmpi6-cabal-install-3.16.1.0.drv",
+      "derivation": "/nix/store/dsmy87gz1q3f49a3wjwagcpabxdhj6cs-cabal-install-3.16.1.0.drv",
       "description": "The command-line interface for Cabal and Hackage",
       "install_id": "cabal-install",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "cabal-install-3.16.1.0",
       "pname": "cabal-install",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:44:08.072971Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:41:21.527023Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -332,7 +342,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/51swwqyhfmrsr5jw7nwskc911gwy6yxv-cabal-install-3.16.1.0"
+        "out": "/nix/store/c5crlgay31plgklhj60ddkmxkh99ldqw-cabal-install-3.16.1.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -341,18 +351,19 @@
     {
       "attr_path": "cabal-install",
       "broken": false,
-      "derivation": "/nix/store/8z5dmz9bg7gfk4nykpdxzf4cn82q7bsc-cabal-install-3.16.1.0.drv",
+      "derivation": "/nix/store/91p8g2h3p5zpvhxx3m1d0fsvrzqsr3d2-cabal-install-3.16.1.0.drv",
       "description": "The command-line interface for Cabal and Hackage",
       "install_id": "cabal-install",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "cabal-install-3.16.1.0",
       "pname": "cabal-install",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:13:05.981708Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:09:00.279964Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -361,7 +372,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/7fvdjsbrhsiqs0w64sw1mxbgllzp8scc-cabal-install-3.16.1.0"
+        "out": "/nix/store/7crlb4czxxcblvxca912h4aa9rsfbqy4-cabal-install-3.16.1.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -370,18 +381,19 @@
     {
       "attr_path": "cabal-install",
       "broken": false,
-      "derivation": "/nix/store/4dnyqihgs4icwf02y1c27n3awpnci31z-cabal-install-3.16.1.0.drv",
+      "derivation": "/nix/store/qzd29pj4yj1mpykm2i3xmxsgxba0vv5k-cabal-install-3.16.1.0.drv",
       "description": "The command-line interface for Cabal and Hackage",
       "install_id": "cabal-install",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "cabal-install-3.16.1.0",
       "pname": "cabal-install",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:47:04.092769Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:40:24.151976Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -390,7 +402,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/9q4mgybs7ksxv9bdkyiwn1wgpffyj46i-cabal-install-3.16.1.0"
+        "out": "/nix/store/pvh1ldz8f3qm59q3q9yrrcll6yfsh4bv-cabal-install-3.16.1.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -399,18 +411,19 @@
     {
       "attr_path": "ghc",
       "broken": false,
-      "derivation": "/nix/store/77rnwmgqcd6ingj1wr85wszqkvspljf9-ghc-9.10.3.drv",
+      "derivation": "/nix/store/yn5mc195a63wyzng1h5sg4dfmph2afar-ghc-9.10.3.drv",
       "description": "Glasgow Haskell Compiler",
       "install_id": "ghc",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "ghc-9.10.3",
       "pname": "ghc",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:13:14.818140Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:12:56.071243Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -419,8 +432,8 @@
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/q0gkchl49abx3vlikl3v2cbwsr7spfq0-ghc-9.10.3-doc",
-        "out": "/nix/store/f8bybrcsifh30k70svzih0adh2030wq5-ghc-9.10.3"
+        "doc": "/nix/store/pm47i7lbn6rydyc8ns4dlv32acpx00cl-ghc-9.10.3-doc",
+        "out": "/nix/store/9ykfwdg0frscqp2v0ff8r7ljvjmmzgln-ghc-9.10.3"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -429,18 +442,19 @@
     {
       "attr_path": "ghc",
       "broken": false,
-      "derivation": "/nix/store/4khyrfvssf0y7rcq13xqadn6j6zskv04-ghc-9.10.3.drv",
+      "derivation": "/nix/store/cdnix7vxkq874crcj6w2ghml4wzrx2l3-ghc-9.10.3.drv",
       "description": "Glasgow Haskell Compiler",
       "install_id": "ghc",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "ghc-9.10.3",
       "pname": "ghc",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:44:09.746661Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:41:23.120660Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -449,8 +463,8 @@
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/kbdying5yj17xmmqdaa4ylz1k80jc4nm-ghc-9.10.3-doc",
-        "out": "/nix/store/352d96bs632x7npjbzkyhcg6jf15g04y-ghc-9.10.3"
+        "doc": "/nix/store/3kiw6bkv0pgmjzvb7jr9r1g2vilvp980-ghc-9.10.3-doc",
+        "out": "/nix/store/7h4xh484pcjxw9brf2swgmn0q8bawc11-ghc-9.10.3"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -459,18 +473,19 @@
     {
       "attr_path": "ghc",
       "broken": false,
-      "derivation": "/nix/store/fi89slp9vzkyxah0yc4ql5zw05i3y28z-ghc-9.10.3.drv",
+      "derivation": "/nix/store/9q2wyf1s89qvah7xsg3zff1jk9fsgwvz-ghc-9.10.3.drv",
       "description": "Glasgow Haskell Compiler",
       "install_id": "ghc",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "ghc-9.10.3",
       "pname": "ghc",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:13:07.134896Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:09:01.589145Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -479,8 +494,8 @@
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/2dza48y1bsfsjjqnfnlgsi9kr2kdr5kz-ghc-9.10.3-doc",
-        "out": "/nix/store/lx2j3ywvkgbfjbrzbjw47lxi5x77gd4w-ghc-9.10.3"
+        "doc": "/nix/store/b1c5d2lvnr2rvzm1r144cya6gc56xy7l-ghc-9.10.3-doc",
+        "out": "/nix/store/nnn1cvb8bczv4xvqhlz6risyhdbzypmx-ghc-9.10.3"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -489,18 +504,19 @@
     {
       "attr_path": "ghc",
       "broken": false,
-      "derivation": "/nix/store/lapsx844l60kkfmgmhqhfg2n0ljfdaw2-ghc-9.10.3.drv",
+      "derivation": "/nix/store/l994zgm35z7gcdkvah4a4hzq9i1vy4jz-ghc-9.10.3.drv",
       "description": "Glasgow Haskell Compiler",
       "install_id": "ghc",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "ghc-9.10.3",
       "pname": "ghc",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:47:05.913133Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:40:25.894224Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -509,8 +525,8 @@
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/n36vfz6wsiv35jxmfybic39cpqq38vyi-ghc-9.10.3-doc",
-        "out": "/nix/store/k493jzz83044mqayvlb6247l35780kxy-ghc-9.10.3"
+        "doc": "/nix/store/d82g4qdgarx0rxbmgf9k68pr5135y1h6-ghc-9.10.3-doc",
+        "out": "/nix/store/61a2wc7hwqg7mqb88g3n1l276zsyrx45-ghc-9.10.3"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -519,18 +535,19 @@
     {
       "attr_path": "libsodium",
       "broken": false,
-      "derivation": "/nix/store/w2dncnxwcq0q9lhs21bz3rwazg1x8rh2-libsodium-1.0.22-unstable-2026-04-09.drv",
+      "derivation": "/nix/store/4l36pb9pygg982r8ai52h35kbcaksg15-libsodium-1.0.22-unstable-2026-04-09.drv",
       "description": "Modern and easy-to-use crypto library",
       "install_id": "libsodium",
       "license": "ISC",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "libsodium-1.0.22-unstable-2026-04-09",
       "pname": "libsodium",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:13:33.398943Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:13:14.646008Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -539,8 +556,8 @@
         "out"
       ],
       "outputs": {
-        "dev": "/nix/store/pamgcz6bprs2xcy0zcyx492r1nxbhc4r-libsodium-1.0.22-unstable-2026-04-09-dev",
-        "out": "/nix/store/k76pj1hviqk0dskprc71l67qps5vyyq7-libsodium-1.0.22-unstable-2026-04-09"
+        "dev": "/nix/store/myksm3lwfzikgixzkdbrxb607mpckcij-libsodium-1.0.22-unstable-2026-04-09-dev",
+        "out": "/nix/store/1lhfaycm5fznrydp51q1dvgr6acp1xjm-libsodium-1.0.22-unstable-2026-04-09"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -549,18 +566,19 @@
     {
       "attr_path": "libsodium",
       "broken": false,
-      "derivation": "/nix/store/07iz58p95ys8ibcamyfjxbkzk1k41vd5-libsodium-1.0.22-unstable-2026-04-09.drv",
+      "derivation": "/nix/store/flbmfg2a9wyagcggqz55w6ymgbsz5s17-libsodium-1.0.22-unstable-2026-04-09.drv",
       "description": "Modern and easy-to-use crypto library",
       "install_id": "libsodium",
       "license": "ISC",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "libsodium-1.0.22-unstable-2026-04-09",
       "pname": "libsodium",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:44:35.204191Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:41:48.190228Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -570,9 +588,9 @@
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/cjj7pmpb4m6p1f8vpvkxmkp2g614ab3n-libsodium-1.0.22-unstable-2026-04-09-debug",
-        "dev": "/nix/store/af5y727a8aw2z761ck97p1bxfl60yz4x-libsodium-1.0.22-unstable-2026-04-09-dev",
-        "out": "/nix/store/qqfyjdhc0y9cs2hzxs9h1l98641z1pfk-libsodium-1.0.22-unstable-2026-04-09"
+        "debug": "/nix/store/c3pk2whzy2i4s2w00swipjswvmhqx001-libsodium-1.0.22-unstable-2026-04-09-debug",
+        "dev": "/nix/store/iqdn0aq1z8w2n0y85207cla2xh3xgm5j-libsodium-1.0.22-unstable-2026-04-09-dev",
+        "out": "/nix/store/nnmiqq34dhr0ranzjivbp0widwc19ya3-libsodium-1.0.22-unstable-2026-04-09"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -581,18 +599,19 @@
     {
       "attr_path": "libsodium",
       "broken": false,
-      "derivation": "/nix/store/s5gk895n8qbj9fy7b5j9yzyybb6135w5-libsodium-1.0.22-unstable-2026-04-09.drv",
+      "derivation": "/nix/store/d69czbg5zbwm4p2wgphdaanqd5a26s4c-libsodium-1.0.22-unstable-2026-04-09.drv",
       "description": "Modern and easy-to-use crypto library",
       "install_id": "libsodium",
       "license": "ISC",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "libsodium-1.0.22-unstable-2026-04-09",
       "pname": "libsodium",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:13:26.370390Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:09:24.810410Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -601,8 +620,8 @@
         "out"
       ],
       "outputs": {
-        "dev": "/nix/store/n22pmc2lmvypsbkmh8kr7bp1p1z3qgxk-libsodium-1.0.22-unstable-2026-04-09-dev",
-        "out": "/nix/store/c0w0mn30f3yj3ivisb73z2n5xikhkl34-libsodium-1.0.22-unstable-2026-04-09"
+        "dev": "/nix/store/kxg2vqsgvbjk7c1ywsq4ldy6vyiwiph7-libsodium-1.0.22-unstable-2026-04-09-dev",
+        "out": "/nix/store/iq20lfj0q5q16j4ylmdzaga5ll68ink5-libsodium-1.0.22-unstable-2026-04-09"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -611,33 +630,31 @@
     {
       "attr_path": "libsodium",
       "broken": false,
-      "derivation": "/nix/store/mjfgfqhlrmjzvqascwz980bx83jp4v61-libsodium-1.0.22-unstable-2026-04-09.drv",
+      "derivation": "/nix/store/j9j744qqzx93m8bps06ri1zylk2kk8xg-libsodium-1.0.22-unstable-2026-04-09.drv",
       "description": "Modern and easy-to-use crypto library",
       "install_id": "libsodium",
       "license": "ISC",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "libsodium-1.0.22-unstable-2026-04-09",
       "pname": "libsodium",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:47:32.928032Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:40:51.806528Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
       "version": "2026-04-09",
       "outputs_to_install": [
         "out",
-        "out",
-        "out",
-        "out",
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/kx3grr5ywk88gwhcxmiizjincr7vqzca-libsodium-1.0.22-unstable-2026-04-09-debug",
-        "dev": "/nix/store/agl1pal60bf2yh91dabymshhzvrpiilr-libsodium-1.0.22-unstable-2026-04-09-dev",
-        "out": "/nix/store/l9fbnxk2cg8g7c58bxjsq220zhqzn80w-libsodium-1.0.22-unstable-2026-04-09"
+        "debug": "/nix/store/hkaagh7bm725ld1wrlwnqvh5c2ippz39-libsodium-1.0.22-unstable-2026-04-09-debug",
+        "dev": "/nix/store/cil2vgf2zq49v7w9zbipm1a99kflg0yq-libsodium-1.0.22-unstable-2026-04-09-dev",
+        "out": "/nix/store/bs6w35m2a5hfkpi8lzbvw6zkl35pdx78-libsodium-1.0.22-unstable-2026-04-09"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -646,18 +663,19 @@
     {
       "attr_path": "libtool",
       "broken": false,
-      "derivation": "/nix/store/kgsmwq2sc8fmlqvz9jrvrgj5h954nsss-libtool-2.5.4.drv",
+      "derivation": "/nix/store/ysyf5bl39fhczkdwpjzgw7rmi2qvcvbm-libtool-2.5.4.drv",
       "description": "GNU Libtool, a generic library support script",
       "install_id": "libtool",
       "license": "GPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "libtool-2.5.4",
       "pname": "libtool",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:13:33.464435Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:13:14.710965Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -666,8 +684,8 @@
         "out"
       ],
       "outputs": {
-        "lib": "/nix/store/1fcpj9592jbfmprbrlq7smkavinsgx6l-libtool-2.5.4-lib",
-        "out": "/nix/store/dsnjyh29p589aqm1wh1snvw5lsaq488y-libtool-2.5.4"
+        "lib": "/nix/store/qc3i6f71iflgq4xbby1yypkawxgxw2rq-libtool-2.5.4-lib",
+        "out": "/nix/store/jjii67kq86zvrignsxqa9yqsi4kc1k9r-libtool-2.5.4"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -676,18 +694,19 @@
     {
       "attr_path": "libtool",
       "broken": false,
-      "derivation": "/nix/store/01zh5djyc3q2a45k55v23v2y52nrwz47-libtool-2.5.4.drv",
+      "derivation": "/nix/store/qnfy2ph4fqb4nz1zzn3n9pyb7n3154jf-libtool-2.5.4.drv",
       "description": "GNU Libtool, a generic library support script",
       "install_id": "libtool",
       "license": "GPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "libtool-2.5.4",
       "pname": "libtool",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:44:35.290783Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:41:48.278121Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -696,8 +715,8 @@
         "out"
       ],
       "outputs": {
-        "lib": "/nix/store/hihrq5y6ls54k8p3r7d1xal0np2k8a54-libtool-2.5.4-lib",
-        "out": "/nix/store/dl7zf77yhqhgx8qa3ssg3gqi6qydn7zq-libtool-2.5.4"
+        "lib": "/nix/store/r9yf9fqq9kv6fr8zyvqys65in6ziyvks-libtool-2.5.4-lib",
+        "out": "/nix/store/sygdjvn1h2xz2ba3kzbcw8a7qy2cwi9g-libtool-2.5.4"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -706,18 +725,19 @@
     {
       "attr_path": "libtool",
       "broken": false,
-      "derivation": "/nix/store/0wjc6zk5yznggddi7phm14335xqgc52z-libtool-2.5.4.drv",
+      "derivation": "/nix/store/4v7nqvzb5blvx2n4bgs5dmc1s9r946g6-libtool-2.5.4.drv",
       "description": "GNU Libtool, a generic library support script",
       "install_id": "libtool",
       "license": "GPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "libtool-2.5.4",
       "pname": "libtool",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:13:26.440414Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:09:24.896144Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -726,8 +746,8 @@
         "out"
       ],
       "outputs": {
-        "lib": "/nix/store/jc8yziibkvyzdwf1s3wy622a1cinv04b-libtool-2.5.4-lib",
-        "out": "/nix/store/1xynwkx5zs7prlk64pfjx0zc1gdf30gp-libtool-2.5.4"
+        "lib": "/nix/store/irsnc1qypxmm4hg108n8f679rr6lrcw2-libtool-2.5.4-lib",
+        "out": "/nix/store/c89f7pa0g8rmmphsgrsw9356w6q5x5la-libtool-2.5.4"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -736,18 +756,19 @@
     {
       "attr_path": "libtool",
       "broken": false,
-      "derivation": "/nix/store/bas25bq4wg1x7vakmx8llryzbl09dck1-libtool-2.5.4.drv",
+      "derivation": "/nix/store/5akrq0li1rniv47m6lnw9sdq2g8wnq8a-libtool-2.5.4.drv",
       "description": "GNU Libtool, a generic library support script",
       "install_id": "libtool",
       "license": "GPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "libtool-2.5.4",
       "pname": "libtool",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:47:33.019619Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:40:51.897674Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -756,8 +777,8 @@
         "out"
       ],
       "outputs": {
-        "lib": "/nix/store/qwyl8kb0r3bsml0k7hz1zj75i0x9dyxq-libtool-2.5.4-lib",
-        "out": "/nix/store/r9jsxf5dmisk8kv8jfhscfa3az62i4qa-libtool-2.5.4"
+        "lib": "/nix/store/9xw59kidx5dh9b0bzk1why292ww1swkd-libtool-2.5.4-lib",
+        "out": "/nix/store/ivn8l2l88sylrnnqd8jwrsm68y7zvcz4-libtool-2.5.4"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -766,30 +787,35 @@
     {
       "attr_path": "pkg-config",
       "broken": false,
-      "derivation": "/nix/store/byk6xh9qr0y4wrpyf11z29as4zfvl6h4-pkg-config-wrapper-0.29.2.drv",
+      "derivation": "/nix/store/hgfmcqfq0jmdf5vwmjg1l9qgdhbyiyms-pkg-config-wrapper-0.29.2.drv",
       "description": "Tool that allows packages to find out information about other packages (wrapper script)",
       "install_id": "pkg-config",
       "license": "GPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "pkg-config-wrapper-0.29.2",
       "pname": "pkg-config",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:13:53.907942Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:13:34.958163Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
       "version": "0.29.2",
       "outputs_to_install": [
         "man",
+        "man",
+        "man",
+        "out",
+        "out",
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/29wlw531i4q0da4maa5bab1hy8p58d6v-pkg-config-wrapper-0.29.2-doc",
-        "man": "/nix/store/pk37i8cqgq803ni2gc7fx8j8dmnlq4hz-pkg-config-wrapper-0.29.2-man",
-        "out": "/nix/store/lzrwr375jqhhbca116kja96xf1md83l8-pkg-config-wrapper-0.29.2"
+        "doc": "/nix/store/lkf67m0zmwsklfrnxzr90maqhnqcin0c-pkg-config-wrapper-0.29.2-doc",
+        "man": "/nix/store/cww3k17vnqmn3nsbibninhgl3gabz3c9-pkg-config-wrapper-0.29.2-man",
+        "out": "/nix/store/jmy04kpx07ig9sdw478zcwinp8m0lh8w-pkg-config-wrapper-0.29.2"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -798,83 +824,19 @@
     {
       "attr_path": "pkg-config",
       "broken": false,
-      "derivation": "/nix/store/wybh89fsyj0rd2aq2pfg9h3p2q211g4m-pkg-config-wrapper-0.29.2.drv",
+      "derivation": "/nix/store/1nzw058inpnq5svxbpzx1im999wfvlb3-pkg-config-wrapper-0.29.2.drv",
       "description": "Tool that allows packages to find out information about other packages (wrapper script)",
       "install_id": "pkg-config",
       "license": "GPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "pkg-config-wrapper-0.29.2",
       "pname": "pkg-config",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:45:07.867600Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:42:19.714452Z",
       "stabilities": [
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.29.2",
-      "outputs_to_install": [
-        "man",
-        "out",
-        "out"
-      ],
-      "outputs": {
-        "doc": "/nix/store/h67f59js5mciz53frb0m71jlbzkvv0y2-pkg-config-wrapper-0.29.2-doc",
-        "man": "/nix/store/wg08qnsfqmyy5mgx74jiid7h1bnv8a8b-pkg-config-wrapper-0.29.2-man",
-        "out": "/nix/store/c7vwy0gl1q0agl2h22gi0m9dg7xxad2l-pkg-config-wrapper-0.29.2"
-      },
-      "system": "aarch64-linux",
-      "group": "toplevel",
-      "priority": 5
-    },
-    {
-      "attr_path": "pkg-config",
-      "broken": false,
-      "derivation": "/nix/store/6h29z1jjx9h3bfq95a7kfqkc9ivask4v-pkg-config-wrapper-0.29.2.drv",
-      "description": "Tool that allows packages to find out information about other packages (wrapper script)",
-      "install_id": "pkg-config",
-      "license": "GPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "name": "pkg-config-wrapper-0.29.2",
-      "pname": "pkg-config",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:13:47.530666Z",
-      "stabilities": [
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.29.2",
-      "outputs_to_install": [
-        "man",
-        "out"
-      ],
-      "outputs": {
-        "doc": "/nix/store/lmzgf4hlx26dxbsl6hnqr0imwkygq6zb-pkg-config-wrapper-0.29.2-doc",
-        "man": "/nix/store/masw8xvkn6ygkbi35myxy0ngzxknpva6-pkg-config-wrapper-0.29.2-man",
-        "out": "/nix/store/8cs8a12z75g9lnpch92y1f7bb9kqmgrz-pkg-config-wrapper-0.29.2"
-      },
-      "system": "x86_64-darwin",
-      "group": "toplevel",
-      "priority": 5
-    },
-    {
-      "attr_path": "pkg-config",
-      "broken": false,
-      "derivation": "/nix/store/8lx42xz31bh9294hjphn7yk5lammcaj1-pkg-config-wrapper-0.29.2.drv",
-      "description": "Tool that allows packages to find out information about other packages (wrapper script)",
-      "install_id": "pkg-config",
-      "license": "GPL-2.0-or-later",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "name": "pkg-config-wrapper-0.29.2",
-      "pname": "pkg-config",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:48:08.208431Z",
-      "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -885,9 +847,80 @@
         "out"
       ],
       "outputs": {
-        "doc": "/nix/store/lghsjphn6xrfac5q2zqnbbxvrmj6c3s7-pkg-config-wrapper-0.29.2-doc",
-        "man": "/nix/store/6ki0phq7gff15ywxghxbhpcg3390x0hp-pkg-config-wrapper-0.29.2-man",
-        "out": "/nix/store/1m05k7xgfnw6jc21xxk5681ni3ar97wf-pkg-config-wrapper-0.29.2"
+        "doc": "/nix/store/7fvjivp8r9pdhv3922508vjgzxidi6kp-pkg-config-wrapper-0.29.2-doc",
+        "man": "/nix/store/zcf4b05gl65i1ixnv9440h1zq15chh5l-pkg-config-wrapper-0.29.2-man",
+        "out": "/nix/store/arqxlwwxqmwycqs5zqcmbzair0mjfxjf-pkg-config-wrapper-0.29.2"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "pkg-config",
+      "broken": false,
+      "derivation": "/nix/store/1lcn6x97s98c9s8sjxv3k3iv05x4qvrh-pkg-config-wrapper-0.29.2.drv",
+      "description": "Tool that allows packages to find out information about other packages (wrapper script)",
+      "install_id": "pkg-config",
+      "license": "GPL-2.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
+      "name": "pkg-config-wrapper-0.29.2",
+      "pname": "pkg-config",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:09:50.236832Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.29.2",
+      "outputs_to_install": [
+        "man",
+        "out"
+      ],
+      "outputs": {
+        "doc": "/nix/store/y9vjqqsrn50xv6mar0ffpk3v90xk9n92-pkg-config-wrapper-0.29.2-doc",
+        "man": "/nix/store/9qd0n1nb130ixha7nn5f0hsnz89nl8vw-pkg-config-wrapper-0.29.2-man",
+        "out": "/nix/store/vplhggifvzl90sqphk9b37bjld2wsd5z-pkg-config-wrapper-0.29.2"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "pkg-config",
+      "broken": false,
+      "derivation": "/nix/store/7mq8skw5qdwpypgy5jcci2qxvhmslnvm-pkg-config-wrapper-0.29.2.drv",
+      "description": "Tool that allows packages to find out information about other packages (wrapper script)",
+      "install_id": "pkg-config",
+      "license": "GPL-2.0-or-later",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
+      "name": "pkg-config-wrapper-0.29.2",
+      "pname": "pkg-config",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:41:26.190149Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.29.2",
+      "outputs_to_install": [
+        "man",
+        "man",
+        "man",
+        "out",
+        "out",
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "doc": "/nix/store/5jahjjs08ip8fmz6fvrm716y1ldypn7l-pkg-config-wrapper-0.29.2-doc",
+        "man": "/nix/store/nb3pmiv91xq2824a0pxdwyp14yrllmw8-pkg-config-wrapper-0.29.2-man",
+        "out": "/nix/store/sq5p43ziv78vxp51rpaajhvz0584lgqw-pkg-config-wrapper-0.29.2"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -896,18 +929,19 @@
     {
       "attr_path": "python3",
       "broken": false,
-      "derivation": "/nix/store/bknb559vqzsgsrjz47gr6yfl8ivz60cs-python3-3.13.13.drv",
+      "derivation": "/nix/store/ffz1bwjdzglryqx0pn3jngal4bz66xfh-python3-3.13.13.drv",
       "description": "High-level dynamically-typed programming language",
       "install_id": "python3",
       "license": "Python-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "python3-3.13.13",
       "pname": "python3",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:13:55.984850Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:13:37.148341Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -917,7 +951,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13"
+        "out": "/nix/store/mfkdmplffnbc0av8r6pknl796a6b1r2n-python3-3.13.13"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -926,30 +960,30 @@
     {
       "attr_path": "python3",
       "broken": false,
-      "derivation": "/nix/store/x2hqw4p7ypn5mh08wgv4h37g6pqnw9ka-python3-3.13.13.drv",
+      "derivation": "/nix/store/v13czlpngkramf29nnn8qa0l4svfflwm-python3-3.13.13.drv",
       "description": "High-level dynamically-typed programming language",
       "install_id": "python3",
       "license": "Python-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "python3-3.13.13",
       "pname": "python3",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:45:10.916575Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:42:22.923986Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
       "version": "3.13.13",
       "outputs_to_install": [
         "out",
-        "out",
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/wsi1phrz2gvs0xa8gxsq34mbdpr0s6h0-python3-3.13.13-debug",
-        "out": "/nix/store/lqn6mbgzzdrqq2qkwddcmxj9z6amdd86-python3-3.13.13"
+        "debug": "/nix/store/qfb6yj603w8qxd86j0cj7w54l1pv3rkz-python3-3.13.13-debug",
+        "out": "/nix/store/smwd56pl54f0pcjdspgh5vnf20c8xwsc-python3-3.13.13"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -958,28 +992,28 @@
     {
       "attr_path": "python3",
       "broken": false,
-      "derivation": "/nix/store/klsjr5grg2dlgbsimgczsz32s6h0s7ps-python3-3.13.13.drv",
+      "derivation": "/nix/store/5vh9qfs54q47jybcd5zhxmap7lgk2dhg-python3-3.13.13.drv",
       "description": "High-level dynamically-typed programming language",
       "install_id": "python3",
       "license": "Python-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "python3-3.13.13",
       "pname": "python3",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:13:49.660379Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:09:53.021160Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
       "version": "3.13.13",
       "outputs_to_install": [
-        "out",
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/fyyi8b1dpk3xpjnn52rznnpvlyivds97-python3-3.13.13"
+        "out": "/nix/store/1137mc2md1ip5pdslybxl05kysjyh4rg-python3-3.13.13"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -988,18 +1022,19 @@
     {
       "attr_path": "python3",
       "broken": false,
-      "derivation": "/nix/store/3qs947by1lp93b4gnfisb3jx67mpkd3c-python3-3.13.13.drv",
+      "derivation": "/nix/store/d8rrzn9gg475brqyfpdaa3w76gzwmvx4-python3-3.13.13.drv",
       "description": "High-level dynamically-typed programming language",
       "install_id": "python3",
       "license": "Python-2.0",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "python3-3.13.13",
       "pname": "python3",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:48:11.369152Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:41:29.489145Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -1007,14 +1042,11 @@
       "outputs_to_install": [
         "out",
         "out",
-        "out",
-        "out",
-        "out",
         "out"
       ],
       "outputs": {
-        "debug": "/nix/store/f8f8fd1yyvay2916vv1lk77v4cy5p3wz-python3-3.13.13-debug",
-        "out": "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3-3.13.13"
+        "debug": "/nix/store/g2pg1an3v5pm2fmwg1g7dw77ddpqirg7-python3-3.13.13-debug",
+        "out": "/nix/store/l9k0anq0z7zz81zcwy035jfwap9ga6rl-python3-3.13.13"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -1023,18 +1055,19 @@
     {
       "attr_path": "secp256k1",
       "broken": false,
-      "derivation": "/nix/store/p7s9q88rj20xr4w7g3aiiivaycjgl4h9-secp256k1-0.7.1.drv",
+      "derivation": "/nix/store/hd4imzskc63rlg4fa9vmmpxkk7jdrga4-secp256k1-0.7.1.drv",
       "description": "Optimized C library for EC operations on curve secp256k1",
       "install_id": "secp256k1",
       "license": "[ MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "secp256k1-0.7.1",
       "pname": "secp256k1",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:15:11.744860Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:14:49.660156Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -1043,7 +1076,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/kdjq3pmjqy24y2gy9n5qdd0sj94wcafm-secp256k1-0.7.1"
+        "out": "/nix/store/5gp96jcylri31rdni71fhyixriqn5x0g-secp256k1-0.7.1"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -1052,18 +1085,19 @@
     {
       "attr_path": "secp256k1",
       "broken": false,
-      "derivation": "/nix/store/xip11qbdhm4p0n14lc1l9p3zarhqb2ap-secp256k1-0.7.1.drv",
+      "derivation": "/nix/store/1a7k8zgpv4wq0xiq0yh9ds6ywvy37d59-secp256k1-0.7.1.drv",
       "description": "Optimized C library for EC operations on curve secp256k1",
       "install_id": "secp256k1",
       "license": "[ MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "secp256k1-0.7.1",
       "pname": "secp256k1",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T03:46:37.510527Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T03:43:48.322536Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -1072,7 +1106,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/dyrpbdqlj0bk50j2yrhwn6l5rbvs0wqa-secp256k1-0.7.1"
+        "out": "/nix/store/gbwbzn99y4r8pd837is7i1q4yrm31xy8-secp256k1-0.7.1"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -1081,18 +1115,19 @@
     {
       "attr_path": "secp256k1",
       "broken": false,
-      "derivation": "/nix/store/ggr0slbhcs6b71c3aj0nfy0q8qx9sxxj-secp256k1-0.7.1.drv",
+      "derivation": "/nix/store/z6gij7k6pny30qaxm1a63iyx2qdizf51-secp256k1-0.7.1.drv",
       "description": "Optimized C library for EC operations on curve secp256k1",
       "install_id": "secp256k1",
       "license": "[ MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "secp256k1-0.7.1",
       "pname": "secp256k1",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:15:05.230880Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:11:22.538964Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -1101,7 +1136,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/92c7qa4hbm4jivpw68a3d0d733injjr5-secp256k1-0.7.1"
+        "out": "/nix/store/63isvfcj4mqavmcljzhxrpc3x05aksq7-secp256k1-0.7.1"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -1110,18 +1145,19 @@
     {
       "attr_path": "secp256k1",
       "broken": false,
-      "derivation": "/nix/store/jj4hy9c0kglijh15ibbq3svywnx30jka-secp256k1-0.7.1.drv",
+      "derivation": "/nix/store/xg4g1hljb6fgfd14379x50il7ym938gc-secp256k1-0.7.1.drv",
       "description": "Optimized C library for EC operations on curve secp256k1",
       "install_id": "secp256k1",
       "license": "[ MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=567a49d1913ce81ac6e9582e3553dd90a955875f",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
       "name": "secp256k1-0.7.1",
       "pname": "secp256k1",
-      "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
-      "rev_count": 1017464,
-      "rev_date": "2026-06-16T02:33:49Z",
-      "scrape_date": "2026-06-17T04:49:40.337602Z",
+      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+      "rev_count": 1027867,
+      "rev_date": "2026-07-05T04:06:12Z",
+      "scrape_date": "2026-07-06T04:43:03.875129Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -1130,7 +1166,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/gd1n28fx8nmy6jhnbfipcw30549l1wvc-secp256k1-0.7.1"
+        "out": "/nix/store/v63d12sl85whvcsa3z6cww1ip9kafwr4-secp256k1-0.7.1"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Other guiding principles:
 - **amaru-consensus**: fix the recheck deferred headers loop ([#1078][], [#1082][])
 - **amaru-node**: support Cardano ledger peer snapshots via `--peer-snapshot` / `AMARU_PEER_SNAPSHOT` for cold-start big-ledger peers in peer selection (complements `--peer-address`) ([#1047](https://github.com/pragma-org/amaru/pull/1047))
 - **amaru-node**: embed best-effort peer snapshots for known networks (for example mainnet, preprod, preview) at build time from cardano-foundation/cardano-configurations; used by default when `--peer-snapshot` is omitted
+- **amaru**: fix the start/restart of a node ([#1095][], [#1098][])
 
 ## [v10.11.20260723](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260723)
 
@@ -247,3 +248,5 @@ Other guiding principles:
 [#1060]: https://github.com/pragma-org/amaru/issues/1060
 [#1078]: https://github.com/pragma-org/amaru/issues/1078
 [#1082]: https://github.com/pragma-org/amaru/pull/1082
+[#1095]: https://github.com/pragma-org/amaru/issues/1095
+[#1098]: https://github.com/pragma-org/amaru/pull/1098

--- a/crates/amaru-consensus/benches/stage_msgs.rs
+++ b/crates/amaru-consensus/benches/stage_msgs.rs
@@ -65,7 +65,7 @@ fn stage_msgs(c: &mut Criterion) {
     let msg: Box<dyn SendData> = Box::new(msg);
     group.bench_function("FetchBlocksMsg::NewTip", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
 
-    let msg = FetchBlocksMsg::recover_stored_blocks(point.hash());
+    let msg = FetchBlocksMsg::recover_stored_blocks(point, point.hash());
     let msg: Box<dyn SendData> = Box::new(msg);
     group.bench_function("FetchBlocksMsg::RecoverStoredBlocks", |b| b.iter(|| black_box(to_cbor(black_box(&msg)))));
 

--- a/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
@@ -23,11 +23,7 @@ use amaru_protocols::{blockfetch::Blocks, manager::ManagerMessage, store_effects
 use amaru_pure_stage::{Effects, OrTerminateWith, ScheduleId, StageRef, TryInStage};
 use tracing::Instrument;
 
-use crate::stages::{
-    block_source::BlockSourceMsg,
-    peer_selection::PeerSelectionMsg,
-    select_chain::{SelectChainMsg, load_parent_point},
-};
+use crate::stages::{block_source::BlockSourceMsg, peer_selection::PeerSelectionMsg, select_chain::SelectChainMsg};
 
 // TODO make configurable
 const MAX_MISSING_BLOCKS_PER_BATCH: usize = 25;
@@ -54,10 +50,11 @@ const MAX_MISSING_BLOCKS_PER_BATCH: usize = 25;
 ///   delegate to `request_missing_blocks` which queries store for gaps and (if any)
 ///   sends `ManagerMessage::FetchBlocks` (with cr=child ref for replies) then schedules
 ///   a `Timeout(req_id)`.
-/// - `RecoverStoredBlocks(best_hash)`: Startup recovery only. If origin, signal upstream
-///   immediately. Otherwise replay any unvalidated-but-stored blocks downstream for
-///   re-validation (using unvalidated_ancestor_hashes + has_block checks), falling back
-///   to `request_missing_blocks` on first gap. Terminates on store errors.
+/// - `RecoverStoredBlocks { from, to }`: Startup recovery only, where `from` is the ledger tip and
+///   `to` the best stored candidate. Walks the stored headers from `to` back down to `from` and
+///   replays them downstream for re-validation (using `ancestors_between` + `has_block` checks),
+///   falling back to `request_missing_blocks` on first gap. Terminates on store errors, and on an
+///   origin `from`, which means the ledger was never bootstrapped.
 /// - `Block(peer, network_block)`: Decode + basic integrity (body_hash match → adversarial
 ///   on fail), ordering checks against current `missing` cursor (parent + first point;
 ///   stragglers logged and dropped). On match: store block, send `(Tip, parent_boundary, block_height)`
@@ -99,7 +96,7 @@ const MAX_MISSING_BLOCKS_PER_BATCH: usize = 25;
 /// - **downstream** (typically validate_block_input via contramap in build): sends `(Tip, parent_Point, block_height)` for each block (newly fetched or recovered stored).
 /// - **block_source** (via child only): `BlockReceived {peer, tip}` for every header seen in replies (even stragglers/old).
 /// - **peer_selection**: `Adversarial(peer)` on body-hash mismatch (main) or header decode failure (child).
-/// - **Store** (via effects): `find_missing_blocks`, `has_block`, `load_header`, `store_block`, `unvalidated_ancestor_hashes`, `load_tip` etc. (many via `or_terminate`).
+/// - **Store** (via effects): `find_missing_blocks`, `has_block`, `load_header`, `store_block`, `load_tip` etc. (many via `or_terminate`).
 /// - Time/schedule via Effects: `schedule_after` for `Timeout`, `cancel_schedule`.
 /// - No direct interaction with validate results (one-way downstream); no header validation performed here (assumes requested ranges; minimal structural checks only).
 ///
@@ -188,10 +185,13 @@ impl FetchBlocks {
         self.request_missing_blocks(tip, parent, eff, parent_context, stage_context).instrument(span).await;
     }
 
-    /// Startup-only recovery: resubmit downloaded blocks whose validity was not
-    /// persisted before shutdown, then fetch from the first missing block.
-    pub async fn recover_stored_blocks(&mut self, eff: Effects<FetchBlocksMsg>, best_hash: HeaderHash) {
-        let span = debug_span!(consensus::blocks::RECOVER_STORED, best_hash = best_hash,);
+    /// Startup-only recovery: resubmit the blocks stored between the ledger tip `from` and the best
+    /// candidate `to`, so the ledger can apply them again, then fetch from the first missing block.
+    ///
+    /// The ledger has no persisted volatile state, so `from` is where it resumes and therefore the
+    /// only parent the first replayed block may have.
+    pub async fn recover_stored_blocks(&mut self, eff: Effects<FetchBlocksMsg>, from: Point, to: HeaderHash) {
+        let span = debug_span!(consensus::blocks::RECOVER_STORED, from = from, to = to);
         let trace_context = (&span).into();
         assert!(
             self.missing.is_none(),
@@ -200,49 +200,59 @@ impl FetchBlocks {
         );
 
         let store = Store::new(eff.clone()).with_trace_context(&trace_context);
-        if best_hash == ORIGIN_HASH {
-            eff.send(&self.upstream, SelectChainMsg::FetchNextFrom(Point::Origin, trace_context)).await;
-            return;
+
+        // An origin ledger tip means that we are trying to recover from an empty ledger with
+        // a non-empty store. This is a misconfiguration, and we should not attempt to replay the stored headers.
+        if from.hash() == ORIGIN_HASH {
+            tracing::error!(%from, %to, "inconsistent data: stored headers found while the ledger has no tip");
+            return eff.terminate().await;
         }
-        let best_tip = store
-            .load_header(&best_hash)
+
+        let Some(to_replay) = store.ancestors_between(from, to).await else {
+            tracing::error!(%from, %to, "the stored headers do not form a chain down to the ledger tip");
+            return eff.terminate().await;
+        };
+
+        let best_tip_header = store
+            .load_header(&to)
             .await
             .or_terminate(&eff, async move |_| {
-                tracing::error!(hash = %best_hash, "cannot load header for best candidate");
+                tracing::error!(hash = %to, "cannot load header for best candidate");
             })
             .await;
-        let unvalidated = store.unvalidated_ancestor_hashes(best_hash).await.0;
 
-        self.block_height = best_tip.block_height().max(self.block_height);
-        let tip = best_tip.tip();
-        tracing::debug!(tip = %tip.point(), "recovering stored blocks");
+        self.block_height = best_tip_header.block_height().max(self.block_height);
+        let tip = best_tip_header.point();
+        tracing::debug!(%tip, "recovering stored blocks");
 
-        let mut parent: Option<Point> = None;
-        for hash in unvalidated {
-            let Some(header) = store.load_header(&hash).await else {
-                tracing::error!(%hash, "failed to load candidate header");
-                return eff.terminate().await;
-            };
-            let tip = header.tip();
-            let block_parent = match parent {
-                Some(p) => p,
-                None => load_parent_point(&eff, &store, &header).await,
-            };
+        // Replay blocks one by done. The replay will have downloaded blocks as a prefix, then
+        // missing blocks. The first ones are retrieved from the chain store and the other ones
+        // are fetched from peers
+        let mut parent = from;
+        let mut to_fetch = Vec::new();
+        let mut path = to_replay.into_iter();
+
+        while let Some(block_tip) = path.next() {
+            let hash = block_tip.hash();
             match store.has_block(&hash).await {
                 Ok(true) => {
-                    tracing::debug!(point = %tip.point(), "validating stored block");
+                    tracing::debug!(point = %block_tip.point(), "validating stored block");
                     let downloaded_block = DownloadedBlock {
-                        tip,
-                        parent: block_parent,
+                        tip: block_tip,
+                        parent,
                         max_block_height: self.block_height,
                         trace_context: trace_context.clone(),
                     };
                     eff.send(&self.downstream, downloaded_block).await;
-                    parent = Some(tip.point());
+                    parent = block_tip.point();
                 }
+                // Nothing beyond this point was ever downloaded, since blocks are only ever stored in
+                // ancestor order. The rest of the path is therefore exactly what remains to fetch.
                 Ok(false) => {
-                    self.request_missing_blocks(tip, block_parent, eff, trace_context.clone(), trace_context).await;
-                    return;
+                    to_fetch.push(block_tip.point());
+                    to_fetch.extend(path.by_ref().map(|block_tip| block_tip.point()));
+                    to_fetch.truncate(MAX_MISSING_BLOCKS_PER_BATCH);
+                    break;
                 }
                 Err(error) => {
                     tracing::error!(%error, %hash, "failed to check stored block");
@@ -251,10 +261,14 @@ impl FetchBlocks {
             }
         }
 
-        tracing::info!(tip = %tip.point(), "no blocks to fetch");
-        self.fetch_next_from(eff, tip.point()).await;
+        // `parent` is the last block handed over for validation, so it is the boundary the fetched
+        // blocks must chain onto. An empty batch means the replay covered the whole path, in which case
+        // this just tells the upstream stage to carry on.
+        let missing = MissingBlocks::new(parent, to_fetch);
+        self.request_blocks(missing, best_tip_header.tip(), parent, eff, trace_context).await;
     }
 
+    /// Find the oldest missing blocks in the chain ending with `tip` and fetch them.
     async fn request_missing_blocks(
         &mut self,
         tip: Tip,
@@ -264,7 +278,7 @@ impl FetchBlocks {
         stage_context: TraceContext,
     ) {
         let store = Store::new(eff.clone()).with_trace_context(&stage_context);
-        match store.find_missing_blocks(tip.hash(), MAX_MISSING_BLOCKS_PER_BATCH).await {
+        let missing = match store.find_missing_blocks(tip.hash(), MAX_MISSING_BLOCKS_PER_BATCH).await {
             Ok(MissingBlocksResult::StartHeaderNotFound) => {
                 tracing::error!("failed to load initial header");
                 return eff.terminate().await;
@@ -272,51 +286,53 @@ impl FetchBlocks {
             Ok(MissingBlocksResult::BoundaryNotFound) => {
                 tracing::debug!("no boundary for missing blocks found given the new tip");
                 self.missing = None;
+                return;
             }
-            Ok(MissingBlocksResult::Found(missing_blocks)) => {
-                self.missing = Some(missing_blocks);
-            }
+            Ok(MissingBlocksResult::Found(missing_blocks)) => missing_blocks,
             Err(error) => {
                 tracing::error!(%error, "failed to find missing blocks");
                 return eff.terminate().await;
             }
-        }
-        let Some(missing) = self.missing.as_ref() else {
-            return;
         };
 
-        match missing.from_to() {
-            None => {
-                self.missing = None;
-                tracing::info!(tip = %tip.point(), parent = %parent, "no blocks to fetch");
-                self.fetch_next_from(eff, tip.point()).await;
-            }
-            Some((from, to)) => {
-                tracing::debug!(%from, %to, length = missing.nb_missing_blocks(), "requesting blocks");
-                self.req_id += 1;
-                self.no_peers_pause = false;
-                self.trace_context = Some(parent_context);
+        self.request_blocks(missing, tip, parent, eff, parent_context).await
+    }
 
-                let now = eff.clock().await;
-                let requested: Vec<HeaderHash> =
-                    missing.missing_points().into_iter().map(|point| point.hash()).collect();
-                eff.send(
-                    &self.manager,
-                    ManagerMessage::FetchBlocks {
-                        from: *from,
-                        through: *to,
-                        id: self.req_id,
-                        cr: self.cleanup_replies.clone(),
-                    },
-                )
-                .await;
-                // Tell the select_chain stage when this block was received so it can record the
-                // block_fetch_wait point of its lifecycle.
-                eff.send(&self.upstream, SelectChainMsg::BlocksRequested(requested, now)).await;
-                let timeout = eff.schedule_after(FetchBlocksMsg::Timeout(self.req_id), Duration::from_secs(5)).await;
-                self.timeout = Some(timeout);
-            }
-        }
+    /// Ask peers for a batch of blocks already known to be missing, or tell the upstream stage to
+    /// carry on when the batch turns out to be empty.
+    async fn request_blocks(
+        &mut self,
+        missing: MissingBlocks,
+        tip: Tip,
+        parent: Point,
+        eff: Effects<FetchBlocksMsg>,
+        parent_context: TraceContext,
+    ) {
+        let Some((from, through)) = missing.from_to().map(|(from, through)| (*from, *through)) else {
+            self.missing = None;
+            tracing::info!(tip = %tip.point(), parent = %parent, "no blocks to fetch");
+            return self.fetch_next_from(eff, tip.point()).await;
+        };
+
+        tracing::debug!(%from, %through, length = missing.nb_missing_blocks(), "requesting blocks");
+        self.req_id += 1;
+        self.no_peers_pause = false;
+        self.trace_context = Some(parent_context);
+
+        let now = eff.clock().await;
+        let requested: Vec<HeaderHash> = missing.missing_points().into_iter().map(|point| point.hash()).collect();
+        self.missing = Some(missing);
+
+        eff.send(
+            &self.manager,
+            ManagerMessage::FetchBlocks { from, through, id: self.req_id, cr: self.cleanup_replies.clone() },
+        )
+        .await;
+        // Tell the select_chain stage when this block was received so it can record the
+        // block_fetch_wait point of its lifecycle.
+        eff.send(&self.upstream, SelectChainMsg::BlocksRequested(requested, now)).await;
+        let timeout = eff.schedule_after(FetchBlocksMsg::Timeout(self.req_id), Duration::from_secs(5)).await;
+        self.timeout = Some(timeout);
     }
 
     pub async fn block(&mut self, peer: Peer, network_block: NetworkBlock, eff: Effects<FetchBlocksMsg>) {
@@ -438,7 +454,7 @@ impl DownloadedBlock {
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum FetchBlocksMsg {
     NewTip { tip: Tip, parent: Point, trace_context: TraceContext },
-    RecoverStoredBlocks(HeaderHash, TraceContext),
+    RecoverStoredBlocks { from: Point, to: HeaderHash, trace_context: TraceContext },
     Block(Peer, NetworkBlock),
     Timeout(u64),
     NoPeersAvailable(u64),
@@ -449,8 +465,8 @@ impl FetchBlocksMsg {
         Self::NewTip { tip, parent, trace_context: Default::default() }
     }
 
-    pub fn recover_stored_blocks(best_hash: HeaderHash) -> Self {
-        Self::RecoverStoredBlocks(best_hash, Default::default())
+    pub fn recover_stored_blocks(from: Point, to: HeaderHash) -> Self {
+        Self::RecoverStoredBlocks { from, to, trace_context: Default::default() }
     }
 }
 
@@ -461,9 +477,9 @@ pub async fn stage(mut state: FetchBlocks, msg: FetchBlocksMsg, eff: Effects<Fet
     .await;
     match msg {
         FetchBlocksMsg::NewTip { tip, parent, trace_context } => state.new_tip(tip, parent, eff, trace_context).await,
-        FetchBlocksMsg::RecoverStoredBlocks(best_hash, trace_context) => {
+        FetchBlocksMsg::RecoverStoredBlocks { from, to, trace_context } => {
             state.trace_context = Some(trace_context);
-            state.recover_stored_blocks(eff, best_hash).await
+            state.recover_stored_blocks(eff, from, to).await
         }
         FetchBlocksMsg::Block(peer, block) => state.block(peer, block, eff).await,
         FetchBlocksMsg::Timeout(req_id) => state.timeout(req_id, eff).await,

--- a/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
@@ -20,8 +20,8 @@ use amaru_kernel::{
 };
 use amaru_ouroboros_traits::{MissingBlocks, StoreError, WriteChainStore, in_memory_chain_store::InMemoryChainStore};
 use amaru_protocols::store_effects::{
-    FindMissingBlocksEffect, GetAnchorHashEffect, GetChildrenEffect, HasBlockEffect, LoadHeaderEffect,
-    LoadHeaderWithValidityEffect, LoadTipEffect, ResourceHeaderStore, StoreBlockEffect,
+    AncestorsBetweenEffect, FindMissingBlocksEffect, GetAnchorHashEffect, GetChildrenEffect, HasBlockEffect,
+    LoadHeaderEffect, LoadHeaderWithValidityEffect, LoadTipEffect, ResourceHeaderStore, StoreBlockEffect,
     UnvalidatedAncestorHashesEffect,
 };
 use amaru_pure_stage::{
@@ -140,7 +140,9 @@ pub fn register_guards() -> DeserializerGuards {
         amaru_pure_stage::register_effect_deserializer::<StoreBlockEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<FindMissingBlocksEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<UnvalidatedAncestorHashesEffect>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<AncestorsBetweenEffect>().boxed(),
         amaru_pure_stage::register_data_deserializer::<(Vec<HeaderHash>, bool)>().boxed(),
+        amaru_pure_stage::register_data_deserializer::<Option<Vec<amaru_kernel::Tip>>>().boxed(),
         amaru_pure_stage::register_data_deserializer::<Result<Option<MissingBlocks>, StoreError>>().boxed(),
     ]
 }
@@ -195,6 +197,10 @@ pub fn te_has_block(at_stage: &str, hash: HeaderHash) -> TraceEntry {
     TraceEntry::suspend(Effect::external(at_stage, Box::new(HasBlockEffect::new(hash))))
 }
 
+pub fn te_ancestors_between(at_stage: &str, from: amaru_kernel::Point, to: HeaderHash) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(at_stage, Box::new(AncestorsBetweenEffect::new(from, to))))
+}
+
 pub fn te_load_header(at_stage: &str, hash: HeaderHash, with_validity: bool) -> TraceEntry {
     TraceEntry::suspend(Effect::external(
         at_stage,
@@ -204,14 +210,6 @@ pub fn te_load_header(at_stage: &str, hash: HeaderHash, with_validity: bool) -> 
             Box::new(LoadHeaderEffect::new(hash))
         },
     ))
-}
-
-pub fn te_load_tip(at_stage: &str, hash: HeaderHash) -> TraceEntry {
-    TraceEntry::suspend(Effect::external(at_stage, Box::new(LoadTipEffect::new(hash))))
-}
-
-pub fn te_unvalidated_ancestor_hashes(at_stage: &str, start: HeaderHash) -> TraceEntry {
-    TraceEntry::suspend(Effect::external(at_stage, Box::new(UnvalidatedAncestorHashesEffect::new(start))))
 }
 
 pub fn te_store_block(at_stage: &str, hash: HeaderHash, block: amaru_kernel::RawBlock) -> TraceEntry {

--- a/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
@@ -26,8 +26,8 @@ use tracing::Level;
 use super::*;
 use crate::stages::{
     fetch_blocks::test_setup::{
-        TestPrep, setup, te_cancel_schedule, te_clock, te_find_missing_blocks, te_has_block, te_load_header,
-        te_load_tip, te_schedule, te_store_block, te_unvalidated_ancestor_hashes, test_peer, test_prep,
+        TestPrep, make_block_header, setup, te_ancestors_between, te_cancel_schedule, te_clock, te_find_missing_blocks,
+        te_has_block, te_load_header, te_schedule, te_store_block, test_peer, test_prep,
     },
     test_utils::{
         assert_trace, start_in_era, te_clock_read, te_input, te_send, te_state, te_terminate, te_terminated, tm_state,
@@ -98,7 +98,7 @@ fn test_recover_stored_blocks_validates_downloaded_unvalidated_blocks() {
     prep.set_anchor(prep.headers.h0.hash());
     prep.set_validity(prep.headers.h0.hash(), true);
 
-    let msg = FetchBlocksMsg::recover_stored_blocks(prep.headers.h2.hash());
+    let msg = FetchBlocksMsg::recover_stored_blocks(prep.headers.h0.point(), prep.headers.h2.hash());
 
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
     let expected = prep.state_with_block_height(3);
@@ -107,17 +107,14 @@ fn test_recover_stored_blocks_validates_downloaded_unvalidated_blocks() {
         &[
             te_state("fb-1", &prep.state),
             te_input("fb-1", &msg),
+            te_ancestors_between("fb-1", prep.headers.h0.point(), prep.headers.h2.hash()),
             te_load_header("fb-1", prep.headers.h2.hash(), false),
-            te_unvalidated_ancestor_hashes("fb-1", prep.headers.h2.hash()),
-            te_load_header("fb-1", prep.headers.h1.hash(), false),
-            te_load_tip("fb-1", prep.headers.h0.hash()),
             te_has_block("fb-1", prep.headers.h1.hash()),
             te_send(
                 "fb-1",
                 "downstream",
                 DownloadedBlock::new(prep.headers.h1.tip(), prep.headers.h0.point(), BlockHeight::from(3)),
             ),
-            te_load_header("fb-1", prep.headers.h2.hash(), false),
             te_has_block("fb-1", prep.headers.h2.hash()),
             te_send(
                 "fb-1",
@@ -132,6 +129,88 @@ fn test_recover_stored_blocks_validates_downloaded_unvalidated_blocks() {
         .assert_and_remove(Level::DEBUG, &["validating stored block"])
         .assert_and_remove(Level::DEBUG, &["validating stored block"])
         .assert_and_remove(Level::INFO, &["no blocks to fetch"])
+        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+/// On a restart, headers usually run ahead of downloaded blocks, so the replay covers a prefix and
+/// the rest has to be fetched. The request must cover the whole gap up to the best candidate, not
+/// just the first block missing from it.
+#[test]
+fn test_recover_stored_blocks_fetches_the_whole_gap_after_the_replayed_prefix() {
+    let prep = test_prep();
+    let h3 = make_block_header(4, 4, Some(prep.headers.h2.hash()));
+    prep.store_headers(&[&prep.headers.h0, &prep.headers.h1, &prep.headers.h2, &h3]);
+    // Only h1 was downloaded before the restart; h2 and h3 are headers we know but have no block for.
+    prep.store_block(&prep.headers.h1);
+    prep.set_anchor(prep.headers.h0.hash());
+    prep.set_validity(prep.headers.h0.hash(), true);
+
+    let msg = FetchBlocksMsg::recover_stored_blocks(prep.headers.h0.point(), h3.hash());
+
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    let timeout_at = Instant::at_offset(Duration::from_secs(10 + 5), start_in_era().relative_time);
+    let schedule_id = ScheduleIds::default().next_at(timeout_at);
+    let requested_at = Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time);
+    let expected = {
+        let mut state = prep.state_with_request(
+            MissingBlocks::new(prep.headers.h1.point(), vec![prep.headers.h2.point(), h3.point()]),
+            1,
+            schedule_id,
+        );
+        state.block_height = BlockHeight::from(4);
+        state.trace_context = Some(Default::default());
+        state
+    };
+    assert_trace(
+        &running,
+        &[
+            te_state("fb-1", &prep.state),
+            te_input("fb-1", &msg),
+            te_ancestors_between("fb-1", prep.headers.h0.point(), h3.hash()),
+            te_load_header("fb-1", h3.hash(), false),
+            te_has_block("fb-1", prep.headers.h1.hash()),
+            te_send(
+                "fb-1",
+                "downstream",
+                DownloadedBlock::new(prep.headers.h1.tip(), prep.headers.h0.point(), BlockHeight::from(4)),
+            ),
+            // The tail of the replay path is the batch to fetch, so no second search of the store.
+            te_has_block("fb-1", prep.headers.h2.hash()),
+            te_clock_read("fb-1"),
+            te_send(
+                "fb-1",
+                "manager",
+                ManagerMessage::FetchBlocks {
+                    from: prep.headers.h2.point(),
+                    through: h3.point(),
+                    id: 1,
+                    cr: prep.cleanup_replies.clone(),
+                },
+            ),
+            te_send(
+                "fb-1",
+                "upstream",
+                SelectChainMsg::BlocksRequested(vec![prep.headers.h2.hash(), h3.hash()], requested_at),
+            ),
+            te_schedule("fb-1", FetchBlocksMsg::Timeout(1), schedule_id),
+            te_state("fb-1", &expected),
+            // The batch chains onto h1, so a timeout must resume from there.
+            te_clock(timeout_at),
+            te_input("fb-1", &FetchBlocksMsg::Timeout(1)),
+            te_send("fb-1", "upstream", SelectChainMsg::fetch_next_from(prep.headers.h1.point())),
+            te_state("fb-1", &{
+                let mut state = expected.clone();
+                state.missing = None;
+                state.timeout = None;
+                state.trace_context = None;
+                state
+            }),
+        ],
+    );
+    logs.assert_and_remove(Level::DEBUG, &["recovering stored blocks"])
+        .assert_and_remove(Level::DEBUG, &["validating stored block"])
+        .assert_and_remove(Level::DEBUG, &["requesting blocks"])
+        .assert_and_remove(Level::ERROR, &["timeout fetching blocks"])
         .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -404,6 +404,7 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
                 // may or may not need to perform the transition again (depending where we interrupted).
                 None if self.most_recent_snapshot() == next_epoch - 1 => {
                     Span::current().record("skipped", true);
+                    self.volatile.transition_already_persisted(next_epoch);
                     return Ok(());
                 }
                 None => (),

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -172,7 +172,7 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
 
         let stake_distributions = initial_stake_distributions(&snapshots, &era_history)?;
 
-        let epoch = unsafe_slot_to_epoch(&era_history, stable.tip()?.slot_or_default());
+        let epoch = initial_epoch(&stable, &snapshots, &era_history)?;
 
         Ok(Self::new_with(
             stable,
@@ -357,10 +357,9 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
     /// corresponds to a block in a different (next) epoch, in which case, we must first transition
     /// into the new epoch before the block can be validated.
     fn try_epoch_transition(&mut self, next_tip: Point) -> Result<(), StateError> {
-        let current_epoch = unsafe_slot_to_epoch(&self.era_history, self.tip().slot_or_default());
         let next_epoch = unsafe_slot_to_epoch(&self.era_history, next_tip.slot_or_default());
 
-        if next_epoch > current_epoch {
+        if next_epoch > self.epoch() {
             let old_protocol_version = self.protocol_version();
 
             self.epoch_transition(next_epoch)?;
@@ -388,26 +387,8 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
 
             let progress = db.epoch_transition_progress()?;
 
-            match progress {
-                Some(resuming_from) => {
-                    Span::current().record("resuming_from", resuming_from.to_string());
-                }
-                // NOTE: Skipping epoch transition
-                //
-                // It is possible to interrupt Amaru just after the epoch transition was flushed
-                // to disk. The consequence of that is: the tip of the immutable db is still in the
-                // previous epoch which will cause the next block we see to trigger an epoch transition.
-                //
-                // However, the epoch transition had already happened and was even persisted to disk
-                // already! So we must not redo it. This strange behaviour occurs because we do not
-                // persist the volatile; so on restart, we rewind `k` blocks in the past, for which we
-                // may or may not need to perform the transition again (depending where we interrupted).
-                None if self.most_recent_snapshot() == next_epoch - 1 => {
-                    Span::current().record("skipped", true);
-                    self.volatile.transition_already_persisted(next_epoch);
-                    return Ok(());
-                }
-                None => (),
+            if let Some(resuming_from) = progress {
+                Span::current().record("resuming_from", resuming_from.to_string());
             }
 
             // NOTE: Crossing states during epoch transition
@@ -999,6 +980,29 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
         } else {
             max(1, self.volatile.len()) as f64 / (u64::from(latest_slot) - u64::from(k_slot)) as f64
         }
+    }
+}
+
+/// Resolve the epoch on restart to initialize the volatile db with.
+pub fn initial_epoch<S, HS>(db: &S, snapshots: &HS, era_history: &EraHistory) -> Result<Epoch, StoreError>
+where
+    S: Store,
+    HS: HistoricalStores,
+{
+    let epoch_from_immutable_tip = unsafe_slot_to_epoch(era_history, db.tip()?.slot_or_default());
+
+    // NOTE: Initial epoch on restart
+    //
+    // It is possible to interrupt Amaru just after the epoch transition was flushed
+    // to disk. The consequence of that is: the tip of the immutable db is still in the
+    // previous epoch which will cause the next block we see to trigger an epoch transition.
+    //
+    // However, the epoch transition had already happened and was even persisted to disk
+    // already! So we must not redo it, we are already in the next epoch!
+    if db.epoch_transition_progress()?.is_none() && snapshots.most_recent_snapshot() == epoch_from_immutable_tip {
+        Ok(epoch_from_immutable_tip + 1)
+    } else {
+        Ok(epoch_from_immutable_tip)
     }
 }
 

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -352,23 +352,6 @@ impl VolatileDB {
         self.overlay.transition(effective_rewards, pools_updates, governance_updates);
     }
 
-    /// Cross an epoch boundary whose transition has already been flushed to the stable store. This
-    /// happens when the node is interrupted right after flushing a boundary: the volatile is not
-    /// persisted, so on restart we rewind before the boundary and walk over it a second time.
-    ///
-    /// Like [`Self::transition`], this seals `current` into `draining` so that each series stays
-    /// homogeneous with respect to epochs. Unlike it, there are no boundary computations to carry:
-    /// rewards, pool updates and governance updates all made it to disk before the interruption and
-    /// must not be applied twice. The overlay's epoch must still move forward, otherwise later reads
-    /// (protocol parameters, governance activity) would be asked for an epoch the volatile claims
-    /// not to have reached.
-    pub fn transition_already_persisted(&mut self, next_epoch: Epoch) {
-        assert!(self.draining.is_empty(), "transitioning volatile series while a draining series is still present");
-
-        self.draining = mem::take(&mut self.current);
-        self.overlay.transition_already_persisted(next_epoch);
-    }
-
     /// Whether an epoch transition has been computed but not yet flushed to the stable store.
     pub fn is_epoch_transition_stable(&self, era_history: &EraHistory, global_parameters: &GlobalParameters) -> bool {
         !self.overlay.is_empty()

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -352,6 +352,23 @@ impl VolatileDB {
         self.overlay.transition(effective_rewards, pools_updates, governance_updates);
     }
 
+    /// Cross an epoch boundary whose transition has already been flushed to the stable store. This
+    /// happens when the node is interrupted right after flushing a boundary: the volatile is not
+    /// persisted, so on restart we rewind before the boundary and walk over it a second time.
+    ///
+    /// Like [`Self::transition`], this seals `current` into `draining` so that each series stays
+    /// homogeneous with respect to epochs. Unlike it, there are no boundary computations to carry:
+    /// rewards, pool updates and governance updates all made it to disk before the interruption and
+    /// must not be applied twice. The overlay's epoch must still move forward, otherwise later reads
+    /// (protocol parameters, governance activity) would be asked for an epoch the volatile claims
+    /// not to have reached.
+    pub fn transition_already_persisted(&mut self, next_epoch: Epoch) {
+        assert!(self.draining.is_empty(), "transitioning volatile series while a draining series is still present");
+
+        self.draining = mem::take(&mut self.current);
+        self.overlay.transition_already_persisted(next_epoch);
+    }
+
     /// Whether an epoch transition has been computed but not yet flushed to the stable store.
     pub fn is_epoch_transition_stable(&self, era_history: &EraHistory, global_parameters: &GlobalParameters) -> bool {
         !self.overlay.is_empty()

--- a/crates/amaru-ledger/src/state/volatile/overlay.rs
+++ b/crates/amaru-ledger/src/state/volatile/overlay.rs
@@ -151,24 +151,6 @@ impl StateOverlay {
         self.governance_updates = Some(Arc::new(governance_updates));
     }
 
-    /// Record that an epoch transition already persisted on disk has been crossed again while
-    /// rebuilding volatile state after restart.
-    pub fn transition_already_persisted(&mut self, next_epoch: Epoch) {
-        assert_eq!(
-            next_epoch,
-            self.epoch + 1,
-            "cannot recover persisted transition from epoch {} into epoch {}",
-            self.epoch,
-            next_epoch,
-        );
-
-        debug!(ledger::epoch_transition::RECORD, from = %self.epoch, to = %next_epoch);
-        self.epoch = next_epoch;
-        self.rewards = RewardsState::NotReady;
-        self.pools_updates = None;
-        self.governance_updates = None;
-    }
-
     /// Flush an overlay to disk.
     ///
     /// Returns the freshly-enacted `(protocol_parameters, governance_activity)` when a governance

--- a/crates/amaru-ledger/src/state/volatile/overlay.rs
+++ b/crates/amaru-ledger/src/state/volatile/overlay.rs
@@ -151,6 +151,24 @@ impl StateOverlay {
         self.governance_updates = Some(Arc::new(governance_updates));
     }
 
+    /// Record that an epoch transition already persisted on disk has been crossed again while
+    /// rebuilding volatile state after restart.
+    pub fn transition_already_persisted(&mut self, next_epoch: Epoch) {
+        assert_eq!(
+            next_epoch,
+            self.epoch + 1,
+            "cannot recover persisted transition from epoch {} into epoch {}",
+            self.epoch,
+            next_epoch,
+        );
+
+        debug!(ledger::epoch_transition::RECORD, from = %self.epoch, to = %next_epoch);
+        self.epoch = next_epoch;
+        self.rewards = RewardsState::NotReady;
+        self.pools_updates = None;
+        self.governance_updates = None;
+    }
+
     /// Flush an overlay to disk.
     ///
     /// Returns the freshly-enacted `(protocol_parameters, governance_activity)` when a governance

--- a/crates/amaru-ledger/src/state/volatile/overlay.rs
+++ b/crates/amaru-ledger/src/state/volatile/overlay.rs
@@ -160,6 +160,51 @@ impl StateOverlay {
         let updated = info_span!(ledger::epoch_transition::APPLY, epoch = self.epoch).in_scope(|| {
             use EpochTransitionProgress::*;
 
+            // NOTE: 3-step epoch transition
+            //
+            // Why are 3 db transactions needed here?
+            //
+            // Two transactions can be explained with a few points:
+            //
+            //  - Calculations that depend on historical data. A snapshot must be taken precisely
+            //    after paying out the rewards, but before ratifying governance actions or pruning
+            //    stake pools. So there's a precise split between these moment and it's nice
+            //    (albeit strictly unnecessary) to make it apparent.
+            //
+            //  - Another compelling reason for the split is the bootstrapping of Amaru. Snapshots
+            //    we produce from the Haskell node correspond precisely to our definition of
+            //    snapshot here (i.e. data at the end of the epoch, after rewards payments but
+            //    before next epoch start). Hence, we must be able to resume from a snapshot
+            //    mid-transaction, and instead of making a special case for the bootstrapping, we
+            //    make it our default behaviour.
+            //
+            // Why the third split then? Because while RocksDB allows for checkpointing in the
+            // middle of a transaction, it does not rollback checkpoints on failures.
+            //
+            // So if anything goes wrong during the transaction but after the checkpoint/snapshot
+            // was taken, we end up in an awkward spot where we need to re-apply the end of epoch,
+            // skip the snapshot, and re-apply the beginning.
+            //
+            // Yet, this puts us in an inconsistent state where a snapshot exists (and other logic
+            // may infer a bunch of decisions from it!), while the actual database state still lives
+            // in the past. So to prevent this, we introduce a third split between the moment the
+            // epoch ended (and was persisted to disk) and the moment the snapshot was taken.
+            //
+            // This way, if anything goes wrong:
+            //
+            // - before the epoch transition or during the epoch-ended transaction: the database
+            //   remains unmodified, and no snapshot was generated.
+            //
+            // - after the epoch-ended or during the snapshot being taken: then we may or may not
+            //   have a snapshot. If we do have a snapshot, we may still report a progress as
+            //   "EpochEnded", which would only cause the snapshot to be taken _again_. Since this
+            //   is an idempotent and rather quick operation, that's not a big problem. If we don't
+            //   have a snapshot, then the progress is also still at "EpochEnded" and the snapshot
+            //   will normally happen on restart.
+            //
+            // - during the epoch start: then we have a stable snapshot and the database is still in
+            //   a correct state because the epoch progress still indicates "SnapshotTaken".
+
             // ---------------------------------------------------------------------------- End of epoch
             db.with_transaction::<_, StateError>(|batch| {
                 let should_end_epoch = batch.try_epoch_transition(None, Some(EpochEnded))?;

--- a/crates/amaru-node/src/stages/build_node.rs
+++ b/crates/amaru-node/src/stages/build_node.rs
@@ -26,6 +26,7 @@ use amaru_kernel::{ConsensusParameters, EraHistory, GlobalParameters, ORIGIN_HAS
 use amaru_ledger::state::State;
 use amaru_mempool::{InMemoryMempool, MempoolConfig};
 use amaru_network::connection::TokioConnections;
+use amaru_observability::{debug, info, info_record};
 use amaru_ouroboros::{ChainStore, ConnectionsResource, MempoolMsg, PoolSummaries, ResourceMempool};
 use amaru_plutus::arena_pool::ArenaPool;
 use amaru_protocols::{
@@ -38,7 +39,7 @@ use amaru_pure_stage::{
     trace_buffer::TraceBuffer,
 };
 use amaru_stores::rocksdb::{RocksDB, RocksDBHistoricalStores, consensus::RocksDBStore};
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use opentelemetry::metrics::Meter;
 use parking_lot::Mutex;
 use tokio::runtime::Handle;
@@ -126,7 +127,10 @@ pub fn build_node(
     // ledger tip.
     initialize_chain_store(chain_store.clone(), ledger_tip)?;
     let ledger_tip = chain_store.load_tip(&ledger_tip.hash()).ok_or(anyhow!("ledger tip header not found"))?;
-    let best_hash = find_best_candidate(chain_store.as_ref())?;
+
+    // The best hash for blocks that were possibly downloaded and validated before a restart,
+    // i.e. before the volatile ledger was dropped.
+    let recovery_best_hash = find_best_candidate(chain_store.as_ref())?;
 
     // Make resources
     let era_history = &config.era_history();
@@ -149,8 +153,15 @@ pub fn build_node(
     let resources = stage_builder.resources().clone();
 
     // Build the stage graph and return a reference to the stages that can be connected from outside this function
-    let node_stages =
-        build_stage_graph(config, era_history, global_parameters, ledger_tip, best_hash, max_epoch, stage_builder);
+    let node_stages = build_stage_graph(
+        config,
+        era_history,
+        global_parameters,
+        ledger_tip,
+        recovery_best_hash,
+        max_epoch,
+        stage_builder,
+    );
 
     let track_peers_sender = node_stages.track_peers_stake_dist_sender();
     block_validator.set_on_stake_dist_updated(Arc::new(move |summaries| {
@@ -247,14 +258,154 @@ pub fn make_state(config: &LedgerConfig) -> anyhow::Result<State<RocksDB, RocksD
 }
 
 fn initialize_chain_store(chain_store: Arc<dyn ChainStore>, ledger_tip: Point) -> anyhow::Result<()> {
-    let anchor_hash = chain_store.get_anchor_hash();
+    info!(consensus::chain_db::INITIALIZE, ledger_tip = %ledger_tip);
 
-    // This corresponds to a bootstrap, we need to correctly initialize the chain store
-    if anchor_hash == ORIGIN_HASH {
-        tracing::info!(anchor = %ledger_tip, "first initialization - setting anchor and best chain");
-        chain_store.set_anchor_hash(&ledger_tip.hash())?;
-        chain_store.set_block_valid(&ledger_tip.hash(), true)?;
+    let best_chain_hash = chain_store.get_best_chain_hash();
+    let has_best_chain = best_chain_hash != ORIGIN_HASH;
+
+    // Every fork branches at or after the immutable tip, which cannot be rolled back, so the
+    // ledger tip is always on the recorded best chain. When it is not, the two databases describe
+    // different chains and truncating the best chain would silently discard headers. This is
+    // checked before any mutation so that a rejected chain database is left untouched.
+    if has_best_chain && chain_store.load_from_best_chain(&ledger_tip).is_none() {
+        bail!(
+            "the chain database is inconsistent with the ledger: its best chain, ending at \
+             {best_chain_hash}, does not contain the ledger tip {ledger_tip}. This happens when \
+             a ledger snapshot is imported on top of a chain database built for another chain. \
+             Remove the chain database so that it can be rebuilt from the ledger tip."
+        );
+    }
+
+    chain_store.set_anchor_hash(&ledger_tip.hash())?;
+    chain_store.set_block_valid(&ledger_tip.hash(), true)?;
+    if has_best_chain {
+        chain_store.switch_to_fork(&ledger_tip, &[])?;
+    } else {
         chain_store.roll_forward_chain(&ledger_tip)?;
     }
+
+    info_record!(consensus::chain_db::INITIALIZE, best_chain_hash = best_chain_hash);
+    clear_valid_descendants_after_ledger_tip(chain_store.as_ref(), ledger_tip)?;
     Ok(())
+}
+
+/// Consider that previously validated blocks haven't been validated now, since the volatile ledger
+/// is going to be reconstructed on a restart.
+fn clear_valid_descendants_after_ledger_tip(chain_store: &dyn ChainStore, ledger_tip: Point) -> anyhow::Result<()> {
+    let mut to_visit = chain_store.get_children(&ledger_tip.hash());
+    let mut count = 0;
+
+    while let Some(hash) = to_visit.pop() {
+        let Some((_header, validity)) = chain_store.load_header_with_validity(&hash) else {
+            continue;
+        };
+
+        if validity == Some(true) {
+            count += 1;
+            chain_store.remove_block_valid(&hash)?;
+        }
+
+        to_visit.extend(chain_store.get_children(&hash));
+    }
+    debug!(consensus::chain_db::CLEAR_VALID_DESCENDANTS, count = count);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use amaru_kernel::{BlockHeader, IsHeader, make_header};
+    use amaru_ouroboros::{BaseReadChainStore, WriteChainStore, in_memory_chain_store::InMemoryChainStore};
+
+    use super::*;
+
+    #[test]
+    fn realign_the_chain_store_on_the_ledger_tip() {
+        // h0 -- h1 -- h2 -- h3   the chain the consensus had validated
+        //         \
+        //          h2a          a fork that was validated and rejected
+        let h0 = header(1, 1, None);
+        let h1 = header(2, 2, Some(&h0));
+        let h2 = header(3, 3, Some(&h1));
+        let h3 = header(4, 4, Some(&h2));
+        let h2a = header(3, 30, Some(&h1));
+
+        let chain_store = Arc::new(InMemoryChainStore::new());
+        for header in [&h0, &h1, &h2, &h3, &h2a] {
+            chain_store.store_header(header).unwrap();
+            chain_store.set_block_valid(&header.hash(), true).unwrap();
+        }
+        chain_store.set_block_valid(&h2a.hash(), false).unwrap();
+        for header in [&h0, &h1, &h2, &h3] {
+            chain_store.roll_forward_chain(&header.point()).unwrap();
+        }
+        chain_store.set_anchor_hash(&h0.hash()).unwrap();
+
+        // the ledger restarts from h1, behind the blocks the consensus had validated
+        initialize_chain_store(chain_store.clone(), h1.point()).unwrap();
+
+        assert_eq!(chain_store.get_anchor_hash(), h1.hash(), "the anchor must move to the ledger tip");
+        assert_eq!(chain_store.get_best_chain_hash(), h1.hash(), "the best chain must end at the ledger tip");
+        assert!(chain_store.load_from_best_chain(&h1.point()).is_some(), "the ledger tip stays on the best chain");
+        assert!(chain_store.load_from_best_chain(&h2.point()).is_none(), "h2 must leave the best chain");
+        assert!(chain_store.load_from_best_chain(&h3.point()).is_none(), "h3 must leave the best chain");
+
+        assert_eq!(validity(chain_store.as_ref(), &h0), Some(true), "blocks before the ledger tip stay validated");
+        assert_eq!(validity(chain_store.as_ref(), &h1), Some(true), "the ledger tip stays validated");
+        assert_eq!(validity(chain_store.as_ref(), &h2), None, "h2 must be applied to the ledger again");
+        assert_eq!(validity(chain_store.as_ref(), &h3), None, "h3 must be applied to the ledger again");
+        assert_eq!(validity(chain_store.as_ref(), &h2a), Some(false), "an invalid block was never applied");
+    }
+
+    #[test]
+    fn start_the_best_chain_on_a_store_that_has_none() {
+        let h0 = header(1, 1, None);
+
+        let chain_store = Arc::new(InMemoryChainStore::new());
+        chain_store.store_header(&h0).unwrap();
+
+        initialize_chain_store(chain_store.clone(), h0.point()).unwrap();
+
+        assert_eq!(chain_store.get_anchor_hash(), h0.hash());
+        assert_eq!(chain_store.get_best_chain_hash(), h0.hash());
+        assert!(chain_store.load_from_best_chain(&h0.point()).is_some(), "the ledger tip starts the best chain");
+        assert_eq!(validity(chain_store.as_ref(), &h0), Some(true));
+    }
+
+    #[test]
+    fn reject_a_chain_store_that_does_not_contain_the_ledger_tip() {
+        // h0 -- h1     the chain the consensus had built
+        //   \
+        //    h1a       the branch the ledger was bootstrapped on
+        let h0 = header(1, 1, None);
+        let h1 = header(2, 2, Some(&h0));
+        let h1a = header(2, 20, Some(&h0));
+
+        let chain_store = Arc::new(InMemoryChainStore::new());
+        for header in [&h0, &h1, &h1a] {
+            chain_store.store_header(header).unwrap();
+        }
+        for header in [&h0, &h1] {
+            chain_store.roll_forward_chain(&header.point()).unwrap();
+        }
+        chain_store.set_anchor_hash(&h0.hash()).unwrap();
+
+        let error = initialize_chain_store(chain_store.clone(), h1a.point()).unwrap_err().to_string();
+
+        assert!(error.contains("inconsistent with the ledger"), "unexpected error: {error}");
+        assert_eq!(chain_store.get_best_chain_hash(), h1.hash(), "the best chain must be left untouched");
+        assert_eq!(chain_store.get_anchor_hash(), h0.hash(), "the anchor must be left untouched");
+        for header in [&h0, &h1, &h1a] {
+            assert_eq!(validity(chain_store.as_ref(), header), None, "no block validity must be recorded");
+        }
+    }
+
+    // HELPERS
+
+    fn header(block_height: u64, slot: u64, parent: Option<&BlockHeader>) -> BlockHeader {
+        BlockHeader::from(make_header(block_height, slot, parent.map(BlockHeader::hash)))
+    }
+
+    fn validity(chain_store: &dyn ChainStore, header: &BlockHeader) -> Option<bool> {
+        chain_store.load_header_with_validity(&header.hash()).and_then(|(_, validity)| validity)
+    }
 }

--- a/crates/amaru-node/src/stages/build_stage_graph.rs
+++ b/crates/amaru-node/src/stages/build_stage_graph.rs
@@ -51,7 +51,7 @@ pub fn build_stage_graph(
     era_history: &EraHistory,
     global_parameters: &GlobalParameters,
     ledger_tip: Tip,
-    best_hash: HeaderHash,
+    recovery_best_hash: HeaderHash,
     max_epoch: Epoch,
     stage_graph: &mut impl StageGraph,
 ) -> NodeStages {
@@ -146,7 +146,10 @@ pub fn build_stage_graph(
     // Include main's useful RecoverStoredBlocks preload
     #[expect(clippy::expect_used)]
     stage_graph
-        .preload(&fetch_blocks, [FetchBlocksMsg::RecoverStoredBlocks(best_hash, trace_context)])
+        .preload(
+            &fetch_blocks,
+            [FetchBlocksMsg::RecoverStoredBlocks { from: ledger_tip.point(), to: recovery_best_hash, trace_context }],
+        )
         .expect("fetch blocks recovery message must be preloaded");
 
     let fetch_blocks_input = stage_graph.contramap(fetch_blocks, "fetch_blocks_input", |msg| {
@@ -157,7 +160,7 @@ pub fn build_stage_graph(
     let select_chain = stage_graph.wire_up(select_chain, SelectChain::new(fetch_blocks_input));
     #[expect(clippy::expect_used)]
     stage_graph
-        .preload(&select_chain, [SelectChainMsg::Initialize(best_hash)])
+        .preload(&select_chain, [SelectChainMsg::Initialize(recovery_best_hash)])
         .expect("initialization message must be preloaded");
     let select_chain_input = stage_graph.contramap(select_chain, "select_chain_input", |msg| {
         let track_peers::NewTip { tip, parent, trace_context, received_at } = msg;

--- a/crates/amaru-node/src/tests/setup.rs
+++ b/crates/amaru-node/src/tests/setup.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use amaru_consensus::{
     effects::{
         ResourceBlockValidation, ResourceConsensusParameters, ResourceEraHistory, ResourceHasStakePools,
-        ResourcePoolSummaries, ResourceTxValidation,
+        ResourcePoolSummaries, ResourceTxValidation, ValidateHeaderEffect,
     },
     headers_tree::data_generation::Action,
     stages::test_utils::start_in_era,
@@ -33,7 +33,7 @@ use amaru_protocols::{
 };
 use amaru_pure_stage::{
     Effects, OrTerminateWith, StageGraph, StageRef,
-    simulation::{RandStdRng, SimulationBuilder},
+    simulation::{RandStdRng, SimulationBuilder, running::OverrideResult},
 };
 use anyhow::anyhow;
 use tracing_subscriber::EnvFilter;
@@ -64,7 +64,12 @@ pub fn create_nodes(rng: &mut RandStdRng, configs: Vec<NodeTestConfig>) -> anyho
 
         let config = config.with_connections(connections.clone());
         let test_node_stages = create_node(&config, &mut stage_graph)?;
-        nodes.push(Node::new(config, stage_graph.run(), test_node_stages));
+
+        let mut running = stage_graph.run();
+        // Don't validate the generated headers, we just want to check the mini-protocols communication.
+        running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| OverrideResult::handled(Ok(())));
+
+        nodes.push(Node::new(config, running, test_node_stages));
     }
 
     // Initialize the nodes by running until the chainsync protocol is registered

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -35,12 +35,22 @@ define_schemas! {
                     required from: u16
                     required to: u16
                 }
+                /// Initialize the store
+                INITIALIZE {
+                    required ledger_tip: amaru_kernel::Point
+                    optional best_chain_hash: amaru_kernel::HeaderHash
+                }
+                /// Remove the valid status of descendants of a given block to reapply those blocks.
+                CLEAR_VALID_DESCENDANTS {
+                    required count: usize
+                }
             }
             blocks {
                 /// Validate downloaded blocks that are not yet validated
                 RECOVER_STORED {
                     tags: setup
-                    required best_hash: amaru_kernel::HeaderHash
+                    required from: amaru_kernel::Point
+                    required to: amaru_kernel::HeaderHash
                 }
                 /// Fetch a range of blocks starting from the specified tip
                 FETCH {

--- a/crates/amaru-ouroboros-traits/src/stores/chain_store/in_memory_chain_store.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/chain_store/in_memory_chain_store.rs
@@ -220,6 +220,13 @@ impl WriteChainStore for InMemoryChainStore {
     }
 
     #[expect(clippy::unwrap_used)]
+    fn remove_block_valid(&self, hash: &HeaderHash) -> Result<(), StoreError> {
+        let mut inner = self.inner.lock().unwrap();
+        inner.block_validity.remove(hash);
+        Ok(())
+    }
+
+    #[expect(clippy::unwrap_used)]
     fn switch_to_fork(&self, fork_point: &Point, forward_points: &[Point]) -> Result<(), StoreError> {
         let mut inner = self.inner.lock().unwrap();
         if let Some(pos) = inner.chain.iter().rposition(|p| p == fork_point) {

--- a/crates/amaru-ouroboros-traits/src/stores/chain_store/overriding_chain_store.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/chain_store/overriding_chain_store.rs
@@ -54,6 +54,7 @@ struct Overrides {
     set_best_chain_hash: Option<Box<dyn FnMut(&dyn ChainStore, &HeaderHash) -> Result<(), StoreError> + Send>>,
     store_block: Option<Box<dyn FnMut(&dyn ChainStore, &HeaderHash, &RawBlock) -> Result<(), StoreError> + Send>>,
     set_block_valid: Option<Box<dyn FnMut(&dyn ChainStore, &HeaderHash, bool) -> Result<(), StoreError> + Send>>,
+    remove_block_valid: Option<Box<dyn FnMut(&dyn ChainStore, &HeaderHash) -> Result<(), StoreError> + Send>>,
     put_nonces: Option<Box<dyn FnMut(&dyn ChainStore, &HeaderHash, &Nonces) -> Result<(), StoreError> + Send>>,
     switch_to_fork: Option<Box<dyn FnMut(&dyn ChainStore, &Point, &[Point]) -> Result<(), StoreError> + Send>>,
     roll_forward_chain: Option<Box<dyn FnMut(&dyn ChainStore, &Point) -> Result<(), StoreError> + Send>>,
@@ -459,6 +460,14 @@ impl WriteChainStore for OverridingChainStore {
         match &mut overrides.set_block_valid {
             Some(f) => f(self.inner.as_ref(), hash, valid),
             None => self.inner.set_block_valid(hash, valid),
+        }
+    }
+
+    fn remove_block_valid(&self, hash: &HeaderHash) -> Result<(), StoreError> {
+        let mut overrides = self.overrides.lock();
+        match &mut overrides.remove_block_valid {
+            Some(f) => f(self.inner.as_ref(), hash),
+            None => self.inner.remove_block_valid(hash),
         }
     }
 

--- a/crates/amaru-ouroboros-traits/src/stores/chain_store/read_chain_store.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/chain_store/read_chain_store.rs
@@ -83,6 +83,47 @@ pub trait ReadChainStore: BaseReadChainStore {
         (hashes, valid)
     }
 
+    /// Return the tips of the headers leading from `from` (exclusive) to `to` (inclusive), in
+    /// parent -> child order, walking a single snapshot.
+    ///
+    /// Example:
+    ///
+    ///   O--A--B--C--D
+    ///         ^     ^
+    ///        from   to
+    ///
+    /// Returns `Some([C, D])`, and `Some([])` when `to` is `from` itself.
+    ///
+    /// Unlike [`Self::unvalidated_ancestor_hashes`] the walk is bounded by `from` rather than by the
+    /// recorded validity of the blocks, so the caller gets a path anchored exactly where it asked.
+    ///
+    /// Returns `None` when a header along the way is missing from the store, or when `to` is not a
+    /// descendant of `from`.
+    fn ancestors_between(&self, from: &Point, to: HeaderHash) -> Option<Vec<Tip>> {
+        let snapshot = self.snapshot();
+        let from_slot = from.slot_or_default();
+        let from_hash = from.hash();
+        let mut tips = Vec::new();
+        let mut current = to;
+
+        while current != from_hash {
+            let header = snapshot.load_header(&current)?;
+
+            // Slots strictly increase along a chain, so a header at or below `from`'s slot that is
+            // not `from` itself proves `to` hangs off a branch that never passes through it. Giving
+            // up here keeps a mismatched pair from reading every header down to the genesis block.
+            if header.slot() <= from_slot {
+                return None;
+            }
+
+            tips.push(header.tip());
+            current = header.parent()?;
+        }
+
+        tips.reverse();
+        Some(tips)
+    }
+
     /// Return the fork point with the best chain (if it exists) and the list of points from
     /// that point to the new best tip (in that order, ending with `start`)
     ///

--- a/crates/amaru-ouroboros-traits/src/stores/chain_store/write_chain_store.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/chain_store/write_chain_store.rs
@@ -29,6 +29,9 @@ pub trait WriteChainStore: Send + Sync {
 
     fn set_block_valid(&self, hash: &HeaderHash, valid: bool) -> Result<(), StoreError>;
 
+    /// Remove the validity flag of a block.
+    fn remove_block_valid(&self, hash: &HeaderHash) -> Result<(), StoreError>;
+
     fn put_nonces(&self, header: &HeaderHash, nonces: &Nonces) -> Result<(), StoreError>;
 
     /// Replace the current best chain from the given fork point with the provided

--- a/crates/amaru-protocols/src/store_effects.rs
+++ b/crates/amaru-protocols/src/store_effects.rs
@@ -140,6 +140,10 @@ impl Store {
         self.effects.external(UnvalidatedAncestorHashesEffect::new(start))
     }
 
+    pub fn ancestors_between(&self, from: Point, to: HeaderHash) -> BoxFuture<'static, Option<Vec<Tip>>> {
+        self.effects.external(AncestorsBetweenEffect::new(from, to).with_trace_context(&self.trace_context))
+    }
+
     pub fn find_ancestor_on_best_chain(
         &self,
         start: HeaderHash,
@@ -206,6 +210,7 @@ pub fn register_deserializers() -> DeserializerGuards {
         amaru_pure_stage::register_effect_deserializer::<SwitchToForkEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<RollForwardChainEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<UnvalidatedAncestorHashesEffect>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<AncestorsBetweenEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<FindAncestorOnBestChainEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<FindAnchorAtHeightEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<FindCommonAncestorEffect>().boxed(),
@@ -819,6 +824,40 @@ impl ExternalEffect for UnvalidatedAncestorHashesEffect {
 
 impl ExternalEffectAPI for UnvalidatedAncestorHashesEffect {
     type Response = (Vec<HeaderHash>, bool);
+}
+
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct AncestorsBetweenEffect {
+    from: Point,
+    to: HeaderHash,
+    trace_context: TraceContext,
+}
+
+impl AncestorsBetweenEffect {
+    pub fn new(from: Point, to: HeaderHash) -> Self {
+        Self { from, to, trace_context: Default::default() }
+    }
+
+    pub fn with_trace_context(mut self, trace_context: &TraceContext) -> Self {
+        self.trace_context = trace_context.clone();
+        self
+    }
+}
+
+impl ExternalEffect for AncestorsBetweenEffect {
+    #[expect(clippy::expect_used)]
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        Self::wrap_sync({
+            let _guard = self.trace_context.attach();
+            let store =
+                resources.get::<ResourceHeaderStore>().expect("AncestorsBetweenEffect requires a chain store").clone();
+            store.ancestors_between(&self.from, self.to)
+        })
+    }
+}
+
+impl ExternalEffectAPI for AncestorsBetweenEffect {
+    type Response = Option<Vec<Tip>>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/crates/amaru-stores/src/rocksdb/consensus/rocksdb_store.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/rocksdb_store.rs
@@ -122,12 +122,6 @@ impl RocksDBStore<DB> {
         self.db.write(batch).map_err(|e| StoreError::WriteError { error: e.to_string() })
     }
 
-    pub fn remove_block_valid(&self, hash: &HeaderHash) -> Result<(), StoreError> {
-        self.db
-            .delete([&HEADER_PREFIX[..], &hash[..], &[0]].concat())
-            .map_err(|e| StoreError::WriteError { error: e.to_string() })
-    }
-
     pub fn remove_block(&self, hash: &HeaderHash) -> Result<(), StoreError> {
         self.with_batch(|batch| {
             batch.delete([&BLOCK_PREFIX[..], &hash[..]].concat());

--- a/crates/amaru-stores/src/rocksdb/consensus/tests.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/tests.rs
@@ -388,6 +388,91 @@ fn switch_to_fork_preserves_state_when_fork_point_is_not_on_best_chain() {
 }
 
 #[test]
+fn ancestors_between_returns_the_path_in_parent_to_child_order() {
+    with_db(|store| {
+        let headers = make_forked_headers();
+        append_best_chain(store.clone(), headers.main());
+
+        let path = store.ancestors_between(&headers.h0.point(), headers.h3.hash()).unwrap();
+
+        assert_eq!(path, vec![headers.h1.tip(), headers.h2.tip(), headers.h3.tip()]);
+    });
+}
+
+#[test]
+fn ancestors_between_is_empty_when_from_is_to() {
+    with_db(|store| {
+        let headers = make_forked_headers();
+        append_best_chain(store.clone(), headers.main());
+
+        assert_eq!(store.ancestors_between(&headers.h0.point(), headers.h0.hash()), Some(vec![]));
+    });
+}
+
+#[test]
+fn ancestors_between_reports_a_from_ahead_of_to() {
+    with_db(|store| {
+        let headers = make_forked_headers();
+        append_best_chain(store.clone(), headers.main());
+        for header in [&headers.h2a, &headers.h3a] {
+            store.store_header(header).unwrap();
+        }
+
+        assert_eq!(store.ancestors_between(&headers.h3a.point(), headers.h3.hash()), None);
+    });
+}
+
+#[test]
+fn ancestors_between_reports_a_missing_header() {
+    with_db(|store| {
+        let headers = make_forked_headers();
+        append_best_chain(store.clone(), headers.main());
+
+        let absent = run_strategy(any_header_hash());
+        assert_eq!(store.ancestors_between(&headers.h0.point(), absent), None);
+    });
+}
+
+#[test]
+fn ancestors_between_follows_a_fork_rather_than_the_best_chain() {
+    with_db(|store| {
+        let headers = make_forked_headers();
+        append_best_chain(store.clone(), headers.main());
+        for header in [&headers.h2a, &headers.h3a] {
+            store.store_header(header).unwrap();
+        }
+
+        let path = store.ancestors_between(&headers.h1.point(), headers.h3a.hash()).unwrap();
+
+        assert_eq!(path, vec![headers.h2a.tip(), headers.h3a.tip()]);
+    });
+}
+
+#[test]
+fn ancestors_between_reports_a_from_on_another_branch() {
+    // h0 -> h1 -> h2 -> h3      the best chain
+    //  \      \
+    //  \       -> h2a -> h3a
+    //   ------ -> sibling
+    // `sibling` shares h2's slot but hangs off h0, so it is not an ancestor of h3a. Walking up from
+    // h3a descends h3a and h2a before reaching h1, whose slot is below `sibling`'s.
+    // The search should stop there and return None.
+    with_db(|store| {
+        let headers = make_forked_headers();
+        append_best_chain(store.clone(), headers.main());
+        for header in [&headers.h2a, &headers.h3a] {
+            store.store_header(header).unwrap();
+        }
+        let sibling = BlockHeader::from(make_header(3, 3, Some(headers.h0.hash())));
+        store.store_header(&sibling).unwrap();
+        assert_ne!(sibling.hash(), headers.h2.hash());
+        assert!(sibling.slot() > headers.h1.slot() && sibling.slot() < headers.h3a.slot());
+
+        assert_eq!(store.ancestors_between(&sibling.point(), headers.h3a.hash()), None);
+    });
+}
+
+#[test]
 fn find_ancestor_on_best_chain_returns_none_when_start_header_is_not_in_store() {
     with_db(|store| {
         let headers = make_forked_headers();

--- a/crates/amaru-stores/src/rocksdb/consensus/write_chain_store.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/write_chain_store.rs
@@ -60,6 +60,12 @@ impl WriteChainStore for RocksDBStore {
             .map_err(|e| StoreError::WriteError { error: e.to_string() })
     }
 
+    fn remove_block_valid(&self, hash: &HeaderHash) -> Result<(), StoreError> {
+        self.db
+            .delete([&HEADER_PREFIX[..], &hash[..], &[0]].concat())
+            .map_err(|e| StoreError::WriteError { error: e.to_string() })
+    }
+
     fn put_nonces(&self, header: &HeaderHash, nonces: &Nonces) -> Result<(), StoreError> {
         self.db
             .put([&NONCES_PREFIX[..], &header[..]].concat(), to_cbor(nonces))

--- a/crates/amaru/src/bin/amaru/cmd/dev/chain/clear_invalid.rs
+++ b/crates/amaru/src/bin/amaru/cmd/dev/chain/clear_invalid.rs
@@ -16,6 +16,7 @@ use std::path::PathBuf;
 
 use amaru::default_chain_dir;
 use amaru_kernel::NetworkName;
+use amaru_ouroboros::WriteChainStore;
 use amaru_stores::rocksdb::{RocksDbConfig, consensus::RocksDBStore};
 
 use crate::cmd::PointOrHash;

--- a/crates/amaru/src/bin/amaru/cmd/dev/chain/remove.rs
+++ b/crates/amaru/src/bin/amaru/cmd/dev/chain/remove.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 
 use amaru::default_chain_dir;
 use amaru_kernel::{IsHeader, NetworkName, Point};
-use amaru_ouroboros::{ChainStore, ChildTipsMode};
+use amaru_ouroboros::{ChainStore, ChildTipsMode, WriteChainStore};
 use amaru_stores::rocksdb::{RocksDbConfig, consensus::RocksDBStore};
 
 #[derive(Debug, clap::Parser)]


### PR DESCRIPTION
This PR fixes the issue described in #1095:

 1. It adds an operation to reset the validity status of a downloaded block in order to reapply blocks that had been previously applied on the volatile part of the ledger before a restart.
  
 2. It adds an operation to get retrieve the ancestors of a given tip. This is used to find all the blocks between:
  - The ledger tip
  - The best tip candidate identified by the chain store (a descendant of the ledger tip)

  3. During start-up, there is a recovery phase to reapply and / or get the blocks from ledger tip to best tip candidate

  4. On the ledger a special operation has been added `transition_already_persisted` to put the volatile ledger in the proper state if the ledger db already contains part of the data flushed before a transaction (@KtorZ does that mean that we could do some more atomic updates somewhere?)
  
  I tested it by bootstrapping and starting the node. I did not observe the "rollback in the future" message anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node start/restart recovery by validating the restart range using a ledger restart boundary and replaying the contiguous stored header prefix before fetching missing blocks.
  * Added stricter chain-store realignment checks (fails fast on inconsistent best chains) and clears stale “valid” flags after recovery.
  * Fixed epoch initialization/transition behavior across interrupted restarts.
* **Improvements**
  * Added fork-aware `ancestors_between` support and updated stored-block recovery/tracing accordingly.
  * Improved consensus store cleanup to reliably remove validity state during block removal, with added test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->