### PR TITLE
ensure bounded schedule usage in peer_selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Other guiding principles:
 - **amaru-ledger**: preserve the `Ratified` status of proposals pruned during ratification ([#1118][])
 - **amaru-kernel**: reduce memory footprint of various types on the critical path.
 - **amaru-ledger**: when a leader changes it reward account, the rewards owed to the previous account must return to the treasury ([#1125](https://github.com/pragma-org/amaru/pull/1125)).
+- **amaru-consensus**: fix peer_selection to only schedule a single cool-down timer and thus properly bound priority mailbox usage. ([#1112](https://github.com/pragma-org/amaru/issues/1112))
 
 ## [v10.11.20260730](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260730)
 

--- a/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
@@ -174,10 +174,11 @@ pub fn setup(prep: &TestPrep, msg: FetchBlocksMsg) -> (SimulationRunning, Deseri
     run_simulation(
         prep.rt.handle(),
         guards,
-        |network| {
+        |mut network| {
             let fb = network.stage("fb", stage);
             let fb = network.wire_up(fb, prep.state.clone());
             network.preload(&fb, [msg]).unwrap();
+            network
         },
         |resources| {
             resources.put::<ResourceHeaderStore>(prep.store.clone());

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use std::{
-    collections::{BTreeMap, BTreeSet, btree_map::Entry},
+    cmp::Reverse,
+    collections::{BTreeMap, BTreeSet, BinaryHeap, btree_map::Entry},
     time::Duration,
 };
 
@@ -21,7 +22,7 @@ use amaru_kernel::{BlockHeight, Peer};
 use amaru_observability::{TraceContext, debug_span};
 use amaru_ouroboros::{ConnectionDirection, ConnectionId};
 use amaru_protocols::manager::ManagerMessage;
-use amaru_pure_stage::{Effects, ScheduleId, StageRef};
+use amaru_pure_stage::{Effects, Instant, ScheduleId, StageRef};
 use rand::{SeedableRng, rngs::StdRng, seq::IteratorRandom};
 use tracing::Instrument;
 
@@ -43,7 +44,7 @@ const STATIC_PEER_BAN_PERIOD: Duration = Duration::from_secs(10);
 ///
 /// Outbound regulation uses a random refill (via `GenerateRandomSeed` external effect)
 /// preferring static peers, then snapshot candidates, then ledger candidates, while
-/// skipping any peer currently tracked in `outbound_peers` or `cooldown_timers`.
+/// skipping any peer currently tracked in `outbound_peers` or `cooldown_until`.
 /// Inbound connections are accepted up to `target_downstream_peers` (excess are
 /// immediately rejected with a `Disconnect`).
 ///
@@ -58,12 +59,15 @@ const STATIC_PEER_BAN_PERIOD: Duration = Duration::from_secs(10);
 /// - `manager`: `StageRef<ManagerMessage>` for all outbound commands.
 /// - `static_peers`, `snapshot_candidates`, `ledger_candidates`: candidate pools (`BTreeSet<Peer>`).
 /// - `peer_removal_cooldown`: duration for non-static bans.
-/// - `cooldown_timers`: `BTreeMap<Peer, ScheduleId>` for active bans (self-scheduled
-///   `CooldownEnded` messages).
+/// - `cooldown_until`: `BTreeMap<Peer, Instant>` of active bans (end time per peer).
+/// - `cooldown_heap`: min-heap of pending `(Instant, Peer)` cool-down entries
+///   (may contain stale entries after re-ban or early `AddPeer` lift).
+/// - `cooldown_timer`: at most one outstanding `schedule_at(CheckCooldowns)` for the
+///   earliest heap entry (`None` when no cool-downs are pending).
 /// - `inbound_peers`: `BTreeMap<Peer, Connection>` (downstream tracking).
 /// - `outbound_peers`: `BTreeMap<Peer, PeerState>` (`Connecting` or `Connected(Connection)`).
 ///
-/// ## Message Handling (core of `stage()` at mod.rs:188)
+/// ## Message Handling
 ///
 /// All behaviour is implemented in the single `match msg` inside `pub async fn stage`.
 /// The stage is purely message-driven; there are no background loops outside scheduled
@@ -84,19 +88,23 @@ const STATIC_PEER_BAN_PERIOD: Duration = Duration::from_secs(10);
 ///   `"removing peer (outbound)"`, calls `regulate_peers`, marks for removal).
 ///   If any removal occurred, sends `ManagerMessage::RemovePeer` to the manager.
 ///   Always calls `cool_down` (which computes `STATIC_PEER_BAN_PERIOD` (10s) for
-///   static peers vs. configured cooldown, schedules a self `CooldownEnded` via
-///   `eff.schedule_after`, cancels any prior timer for the same peer, and records
-///   the new `ScheduleId` in `cooldown_timers`).
+///   static peers vs. configured cooldown, pushes onto the cool-down min-heap, and
+///   arms `eff.schedule_at(CheckCooldowns)` only when the live cool-down set goes from
+///   empty to one item, or when the new end time is earlier than the currently armed timer).
 ///
 /// - **AddPeer**: Manual/test hook. If the peer
-///   has an active cooldown timer, cancels the schedule (`eff.cancel_schedule`) and
-///   records `was_banned = true`. If the peer is not already in `outbound_peers`:
-///   logs `"peer_selection.add_peer"` (with `was_banned`), sends `ManagerMessage::AddPeer`,
-///   and inserts as `Connecting`. Otherwise logs that it is not adding.
+///   has an active cool-down, removes it from `cooldown_until` (`was_banned = true`)
+///   and cancels the armed timer if no cool-downs remain. If the peer is not already
+///   in `outbound_peers`: logs `"peer_selection.add_peer"` (with `was_banned`), sends
+///   `ManagerMessage::AddPeer`, and inserts as `Connecting`. Otherwise logs that it is
+///   not adding.
 ///
-/// - **CooldownEnded**: Removes the peer from
-///   `cooldown_timers` (idempotent for stale messages). Unconditionally calls
-///   `regulate_peers` (which may trigger `GenerateRandomSeed` + `AddPeer` sends).
+/// - **CheckCooldowns**: Clears any armed timer (cancel is a no-op if this message was
+///   the delivery), drains all due min-heap entries (removes a peer from `cooldown_until`
+///   when its stored deadline is `<= now` — so a re-ban with a later deadline is kept),
+///   calls `regulate_peers`, then arms the next earliest heap entry via `schedule_at`
+///   (if any). A past `Instant` is delivered on the priority path as soon as the runtime
+///   can run this stage again.
 ///
 /// - **Connected**:
 ///   - `Inbound`: If `inbound_peers.len() >= target_downstream_peers`, logs
@@ -126,7 +134,7 @@ const STATIC_PEER_BAN_PERIOD: Duration = Duration::from_secs(10);
 /// ## Helper Methods
 ///
 /// - `ban_peer`: Core removal + ban logic (used only by `Adversarial`).
-/// - `cool_down`: Computes ban period, schedules `CooldownEnded`,   cancels prior timer for the peer.
+/// - `cool_down`: Computes ban end, pushes onto the min-heap, arms at most one timer.
 /// - `regulate_peers`: Core outbound refill logic (see below).
 ///
 /// ## Ledger-Check Child Protocol
@@ -148,23 +156,24 @@ const STATIC_PEER_BAN_PERIOD: Duration = Duration::from_secs(10);
 ///
 /// ## Regulation, Schedules, and Effects
 ///
-/// `regulate_peers` (called from `CooldownEnded`, outbound non-retry disconnect,
+/// `regulate_peers` (called from `CheckCooldowns`, outbound non-retry disconnect,
 /// `ConnectFailed`, `LedgerCheckCandidates`, and outbound removal inside `ban_peer`)
 /// early-returns if `outbound_peers.len() >= target_upstream_peers`. Otherwise it
 /// obtains a seed via `eff.external(GenerateRandomSeed)`, builds an `StdRng`, and
 /// does three passes (statics, then snapshot_candidates, then ledger_candidates):
-/// - Filters candidates to those absent from `outbound_peers` and `cooldown_timers`.
+/// - Filters candidates to those absent from `outbound_peers` and `cooldown_until`.
 /// - `choose_multiple` up to the deficit.
 /// - For each: logs `"peer_selection.add_peer"`, sends `ManagerMessage::AddPeer`,
 ///   inserts as `Connecting`.
 ///
 /// Schedules (via `Effects`):
-/// - Cooldown `CooldownEnded(Peer)` messages (from `cool_down`).
+/// - At most one `CheckCooldowns` armed via `schedule_at` (from `cool_down` /
+///   `arm_next_cooldown`); remaining cool-downs live only in the min-heap.
 /// - Child-internal `()` triggers (60s cadence, conditional on height delta).
 ///
-/// Other effects used: `eff.send` (to manager and child), `eff.schedule_after`,
-/// `eff.cancel_schedule`, `eff.stage`/`eff.wire_up`, `eff.me()`, `eff.external`,
-/// and `Ledger` (via effects facade).
+/// Other effects used: `eff.send` (to manager and child), `eff.clock`, `eff.schedule_at`,
+/// `eff.schedule_after`, `eff.cancel_schedule`, `eff.stage`/`eff.wire_up`, `eff.me()`,
+/// `eff.external`, and `Ledger` (via effects facade).
 ///
 /// ## Logging, Errors, and Invariants
 ///
@@ -173,13 +182,14 @@ const STATIC_PEER_BAN_PERIOD: Duration = Duration::from_secs(10);
 ///   rejection, removals with `is_static`, outbound replacement warnings).
 /// - Ledger child errors are logged at `warn!` but do not crash the parent
 ///   (just reschedule with no candidate update).
-/// - Stale messages are tolerated (e.g., `CooldownEnded` for absent peers still
+/// - Stale messages are tolerated (e.g., `CheckCooldowns` with nothing due still
 ///   runs `regulate_peers`; duplicate `AddPeer` is a no-op after logging).
-/// - Map invariants: `cooldown_timers` entries are created only in `cool_down`,
-///   removed in `CooldownEnded`/`AddPeer` (with cancel), and filtered in
-///   `regulate_peers`. Inbound/outbound maps are updated only on exact id matches
-///   in disconnect paths. `outbound_peers` length is the primary signal for
-///   regulation. `static_peers` and `snapshot_candidates` are never mutated after `new`.
+/// - Cool-down invariants: live bans are only in `cooldown_until` (created in
+///   `cool_down`, removed in `CheckCooldowns`/`AddPeer`); the heap may lag with
+///   stale entries; at most one `cooldown_timer` is outstanding. Inbound/outbound
+///   maps are updated only on exact id matches in disconnect paths.
+///   `outbound_peers` length is the primary signal for regulation. `static_peers`
+///   and `snapshot_candidates` are never mutated after `new`.
 /// - `Connection` and `PeerState` are simple value types for tracking duplex
 ///   capability and lifecycle.
 ///
@@ -188,7 +198,7 @@ const STATIC_PEER_BAN_PERIOD: Duration = Duration::from_secs(10);
 /// trace helpers) and `tests.rs` (covering Initialize, every `PeerSelectionMsg`
 /// arm, double-adversarial timer replacement, regulate preference/skipping,
 /// will_retry vs. normal disconnect, inbound caps, etc.).
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PeerSelection {
     target_upstream_peers: usize,
     target_downstream_peers: usize,
@@ -197,9 +207,34 @@ pub struct PeerSelection {
     snapshot_candidates: BTreeSet<Peer>,
     ledger_candidates: BTreeSet<Peer>,
     peer_removal_cooldown: Duration,
-    cooldown_timers: BTreeMap<Peer, ScheduleId>,
+    cooldown_until: BTreeMap<Peer, Instant>,
+    cooldown_heap: BinaryHeap<Reverse<(Instant, Peer)>>,
+    cooldown_timer: Option<ScheduleId>,
     inbound_peers: BTreeMap<Peer, Connection>,
     outbound_peers: BTreeMap<Peer, PeerState>,
+}
+
+impl PartialEq for PeerSelection {
+    fn eq(&self, other: &Self) -> bool {
+        self.target_upstream_peers == other.target_upstream_peers
+            && self.target_downstream_peers == other.target_downstream_peers
+            && self.manager == other.manager
+            && self.static_peers == other.static_peers
+            && self.snapshot_candidates == other.snapshot_candidates
+            && self.ledger_candidates == other.ledger_candidates
+            && self.peer_removal_cooldown == other.peer_removal_cooldown
+            && self.cooldown_until == other.cooldown_until
+            && self.cooldown_timer == other.cooldown_timer
+            && self.inbound_peers == other.inbound_peers
+            && self.outbound_peers == other.outbound_peers
+            && {
+                let mut left: Vec<_> = self.cooldown_heap.iter().collect();
+                let mut right: Vec<_> = other.cooldown_heap.iter().collect();
+                left.sort();
+                right.sort();
+                left == right
+            }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -234,8 +269,8 @@ pub enum PeerSelectionMsg {
     Adversarial(Peer, TraceContext),
     /// Manually add a peer, mostly for testing.
     AddPeer(Peer),
-    /// The cooldown period for a peer has ended, and the peer can be re-added.
-    CooldownEnded(Peer),
+    /// Wake-up to drain cool-downs whose end time is at or before now, then re-arm the next.
+    CheckCooldowns,
     /// A peer has connected and the peer_selection stage can start tracking it.
     ///
     /// This may be a downstream peer or the successful result of a connection attempt.
@@ -272,7 +307,9 @@ impl PeerSelection {
             static_peers,
             snapshot_candidates,
             peer_removal_cooldown: Duration::from_secs(peer_removal_cooldown_secs),
-            cooldown_timers: BTreeMap::new(),
+            cooldown_until: BTreeMap::new(),
+            cooldown_heap: BinaryHeap::new(),
+            cooldown_timer: None,
             inbound_peers: BTreeMap::new(),
             outbound_peers: BTreeMap::new(),
         }
@@ -304,10 +341,56 @@ impl PeerSelection {
 
     async fn cool_down(&mut self, peer: Peer, eff: &Effects<PeerSelectionMsg>, is_static: bool) {
         let ban_period = if is_static { STATIC_PEER_BAN_PERIOD } else { self.peer_removal_cooldown };
-        let id = eff.schedule_after(PeerSelectionMsg::CooldownEnded(peer.clone()), ban_period).await;
-        let old = self.cooldown_timers.insert(peer, id);
-        if let Some(id) = old {
-            eff.cancel_schedule(id).await;
+        let now = eff.clock().await;
+        let when = now + ban_period;
+
+        let was_empty = self.cooldown_until.is_empty();
+        self.cooldown_until.insert(peer.clone(), when);
+        self.cooldown_heap.push(Reverse((when, peer)));
+
+        match self.cooldown_timer {
+            None if was_empty => {
+                let id = eff.schedule_at(PeerSelectionMsg::CheckCooldowns, when).await;
+                self.cooldown_timer = Some(id);
+            }
+            None => {
+                self.arm_next_cooldown(eff).await;
+            }
+            Some(id) if id.time() > when => {
+                eff.cancel_schedule(id).await;
+                let id = eff.schedule_at(PeerSelectionMsg::CheckCooldowns, when).await;
+                self.cooldown_timer = Some(id);
+            }
+            Some(_) => {}
+        }
+    }
+
+    async fn arm_next_cooldown(&mut self, eff: &Effects<PeerSelectionMsg>) {
+        while let Some(Reverse((when, peer))) = self.cooldown_heap.peek() {
+            if let Some(until) = self.cooldown_until.get(peer)
+                && until == when
+            {
+                break; // stop discarding when we find the next valid entry
+            }
+            self.cooldown_heap.pop();
+        }
+        if let Some(Reverse((when, _))) = self.cooldown_heap.peek() {
+            let id = eff.schedule_at(PeerSelectionMsg::CheckCooldowns, *when).await;
+            self.cooldown_timer = Some(id);
+        }
+    }
+
+    fn drain_due_cooldowns(&mut self, now: Instant) {
+        while let Some(Reverse((when, _))) = self.cooldown_heap.peek() {
+            if *when > now {
+                break;
+            }
+            let Some(Reverse((_when, peer))) = self.cooldown_heap.pop() else {
+                break;
+            };
+            if self.cooldown_until.get(&peer).is_some_and(|until| *until <= now) {
+                self.cooldown_until.remove(&peer);
+            }
         }
     }
 
@@ -328,7 +411,7 @@ impl PeerSelection {
             let candidates = self
                 .static_peers
                 .iter()
-                .filter(|p| !self.outbound_peers.contains_key(p) && !self.cooldown_timers.contains_key(p))
+                .filter(|p| !self.outbound_peers.contains_key(p) && !self.cooldown_until.contains_key(p))
                 .cloned()
                 .choose_multiple(&mut rng, target_upstream_peers - outbound);
             for peer in candidates {
@@ -343,7 +426,7 @@ impl PeerSelection {
             let candidates = self
                 .snapshot_candidates
                 .iter()
-                .filter(|p| !self.outbound_peers.contains_key(p) && !self.cooldown_timers.contains_key(p))
+                .filter(|p| !self.outbound_peers.contains_key(p) && !self.cooldown_until.contains_key(p))
                 .cloned()
                 .choose_multiple(&mut rng, target_upstream_peers - outbound);
             for peer in candidates {
@@ -358,7 +441,7 @@ impl PeerSelection {
             let candidates = self
                 .ledger_candidates
                 .iter()
-                .filter(|p| !self.outbound_peers.contains_key(p) && !self.cooldown_timers.contains_key(p))
+                .filter(|p| !self.outbound_peers.contains_key(p) && !self.cooldown_until.contains_key(p))
                 .cloned()
                 .choose_multiple(&mut rng, target_upstream_peers - outbound);
             for peer in candidates {
@@ -398,17 +481,23 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
             let span = debug_span!(parent_context: trace_context, consensus::peer::BAN, peer = peer.clone());
             state.ban_peer(peer, &eff).instrument(span).await;
         }
-        PeerSelectionMsg::CooldownEnded(peer) => {
-            state.cooldown_timers.remove(&peer);
+        PeerSelectionMsg::CheckCooldowns => {
+            if let Some(id) = state.cooldown_timer.take() {
+                eff.cancel_schedule(id).await;
+            }
+            let now = eff.clock().await;
+            state.drain_due_cooldowns(now);
             state.regulate_peers(&eff).await;
+            state.arm_next_cooldown(&eff).await;
         }
         PeerSelectionMsg::AddPeer(peer) => {
-            let was_banned = if let Some(schedule_id) = state.cooldown_timers.remove(&peer) {
-                eff.cancel_schedule(schedule_id).await;
-                true
-            } else {
-                false
-            };
+            let was_banned = state.cooldown_until.remove(&peer).is_some();
+            if was_banned && state.cooldown_until.is_empty() {
+                if let Some(id) = state.cooldown_timer.take() {
+                    eff.cancel_schedule(id).await;
+                }
+                state.cooldown_heap.clear();
+            }
 
             if !state.outbound_peers.contains_key(&peer) {
                 tracing::info!(%peer, was_banned, "peer_selection.add_peer");

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -198,7 +198,7 @@ const STATIC_PEER_BAN_PERIOD: Duration = Duration::from_secs(10);
 /// trace helpers) and `tests.rs` (covering Initialize, every `PeerSelectionMsg`
 /// arm, double-adversarial timer replacement, regulate preference/skipping,
 /// will_retry vs. normal disconnect, inbound caps, etc.).
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PeerSelection {
     target_upstream_peers: usize,
     target_downstream_peers: usize,
@@ -207,34 +207,10 @@ pub struct PeerSelection {
     snapshot_candidates: BTreeSet<Peer>,
     ledger_candidates: BTreeSet<Peer>,
     peer_removal_cooldown: Duration,
-    cooldown_until: BTreeMap<Peer, Instant>,
-    cooldown_heap: BinaryHeap<Reverse<(Instant, Peer)>>,
+    cooldowns: Cooldowns,
     cooldown_timer: Option<ScheduleId>,
     inbound_peers: BTreeMap<Peer, Connection>,
     outbound_peers: BTreeMap<Peer, PeerState>,
-}
-
-impl PartialEq for PeerSelection {
-    fn eq(&self, other: &Self) -> bool {
-        self.target_upstream_peers == other.target_upstream_peers
-            && self.target_downstream_peers == other.target_downstream_peers
-            && self.manager == other.manager
-            && self.static_peers == other.static_peers
-            && self.snapshot_candidates == other.snapshot_candidates
-            && self.ledger_candidates == other.ledger_candidates
-            && self.peer_removal_cooldown == other.peer_removal_cooldown
-            && self.cooldown_until == other.cooldown_until
-            && self.cooldown_timer == other.cooldown_timer
-            && self.inbound_peers == other.inbound_peers
-            && self.outbound_peers == other.outbound_peers
-            && {
-                let mut left: Vec<_> = self.cooldown_heap.iter().collect();
-                let mut right: Vec<_> = other.cooldown_heap.iter().collect();
-                left.sort();
-                right.sort();
-                left == right
-            }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -307,8 +283,7 @@ impl PeerSelection {
             static_peers,
             snapshot_candidates,
             peer_removal_cooldown: Duration::from_secs(peer_removal_cooldown_secs),
-            cooldown_until: BTreeMap::new(),
-            cooldown_heap: BinaryHeap::new(),
+            cooldowns: Cooldowns::default(),
             cooldown_timer: None,
             inbound_peers: BTreeMap::new(),
             outbound_peers: BTreeMap::new(),
@@ -344,9 +319,7 @@ impl PeerSelection {
         let now = eff.clock().await;
         let when = now + ban_period;
 
-        let was_empty = self.cooldown_until.is_empty();
-        self.cooldown_until.insert(peer.clone(), when);
-        self.cooldown_heap.push(Reverse((when, peer)));
+        let was_empty = self.cooldowns.add_and_is_first(peer.clone(), when);
 
         match self.cooldown_timer {
             None if was_empty => {
@@ -366,31 +339,10 @@ impl PeerSelection {
     }
 
     async fn arm_next_cooldown(&mut self, eff: &Effects<PeerSelectionMsg>) {
-        while let Some(Reverse((when, peer))) = self.cooldown_heap.peek() {
-            if let Some(until) = self.cooldown_until.get(peer)
-                && until == when
-            {
-                break; // stop discarding when we find the next valid entry
-            }
-            self.cooldown_heap.pop();
-        }
-        if let Some(Reverse((when, _))) = self.cooldown_heap.peek() {
-            let id = eff.schedule_at(PeerSelectionMsg::CheckCooldowns, *when).await;
+        self.cooldowns.discard_stale();
+        if let Some((when, _)) = self.cooldowns.peek() {
+            let id = eff.schedule_at(PeerSelectionMsg::CheckCooldowns, when).await;
             self.cooldown_timer = Some(id);
-        }
-    }
-
-    fn drain_due_cooldowns(&mut self, now: Instant) {
-        while let Some(Reverse((when, _))) = self.cooldown_heap.peek() {
-            if *when > now {
-                break;
-            }
-            let Some(Reverse((_when, peer))) = self.cooldown_heap.pop() else {
-                break;
-            };
-            if self.cooldown_until.get(&peer).is_some_and(|until| *until <= now) {
-                self.cooldown_until.remove(&peer);
-            }
         }
     }
 
@@ -411,7 +363,7 @@ impl PeerSelection {
             let candidates = self
                 .static_peers
                 .iter()
-                .filter(|p| !self.outbound_peers.contains_key(p) && !self.cooldown_until.contains_key(p))
+                .filter(|p| !self.outbound_peers.contains_key(p) && !self.cooldowns.is_cooling(p))
                 .cloned()
                 .choose_multiple(&mut rng, target_upstream_peers - outbound);
             for peer in candidates {
@@ -426,7 +378,7 @@ impl PeerSelection {
             let candidates = self
                 .snapshot_candidates
                 .iter()
-                .filter(|p| !self.outbound_peers.contains_key(p) && !self.cooldown_until.contains_key(p))
+                .filter(|p| !self.outbound_peers.contains_key(p) && !self.cooldowns.is_cooling(p))
                 .cloned()
                 .choose_multiple(&mut rng, target_upstream_peers - outbound);
             for peer in candidates {
@@ -441,7 +393,7 @@ impl PeerSelection {
             let candidates = self
                 .ledger_candidates
                 .iter()
-                .filter(|p| !self.outbound_peers.contains_key(p) && !self.cooldown_until.contains_key(p))
+                .filter(|p| !self.outbound_peers.contains_key(p) && !self.cooldowns.is_cooling(p))
                 .cloned()
                 .choose_multiple(&mut rng, target_upstream_peers - outbound);
             for peer in candidates {
@@ -449,6 +401,78 @@ impl PeerSelection {
                 eff.send(&self.manager, ManagerMessage::AddPeer(peer.clone())).await;
                 self.outbound_peers.insert(peer, PeerState::Connecting);
             }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+struct Cooldowns {
+    cooldown_until: BTreeMap<Peer, Instant>,
+    cooldown_heap: BinaryHeap<Reverse<(Instant, Peer)>>,
+}
+
+impl Cooldowns {
+    /// Adds a peer to the cooldowns, returning true if this was the first entry.
+    fn add_and_is_first(&mut self, peer: Peer, until: Instant) -> bool {
+        let was_empty = self.cooldown_until.is_empty();
+        self.cooldown_until.insert(peer.clone(), until);
+        self.cooldown_heap.push(Reverse((until, peer)));
+        was_empty
+    }
+
+    fn discard_stale(&mut self) {
+        while let Some(Reverse((when, peer))) = self.cooldown_heap.peek() {
+            if let Some(until) = self.cooldown_until.get(peer)
+                && until == when
+            {
+                break; // stop discarding when we find the next valid entry
+            }
+            self.cooldown_heap.pop();
+        }
+    }
+
+    fn peek(&self) -> Option<(Instant, Peer)> {
+        self.cooldown_heap.peek().map(|Reverse((when, peer))| (*when, peer.clone()))
+    }
+
+    fn drain_due(&mut self, now: Instant) {
+        while let Some(Reverse((when, _))) = self.cooldown_heap.peek() {
+            if *when > now {
+                break;
+            }
+            let Some(Reverse((_when, peer))) = self.cooldown_heap.pop() else {
+                break;
+            };
+            if self.cooldown_until.get(&peer).is_some_and(|until| *until <= now) {
+                self.cooldown_until.remove(&peer);
+            }
+        }
+    }
+
+    fn is_cooling(&self, peer: &Peer) -> bool {
+        self.cooldown_until.contains_key(peer)
+    }
+
+    /// Removes a peer from the cooldowns, returning true if this empties the cooldowns.
+    fn remove_and_was_last(&mut self, peer: &Peer) -> bool {
+        let was_banned = self.cooldown_until.remove(peer).is_some();
+        if self.cooldown_until.is_empty() {
+            self.cooldown_heap.clear();
+            was_banned
+        } else {
+            false
+        }
+    }
+}
+
+impl PartialEq for Cooldowns {
+    fn eq(&self, other: &Self) -> bool {
+        self.cooldown_until == other.cooldown_until && {
+            let mut left: Vec<_> = self.cooldown_heap.iter().collect();
+            let mut right: Vec<_> = other.cooldown_heap.iter().collect();
+            left.sort();
+            right.sort();
+            left == right
         }
     }
 }
@@ -486,17 +510,16 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
                 eff.cancel_schedule(id).await;
             }
             let now = eff.clock().await;
-            state.drain_due_cooldowns(now);
+            state.cooldowns.drain_due(now);
             state.regulate_peers(&eff).await;
             state.arm_next_cooldown(&eff).await;
         }
         PeerSelectionMsg::AddPeer(peer) => {
-            let was_banned = state.cooldown_until.remove(&peer).is_some();
-            if was_banned && state.cooldown_until.is_empty() {
-                if let Some(id) = state.cooldown_timer.take() {
-                    eff.cancel_schedule(id).await;
-                }
-                state.cooldown_heap.clear();
+            let was_banned = state.cooldowns.is_cooling(&peer);
+            if state.cooldowns.remove_and_was_last(&peer)
+                && let Some(id) = state.cooldown_timer.take()
+            {
+                eff.cancel_schedule(id).await;
             }
 
             if !state.outbound_peers.contains_key(&peer) {

--- a/crates/amaru-consensus/src/stages/peer_selection/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/test_setup.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeSet, time::Duration};
+use std::{cmp::Reverse, collections::BTreeSet, time::Duration};
 
 use amaru_kernel::{Peer, Tip};
 use amaru_protocols::manager::ManagerMessage;
@@ -27,7 +27,7 @@ use super::*;
 pub use crate::stages::test_utils::TraceMatch;
 use crate::{
     effects::{GenerateRandomSeed, RegisteredRelaySocketAddrsEffect, TipEffect, VolatileTipEffect},
-    stages::test_utils::{Logs, run_simulation},
+    stages::test_utils::{Logs, SimulationRunMode, run_simulation_with, start_in_era},
 };
 
 /// Matches an `AddStage` effect whose generated name starts with the given prefix.
@@ -60,18 +60,44 @@ pub fn cooldown_duration() -> Duration {
 ///
 /// Matches `run_simulation`: initial clock at +10s and `global_epoch_offset` from `start_in_era()`.
 pub fn cooldown_instant() -> Instant {
-    use crate::stages::test_utils::start_in_era;
     Instant::at_offset(Duration::from_secs(SIM_INITIAL_CLOCK_SECS) + cooldown_duration(), start_in_era().relative_time)
+}
+
+/// Absolute time `delay` after simulation t0.
+pub fn sim_at(delay: Duration) -> Instant {
+    Instant::at_offset(Duration::from_secs(SIM_INITIAL_CLOCK_SECS) + delay, start_in_era().relative_time)
 }
 
 pub fn first_schedule_id() -> ScheduleId {
     ScheduleIds::default().next_at(cooldown_instant())
 }
 
-pub fn second_schedule_id() -> ScheduleId {
+/// End time for a static-peer ban started at simulation t0 (`STATIC_PEER_BAN_PERIOD` = 10s).
+pub fn static_cooldown_instant() -> Instant {
+    Instant::at_offset(Duration::from_secs(SIM_INITIAL_CLOCK_SECS + 10), start_in_era().relative_time)
+}
+
+pub fn first_static_schedule_id() -> ScheduleId {
+    ScheduleIds::default().next_at(static_cooldown_instant())
+}
+
+/// Second schedule id after a prior schedule at `prior_when` (counter advances once).
+pub fn second_schedule_id_at(when: Instant) -> ScheduleId {
     let ids = ScheduleIds::default();
-    let _ = ids.next_at(cooldown_instant());
-    ids.next_at(cooldown_instant())
+    let _ = ids.next_at(when);
+    ids.next_at(when)
+}
+
+/// Build the cool-down fields after a single non-static ban armed at `cooldown_instant()`.
+pub fn with_single_cooldown(state: &mut PeerSelection, peer: Peer, schedule_id: ScheduleId) {
+    let when = cooldown_instant();
+    state.cooldown_until.insert(peer.clone(), when);
+    state.cooldown_heap.push(Reverse((when, peer)));
+    state.cooldown_timer = Some(schedule_id);
+}
+
+pub fn te_clock_suspend(at_stage: impl AsRef<str>) -> TraceEntry {
+    TraceEntry::suspend(Effect::Clock { at_stage: Name::from(at_stage.as_ref()) })
 }
 
 pub struct TestPrep {
@@ -115,24 +141,42 @@ pub fn setup_preload(
     prep: &TestPrep,
     messages: impl IntoIterator<Item = PeerSelectionMsg>,
 ) -> (SimulationRunning, DeserializerGuards, Logs) {
+    setup_preload_with_mode(prep, messages, SimulationRunMode::UntilBlocked)
+}
+
+/// Like [`setup_preload`], but stops at the first scheduled wakeup without advancing time.
+/// Used by tests that need to inject messages while a cool-down timer is still pending.
+pub fn setup_preload_until_sleeping(
+    prep: &TestPrep,
+    messages: impl IntoIterator<Item = PeerSelectionMsg>,
+) -> (SimulationRunning, DeserializerGuards, Logs) {
+    setup_preload_with_mode(prep, messages, SimulationRunMode::UntilSleeping)
+}
+
+fn setup_preload_with_mode(
+    prep: &TestPrep,
+    messages: impl IntoIterator<Item = PeerSelectionMsg>,
+    mode: SimulationRunMode,
+) -> (SimulationRunning, DeserializerGuards, Logs) {
     let guards = register_guards();
 
-    run_simulation(
+    run_simulation_with(
         prep.rt.handle(),
         guards,
         |network| {
+            // Larger bulk mailbox so tests can preload many adversarial messages without
+            // hitting the default size of 10 (the cool-down fix is about the *priority*
+            // mailbox, not bulk preload).
+            let mut network = network.with_mailbox_size(64);
             let ps = network.stage("ps", stage);
             let ps = network.wire_up(ps, prep.state.clone());
             network.preload(&ps, messages).unwrap();
+            network
         },
-        |_resources| {
-            // Resources (if any) would go here. Ledger effects are overridden below.
-        },
+        |_resources| {},
         |running| {
             running.use_virtual_child_stages(true);
 
-            // Override ledger external effects so the internal "peer-selection/ledger-check"
-            // child created on Initialize does not require a real Ledger resource.
             running
                 .override_external_effect::<VolatileTipEffect>(usize::MAX, |_| OverrideResult::handled(Tip::origin()));
             running.override_external_effect::<TipEffect>(usize::MAX, |_| OverrideResult::handled(Tip::origin()));
@@ -140,11 +184,17 @@ pub fn setup_preload(
                 OverrideResult::handled(Ok(BTreeSet::new()))
             });
 
-            // Make peer selection's random choices fully deterministic in tests.
+            // NOTE: Make peer selection's random choices fully deterministic in tests.
             running
                 .override_external_effect::<GenerateRandomSeed>(usize::MAX, |_| OverrideResult::handled([0x42u8; 32]));
         },
+        mode,
     )
+}
+
+/// Stage ref matching the wired `ps` stage in [`setup_preload`].
+pub fn peer_selection_stage() -> StageRef<PeerSelectionMsg> {
+    StageRef::named_for_tests("ps-1")
 }
 
 pub fn te_send(from: impl AsRef<str>, to: impl AsRef<str>, msg: impl amaru_pure_stage::SendData) -> TraceEntry {

--- a/crates/amaru-consensus/src/stages/peer_selection/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/test_setup.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{cmp::Reverse, collections::BTreeSet, time::Duration};
+use std::{collections::BTreeSet, time::Duration};
 
 use amaru_kernel::{Peer, Tip};
 use amaru_protocols::manager::ManagerMessage;
@@ -90,9 +90,7 @@ pub fn second_schedule_id_at(when: Instant) -> ScheduleId {
 
 /// Build the cool-down fields after a single non-static ban armed at `cooldown_instant()`.
 pub fn with_single_cooldown(state: &mut PeerSelection, peer: Peer, schedule_id: ScheduleId) {
-    let when = cooldown_instant();
-    state.cooldown_until.insert(peer.clone(), when);
-    state.cooldown_heap.push(Reverse((when, peer)));
+    state.cooldowns.add_and_is_first(peer, cooldown_instant());
     state.cooldown_timer = Some(schedule_id);
 }
 
@@ -184,7 +182,7 @@ fn setup_preload_with_mode(
                 OverrideResult::handled(Ok(BTreeSet::new()))
             });
 
-            // NOTE: Make peer selection's random choices fully deterministic in tests.
+            // NOTE: This makes peer selection's random choices fully deterministic in tests.
             running
                 .override_external_effect::<GenerateRandomSeed>(usize::MAX, |_| OverrideResult::handled([0x42u8; 32]));
         },

--- a/crates/amaru-consensus/src/stages/peer_selection/tests.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/tests.rs
@@ -138,7 +138,7 @@ fn test_regulate_prefers_static_before_snapshot_before_ledger() {
     prep.state.ledger_candidates.insert(l1.clone());
     // Start with empty outbound and trigger regulate via CheckCooldowns.
     let dummy = TestPrep::peer("dummy:9");
-    prep.state.cooldown_until.insert(dummy.clone(), cooldown_instant());
+    prep.state.cooldowns.cooldown_until.insert(dummy.clone(), cooldown_instant());
 
     let (running, _guards, mut logs) = setup_preload(&prep, [PeerSelectionMsg::CheckCooldowns]);
 
@@ -474,7 +474,7 @@ fn test_adversarial_twice_extends_cooldown_single_timer() {
     // Second ban at the same simulation time reuses the armed timer; heap gets another entry.
     let after_second = {
         let mut s = after_first.clone();
-        s.cooldown_heap.push(std::cmp::Reverse((cooldown_instant(), p.clone())));
+        s.cooldowns.add_and_is_first(p.clone(), cooldown_instant());
         s
     };
     let (running, _guards, mut logs) =
@@ -541,9 +541,9 @@ fn test_reban_later_deadline_survives_early_timer() {
             tm_state(
                 "ps-1",
                 move |s: &PeerSelection| {
-                    s.cooldown_until.get(&p) == Some(&later_when)
+                    s.cooldowns.cooldown_until.get(&p) == Some(&later_when)
                         && s.cooldown_timer == Some(sid1)
-                        && s.cooldown_heap.len() == 1
+                        && s.cooldowns.cooldown_heap.len() == 1
                 },
                 "re-ban deadline preserved after early CheckCooldowns; timer re-armed",
             ),
@@ -554,7 +554,9 @@ fn test_reban_later_deadline_survives_early_timer() {
             tm_state(
                 "ps-1",
                 |s: &PeerSelection| {
-                    s.cooldown_until.is_empty() && s.cooldown_timer.is_none() && s.cooldown_heap.is_empty()
+                    s.cooldowns.cooldown_until.is_empty()
+                        && s.cooldown_timer.is_none()
+                        && s.cooldowns.cooldown_heap.is_empty()
                 },
                 "ban lifted only at the later deadline",
             ),
@@ -654,7 +656,7 @@ fn test_regulate_prefers_static_before_ledger() {
 
     // Trigger regulate via CheckCooldowns of a non-existent peer (cheap way to call it)
     let dummy = TestPrep::peer("dummy:9");
-    prep.state.cooldown_until.insert(dummy.clone(), cooldown_instant());
+    prep.state.cooldowns.cooldown_until.insert(dummy.clone(), cooldown_instant());
 
     let (running, _guards, mut logs) = setup_preload(&prep, [PeerSelectionMsg::CheckCooldowns]);
 
@@ -689,7 +691,7 @@ fn test_regulate_skips_peers_in_cooldown() {
 
     // Put one static peer in cooldown
     let banned = TestPrep::peer("static1:1");
-    prep.state.cooldown_until.insert(banned.clone(), cooldown_instant());
+    prep.state.cooldowns.cooldown_until.insert(banned.clone(), cooldown_instant());
 
     // Have a ledger candidate
     let ledger = TestPrep::peer("ledger1:1");
@@ -697,7 +699,7 @@ fn test_regulate_skips_peers_in_cooldown() {
 
     // Trigger regulate
     let dummy = TestPrep::peer("dummy:9");
-    prep.state.cooldown_until.insert(dummy.clone(), cooldown_instant());
+    prep.state.cooldowns.cooldown_until.insert(dummy.clone(), cooldown_instant());
 
     let (running, _guards, mut logs) = setup_preload(&prep, [PeerSelectionMsg::CheckCooldowns]);
 
@@ -713,7 +715,7 @@ fn test_regulate_skips_peers_in_cooldown() {
                 |s: &PeerSelection| {
                     s.outbound_peers.len() == 2
                         && !s.outbound_peers.contains_key(&banned)
-                        && s.cooldown_until.contains_key(&banned)
+                        && s.cooldowns.is_cooling(&banned)
                 },
                 "final state with two new outbound peers; banned static still cooling down",
             ),
@@ -786,7 +788,9 @@ fn test_many_cooldowns_arm_only_one_schedule() {
             tm_state(
                 "ps-1",
                 |s: &PeerSelection| {
-                    s.cooldown_until.len() == 15 && s.cooldown_timer.is_some() && s.cooldown_heap.len() == 15
+                    s.cooldowns.cooldown_until.len() == 15
+                        && s.cooldown_timer.is_some()
+                        && s.cooldowns.cooldown_heap.len() == 15
                 },
                 "all 15 peers cooling down under a single armed timer",
             ),
@@ -794,7 +798,7 @@ fn test_many_cooldowns_arm_only_one_schedule() {
             te_input("ps-1", &PeerSelectionMsg::CheckCooldowns).into(),
             tm_state(
                 "ps-1",
-                |s: &PeerSelection| s.cooldown_until.is_empty() && s.cooldown_timer.is_none(),
+                |s: &PeerSelection| s.cooldowns.cooldown_until.is_empty() && s.cooldown_timer.is_none(),
                 "all cool-downs drained when the single timer fires",
             ),
         ],
@@ -819,9 +823,7 @@ fn test_second_cooldown_does_not_schedule_again() {
     };
     let after_second = {
         let mut s = after_first.clone();
-        let when = cooldown_instant();
-        s.cooldown_until.insert(p2.clone(), when);
-        s.cooldown_heap.push(std::cmp::Reverse((when, p2.clone())));
+        s.cooldowns.add_and_is_first(p2.clone(), cooldown_instant());
         s
     };
 
@@ -884,10 +886,10 @@ fn test_earlier_cooldown_reschedules_timer() {
             tm_state(
                 "ps-1",
                 |s: &PeerSelection| {
-                    s.cooldown_until.len() == 2
+                    s.cooldowns.cooldown_until.len() == 2
                         && s.cooldown_timer == Some(sid_other)
-                        && s.cooldown_heap.peek().map(|std::cmp::Reverse((t, _))| *t) == Some(cooldown_instant())
-                        && s.cooldown_until.get(&static_peer).copied() == Some(static_cooldown_instant())
+                        && s.cooldowns.peek().map(|(t, _)| t) == Some(cooldown_instant())
+                        && s.cooldowns.cooldown_until.get(&static_peer).copied() == Some(static_cooldown_instant())
                 },
                 "timer re-armed to the earlier non-static cool-down",
             ),

--- a/crates/amaru-consensus/src/stages/peer_selection/tests.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/tests.rs
@@ -25,8 +25,10 @@ use tracing::Level;
 use super::*;
 use crate::stages::{
     peer_selection::test_setup::{
-        TestPrep, cooldown_instant, first_schedule_id, second_schedule_id, setup, setup_preload, te_cancel_schedule,
-        te_clock, te_random_seed, te_schedule, te_send, test_prep, test_prep_with_snapshot, tm_add_stage_starts_with,
+        TestPrep, cooldown_duration, cooldown_instant, first_schedule_id, first_static_schedule_id,
+        peer_selection_stage, second_schedule_id_at, setup, setup_preload, setup_preload_until_sleeping, sim_at,
+        static_cooldown_instant, te_cancel_schedule, te_clock, te_clock_suspend, te_random_seed, te_schedule, te_send,
+        test_prep, test_prep_with_snapshot, tm_add_stage_starts_with, with_single_cooldown,
     },
     test_utils::{assert_trace, te_input, te_state, tm_state},
 };
@@ -134,12 +136,11 @@ fn test_regulate_prefers_static_before_snapshot_before_ledger() {
     let mut prep = test_prep_with_snapshot(&["static1:1"], &["snap1:1", "snap2:2"]);
     let l1 = TestPrep::peer("ledger1:1");
     prep.state.ledger_candidates.insert(l1.clone());
-    // Start with empty outbound and trigger regulate via CooldownEnded.
+    // Start with empty outbound and trigger regulate via CheckCooldowns.
     let dummy = TestPrep::peer("dummy:9");
-    let sid = first_schedule_id();
-    prep.state.cooldown_timers.insert(dummy.clone(), sid);
+    prep.state.cooldown_until.insert(dummy.clone(), cooldown_instant());
 
-    let (running, _guards, mut logs) = setup_preload(&prep, [PeerSelectionMsg::CooldownEnded(dummy.clone())]);
+    let (running, _guards, mut logs) = setup_preload(&prep, [PeerSelectionMsg::CheckCooldowns]);
 
     // target is 3: static first, then one snapshot, then one ledger (or two snapshots).
     // With seed [0x42; 32], choose_multiple is deterministic; we only assert counts and that
@@ -147,7 +148,7 @@ fn test_regulate_prefers_static_before_snapshot_before_ledger() {
     assert_trace_contains(
         &running,
         &[
-            te_input("ps-1", &PeerSelectionMsg::CooldownEnded(dummy)).into(),
+            te_input("ps-1", &PeerSelectionMsg::CheckCooldowns).into(),
             tm_send_match::<ManagerMessage>("ps-1", "manager", |m| matches!(m, ManagerMessage::AddPeer(_))),
             tm_send_match::<ManagerMessage>("ps-1", "manager", |m| matches!(m, ManagerMessage::AddPeer(_))),
             tm_send_match::<ManagerMessage>("ps-1", "manager", |m| matches!(m, ManagerMessage::AddPeer(_))),
@@ -231,14 +232,13 @@ fn test_add_peer_during_cooldown_cancels_timer() {
     let p = TestPrep::peer("8.8.8.8:8");
     let state = prep.state.clone();
     let sid = first_schedule_id();
-    let after_remove = {
+    let after_ban = {
         let mut s = state.clone();
-        s.cooldown_timers.insert(p.clone(), sid);
+        with_single_cooldown(&mut s, p.clone(), sid);
         s
     };
     let after_add = {
-        let mut s = after_remove.clone();
-        s.cooldown_timers.remove(&p);
+        let mut s = state.clone();
         s.outbound_peers.insert(p.clone(), PeerState::Connecting);
         s
     };
@@ -249,8 +249,9 @@ fn test_add_peer_during_cooldown_cancels_timer() {
         &[
             te_state("ps-1", &state),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())),
-            te_schedule("ps-1", PeerSelectionMsg::CooldownEnded(p.clone()), sid),
-            te_state("ps-1", &after_remove),
+            te_clock_suspend("ps-1"),
+            te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid),
+            te_state("ps-1", &after_ban),
             te_input("ps-1", &PeerSelectionMsg::AddPeer(p.clone())),
             te_cancel_schedule("ps-1", sid),
             te_send("ps-1", "manager", ManagerMessage::AddPeer(p.clone())),
@@ -274,7 +275,7 @@ fn test_adversarial_outbound_connected() {
     let sid = first_schedule_id();
     let after = {
         let mut s = state.clone();
-        s.cooldown_timers.insert(p.clone(), sid);
+        with_single_cooldown(&mut s, p.clone(), sid);
         s
     };
     let (running, _guards, mut logs) = setup(&prep, PeerSelectionMsg::adversarial(p.clone()));
@@ -283,10 +284,13 @@ fn test_adversarial_outbound_connected() {
         &[
             te_state("ps-1", &state),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())),
-            te_schedule("ps-1", PeerSelectionMsg::CooldownEnded(p.clone()), sid),
+            te_clock_suspend("ps-1"),
+            te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid),
             te_state("ps-1", &after),
             te_clock(cooldown_instant()),
-            te_input("ps-1", &PeerSelectionMsg::CooldownEnded(p.clone())),
+            te_input("ps-1", &PeerSelectionMsg::CheckCooldowns),
+            te_cancel_schedule("ps-1", sid),
+            te_clock_suspend("ps-1"),
             te_random_seed("ps-1"),
             te_state("ps-1", &state),
         ],
@@ -296,48 +300,66 @@ fn test_adversarial_outbound_connected() {
 }
 
 // ---------------------------------------------------------------------------
-// CooldownEnded
+// CheckCooldowns
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_cooldown_ended_stale() {
+fn test_check_cooldowns_stale() {
     let prep = test_prep(&[]);
-    let p = TestPrep::peer("6.6.6.6:6");
     let state = prep.state.clone();
-    let msg = PeerSelectionMsg::CooldownEnded(p);
+    let msg = PeerSelectionMsg::CheckCooldowns;
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
     assert_trace(
         &running,
-        &[te_state("ps-1", &state), te_input("ps-1", &msg), te_random_seed("ps-1"), te_state("ps-1", &state)],
+        &[
+            te_state("ps-1", &state),
+            te_input("ps-1", &msg),
+            te_clock_suspend("ps-1"),
+            te_random_seed("ps-1"),
+            te_state("ps-1", &state),
+        ],
     );
     logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 
 #[test]
-fn test_cooldown_ended_triggers_regulate() {
+fn test_check_cooldowns_before_due_does_not_lift_ban() {
     let prep = test_prep(&[]);
     let p = TestPrep::peer("5.5.5.5:5");
     let state = prep.state.clone();
-    let sid = first_schedule_id();
-    let after_remove = {
+    let sid0 = first_schedule_id();
+    let sid1 = second_schedule_id_at(cooldown_instant());
+    let after_ban = {
         let mut s = state.clone();
-        s.cooldown_timers.insert(p.clone(), sid);
+        with_single_cooldown(&mut s, p.clone(), sid0);
+        s
+    };
+    let after_early = {
+        let mut s = after_ban.clone();
+        // Early CheckCooldowns cancels and re-arms; the ban itself stays until due.
+        s.cooldown_timer = Some(sid1);
         s
     };
     let (running, _guards, mut logs) =
-        setup_preload(&prep, [PeerSelectionMsg::adversarial(p.clone()), PeerSelectionMsg::CooldownEnded(p.clone())]);
+        setup_preload(&prep, [PeerSelectionMsg::adversarial(p.clone()), PeerSelectionMsg::CheckCooldowns]);
     assert_trace(
         &running,
         &[
             te_state("ps-1", &state),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())),
-            te_schedule("ps-1", PeerSelectionMsg::CooldownEnded(p.clone()), sid),
-            te_state("ps-1", &after_remove),
-            te_input("ps-1", &PeerSelectionMsg::CooldownEnded(p.clone())),
+            te_clock_suspend("ps-1"),
+            te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid0),
+            te_state("ps-1", &after_ban),
+            te_input("ps-1", &PeerSelectionMsg::CheckCooldowns),
+            te_cancel_schedule("ps-1", sid0),
+            te_clock_suspend("ps-1"),
             te_random_seed("ps-1"),
-            te_state("ps-1", &state),
+            te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid1),
+            te_state("ps-1", &after_early),
             te_clock(cooldown_instant()),
-            te_input("ps-1", &PeerSelectionMsg::CooldownEnded(p.clone())),
+            te_input("ps-1", &PeerSelectionMsg::CheckCooldowns),
+            te_cancel_schedule("ps-1", sid1),
+            te_clock_suspend("ps-1"),
             te_random_seed("ps-1"),
             te_state("ps-1", &state),
         ],
@@ -428,14 +450,8 @@ fn test_disconnected_outbound_connecting_schedules_cooldown() {
     let mut state_conn = state.clone();
     state_conn.outbound_peers.insert(p.clone(), PeerState::Connecting);
     let msg = PeerSelectionMsg::Disconnected(p.clone(), ConnectionId::initial(), ConnectionDirection::Outbound, true);
-    let sid = first_schedule_id();
-    let _after = {
-        let mut s = state_conn.clone();
-        s.outbound_peers.remove(&p);
-        s.cooldown_timers.insert(p.clone(), sid);
-        s
-    };
     let (running, _guards, mut logs) = setup_preload(&prep, [msg.clone()]);
+    // will_retry == true is a no-op: no cool-down, no regulation.
     assert_trace(&running, &[te_state("ps-1", &state), te_input("ps-1", &msg), te_state("ps-1", &state)]);
     logs.assert_no_remaining_at([Level::WARN, Level::ERROR]);
 }
@@ -445,25 +461,20 @@ fn test_disconnected_outbound_connecting_schedules_cooldown() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_adversarial_twice_cancels_and_reschedules() {
+fn test_adversarial_twice_extends_cooldown_single_timer() {
     let prep = test_prep(&[]);
     let p = TestPrep::peer("11.11.11.11:11");
     let state = prep.state.clone();
     let sid0 = first_schedule_id();
-    let sid1 = second_schedule_id();
     let after_first = {
         let mut s = state.clone();
-        s.cooldown_timers.insert(p.clone(), sid0);
+        with_single_cooldown(&mut s, p.clone(), sid0);
         s
     };
+    // Second ban at the same simulation time reuses the armed timer; heap gets another entry.
     let after_second = {
         let mut s = after_first.clone();
-        s.cooldown_timers.insert(p.clone(), sid1);
-        s
-    };
-    let final_state = {
-        let mut s = after_second.clone();
-        s.cooldown_timers.clear();
+        s.cooldown_heap.push(std::cmp::Reverse((cooldown_instant(), p.clone())));
         s
     };
     let (running, _guards, mut logs) =
@@ -473,21 +484,82 @@ fn test_adversarial_twice_cancels_and_reschedules() {
         &[
             te_state("ps-1", &state),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())),
-            te_schedule("ps-1", PeerSelectionMsg::CooldownEnded(p.clone()), sid0),
+            te_clock_suspend("ps-1"),
+            te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid0),
             te_state("ps-1", &after_first),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())),
-            te_schedule("ps-1", PeerSelectionMsg::CooldownEnded(p.clone()), sid1),
-            te_cancel_schedule("ps-1", sid0),
+            te_clock_suspend("ps-1"),
             te_state("ps-1", &after_second),
             te_clock(cooldown_instant()),
-            te_input("ps-1", &PeerSelectionMsg::CooldownEnded(p.clone())),
+            te_input("ps-1", &PeerSelectionMsg::CheckCooldowns),
+            te_cancel_schedule("ps-1", sid0),
+            te_clock_suspend("ps-1"),
             te_random_seed("ps-1"),
-            te_state("ps-1", &final_state),
+            te_state("ps-1", &state),
         ],
     );
     logs.assert_and_remove(Level::DEBUG, &["peer_selection.adversarial"])
         .assert_and_remove(Level::DEBUG, &["peer_selection.adversarial"])
         .assert_no_remaining_at([Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_reban_later_deadline_survives_early_timer() {
+    // Ban at t0 (when = t0+1s). Advance to t0+500ms and re-ban (when = t0+1.5s) while the
+    // original timer is still armed. When that timer fires at t0+1s, the extended ban must
+    // remain; only the later CheckCooldowns at t0+1.5s may lift it.
+    use std::time::Duration;
+
+    let prep = test_prep(&[]);
+    let p = TestPrep::peer("12.12.12.12:12");
+    let intermediate = sim_at(Duration::from_millis(500));
+    let first_when = cooldown_instant();
+    let later_when = intermediate + cooldown_duration();
+    let sid0 = first_schedule_id();
+    let sid1 = second_schedule_id_at(later_when);
+
+    let (mut running, _guards, _logs) = setup_preload_until_sleeping(&prep, [PeerSelectionMsg::adversarial(p.clone())]);
+
+    assert!(!running.skip_to_next_wakeup(Some(intermediate)));
+    assert_eq!(running.now(), intermediate);
+
+    running.enqueue_msg(peer_selection_stage(), [PeerSelectionMsg::adversarial(p.clone())]);
+    running.run_until_blocked_incl_effects(prep.rt.handle());
+
+    assert_trace_contains(
+        &running,
+        &[
+            te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())).into(),
+            te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid0).into(),
+            te_clock(intermediate).into(),
+            te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())).into(),
+            // Original timer fires while the map still holds the later deadline.
+            te_clock(first_when).into(),
+            te_input("ps-1", &PeerSelectionMsg::CheckCooldowns).into(),
+            te_cancel_schedule("ps-1", sid0).into(),
+            te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid1).into(),
+            tm_state(
+                "ps-1",
+                move |s: &PeerSelection| {
+                    s.cooldown_until.get(&p) == Some(&later_when)
+                        && s.cooldown_timer == Some(sid1)
+                        && s.cooldown_heap.len() == 1
+                },
+                "re-ban deadline preserved after early CheckCooldowns; timer re-armed",
+            ),
+            // Extended cool-down finally ends.
+            te_clock(later_when).into(),
+            te_input("ps-1", &PeerSelectionMsg::CheckCooldowns).into(),
+            te_cancel_schedule("ps-1", sid1).into(),
+            tm_state(
+                "ps-1",
+                |s: &PeerSelection| {
+                    s.cooldown_until.is_empty() && s.cooldown_timer.is_none() && s.cooldown_heap.is_empty()
+                },
+                "ban lifted only at the later deadline",
+            ),
+        ],
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -572,93 +644,78 @@ fn test_disconnected_outbound_connected_normal() {
 
 #[test]
 fn test_regulate_prefers_static_before_ledger() {
-    let prep = test_prep(&["static1:1", "static2:2"]);
-    let mut state = prep.state.clone();
+    let mut prep = test_prep(&["static1:1", "static2:2"]);
 
     // Seed some ledger candidates
     let l1 = TestPrep::peer("ledger1:1");
     let l2 = TestPrep::peer("ledger2:2");
-    state.ledger_candidates.insert(l1.clone());
-    state.ledger_candidates.insert(l2.clone());
+    prep.state.ledger_candidates.insert(l1.clone());
+    prep.state.ledger_candidates.insert(l2.clone());
 
-    // Trigger regulate via CooldownEnded of a non-existent peer (cheap way to call it)
+    // Trigger regulate via CheckCooldowns of a non-existent peer (cheap way to call it)
     let dummy = TestPrep::peer("dummy:9");
-    let sid = first_schedule_id();
-    state.cooldown_timers.insert(dummy.clone(), sid);
+    prep.state.cooldown_until.insert(dummy.clone(), cooldown_instant());
 
-    let _after = {
-        let mut s = state.clone();
-        s.cooldown_timers.remove(&dummy);
-        // regulate should first take the two static peers (they are not in outbound or cooldown)
-        s.outbound_peers.insert(TestPrep::peer("static1:1"), PeerState::Connecting);
-        s.outbound_peers.insert(TestPrep::peer("static2:2"), PeerState::Connecting);
-        s
-    };
-
-    let (running, _guards, mut logs) = setup_preload(&prep, [PeerSelectionMsg::CooldownEnded(dummy.clone())]);
+    let (running, _guards, mut logs) = setup_preload(&prep, [PeerSelectionMsg::CheckCooldowns]);
 
     // te_input + AddPeer messages to manager (via tm_send_match on the variant) + final state (count only)
     assert_trace_contains(
         &running,
         &[
-            te_input("ps-1", &PeerSelectionMsg::CooldownEnded(dummy.clone())).into(),
+            te_input("ps-1", &PeerSelectionMsg::CheckCooldowns).into(),
             tm_send_match::<ManagerMessage>("ps-1", "manager", |msg| matches!(msg, ManagerMessage::AddPeer(_))),
             tm_send_match::<ManagerMessage>("ps-1", "manager", |msg| matches!(msg, ManagerMessage::AddPeer(_))),
             tm_state(
                 "ps-1",
-                |s: &PeerSelection| s.outbound_peers.len() == 2,
-                "final state with two new outbound peers from statics",
+                |s: &PeerSelection| {
+                    s.outbound_peers.len() == 3
+                        && s.outbound_peers.contains_key(&TestPrep::peer("static1:1"))
+                        && s.outbound_peers.contains_key(&TestPrep::peer("static2:2"))
+                },
+                "statics preferred; target filled including one ledger peer",
             ),
         ],
     );
 
     logs.assert_and_remove(Level::INFO, &["peer_selection.add_peer"])
         .assert_and_remove(Level::INFO, &["peer_selection.add_peer"])
+        .assert_and_remove(Level::INFO, &["peer_selection.add_peer"])
         .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 
 #[test]
 fn test_regulate_skips_peers_in_cooldown() {
-    let prep = test_prep(&["static1:1", "static2:2"]);
-    let mut state = prep.state.clone();
+    let mut prep = test_prep(&["static1:1", "static2:2"]);
 
     // Put one static peer in cooldown
     let banned = TestPrep::peer("static1:1");
-    let sid = first_schedule_id();
-    state.cooldown_timers.insert(banned.clone(), sid);
+    prep.state.cooldown_until.insert(banned.clone(), cooldown_instant());
 
     // Have a ledger candidate
     let ledger = TestPrep::peer("ledger1:1");
-    state.ledger_candidates.insert(ledger.clone());
+    prep.state.ledger_candidates.insert(ledger.clone());
 
     // Trigger regulate
     let dummy = TestPrep::peer("dummy:9");
-    let dsid = second_schedule_id();
-    state.cooldown_timers.insert(dummy.clone(), dsid);
+    prep.state.cooldown_until.insert(dummy.clone(), cooldown_instant());
 
-    let _after = {
-        let mut s = state.clone();
-        s.cooldown_timers.remove(&dummy);
-        // Should pick the non-banned static2 first? Wait, static1 is banned.
-        // Actually static2 is available. Then ledger.
-        s.outbound_peers.insert(TestPrep::peer("static2:2"), PeerState::Connecting);
-        s.outbound_peers.insert(ledger.clone(), PeerState::Connecting);
-        s
-    };
-
-    let (running, _guards, mut logs) = setup_preload(&prep, [PeerSelectionMsg::CooldownEnded(dummy.clone())]);
+    let (running, _guards, mut logs) = setup_preload(&prep, [PeerSelectionMsg::CheckCooldowns]);
 
     // te_input + AddPeer messages (banned peer skipped) + final state (count only)
     assert_trace_contains(
         &running,
         &[
-            te_input("ps-1", &PeerSelectionMsg::CooldownEnded(dummy.clone())).into(),
+            te_input("ps-1", &PeerSelectionMsg::CheckCooldowns).into(),
             tm_send_match::<ManagerMessage>("ps-1", "manager", |msg| matches!(msg, ManagerMessage::AddPeer(_))),
             tm_send_match::<ManagerMessage>("ps-1", "manager", |msg| matches!(msg, ManagerMessage::AddPeer(_))),
             tm_state(
                 "ps-1",
-                |s: &PeerSelection| s.outbound_peers.len() == 2,
-                "final state with two new outbound peers",
+                |s: &PeerSelection| {
+                    s.outbound_peers.len() == 2
+                        && !s.outbound_peers.contains_key(&banned)
+                        && s.cooldown_until.contains_key(&banned)
+                },
+                "final state with two new outbound peers; banned static still cooling down",
             ),
         ],
     );
@@ -703,4 +760,142 @@ fn test_disconnected_outbound_peer_also_in_inbound() {
     );
 
     logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+// ---------------------------------------------------------------------------
+// Bounded cool-down scheduling (issue #1112)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_many_cooldowns_arm_only_one_schedule() {
+    let prep = test_prep(&[]);
+    // More peers than PRIORITY_MAILBOX_SIZE (10): per-peer schedules would panic.
+    let peers: Vec<_> = (0..15).map(|i| TestPrep::peer(&format!("9.9.9.{i}:9"))).collect();
+    let msgs: Vec<_> = peers.iter().cloned().map(PeerSelectionMsg::adversarial).collect();
+    let first = peers[0].clone();
+    let sid = first_schedule_id();
+
+    let (running, _guards, mut logs) = setup_preload(&prep, msgs);
+
+    assert_trace_contains(
+        &running,
+        &[
+            te_input("ps-1", &PeerSelectionMsg::adversarial(first.clone())).into(),
+            te_clock_suspend("ps-1").into(),
+            te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid).into(),
+            tm_state(
+                "ps-1",
+                |s: &PeerSelection| {
+                    s.cooldown_until.len() == 15 && s.cooldown_timer.is_some() && s.cooldown_heap.len() == 15
+                },
+                "all 15 peers cooling down under a single armed timer",
+            ),
+            te_clock(cooldown_instant()).into(),
+            te_input("ps-1", &PeerSelectionMsg::CheckCooldowns).into(),
+            tm_state(
+                "ps-1",
+                |s: &PeerSelection| s.cooldown_until.is_empty() && s.cooldown_timer.is_none(),
+                "all cool-downs drained when the single timer fires",
+            ),
+        ],
+    );
+
+    for _ in 0..15 {
+        logs.assert_and_remove(Level::DEBUG, &["peer_selection.adversarial"]);
+    }
+    logs.assert_no_remaining_at([Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_second_cooldown_does_not_schedule_again() {
+    let prep = test_prep(&[]);
+    let p1 = TestPrep::peer("1.1.1.1:1");
+    let p2 = TestPrep::peer("2.2.2.2:2");
+    let sid = first_schedule_id();
+    let after_first = {
+        let mut s = prep.state.clone();
+        with_single_cooldown(&mut s, p1.clone(), sid);
+        s
+    };
+    let after_second = {
+        let mut s = after_first.clone();
+        let when = cooldown_instant();
+        s.cooldown_until.insert(p2.clone(), when);
+        s.cooldown_heap.push(std::cmp::Reverse((when, p2.clone())));
+        s
+    };
+
+    let (running, _guards, mut logs) =
+        setup_preload(&prep, [PeerSelectionMsg::adversarial(p1.clone()), PeerSelectionMsg::adversarial(p2.clone())]);
+
+    // Only the empty→one transition schedules; the second peer only joins the heap.
+    assert_trace(
+        &running,
+        &[
+            te_state("ps-1", &prep.state),
+            te_input("ps-1", &PeerSelectionMsg::adversarial(p1.clone())),
+            te_clock_suspend("ps-1"),
+            te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid),
+            te_state("ps-1", &after_first),
+            te_input("ps-1", &PeerSelectionMsg::adversarial(p2.clone())),
+            te_clock_suspend("ps-1"),
+            te_state("ps-1", &after_second),
+            te_clock(cooldown_instant()),
+            te_input("ps-1", &PeerSelectionMsg::CheckCooldowns),
+            te_cancel_schedule("ps-1", sid),
+            te_clock_suspend("ps-1"),
+            te_random_seed("ps-1"),
+            te_state("ps-1", &prep.state),
+        ],
+    );
+
+    logs.assert_and_remove(Level::DEBUG, &["peer_selection.adversarial"])
+        .assert_and_remove(Level::DEBUG, &["peer_selection.adversarial"])
+        .assert_no_remaining_at([Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_earlier_cooldown_reschedules_timer() {
+    // Static ban = 10s, non-static = 1s. Ban static first, then a non-static peer so the shorter
+    // cool-down cancels and re-arms the single timer.
+    let mut prep = test_prep(&["static1:1"]);
+    let static_peer = TestPrep::peer("static1:1");
+    let other = TestPrep::peer("other:1");
+    prep.state.outbound_peers.insert(static_peer.clone(), PeerState::Connecting);
+
+    let sid_static = first_static_schedule_id();
+    let sid_other = second_schedule_id_at(cooldown_instant());
+
+    let (running, _guards, mut logs) = setup_preload(
+        &prep,
+        [PeerSelectionMsg::adversarial(static_peer.clone()), PeerSelectionMsg::adversarial(other.clone())],
+    );
+
+    assert_trace_contains(
+        &running,
+        &[
+            te_input("ps-1", &PeerSelectionMsg::adversarial(static_peer.clone())).into(),
+            te_clock_suspend("ps-1").into(),
+            te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid_static).into(),
+            te_input("ps-1", &PeerSelectionMsg::adversarial(other.clone())).into(),
+            te_clock_suspend("ps-1").into(),
+            te_cancel_schedule("ps-1", sid_static).into(),
+            te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid_other).into(),
+            tm_state(
+                "ps-1",
+                |s: &PeerSelection| {
+                    s.cooldown_until.len() == 2
+                        && s.cooldown_timer == Some(sid_other)
+                        && s.cooldown_heap.peek().map(|std::cmp::Reverse((t, _))| *t) == Some(cooldown_instant())
+                        && s.cooldown_until.get(&static_peer).copied() == Some(static_cooldown_instant())
+                },
+                "timer re-armed to the earlier non-static cool-down",
+            ),
+        ],
+    );
+
+    logs.assert_and_remove(Level::DEBUG, &["peer_selection.adversarial"])
+        .assert_and_remove(Level::WARN, &["removing peer (outbound)"])
+        .assert_and_remove(Level::DEBUG, &["peer_selection.adversarial"])
+        .assert_no_remaining_at([Level::WARN, Level::ERROR]);
 }

--- a/crates/amaru-consensus/src/stages/select_chain/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/test_setup.rs
@@ -156,10 +156,11 @@ pub fn setup(prep: &TestPrep, msg: SelectChainMsg) -> (SimulationRunning, Deseri
     run_simulation(
         prep.rt.handle(),
         register_guards(),
-        |network| {
+        |mut network| {
             let sc = network.stage("sc", stage);
             let sc = network.wire_up(sc, prep.state.clone());
             network.preload(&sc, [msg]).unwrap();
+            network
         },
         |resources| {
             resources.put::<ResourceHeaderStore>(prep.store.clone());

--- a/crates/amaru-consensus/src/stages/test_utils.rs
+++ b/crates/amaru-consensus/src/stages/test_utils.rs
@@ -233,10 +233,11 @@ pub enum SimulationRunMode {
 /// The caller provides:
 /// - `guards`: the deserializers required for the stage, its messages, child stages, and any
 ///   external effects (typically built by a per-stage `register_guards()` function).
-/// - `build_network`: a closure that receives a fresh `&mut SimulationBuilder` and is
-///   responsible for installing any stage(s) (`network.stage(...)`), wiring them up,
-///   and preloading input messages. Resource installation should be done via the
-///   `setup_resources` closure (see below).
+/// - `build_network`: a closure that receives a fresh `SimulationBuilder` by value (so
+///   builder options like [`SimulationBuilder::with_mailbox_size`] can be applied), installs
+///   stage(s) (`network.stage(...)`), wires them up, preloads input messages, and returns
+///   the builder. Resource installation should be done via the `setup_resources` closure
+///   (see below).
 /// - `setup_resources`: a function that will be called with `&Resources` (from the
 ///   `SimulationBuilder`) so the caller can put stores, validators, etc.
 /// - `setup_overrides`: a function that will be called with `&mut SimulationRunning` after
@@ -248,7 +249,7 @@ pub enum SimulationRunMode {
 pub fn run_simulation<F, G>(
     rt: &Handle,
     guards: DeserializerGuards,
-    build_network: impl FnOnce(&mut SimulationBuilder),
+    build_network: impl FnOnce(SimulationBuilder) -> SimulationBuilder,
     setup_resources: F,
     setup_overrides: G,
 ) -> (SimulationRunning, DeserializerGuards, Logs)
@@ -260,11 +261,14 @@ where
 }
 
 /// Like [`run_simulation`], but chooses how far to drive the simulation after setup.
+///
+/// `build_network` receives the builder by value so callers can apply builder options
+/// (e.g. [`SimulationBuilder::with_mailbox_size`]) before staging/wiring/preloading.
 #[track_caller]
 pub fn run_simulation_with<F, G>(
     rt: &Handle,
     guards: DeserializerGuards,
-    build_network: impl FnOnce(&mut SimulationBuilder),
+    build_network: impl FnOnce(SimulationBuilder) -> SimulationBuilder,
     setup_resources: F,
     setup_overrides: G,
     mode: SimulationRunMode,
@@ -284,14 +288,14 @@ where
     logs.set_guard(sub);
 
     let since_network_start = start_in_era().relative_time;
-    let mut network = SimulationBuilder::default()
+    let network = SimulationBuilder::default()
         .with_trace_buffer(TraceBuffer::new_shared(100, 1000000))
         .with_global_epoch_offset(since_network_start)
         .with_initial_clock(Instant::at_offset(Duration::from_secs(10), since_network_start));
 
     setup_resources(network.resources());
 
-    build_network(&mut network);
+    let network = build_network(network);
 
     let mut running = network.run();
     running.use_virtual_child_stages(true);

--- a/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
@@ -286,10 +286,11 @@ fn setup_inner(
     run_simulation_with(
         rt,
         register_guards(),
-        |network| {
+        |mut network| {
             let tp = network.stage("tp", stage);
             let tp = network.wire_up(tp, state);
             network.preload(&tp, msg).unwrap();
+            network
         },
         |resources| {
             resources.put::<ResourceHeaderStore>(store.clone());

--- a/crates/amaru-consensus/src/stages/validate_block/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/validate_block/test_setup.rs
@@ -183,10 +183,11 @@ pub fn setup(prep: &TestPrep, msg: ValidateBlockMsg) -> (SimulationRunning, Dese
     run_simulation(
         prep.rt.handle(),
         guards,
-        |network| {
+        |mut network| {
             let vb = network.stage("vb", stage);
             let vb = network.wire_up(vb, prep.state.clone());
             network.preload(&vb, [msg]).unwrap();
+            network
         },
         |resources| {
             resources.put::<ResourceHeaderStore>(prep.store.clone());


### PR DESCRIPTION
fixes #1112


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed consensus peer selection to use a single shared cooldown timer, improving reliability and resource usage.
  * Prevented priority mailbox growth from becoming unbounded.
  * Improved handling of multiple temporarily unavailable peers, including timer reuse, rescheduling, and cancellation.
  * Ensured peers remain excluded during active cooldowns and become eligible again after cooldown expiration.
  * Improved handling of repeated bans and overlapping cooldown periods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->