### PR TITLE
fix: proposal ratification status + treasure withdrawal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ Other guiding principles:
 
 - **amaru-node**: invalidate peer snapshot commit metadata cache when switching to older or newer commits. ([#1114](https://github.com/pragma-org/amaru/issues/1114))
 - **amaru-ledger**: populate `recently_pruned_proposals` when importing a cardano-node snapshot.
+- **amaru-ledger**: debit the treasury when enacted withdrawals are paid out at the epoch boundary ([#1118][])
+- **amaru-ledger**: preserve the `Ratified` status of proposals pruned during ratification ([#1118][])
 
 ## [v10.11.20260730](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260730)
 
@@ -286,3 +288,4 @@ Other guiding principles:
 [#1098]: https://github.com/pragma-org/amaru/pull/1098
 [#1101]: https://github.com/pragma-org/amaru/pull/1101
 [#1109]: https://github.com/pragma-org/amaru/pull/1109
+[#1118]: https://github.com/pragma-org/amaru/pull/1118

--- a/crates/amaru-kernel/src/cardano/stake_credential.rs
+++ b/crates/amaru-kernel/src/cardano/stake_credential.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
+
 use crate::{
     Address, HasOwnership, Hash, Network, cbor,
     size::{KEY, SCRIPT},
@@ -32,6 +34,15 @@ use crate::{
 pub enum StakeCredential {
     ScriptHash(Hash<{ SCRIPT }>),
     AddrKeyhash(Hash<{ KEY }>),
+}
+
+impl fmt::Display for StakeCredential {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ScriptHash(h) => write!(f, "script({h})"),
+            Self::AddrKeyhash(h) => write!(f, "key({h})"),
+        }
+    }
 }
 
 impl<'b, C> cbor::Decode<'b, C> for StakeCredential {

--- a/crates/amaru-ledger/src/epoch_transition/pools_updates.rs
+++ b/crates/amaru-ledger/src/epoch_transition/pools_updates.rs
@@ -65,8 +65,8 @@ impl PoolsEpochTransitionUpdates {
         &self.updated
     }
 
-    pub fn refunds(&self) -> impl Iterator<Item = (&StakeCredential, Lovelace)> {
-        self.refunds.iter().map(|(account, refund)| (account, *refund))
+    pub fn refunds(&self) -> impl Iterator<Item = (&StakeCredential, &Lovelace)> {
+        self.refunds.iter()
     }
 
     /// The pending pool-deposit refund for the given account, or `0`. Refunds land on the reward
@@ -419,7 +419,7 @@ mod tests {
         pools_updates.retire_pool(Epoch::from(0), &pool_b, pending_b);
 
         let refunds = pools_updates.refunds().collect::<Vec<_>>();
-        assert_eq!(refunds, vec![(&reward_credential, deposit_a + deposit_b)]);
+        assert_eq!(refunds, vec![(&reward_credential, &(deposit_a + deposit_b))]);
     }
 
     fn reward_account_from_stake_credential(credential: &StakeCredential) -> RewardAccount {

--- a/crates/amaru-ledger/src/epoch_transition/ratification.rs
+++ b/crates/amaru-ledger/src/epoch_transition/ratification.rs
@@ -177,7 +177,9 @@ impl GovernanceUpdates {
 
                     if expired || ratified_or_evicted {
                         info!(ledger::proposal::DROP, id = %id, expired, ratified_or_evicted);
-                        ctx.pruned_proposals.insert(id, RatificationStatus::NotRatified); // For expired proposals
+                        // Expired proposals aren't in the pruned set yet; ratified or evicted ones
+                        // already are, and must keep the status recorded during ratification.
+                        ctx.pruned_proposals.entry(id).or_insert(RatificationStatus::NotRatified);
                         let return_account = proposal.return_account;
                         let deposit = proposal.deposit;
                         payouts
@@ -396,4 +398,88 @@ fn opt_str(s: String) -> Box<dyn tracing::Value> {
 
 fn opt_root(root: Option<&ProposalId>) -> Box<dyn tracing::Value> {
     root.map(|r| Box::new(r.to_string()) as Box<dyn tracing::Value>).unwrap_or_else(|| Box::new(tracing::field::Empty))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::VecDeque, sync::Mutex};
+
+    use amaru_kernel::{GovernanceAction, PREPROD_DEFAULT_PROTOCOL_PARAMETERS, PREPROD_ERA_HISTORY, any_proposal_id};
+    use proptest::{prelude::Strategy, strategy::ValueTree, test_runner::TestRunner};
+
+    use super::*;
+    use crate::{
+        state::StakeDistributionView, store::columns::proposals, summary::stake_distribution::StakeDistribution,
+    };
+
+    fn empty_stake_distribution(epoch: Epoch) -> StakeDistribution {
+        StakeDistribution {
+            epoch,
+            treasury: 0,
+            reserves: 0,
+            active_stake: 0,
+            pools_voting_stake: 0,
+            dreps_voting_stake: 0,
+            accounts: BTreeMap::new(),
+            pools: BTreeMap::new(),
+            dreps: BTreeMap::new(),
+        }
+    }
+
+    fn any_information_proposal(runner: &mut TestRunner, valid_until: Epoch) -> Proposal {
+        let mut row = proposals::tests::any_row(1_000).new_tree(runner).unwrap().current();
+        row.valid_until = valid_until;
+        row.proposal.deposit = 100_000;
+        row.proposal.gov_action = GovernanceAction::Information;
+        row
+    }
+
+    #[test]
+    fn dropped_proposals_keep_their_ratification_status() {
+        let mut runner = TestRunner::default();
+        let epoch = Epoch::from(10);
+
+        let ratified_id = any_proposal_id().new_tree(&mut runner).unwrap().current();
+        let expired_id = any_proposal_id().new_tree(&mut runner).unwrap().current();
+
+        let ratified = any_information_proposal(&mut runner, epoch + 5);
+        let expired = any_information_proposal(&mut runner, epoch);
+
+        let withdrawal_account = expect_stake_credential(&ratified.proposal.reward_account);
+
+        let distributions = Mutex::new(VecDeque::from([empty_stake_distribution(epoch)]));
+        let ctx = RatificationContext {
+            epoch,
+            treasury: 1_000_000_000,
+            stake_distribution: StakeDistributionView::new(distributions.lock().unwrap(), epoch).unwrap(),
+            protocol_parameters: PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone(),
+            pruned_proposals: BTreeMap::from([(Rc::new(ratified_id), RatificationStatus::Ratified)]),
+            withdrawals: BTreeMap::from([(withdrawal_account, 70_000)]),
+            constitutional_committee: None,
+            constitutional_committee_update: None,
+            new_constitution: None,
+            votes: BTreeMap::new(),
+        };
+
+        let updates = GovernanceUpdates::new(
+            ProposalsRootsRc::default(),
+            [(ratified_id, ratified), (expired_id, expired)].into_iter(),
+            &PREPROD_ERA_HISTORY,
+            &PREPROD_DEFAULT_PROTOCOL_PARAMETERS,
+            ctx,
+        )
+        .unwrap();
+
+        assert_eq!(
+            updates.pruned_proposals.get(&ratified_id),
+            Some(&RatificationStatus::Ratified),
+            "a proposal pruned during ratification must keep its 'Ratified' status"
+        );
+        assert_eq!(
+            updates.pruned_proposals.get(&expired_id),
+            Some(&RatificationStatus::NotRatified),
+            "an expired proposal is 'NotRatified'"
+        );
+        assert_eq!(updates.treasury_withdrawals, 70_000, "enacted withdrawals are totalled for the treasury debit");
+    }
 }

--- a/crates/amaru-ledger/src/epoch_transition/ratification.rs
+++ b/crates/amaru-ledger/src/epoch_transition/ratification.rs
@@ -15,7 +15,6 @@
 use std::{collections::BTreeMap, fmt, rc::Rc};
 
 use amaru_kernel::{
-    AsHash,
     Constitution,
     Epoch,
     EraHistory,
@@ -26,7 +25,6 @@ use amaru_kernel::{
     ProtocolParameters,
     RatificationStatus,
     StakeCredential,
-    StakeCredentialKind,
     cbor,
     // NOTE: We have to import cbor as minicbor here because we derive 'Encode' and 'Decode' traits
     // instances for some types, and the macro rule handling that seems to be explicitly looking
@@ -58,14 +56,13 @@ pub struct GovernanceUpdates {
     /// conflicting proposal being dropped.
     pub pruned_proposals: BTreeMap<ProposalId, RatificationStatus>,
 
-    /// Payouts done to accounts; either because of a deposit refunds or because of a treasury
-    /// withdrawal.
-    pub payouts: BTreeMap<StakeCredential, Lovelace>,
+    /// Refunds from proposals' deposits that are now being returned due to expiration, enactment or
+    /// pruning thereof.
+    pub deposit_refunds: BTreeMap<StakeCredential, Lovelace>,
 
-    /// Total amount withdrawn from the treasury by enacted proposals. Kept separate from
-    /// `payouts`, which merges withdrawals with deposit refunds that must not be debited from
-    /// the treasury.
-    pub treasury_withdrawals: Lovelace,
+    /// Withdrawals from the treasury by enacted proposals. Kept separate from
+    /// `deposit_refunds` which don't come from the treasury at all.
+    pub treasury_withdrawals: BTreeMap<StakeCredential, Lovelace>,
 
     /// Captures whether the resulting epoch is considered 'dormant' (i.e. no active proposals
     /// left to vote on at the beginning of the epoch, after ratification).
@@ -98,6 +95,20 @@ struct ProposalMetadata {
 }
 
 impl GovernanceUpdates {
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn default(protocol_parameters: ProtocolParameters) -> Self {
+        Self {
+            roots: ProposalsRoots::default(),
+            protocol_parameters,
+            pruned_proposals: BTreeMap::default(),
+            deposit_refunds: BTreeMap::default(),
+            treasury_withdrawals: BTreeMap::default(),
+            is_dormant_epoch: true,
+            constitutional_committee: None,
+            new_constitution: None,
+        }
+    }
+
     /// Look at every still-active governance proposal and ratify them in order of priority and
     /// submission.
     ///
@@ -168,9 +179,7 @@ impl GovernanceUpdates {
                 // Once ratified, we can go over each proposal and figure out refunds due to
                 // enactment, expiry or conflicts with other enacted proposals.
                 let mut is_dormant_epoch = true;
-                let treasury_withdrawals = ctx.withdrawals.values().sum();
-                let mut payouts = ctx.withdrawals;
-                let mut payouts_str = String::new();
+                let mut deposit_refunds = BTreeMap::new();
                 for (id, proposal) in proposals_metadata.into_iter() {
                     let expired = ctx.epoch == proposal.valid_until;
                     let ratified_or_evicted = ctx.pruned_proposals.contains_key(&id);
@@ -182,16 +191,12 @@ impl GovernanceUpdates {
                         ctx.pruned_proposals.entry(id).or_insert(RatificationStatus::NotRatified);
                         let return_account = proposal.return_account;
                         let deposit = proposal.deposit;
-                        payouts
+                        deposit_refunds
                             .entry(return_account)
                             .and_modify(|balance| {
                                 *balance += deposit;
-                                trace_return_account(&mut payouts_str, &return_account, *balance);
                             })
-                            .or_insert_with(|| {
-                                trace_return_account(&mut payouts_str, &return_account, deposit);
-                                deposit
-                            });
+                            .or_insert_with(|| deposit);
                     } else {
                         // NOTE: dormant epochs
                         //
@@ -249,7 +254,8 @@ impl GovernanceUpdates {
                 info!(
                     ledger::ratification::SUMMARIZE,
                     pruned_proposals = @opt_str(pruned_proposals_str),
-                    payouts = @opt_str(payouts_str),
+                    refunds = @opt_map(&deposit_refunds),
+                    withdrawals = @opt_map(&ctx.withdrawals),
                     new_constitution =
                         @opt_str(ctx.new_constitution.as_ref().map(|c| c.anchor.url.clone()).unwrap_or_default()),
                     constitutional_committee_update = @opt_str(
@@ -265,12 +271,12 @@ impl GovernanceUpdates {
                 Ok(Self {
                     roots: roots.unwrap_or_clone(),
                     pruned_proposals,
-                    payouts,
-                    treasury_withdrawals,
-                    is_dormant_epoch,
+                    deposit_refunds,
+                    treasury_withdrawals: ctx.withdrawals,
                     protocol_parameters: ctx.protocol_parameters,
                     new_constitution: ctx.new_constitution,
                     constitutional_committee: ctx.constitutional_committee_update,
+                    is_dormant_epoch,
                 })
             },
         )
@@ -281,21 +287,14 @@ impl GovernanceUpdates {
     /// the reward balance at the epoch boundary, so they count towards a withdrawable balance
     /// during the straddle.
     pub fn payout(&self, account: &StakeCredential) -> Lovelace {
-        self.payouts.get(account).copied().unwrap_or(0)
+        let refund = self.deposit_refunds.get(account).copied().unwrap_or(0);
+        let withdrawal = self.treasury_withdrawals.get(account).copied().unwrap_or(0);
+
+        refund + withdrawal
     }
 }
 
 // ----------------------------------------------------------------------------------------- Tracing
-
-fn trace_return_account(s: &mut String, return_account: &StakeCredential, balance: Lovelace) {
-    *s += &format!(
-        "{}({}) {}: {}",
-        if s.is_empty() { "" } else { ", " },
-        StakeCredentialKind::from(return_account),
-        return_account.as_hash(),
-        balance
-    );
-}
 
 fn diff_protocol_parameters(old: &ProtocolParameters, new: &ProtocolParameters) {
     // NOTE: destructuring for completeness static checks
@@ -396,6 +395,14 @@ fn opt_str(s: String) -> Box<dyn tracing::Value> {
     if s.is_empty() { Box::new(tracing::field::Empty) as Box<dyn tracing::Value> } else { Box::new(s) }
 }
 
+fn opt_map<K: fmt::Display, V: fmt::Display>(map: &BTreeMap<K, V>) -> Box<dyn tracing::Value> {
+    let mut s = String::new();
+    for (k, v) in map {
+        s += &format!("{}{k}={v}", if s.is_empty() { "" } else { ", " });
+    }
+    opt_str(s)
+}
+
 fn opt_root(root: Option<&ProposalId>) -> Box<dyn tracing::Value> {
     root.map(|r| Box::new(r.to_string()) as Box<dyn tracing::Value>).unwrap_or_else(|| Box::new(tracing::field::Empty))
 }
@@ -480,6 +487,10 @@ mod tests {
             Some(&RatificationStatus::NotRatified),
             "an expired proposal is 'NotRatified'"
         );
-        assert_eq!(updates.treasury_withdrawals, 70_000, "enacted withdrawals are totalled for the treasury debit");
+        assert_eq!(
+            updates.treasury_withdrawals.values().sum::<Lovelace>(),
+            70_000,
+            "enacted withdrawals are totalled for the treasury debit"
+        );
     }
 }

--- a/crates/amaru-ledger/src/epoch_transition/ratification.rs
+++ b/crates/amaru-ledger/src/epoch_transition/ratification.rs
@@ -62,6 +62,11 @@ pub struct GovernanceUpdates {
     /// withdrawal.
     pub payouts: BTreeMap<StakeCredential, Lovelace>,
 
+    /// Total amount withdrawn from the treasury by enacted proposals. Kept separate from
+    /// `payouts`, which merges withdrawals with deposit refunds that must not be debited from
+    /// the treasury.
+    pub treasury_withdrawals: Lovelace,
+
     /// Captures whether the resulting epoch is considered 'dormant' (i.e. no active proposals
     /// left to vote on at the beginning of the epoch, after ratification).
     pub is_dormant_epoch: bool,
@@ -163,6 +168,7 @@ impl GovernanceUpdates {
                 // Once ratified, we can go over each proposal and figure out refunds due to
                 // enactment, expiry or conflicts with other enacted proposals.
                 let mut is_dormant_epoch = true;
+                let treasury_withdrawals = ctx.withdrawals.values().sum();
                 let mut payouts = ctx.withdrawals;
                 let mut payouts_str = String::new();
                 for (id, proposal) in proposals_metadata.into_iter() {
@@ -258,6 +264,7 @@ impl GovernanceUpdates {
                     roots: roots.unwrap_or_clone(),
                     pruned_proposals,
                     payouts,
+                    treasury_withdrawals,
                     is_dormant_epoch,
                     protocol_parameters: ctx.protocol_parameters,
                     new_constitution: ctx.new_constitution,

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -491,8 +491,8 @@ mod tests {
     };
 
     use amaru_kernel::{
-        Epoch, Hash, PREPROD_DEFAULT_PROTOCOL_PARAMETERS, Point, ProposalsRoots, Slot, StakeCredential,
-        any_modern_output, any_transaction_input, utils::tests::run_strategy,
+        Epoch, Hash, PREPROD_DEFAULT_PROTOCOL_PARAMETERS, Point, Slot, StakeCredential, any_modern_output,
+        any_transaction_input, utils::tests::run_strategy,
     };
     use num::Zero;
     use test_case::test_case;
@@ -1121,7 +1121,7 @@ mod tests {
         // like a pool-deposit refund.
         let mut db = VolatileDB::default();
         let mut updates = committee_update(None);
-        updates.payouts = BTreeMap::from([(cred(1), 3_000_000)]);
+        updates.deposit_refunds = BTreeMap::from([(cred(1), 3_000_000)]);
         db.transition(None, PoolsEpochTransitionUpdates::default(), updates);
         assert_eq!(db.resolve_account(&cred(1)).1, RewardsAtTip::Add(3_000_000));
     }
@@ -1257,14 +1257,8 @@ mod tests {
 
     fn committee_update(committee: Option<CommitteeUpdate>) -> GovernanceUpdates {
         GovernanceUpdates {
-            roots: ProposalsRoots::default(),
-            protocol_parameters: PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone(),
-            pruned_proposals: BTreeMap::new(),
-            payouts: BTreeMap::new(),
-            treasury_withdrawals: 0,
-            is_dormant_epoch: false,
             constitutional_committee: committee,
-            new_constitution: None,
+            ..GovernanceUpdates::default(PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone())
         }
     }
 }

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -1261,6 +1261,7 @@ mod tests {
             protocol_parameters: PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone(),
             pruned_proposals: BTreeMap::new(),
             payouts: BTreeMap::new(),
+            treasury_withdrawals: 0,
             is_dormant_epoch: false,
             constitutional_committee: committee,
             new_constitution: None,

--- a/crates/amaru-ledger/src/state/volatile/overlay.rs
+++ b/crates/amaru-ledger/src/state/volatile/overlay.rs
@@ -388,7 +388,7 @@ impl StateOverlay {
 mod test {
     use std::collections::{BTreeMap, BTreeSet};
 
-    use amaru_kernel::{Hash, PREPROD_DEFAULT_PROTOCOL_PARAMETERS, ProposalsRoots};
+    use amaru_kernel::{Hash, PREPROD_DEFAULT_PROTOCOL_PARAMETERS};
 
     use super::*;
     use crate::epoch_transition::Computed;
@@ -401,7 +401,7 @@ mod test {
             most_recent_snapshot: RefCell::new(None),
             rewards: RewardsState::Effective(Arc::new(effective_rewards())),
             pools_updates: Some(Arc::new(PoolsEpochTransitionUpdates::default())),
-            governance_updates: Some(Arc::new(governance_updates())),
+            governance_updates: Some(Arc::new(GovernanceUpdates::default(PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone()))),
         };
 
         overlay.rollback();
@@ -437,18 +437,5 @@ mod test {
         let computed =
             Rewards::<Computed>::new(1_000, 7, 142, BTreeMap::from([(credential(1), 100), (credential(2), 42)]));
         Rewards::<Effective>::new(computed, BTreeSet::from([credential(2)]))
-    }
-
-    fn governance_updates() -> GovernanceUpdates {
-        GovernanceUpdates {
-            roots: ProposalsRoots::default(),
-            protocol_parameters: PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone(),
-            pruned_proposals: BTreeMap::new(),
-            payouts: BTreeMap::new(),
-            treasury_withdrawals: 0,
-            is_dormant_epoch: true,
-            constitutional_committee: None,
-            new_constitution: None,
-        }
     }
 }

--- a/crates/amaru-ledger/src/state/volatile/overlay.rs
+++ b/crates/amaru-ledger/src/state/volatile/overlay.rs
@@ -445,6 +445,7 @@ mod test {
             protocol_parameters: PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone(),
             pruned_proposals: BTreeMap::new(),
             payouts: BTreeMap::new(),
+            treasury_withdrawals: 0,
             is_dormant_epoch: true,
             constitutional_committee: None,
             new_constitution: None,

--- a/crates/amaru-ledger/src/store/epoch_transition.rs
+++ b/crates/amaru-ledger/src/store/epoch_transition.rs
@@ -238,6 +238,16 @@ pub fn apply_governance_updates<'store>(
 
         pay_or_refund_accounts(db, updates.payouts.iter().map(|(k, v)| (k, *v)))?;
 
+        // Withdrawals move money out of the treasury into reward accounts. Deposit refunds do
+        // not; they were never part of the treasury. Withdrawals whose target account no longer
+        // exists flow back into the treasury as leftovers just above.
+        if updates.treasury_withdrawals > 0 {
+            db.with_pots(|mut row| {
+                let pots = row.borrow_mut();
+                pots.treasury = pots.treasury.saturating_sub(updates.treasury_withdrawals);
+            })?;
+        }
+
         let mut governance_activity = db.governance_activity()?;
         if updates.is_dormant_epoch {
             governance_activity.consecutive_dormant_epochs += 1;

--- a/crates/amaru-ledger/src/store/epoch_transition.rs
+++ b/crates/amaru-ledger/src/store/epoch_transition.rs
@@ -139,7 +139,7 @@ pub fn reset_blocks_count<'store>(db: &impl TransactionalContext<'store>) -> Res
 /// Return deposits back to reward accounts, adding leftovers to the treasury.
 pub fn pay_or_refund_accounts<'store, 'iter>(
     db: &impl TransactionalContext<'store>,
-    payouts: impl IntoIterator<Item = (&'iter StakeCredential, Lovelace)>,
+    payouts: impl IntoIterator<Item = (&'iter StakeCredential, &'iter Lovelace)>,
 ) -> Result<(), StoreError> {
     debug_span!(stores::ledger::overlay::PAY_OR_REFUND_ACCOUNTS,).in_scope(|| {
         let (leftovers, paid) = payouts.into_iter().try_fold::<_, _, Result<_, StoreError>>(
@@ -152,7 +152,7 @@ pub fn pay_or_refund_accounts<'store, 'iter>(
                     %deposit,
                 );
 
-                Ok((leftovers + db.refund(account, deposit)?, paid + deposit))
+                Ok((leftovers + db.refund(account, *deposit)?, paid + *deposit))
             },
         )?;
 
@@ -236,15 +236,15 @@ pub fn apply_governance_updates<'store>(
 
         db.set_protocol_parameters(&updates.protocol_parameters)?;
 
-        pay_or_refund_accounts(db, updates.payouts.iter().map(|(k, v)| (k, *v)))?;
+        pay_or_refund_accounts(db, updates.deposit_refunds.iter().chain(updates.treasury_withdrawals.iter()))?;
 
         // Withdrawals move money out of the treasury into reward accounts. Deposit refunds do
         // not; they were never part of the treasury. Withdrawals whose target account no longer
         // exists flow back into the treasury as leftovers just above.
-        if updates.treasury_withdrawals > 0 {
+        if !updates.treasury_withdrawals.is_empty() {
             db.with_pots(|mut row| {
                 let pots = row.borrow_mut();
-                pots.treasury = pots.treasury.saturating_sub(updates.treasury_withdrawals);
+                pots.treasury -= updates.treasury_withdrawals.values().sum::<Lovelace>();
             })?;
         }
 

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -661,7 +661,8 @@ define_schemas! {
                 public SUMMARIZE {
                     required is_dormant_epoch: bool
                     optional pruned_proposals: String
-                    optional payouts: String
+                    optional refunds: String
+                    optional withdrawals: String
                     optional new_constitution: String
                     optional constitutional_committee_update: String
                 }

--- a/crates/amaru-stores/src/lib.rs
+++ b/crates/amaru-stores/src/lib.rs
@@ -17,17 +17,19 @@ pub mod rocksdb;
 
 #[cfg(test)]
 pub mod tests {
+    use std::collections::BTreeMap;
+
     use amaru_kernel::{
-        Anchor, DRepRegistration, Epoch, EraHistory, Hash, MemoizedTransactionOutput,
-        PREPROD_DEFAULT_PROTOCOL_PARAMETERS, PREPROD_ERA_HISTORY, Point, PoolId, PoolParams, Slot, StakeCredential,
-        TransactionInput, any_certificate_pointer, any_hash28, any_lovelace, any_pool_params, any_proposal_id,
-        any_stake_credential,
+        Anchor, DRepRegistration, Epoch, EraHistory, Hash, Lovelace, MemoizedTransactionOutput,
+        PREPROD_DEFAULT_PROTOCOL_PARAMETERS, PREPROD_ERA_HISTORY, Point, PoolId, PoolParams, ProposalsRoots, Slot,
+        StakeCredential, TransactionInput, any_certificate_pointer, any_hash28, any_lovelace, any_pool_params,
+        any_proposal_id, any_stake_credential,
     };
     use amaru_ledger::{
-        epoch_transition::{GovernanceActivity, pools_updates::PoolCertificates},
+        epoch_transition::{GovernanceActivity, GovernanceUpdates, pools_updates::PoolCertificates},
         state::volatile::Resettable,
         store::{
-            Columns, ReadStore, Store, StoreError, TransactionalContext,
+            Columns, ReadStore, Store, StoreError, TransactionalContext, apply_governance_updates,
             columns::{
                 accounts, cc_members, dreps, proposals,
                 slots::tests::any_slot,
@@ -495,6 +497,57 @@ pub mod tests {
         Ok(())
     }
 
+    pub fn test_treasury_withdrawal_debits_pots(
+        store: &impl Store,
+        fixture: &Fixture,
+        runner: &mut TestRunner,
+    ) -> Result<(), StoreError> {
+        let withdrawal = 70_000;
+        let initial_treasury = 1_000_000;
+
+        let context = store.create_transaction();
+        context.with_pots(|mut row| row.borrow_mut().treasury = initial_treasury)?;
+        context.commit()?;
+
+        let rewards_before = read_rewards(store, &fixture.account_key)?;
+
+        let context = store.create_transaction();
+        apply_governance_updates(
+            &context,
+            &make_governance_updates(BTreeMap::from([(fixture.account_key, withdrawal)]), withdrawal),
+        )?;
+        context.commit()?;
+
+        assert_eq!(
+            store.pots()?.treasury,
+            initial_treasury - withdrawal,
+            "an enacted withdrawal must be debited from the treasury"
+        );
+        assert_eq!(
+            read_rewards(store, &fixture.account_key)?,
+            rewards_before + withdrawal,
+            "an enacted withdrawal must be credited to the target account"
+        );
+
+        let unknown = any_stake_credential().new_tree(runner).unwrap().current();
+        assert_ne!(unknown, fixture.account_key);
+
+        let context = store.create_transaction();
+        apply_governance_updates(
+            &context,
+            &make_governance_updates(BTreeMap::from([(unknown, withdrawal)]), withdrawal),
+        )?;
+        context.commit()?;
+
+        assert_eq!(
+            store.pots()?.treasury,
+            initial_treasury - withdrawal,
+            "a withdrawal to an unregistered account must flow back into the treasury"
+        );
+
+        Ok(())
+    }
+
     pub fn test_slot_updated(store: &impl Store, fixture: &Fixture) -> Result<(), StoreError> {
         let issuers: Vec<_> = store.iter_block_issuers()?.collect();
 
@@ -503,5 +556,32 @@ pub mod tests {
         assert!(found, "expected slot {:?} with issuer {:?} not found", fixture.slot, fixture.slot_leader);
 
         Ok(())
+    }
+
+    // HELPERS
+
+    fn read_rewards(store: &impl Store, credential: &StakeCredential) -> Result<u64, StoreError> {
+        let context = store.create_transaction();
+        let mut rewards = None;
+        context.with_accounts(|mut accounts| {
+            rewards = accounts
+                .find(|(key, _)| key == credential)
+                .and_then(|(_, row)| row.borrow().as_ref().map(|account| account.rewards));
+        })?;
+        context.commit()?;
+        rewards.ok_or_else(|| StoreError::Internal("missing account".into()))
+    }
+
+    fn make_governance_updates(payouts: BTreeMap<StakeCredential, u64>, withdrawal: Lovelace) -> GovernanceUpdates {
+        GovernanceUpdates {
+            roots: ProposalsRoots::default(),
+            protocol_parameters: PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone(),
+            pruned_proposals: BTreeMap::new(),
+            payouts,
+            treasury_withdrawals: withdrawal,
+            is_dormant_epoch: false,
+            constitutional_committee: None,
+            new_constitution: None,
+        }
     }
 }

--- a/crates/amaru-stores/src/lib.rs
+++ b/crates/amaru-stores/src/lib.rs
@@ -21,9 +21,9 @@ pub mod tests {
 
     use amaru_kernel::{
         Anchor, DRepRegistration, Epoch, EraHistory, Hash, Lovelace, MemoizedTransactionOutput,
-        PREPROD_DEFAULT_PROTOCOL_PARAMETERS, PREPROD_ERA_HISTORY, Point, PoolId, PoolParams, ProposalsRoots, Slot,
-        StakeCredential, TransactionInput, any_certificate_pointer, any_hash28, any_lovelace, any_pool_params,
-        any_proposal_id, any_stake_credential,
+        PREPROD_DEFAULT_PROTOCOL_PARAMETERS, PREPROD_ERA_HISTORY, Point, PoolId, PoolParams, Slot, StakeCredential,
+        TransactionInput, any_certificate_pointer, any_hash28, any_lovelace, any_pool_params, any_proposal_id,
+        any_stake_credential,
     };
     use amaru_ledger::{
         epoch_transition::{GovernanceActivity, GovernanceUpdates, pools_updates::PoolCertificates},
@@ -514,7 +514,7 @@ pub mod tests {
         let context = store.create_transaction();
         apply_governance_updates(
             &context,
-            &make_governance_updates(BTreeMap::from([(fixture.account_key, withdrawal)]), withdrawal),
+            &make_governance_updates(BTreeMap::new(), BTreeMap::from([(fixture.account_key, withdrawal)])),
         )?;
         context.commit()?;
 
@@ -535,7 +535,7 @@ pub mod tests {
         let context = store.create_transaction();
         apply_governance_updates(
             &context,
-            &make_governance_updates(BTreeMap::from([(unknown, withdrawal)]), withdrawal),
+            &make_governance_updates(BTreeMap::new(), BTreeMap::from([(unknown, withdrawal)])),
         )?;
         context.commit()?;
 
@@ -572,16 +572,14 @@ pub mod tests {
         rewards.ok_or_else(|| StoreError::Internal("missing account".into()))
     }
 
-    fn make_governance_updates(payouts: BTreeMap<StakeCredential, u64>, withdrawal: Lovelace) -> GovernanceUpdates {
+    fn make_governance_updates(
+        deposit_refunds: BTreeMap<StakeCredential, Lovelace>,
+        treasury_withdrawals: BTreeMap<StakeCredential, Lovelace>,
+    ) -> GovernanceUpdates {
         GovernanceUpdates {
-            roots: ProposalsRoots::default(),
-            protocol_parameters: PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone(),
-            pruned_proposals: BTreeMap::new(),
-            payouts,
-            treasury_withdrawals: withdrawal,
-            is_dormant_epoch: false,
-            constitutional_committee: None,
-            new_constitution: None,
+            deposit_refunds,
+            treasury_withdrawals,
+            ..GovernanceUpdates::default(PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone())
         }
     }
 }

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -1037,7 +1037,7 @@ mod tests {
         tests::{
             Fixture, add_test_data_to_store, test_epoch_transition, test_read_account, test_read_drep, test_read_pool,
             test_read_utxo, test_refund_account, test_remove_account, test_remove_drep, test_remove_pool,
-            test_remove_utxo, test_slot_updated,
+            test_remove_utxo, test_slot_updated, test_treasury_withdrawal_debits_pots,
         },
     };
 
@@ -1119,6 +1119,13 @@ mod tests {
         let mut runner = TestRunner::default();
         let (store, _) = setup_rocksdb_store(&mut runner)?;
         test_epoch_transition(&store)
+    }
+
+    #[test]
+    fn test_rocksdb_treasury_withdrawal_debits_pots() -> Result<(), StoreError> {
+        let mut runner = TestRunner::default();
+        let (store, fixture) = setup_rocksdb_store(&mut runner)?;
+        test_treasury_withdrawal_debits_pots(&store, &fixture, &mut runner)
     }
 
     #[test]

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -1053,7 +1053,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
 | `skip` | `TRACE` | public | Skip the remaining proposals for this epoch | reason |  |
-| `summarize` | `TRACE` | public | Summary of the outcome of a ratification round | is_dormant_epoch | pruned_proposals, payouts, new_constitution, constitutional_committee_update |
+| `summarize` | `TRACE` | public | Summary of the outcome of a ratification round | is_dormant_epoch | pruned_proposals, refunds, withdrawals, new_constitution, constitutional_committee_update |
 
 <details><summary>span: `skip`</summary>
 
@@ -1069,7 +1069,8 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | --- | --- | --- |
 | `is_dormant_epoch` | `boolean` | ✓ |
 | `pruned_proposals` | `string` |  |
-| `payouts` | `string` |  |
+| `refunds` | `string` |  |
+| `withdrawals` | `string` |  |
 | `new_constitution` | `string` |  |
 | `constitutional_committee_update` | `string` |  |
 

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -2040,7 +2040,10 @@
         "pruned_proposals": {
           "type": "string"
         },
-        "payouts": {
+        "refunds": {
+          "type": "string"
+        },
+        "withdrawals": {
           "type": "string"
         },
         "new_constitution": {
@@ -2055,7 +2058,8 @@
       ],
       "optional": [
         "pruned_proposals",
-        "payouts",
+        "refunds",
+        "withdrawals",
         "new_constitution",
         "constitutional_committee_update"
       ],


### PR DESCRIPTION
This PR fixes 2 issues found when syncing with `mainnet`:

 1. The ratification status of pruned ratified or evicted proposals was lost.
 2. The treasury withdrawal amounts were not correctly removed from treasury

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected treasury withdrawal accounting during epoch transitions.
  * Successful withdrawals now debit the treasury and credit registered accounts.
  * Withdrawals to unknown accounts are returned to the treasury.
  * Preserved existing governance proposal statuses, including pruned proposals.
  * Improved expiry handling and kept deposit refunds separate from treasury deductions.
  * Updated governance reporting to distinguish deposit refunds from treasury withdrawals.

* **Documentation**
  * Added unreleased changelog entries covering these ledger fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->