### PR TITLE
feat: set the timeout fetching block message to warn

### DIFF
--- a/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
@@ -402,7 +402,7 @@ impl FetchBlocks {
         if self.no_peers_pause {
             tracing::debug!(%req_id, "retrying block fetch after no-peers pause");
         } else {
-            tracing::error!(%req_id, "timeout fetching blocks");
+            tracing::warn!(%req_id, "timeout fetching blocks");
         }
         match self.missing.as_ref().map(|m| m.boundary()) {
             None => (),

--- a/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
@@ -196,7 +196,7 @@ fn test_new_tip_blocks_to_fetch() {
         ],
     );
     logs.assert_and_remove(Level::DEBUG, &["requesting blocks"])
-        .assert_and_remove(Level::ERROR, &["timeout fetching blocks"])
+        .assert_and_remove(Level::WARN, &["timeout fetching blocks"])
         .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted block-fetch timeout logging to use a warning level instead of an error level when retries remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->