### PR TITLE
chore: improve `make generate-traces-doc`

### DIFF
--- a/crates/amaru/build/stake_distribution.rs
+++ b/crates/amaru/build/stake_distribution.rs
@@ -26,11 +26,13 @@ use crate::{emit_rerun_if_changed, write_if_changed};
 /// case per stake distribution fixture.
 pub(crate) fn write_stake_distribution_test_cases_file(network: &str) -> Result<()> {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
+    let workspace_dir = manifest_dir.join("../..");
     let fixtures_root = manifest_dir.join("tests").join("conformance").join("stake-distributions");
     let network_dir = fixtures_root.join(network);
-    let ledger_dir = default_ledger_dir(&manifest_dir, network);
+    let ledger_dir = default_ledger_dir(&workspace_dir, network);
 
     emit_rerun_if_changed(&network_dir);
+    ensure_ledger_dir(&ledger_dir, &workspace_dir);
 
     let epochs = stake_distribution_epochs(&network_dir)?;
     let available_epochs = available_ledger_snapshot_epochs(&ledger_dir)?;
@@ -43,8 +45,26 @@ pub(crate) fn write_stake_distribution_test_cases_file(network: &str) -> Result<
 }
 
 /// Return the local ledger database directory for `network`, at the workspace root.
-fn default_ledger_dir(manifest_dir: &Path, network: &str) -> PathBuf {
-    manifest_dir.join("../..").join(format!("ledger.{network}.db"))
+fn default_ledger_dir(workspace_dir: &Path, network: &str) -> PathBuf {
+    workspace_dir.join(format!("ledger.{network}.db"))
+}
+
+/// Create `ledger_dir` when it is missing, so that cargo has an existing path to watch.
+///
+/// Cargo treats a `rerun-if-changed` on a missing path as permanently stale, which would rebuild
+/// this crate on every build; but dropping the watch altogether would leave the generated test
+/// cases partitioned against the snapshots available when the directory did not exist yet, and
+/// silently skip the conformance tests once it appears. An empty placeholder gives cargo something
+/// stable to watch, whose modification time changes as soon as snapshots are imported into it.
+///
+/// Only done inside the amaru workspace: when this crate is built from a registry checkout, the
+/// workspace root is not ours to write to.
+fn ensure_ledger_dir(ledger_dir: &Path, workspace_dir: &Path) {
+    if !workspace_dir.join("Cargo.toml").is_file() {
+        return;
+    }
+
+    let _ = fs::create_dir_all(ledger_dir);
 }
 
 /// List the epochs having a fixture file in `network_dir`, most recent first.

--- a/crates/amaru/src/bin/amaru/cmd/node/bootstrap.rs
+++ b/crates/amaru/src/bin/amaru/cmd/node/bootstrap.rs
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{error::Error, path::PathBuf};
+use std::{
+    error::Error,
+    fs, io,
+    path::{Path, PathBuf},
+};
 
 use amaru::{
     bootstrap::bootstrap,
@@ -94,17 +98,20 @@ async fn run(args: Args) -> Result<(), Box<dyn Error>> {
         epoch = @args.epoch.map(|e| e.to_string()),
     );
 
-    if ledger_dir.exists() || chain_dir.exists() {
+    let ledger_dir_populated = is_populated(&ledger_dir)?;
+    let chain_dir_populated = is_populated(&chain_dir)?;
+
+    if ledger_dir_populated || chain_dir_populated {
         let mut messages = Vec::new();
 
-        if ledger_dir.exists() {
+        if ledger_dir_populated {
             let dir = relative_path(&ledger_dir)?.display().to_string();
             let hint = "ledger directory already exists: use another location or remove it manually";
             warn!(cli::ledger_db::EXIST, dir = %dir, hint = hint);
             messages.push(format!("{hint} ({dir})"));
         }
 
-        if chain_dir.exists() {
+        if chain_dir_populated {
             let dir = relative_path(&chain_dir)?.display().to_string();
             let hint = "chain directory already exists: use another location or remove it manually";
             warn!(cli::chain_db::EXIST, dir = %dir, hint = hint);
@@ -115,4 +122,17 @@ async fn run(args: Args) -> Result<(), Box<dyn Error>> {
     }
 
     bootstrap(network, &global_parameters, ledger_dir, chain_dir, args.epoch).await
+}
+
+/// Whether `dir` holds anything. An empty directory is no more a database than a missing one, and
+/// the build script keeps empty ledger directories around for cargo to watch.
+///
+/// A directory that cannot be read is not reported as empty: this guards existing databases, so it
+/// must not let a bootstrap through on a failed inspection.
+fn is_populated(dir: &Path) -> Result<bool, io::Error> {
+    match fs::read_dir(dir) {
+        Ok(mut entries) => Ok(entries.next().is_some()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(io::Error::new(err.kind(), format!("{}: {err}", dir.display()))),
+    }
 }

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -650,7 +650,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `lifecycle` | `TRACE` | public | Event recorded once per header, when its processing reaches a terminal state. It covers the four network-health processing points of a header's lifecycle: reception of the header, request of its block, reception of its block and local adoption of the block. \`outcome\` describes the terminal state (including headers rejected on reception, which carry no durations). The optional durations are the intervals between those points: - \`block_fetch_wait_micros\`: reception of the header to the request of its block - \`block_fetch_micros\`: request of the block to its reception - \`forward_micros\`: reception of the header to the adoption of its block | peer, header_hash, outcome, error, block_fetch_wait_micros, block_fetch_micros, forward_micros |  |
+| `lifecycle` | `TRACE` | public | Event recorded once per header, when its processing reaches a terminal state. It covers the four network-health processing points of a header's lifecycle: reception of the header, request of its block, reception of its block and local adoption of the block. \`outcome\` describes the terminal state (including headers rejected on reception, which carry no durations). The optional durations are the intervals between those points: - \`block_fetch_wait_micros\`: reception of the header to the request of its block - \`block_fetch_micros\`: request of the block to its reception - \`forward_micros\`: reception of the header to the adoption of its block |  | peer, header_hash, outcome, error, block_fetch_wait_micros, block_fetch_micros, forward_micros |
 
 <details><summary>span: `lifecycle`</summary>
 
@@ -958,7 +958,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `summarize` | `TRACE` | public | Summary of the governance proposal roots after ratification | constitution, constitutional_committee, hard_fork, protocol_parameters |  |
+| `summarize` | `TRACE` | public | Summary of the governance proposal roots after ratification |  | constitution, constitutional_committee, hard_fork, protocol_parameters |
 
 <details><summary>span: `summarize`</summary>
 
@@ -990,7 +990,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `ratify` | `TRACE` | public | Ratify a protocol parameters update; only changed parameters are recorded | protocol_version, max_block_body_size, max_transaction_size, max_block_header_size, max_tx_ex_units, max_block_ex_units, max_value_size, max_collateral_inputs, min_fee_a, min_fee_b, stake_credential_deposit, stake_pool_deposit, monetary_expansion_rate, treasury_expansion_rate, min_pool_cost, lovelace_per_utxo_byte, prices, min_fee_ref_script_lovelace_per_byte, max_ref_script_size_per_tx, max_ref_script_size_per_block, ref_script_cost_stride, ref_script_cost_multiplier, stake_pool_max_retirement_epoch, optimal_stake_pools_count, pledge_influence, collateral_percentage, cost_models, pool_voting_thresholds, drep_voting_thresholds, min_committee_size, max_committee_term_length, gov_action_lifetime, gov_action_deposit, drep_deposit, drep_expiry |  |
+| `ratify` | `TRACE` | public | Ratify a protocol parameters update; only changed parameters are recorded |  | protocol_version, max_block_body_size, max_transaction_size, max_block_header_size, max_tx_ex_units, max_block_ex_units, max_value_size, max_collateral_inputs, min_fee_a, min_fee_b, stake_credential_deposit, stake_pool_deposit, monetary_expansion_rate, treasury_expansion_rate, min_pool_cost, lovelace_per_utxo_byte, prices, min_fee_ref_script_lovelace_per_byte, max_ref_script_size_per_tx, max_ref_script_size_per_block, ref_script_cost_stride, ref_script_cost_multiplier, stake_pool_max_retirement_epoch, optimal_stake_pools_count, pledge_influence, collateral_percentage, cost_models, pool_voting_thresholds, drep_voting_thresholds, min_committee_size, max_committee_term_length, gov_action_lifetime, gov_action_deposit, drep_deposit, drep_expiry |
 
 <details><summary>span: `ratify`</summary>
 
@@ -1065,7 +1065,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `collect` | `TRACE` | public | Fetch candidate relays from the immutable store | count |  |
+| `collect` | `TRACE` | public | Fetch candidate relays from the immutable store |  | count |
 
 <details><summary>span: `collect`</summary>
 
@@ -1361,7 +1361,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `hydrate` | `TRACE` | public | Resolve accounts from the volatile db or the stable one | from_volatile, from_db |  |
+| `hydrate` | `TRACE` | public | Resolve accounts from the volatile db or the stable one |  | from_volatile, from_db |
 
 <details><summary>span: `hydrate`</summary>
 
@@ -1376,7 +1376,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `hydrate` | `TRACE` | public | Resolve committee members from the volatile db or the stable one | from_volatile, from_db |  |
+| `hydrate` | `TRACE` | public | Resolve committee members from the volatile db or the stable one |  | from_volatile, from_db |
 
 <details><summary>span: `hydrate`</summary>
 
@@ -1391,7 +1391,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `hydrate` | `TRACE` | public | Resolve dreps from the volatile db or the stable one | from_volatile, from_db |  |
+| `hydrate` | `TRACE` | public | Resolve dreps from the volatile db or the stable one |  | from_volatile, from_db |
 
 <details><summary>span: `hydrate`</summary>
 
@@ -1406,7 +1406,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `hydrate` | `TRACE` | public | Resolve transaction inputs from the volatile db or the stable one | from_volatile, from_db |  |
+| `hydrate` | `TRACE` | public | Resolve transaction inputs from the volatile db or the stable one |  | from_volatile, from_db |
 
 <details><summary>span: `hydrate`</summary>
 
@@ -1421,7 +1421,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `hydrate` | `TRACE` | public | Resolve pools from the volatile db or the stable one | from_volatile, from_db |  |
+| `hydrate` | `TRACE` | public | Resolve pools from the volatile db or the stable one |  | from_volatile, from_db |
 
 <details><summary>span: `hydrate`</summary>
 
@@ -1436,7 +1436,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `hydrate` | `TRACE` | public | Resolve proposals from the volatile db or the stable one | from_volatile, from_db |  |
+| `hydrate` | `TRACE` | public | Resolve proposals from the volatile db or the stable one |  | from_volatile, from_db |
 
 <details><summary>span: `hydrate`</summary>
 
@@ -1724,8 +1724,8 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | `add` | `TRACE` | public | Batch-upsert account entries |  |  |
 | `get` | `TRACE` | public | Point-read an account entry |  |  |
 | `remove` | `TRACE` | public | Batch-delete account entries |  |  |
-| `reset_many` | `TRACE` | public | Reset rewards counters for many accounts | credential, reason |  |
-| `set` | `TRACE` | public | Update rewards balance for a single account | credential_type, account, reason |  |
+| `reset_many` | `TRACE` | public | Reset rewards counters for many accounts |  | credential, reason |
+| `set` | `TRACE` | public | Update rewards balance for a single account |  | credential_type, account, reason |
 
 <details><summary>span: `reset_many`</summary>
 
@@ -1757,10 +1757,10 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `add` | `TRACE` | public | Batch-upsert DRep registrations | credential, reason |  |
+| `add` | `TRACE` | public | Batch-upsert DRep registrations |  | credential, reason |
 | `get` | `TRACE` | public | Point-read a DRep entry |  |  |
-| `remove` | `TRACE` | public | Record DRep de-registration | drep, reason |  |
-| `set_valid_until` | `TRACE` | public | Refresh DRep expiry after a vote | credential, reason |  |
+| `remove` | `TRACE` | public | Record DRep de-registration |  | drep, reason |
+| `set_valid_until` | `TRACE` | public | Refresh DRep expiry after a vote |  | credential, reason |
 
 <details><summary>span: `add`</summary>
 
@@ -1828,8 +1828,8 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
 | `apply_governance_updates` | `TRACE` | public | Enact all governance updates and flush their outcome to disk |  |  |
-| `pay_or_refund_accounts` | `TRACE` | public | Pay withdrawals to accounts, or refund deposits | total_paid_or_refunded, treasury_leftovers |  |
-| `pay_rewards` | `TRACE` | public | Pay rewards to all accounts before the epoch end | accounts_paid, rewards_paid, treasury_delta, reserves_delta |  |
+| `pay_or_refund_accounts` | `TRACE` | public | Pay withdrawals to accounts, or refund deposits |  | total_paid_or_refunded, treasury_leftovers |
+| `pay_rewards` | `TRACE` | public | Pay rewards to all accounts before the epoch end |  | accounts_paid, rewards_paid, treasury_delta, reserves_delta |
 | `record_pruned_proposals` | `TRACE` | public | Pruned proposals at an epoch boundary, recorded to facilitate future stake distribution calculations. |  |  |
 | `reset_blocks_count` | `TRACE` | public | Reset blocks count to zero |  |  |
 | `reset_fees` | `TRACE` | public | Reset fees to zero |  |  |
@@ -1879,7 +1879,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | --- | --- | --- | --- | --- | --- |
 | `add` | `TRACE` | public | Batch-upsert pool entries |  |  |
 | `get` | `TRACE` | public | Point-read a pool entry |  |  |
-| `remove` | `TRACE` | public | Schedule pool retirement | pool, reason |  |
+| `remove` | `TRACE` | public | Schedule pool retirement |  | pool, reason |
 
 <details><summary>span: `remove`</summary>
 
@@ -1938,7 +1938,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `validate` | `TRACE` | public | Validate sufficient snapshots exist | snapshot_count, continuous_ranges |  |
+| `validate` | `TRACE` | public | Validate sufficient snapshots exist |  | snapshot_count, continuous_ranges |
 
 <details><summary>span: `validate`</summary>
 

--- a/scripts/generate-traces-doc
+++ b/scripts/generate-traces-doc
@@ -34,54 +34,41 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 EOF
 
-# Extract and group spans by target
-TARGETS=$(jq -r '.definitions | to_entries | map(.value.target) | unique | sort | .[]' "${SCHEMAS_JSON}")
+# Render one section per target, each with a summary table of its spans and a collapsible
+# field table per span.
+jq -r '
+  # Descriptions are free-form prose, so neutralise the characters that would otherwise be read as
+  # markdown markup or split the row into extra columns.
+  def escape_table_cell: gsub("`"; "\\`") | gsub("\\|"; "\\|");
 
-for target in $TARGETS; do
-  # Add target section
-  cat >> "${OUTPUT_FILE}" << ENTRY
+  def span_row:
+    "| `\(.name)` | `\(.level)` | \(if .public then "public" else "" end) | \(.description // "" | escape_table_cell) | \((.required // []) | join(", ")) | \((.optional // []) | join(", ")) |";
 
-## target: \`${target}\`
+  def field_rows:
+    (.required // []) as $required
+    | (.properties // {})
+    | to_entries
+    | map(. as $field | "| `\($field.key)` | `\($field.value.type)` | \(if ($required | index($field.key)) then "✓" else "" end) |");
 
-| name | level | public | description | required fields | optional fields |
-| --- | --- | --- | --- | --- | --- |
-ENTRY
+  def span_details:
+    if ((.properties // {}) | length) > 0 then
+      ["", "<details><summary>span: `\(.name)`</summary>", "", "| field | type | required |", "| --- | --- | --- |"]
+      + field_rows
+      + ["", "</details>"]
+    else
+      []
+    end;
 
-  # Get all spans for this target and output table rows (sorted by name)
-  jq -r ".definitions | to_entries | sort_by(.value.name) | .[] | select(.value.target == \"${target}\") | [.value.name, .value.level, (if .value.public then \"public\" else \"\" end), (.value.description // \"\"), (.value.required | join(\", \") // \"\"), (.value.optional | join(\", \") // \"\")] | @tsv" "${SCHEMAS_JSON}" | while IFS=$'\t' read -r name level public description required optional; do
-    # Escape backticks in description if any
-    description="${description//\`/\\\`}"
-    echo "| \`${name}\` | \`${level}\` | ${public} | ${description} | ${required} | ${optional} |" >> "${OUTPUT_FILE}"
-  done
-
-  # Add details for each span (in sorted order by name)
-  jq -r ".definitions | to_entries | sort_by(.value.name) | .[] | select(.value.target == \"${target}\") | .value.name" "${SCHEMAS_JSON}" | while read -r name; do
-    SPAN_DATA=$(jq -r ".definitions | to_entries[] | select(.value.target == \"${target}\" and .value.name == \"${name}\") | .value" "${SCHEMAS_JSON}")
-
-    HAS_FIELDS=$(echo "$SPAN_DATA" | jq -r '.properties | keys | length')
-
-    if [ "$HAS_FIELDS" -gt 0 ]; then
-      cat >> "${OUTPUT_FILE}" << ENTRY
-
-<details><summary>span: \`${name}\`</summary>
-
-| field | type | required |
-| --- | --- | --- |
-ENTRY
-
-      # Get all properties and show with required flag
-      echo "$SPAN_DATA" | jq -r '.properties | to_entries[] | .key' | while read -r field; do
-        FIELD_TYPE=$(echo "$SPAN_DATA" | jq -r ".properties[\"${field}\"].type")
-        IS_REQUIRED=$(echo "$SPAN_DATA" | jq -r "(.required // []) | contains([\"${field}\"])")
-        REQUIRED_BADGE=$([ "$IS_REQUIRED" = "true" ] && echo "✓" || echo "")
-        echo "| \`${field}\` | \`${FIELD_TYPE}\` | ${REQUIRED_BADGE} |" >> "${OUTPUT_FILE}"
-      done
-
-      echo "" >> "${OUTPUT_FILE}"
-      echo "</details>" >> "${OUTPUT_FILE}"
-    fi
-  done
-done
+  [.definitions[]] as $spans
+  | [ ($spans | map(.target) | unique)[] as $target
+      | ($spans | map(select(.target == $target)) | sort_by(.name)) as $group
+      | ["", "## target: `\($target)`", "", "| name | level | public | description | required fields | optional fields |", "| --- | --- | --- | --- | --- | --- |"]
+        + ($group | map(span_row))
+        + ($group | map(span_details) | add // [])
+    ]
+  | flatten
+  | .[]
+' "${SCHEMAS_JSON}" >> "${OUTPUT_FILE}"
 
 # Add footer
 cat >> "${OUTPUT_FILE}" << 'EOF'

--- a/scripts/refresh-from-mithril
+++ b/scripts/refresh-from-mithril
@@ -80,10 +80,25 @@ write_metadata() {
     > "$metadata_file"
 }
 
+# Fails when the directory cannot be inspected, rather than reporting it as empty: callers use this
+# to decide whether a directory is safe to discard.
+is_empty_dir() {
+  local dir="$1" entries
+
+  [[ -d "$dir" ]] || return 1
+
+  entries=$(ls -A "$dir") || die "cannot inspect $dir"
+  [[ -z "$entries" ]]
+}
+
 install_dir() {
   local source="$1" target="$2"
 
-  if [[ -e "$target" ]] && ! truthy "$REPLACE_EXISTING"; then
+  # An empty directory holds no database: the build script keeps such placeholders around for cargo
+  # to watch, so drop them instead of refusing to install or backing them up.
+  if is_empty_dir "$target"; then
+    rmdir "$target" || die "cannot remove the empty directory $target"
+  elif [[ -e "$target" ]] && ! truthy "$REPLACE_EXISTING"; then
     die "$target already exists; set REPLACE_EXISTING=true to replace it"
   fi
 


### PR DESCRIPTION
This task is slow because cargo is rebuilding more often than necessary. 

Indeed cargo treats `rerun-if-changed` on a missing path as permanently stale and the `stake_distributions` part of the build script expects to find the ledger files.

In addition, `jq` was called too many times where it can be called once per target.

Finally, there was a bug in the processing of fields.  The script was piping `@tsv` into `IFS=$'\t' read`, but `tab` is an IFS whitespace character, so bash collapses consecutive tabs. For the 19 spans with no required fields, the empty column was dropped and their optional fields were printed under "required fields" (`amaru::ledger::validation_context::accounts::hydrate` is such an example).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build and change tracking by reliably creating required ledger directories.
  * Fixed setup and refresh workflows so empty placeholder directories no longer block installation.
  * Improved node setup validation by distinguishing missing and empty directories from populated data directories.

* **Documentation**
  * Corrected required and optional field classifications in generated trace documentation.
  * Improved trace documentation generation for clearer, consistently ordered event tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->