### PR TITLE
test: fix a flaky test checking spans

### DIFF
--- a/crates/amaru-observability/macros/tests/validation.rs
+++ b/crates/amaru-observability/macros/tests/validation.rs
@@ -381,7 +381,8 @@ mod async_functions {
         }
     }
 
-    fn assert_send<T: Send>(_: T) {}
+    /// Just check that T has type `Send` but don't evaluate the argument
+    fn assert_send<T: Send>(_: fn(u64) -> T) {}
 
     fn traced_async_with_trace_span(point_slot: u64) -> impl Future<Output = bool> + Send {
         async move { tracing::Span::current().metadata().is_some() }
@@ -390,12 +391,12 @@ mod async_functions {
 
     #[test]
     fn test_traced_async_future_is_send() {
-        assert_send(traced_async(42));
+        assert_send(traced_async);
     }
 
     #[test]
     fn test_trace_span_instrument_future_is_send() {
-        assert_send(traced_async_with_trace_span(42));
+        assert_send(traced_async_with_trace_span);
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
This PR fixes a flaky test execution (observed [here](https://github.com/pragma-org/amaru/actions/runs/30620201652/job/91122712769?pr=1117)).

The test using `assert_send` is just there to typecheck a value but it actually executes a function invoking the `trace_span!` macro. This starts executing the internal tracing machinery without a default subscribe (what is done in the other tests like  `test_trace_span_instrument_runs_inside_span`). As a result the second test doesn't get a proper context for its span.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated compile-time validation tests to correctly verify that traced asynchronous functions meet sendability requirements.
  * Improved test coverage without invoking asynchronous functions during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->