### PR TITLE
Fix pools memory growth in volatile, box a few types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Other guiding principles:
 ### Fixed
 
 - **amaru-node**: invalidate peer snapshot commit metadata cache when switching to older or newer commits. ([#1114](https://github.com/pragma-org/amaru/issues/1114))
+- **amaru-kernel**: reduce memory footprint of various types on the critical path.
 
 ## [v10.11.20260730](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260730)
 

--- a/crates/amaru-kernel/src/cardano/certificate.rs
+++ b/crates/amaru-kernel/src/cardano/certificate.rs
@@ -12,32 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeSet;
-
-use crate::utils::cbor::SerialisedAsSet;
 pub use crate::{
     Anchor, DRep, Epoch, Hash, Lovelace, PoolId, PoolMetadata, RationalNumber, Relay, RewardAccount, StakeCredential,
     cbor,
     size::{KEY, VRF_KEY},
 };
+use crate::{PoolParams, utils::cbor::SerialisedAsSet};
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum Certificate {
     StakeRegistration(StakeCredential),
     StakeDeregistration(StakeCredential),
     StakeDelegation(StakeCredential, PoolId),
-    // TODO: reduce duplication with [`crate::PoolParams`]
-    PoolRegistration {
-        operator: PoolId,
-        vrf_keyhash: Hash<VRF_KEY>,
-        pledge: Lovelace,
-        cost: Lovelace,
-        margin: RationalNumber,
-        reward_account: RewardAccount,
-        pool_owners: BTreeSet<Hash<KEY>>,
-        relays: Vec<Relay>,
-        pool_metadata: Option<PoolMetadata>,
-    },
+    PoolRegistration(Box<PoolParams>),
     PoolRetirement(PoolId, Epoch),
     Reg(StakeCredential, Lovelace),
     UnReg(StakeCredential, Lovelace),
@@ -47,10 +34,10 @@ pub enum Certificate {
     VoteRegDeleg(StakeCredential, DRep, Lovelace),
     StakeVoteRegDeleg(StakeCredential, PoolId, DRep, Lovelace),
     AuthCommitteeHot(StakeCredential, StakeCredential),
-    ResignCommitteeCold(StakeCredential, Option<Anchor>),
-    RegDRepCert(StakeCredential, Lovelace, Option<Anchor>),
+    ResignCommitteeCold(StakeCredential, Option<Box<Anchor>>),
+    RegDRepCert(StakeCredential, Lovelace, Option<Box<Anchor>>),
     UnRegDRepCert(StakeCredential, Lovelace),
-    UpdateDRepCert(StakeCredential, Option<Anchor>),
+    UpdateDRepCert(StakeCredential, Option<Box<Anchor>>),
 }
 
 impl<C> cbor::encode::Encode<C> for Certificate {
@@ -79,29 +66,22 @@ impl<C> cbor::encode::Encode<C> for Certificate {
                 e.encode_with(b, ctx)?;
             }
 
-            Self::PoolRegistration {
-                operator,
-                vrf_keyhash,
-                pledge,
-                cost,
-                margin,
-                reward_account,
-                pool_owners,
-                relays,
-                pool_metadata,
-            } => {
+            Self::PoolRegistration(params) => {
+                let PoolParams { id: operator, vrf, pledge, cost, margin, reward_account, owners, relays, metadata } =
+                    params.as_ref();
+
                 e.array(10)?;
                 e.u16(3)?;
 
                 e.encode_with(operator, ctx)?;
-                e.encode_with(vrf_keyhash, ctx)?;
+                e.encode_with(vrf, ctx)?;
                 e.encode_with(pledge, ctx)?;
                 e.encode_with(cost, ctx)?;
                 e.encode_with(margin, ctx)?;
                 e.encode_with(reward_account, ctx)?;
-                e.encode_with(SerialisedAsSet(pool_owners), ctx)?;
+                e.encode_with(SerialisedAsSet(owners), ctx)?;
                 e.encode_with(relays, ctx)?;
-                e.encode_with(pool_metadata, ctx)?;
+                e.encode_with(metadata, ctx)?;
             }
 
             Self::PoolRetirement(a, b) => {
@@ -230,27 +210,27 @@ impl<'b, C> cbor::decode::Decode<'b, C> for Certificate {
             }
 
             3 => {
-                let operator = d.decode_with(ctx)?;
-                let vrf_keyhash = d.decode_with(ctx)?;
+                let id = d.decode_with(ctx)?;
+                let vrf = d.decode_with(ctx)?;
                 let pledge = d.decode_with(ctx)?;
                 let cost = d.decode_with(ctx)?;
                 let margin = d.decode_with(ctx)?;
                 let reward_account = d.decode_with(ctx)?;
-                let SerialisedAsSet(pool_owners) = d.decode_with(ctx)?;
+                let SerialisedAsSet(owners) = d.decode_with(ctx)?;
                 let relays = d.decode_with(ctx)?;
-                let pool_metadata = d.decode_with(ctx)?;
+                let metadata = d.decode_with(ctx)?;
 
-                Ok(Self::PoolRegistration {
-                    operator,
-                    vrf_keyhash,
+                Ok(Self::PoolRegistration(Box::new(PoolParams {
+                    id,
+                    vrf,
                     pledge,
                     cost,
                     margin,
                     reward_account,
-                    pool_owners,
+                    owners,
                     relays,
-                    pool_metadata,
-                })
+                    metadata,
+                })))
             }
 
             4 => {

--- a/crates/amaru-kernel/src/cardano/drep_state.rs
+++ b/crates/amaru-kernel/src/cardano/drep_state.rs
@@ -22,7 +22,7 @@ use crate::{
 #[derive(Debug)]
 pub struct DRepState {
     pub expiry: Epoch,
-    pub anchor: Option<Anchor>,
+    pub anchor: Option<Box<Anchor>>,
     pub deposit: Lovelace,
     pub delegators: BTreeSet<StakeCredential>,
 }

--- a/crates/amaru-kernel/src/cardano/memoized/datum.rs
+++ b/crates/amaru-kernel/src/cardano/memoized/datum.rs
@@ -23,8 +23,26 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MemoizedDatum {
     None,
-    Hash(Hash<DATUM>),
-    Inline(MemoizedPlutusData),
+    Hash(Box<Hash<DATUM>>),
+    Inline(Box<MemoizedPlutusData>),
+}
+
+impl From<Hash<DATUM>> for MemoizedDatum {
+    fn from(hash: Hash<DATUM>) -> Self {
+        Self::Hash(Box::new(hash))
+    }
+}
+
+impl From<Option<Hash<DATUM>>> for MemoizedDatum {
+    fn from(opt: Option<Hash<DATUM>>) -> Self {
+        opt.map(MemoizedDatum::from).unwrap_or(MemoizedDatum::None)
+    }
+}
+
+impl From<MemoizedPlutusData> for MemoizedDatum {
+    fn from(data: MemoizedPlutusData) -> Self {
+        Self::Inline(Box::new(data))
+    }
 }
 
 impl serde::Serialize for MemoizedDatum {
@@ -58,8 +76,8 @@ impl<'de> serde::Deserialize<'de> for MemoizedDatum {
 
         match serde::Deserialize::deserialize(deserializer)? {
             PlaceholderDatum::Unit(()) => Ok(MemoizedDatum::None),
-            PlaceholderDatum::Hash(bytes) => Ok(MemoizedDatum::Hash(bytes)),
-            PlaceholderDatum::Data(data) => Ok(MemoizedDatum::Inline(data)),
+            PlaceholderDatum::Hash(hash) => Ok(MemoizedDatum::from(hash)),
+            PlaceholderDatum::Data(data) => Ok(MemoizedDatum::from(data)),
         }
     }
 }
@@ -79,7 +97,7 @@ impl<'b, C> cbor::Decode<'b, C> for MemoizedDatum {
                         return Err(cbor::decode::Error::message("unknown tag for datum tag"));
                     }
                     let plutus_data: MemoizedPlutusData = cbor::decode_with(d.bytes()?, ctx)?;
-                    Ok(MemoizedDatum::Inline(plutus_data))
+                    Ok(MemoizedDatum::from(plutus_data))
                 }
                 _ => Err(cbor::decode::Error::message(format!("unknown datum option: {}", datum_option))),
             }
@@ -93,7 +111,7 @@ impl<'b, C> cbor::Decode<'b, C> for Legacy<MemoizedDatum> {
         if raw.len() != 32 {
             return Err(cbor::decode::Error::message(format!("expected datum hash of length 32, got {}", raw.len())));
         }
-        Ok(Legacy(MemoizedDatum::Hash(Hash::<DATUM>::from(raw))))
+        Ok(Legacy(MemoizedDatum::from(Hash::<DATUM>::from(raw))))
     }
 }
 
@@ -119,11 +137,5 @@ impl<C> cbor::Encode<C> for MemoizedDatum {
         }
 
         Ok(())
-    }
-}
-
-impl From<Option<Hash<DATUM>>> for MemoizedDatum {
-    fn from(opt: Option<Hash<DATUM>>) -> Self {
-        opt.map(MemoizedDatum::Hash).unwrap_or(MemoizedDatum::None)
     }
 }

--- a/crates/amaru-kernel/src/cardano/memoized/transaction_output.rs
+++ b/crates/amaru-kernel/src/cardano/memoized/transaction_output.rs
@@ -38,7 +38,7 @@ pub struct MemoizedTransactionOutput {
     pub datum: MemoizedDatum,
 
     #[serde(serialize_with = "serialize_script")]
-    pub script: Option<MemoizedScript>,
+    pub script: Option<Box<MemoizedScript>>,
 }
 
 #[derive(serde::Deserialize)]
@@ -52,12 +52,21 @@ struct MemoizedTransactionOutputDe {
     datum: MemoizedDatum,
 
     #[serde(deserialize_with = "deserialize_script")]
-    script: Option<MemoizedScript>,
+    script: Option<Box<MemoizedScript>>,
 }
 
 impl From<MemoizedTransactionOutputDe> for MemoizedTransactionOutput {
     fn from(de: MemoizedTransactionOutputDe) -> Self {
-        Self::new(false, de.address, de.value, de.datum, de.script)
+        let mut output = Self {
+            original_size: 0,
+            is_legacy: false,
+            address: de.address,
+            value: de.value,
+            datum: de.datum,
+            script: de.script,
+        };
+        output.original_size = to_cbor(&output).len();
+        output
     }
 }
 
@@ -71,7 +80,7 @@ impl MemoizedTransactionOutput {
         datum: MemoizedDatum,
         script: Option<MemoizedScript>,
     ) -> Self {
-        let mut output = Self { original_size: 0, is_legacy, address, value, datum, script };
+        let mut output = Self { original_size: 0, is_legacy, address, value, datum, script: script.map(Box::new) };
         output.original_size = to_cbor(&output).len();
         output
     }
@@ -163,7 +172,7 @@ fn decode_modern_output<C>(
                 2 => state.2 = d.decode_with(ctx)?,
                 3 => {
                     let SerialisedAsCbor(script) = d.decode_with(ctx)?;
-                    state.3 = Some(script)
+                    state.3 = Some(Box::new(script))
                 }
                 _ => return cbor::unexpected_field::<MemoizedTransactionOutput, _>(field),
             }
@@ -195,10 +204,10 @@ impl<C> cbor::Encode<C> for MemoizedTransactionOutput {
             e.begin_array()?;
             e.bytes(&self.address.to_vec())?;
             e.encode_with(&self.value, ctx)?;
-            match self.datum {
+            match &self.datum {
                 MemoizedDatum::None => (),
                 MemoizedDatum::Hash(hash) => {
-                    e.bytes(&hash[..])?;
+                    e.bytes(&hash.as_ref()[..])?;
                 }
                 MemoizedDatum::Inline(..) => unreachable!("legacy output with inline datum ?!"),
             }
@@ -298,7 +307,7 @@ fn deserialize_value<'de, D: serde::de::Deserializer<'de>>(deserializer: D) -> R
 }
 
 pub fn serialize_script<S: serde::ser::Serializer>(
-    opt: &Option<MemoizedScript>,
+    opt: &Option<Box<MemoizedScript>>,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
     match opt {
@@ -309,10 +318,12 @@ pub fn serialize_script<S: serde::ser::Serializer>(
 
 pub fn deserialize_script<'de, D: serde::de::Deserializer<'de>>(
     deserializer: D,
-) -> Result<Option<MemoizedScript>, D::Error> {
+) -> Result<Option<Box<MemoizedScript>>, D::Error> {
     match serde::Deserialize::deserialize(deserializer)? {
         None::<super::PlaceholderScript> => Ok(None),
-        Some(placeholder) => Ok(Some(MemoizedScript::try_from(placeholder).map_err(serde::de::Error::custom)?)),
+        Some(placeholder) => {
+            Ok(Some(MemoizedScript::try_from(placeholder).map(Box::new).map_err(serde::de::Error::custom)?))
+        }
     }
 }
 
@@ -337,7 +348,7 @@ pub mod tests {
     }
 
     pub fn any_datum() -> impl Strategy<Value = MemoizedDatum> {
-        prop_oneof![Just(MemoizedDatum::None), any_hash32().prop_map(MemoizedDatum::Hash)]
+        prop_oneof![Just(MemoizedDatum::None), any_hash32().prop_map(MemoizedDatum::from)]
     }
 
     pub fn any_modern_output() -> impl Strategy<Value = MemoizedTransactionOutput> {
@@ -346,7 +357,7 @@ pub mod tests {
     }
 
     pub fn any_legacy_output() -> impl Strategy<Value = MemoizedTransactionOutput> {
-        (any_shelley_address(), any_value(), option::of(any_hash32().prop_map(MemoizedDatum::Hash))).prop_map(
+        (any_shelley_address(), any_value(), option::of(any_hash32().prop_map(MemoizedDatum::from))).prop_map(
             |(address, value, datum_opt)| {
                 MemoizedTransactionOutput::new(true, address, value, datum_opt.unwrap_or(MemoizedDatum::None), None)
             },
@@ -358,7 +369,7 @@ pub mod tests {
         let hash_bytes = [1u8; 32];
         let datum_hash = Hash::<32>::from(hash_bytes);
 
-        let datum = MemoizedDatum::Hash(datum_hash);
+        let datum = MemoizedDatum::from(datum_hash);
 
         let original = MemoizedTransactionOutput::new(
             false,
@@ -384,7 +395,7 @@ pub mod tests {
         let hash_bytes = [1u8; 32];
         let datum_hash = Hash::<32>::from(hash_bytes);
 
-        let datum = MemoizedDatum::Hash(datum_hash);
+        let datum = MemoizedDatum::from(datum_hash);
 
         let original = MemoizedTransactionOutput::new(
             true,

--- a/crates/amaru-kernel/src/cardano/pool_params.rs
+++ b/crates/amaru-kernel/src/cardano/pool_params.rs
@@ -87,10 +87,7 @@ mod tests {
     use proptest::{option, prelude::*, prop_compose};
 
     use super::*;
-    use crate::{
-        Bytes, RationalNumber, Relay, any_hash28, any_hash32, prop_cbor_roundtrip,
-        size::{CREDENTIAL, KEY},
-    };
+    use crate::{Bytes, RationalNumber, Relay, any_hash28, any_hash32, prop_cbor_roundtrip, size::CREDENTIAL};
 
     prop_cbor_roundtrip!(PoolParams, any_pool_params());
 
@@ -145,7 +142,7 @@ mod tests {
             cost in any::<u64>(),
             margin in 0..100u64,
             reward_account in any::<[u8; CREDENTIAL]>(),
-            owners in any::<Vec<[u8; KEY]>>(),
+            owners in proptest::collection::vec(any_hash28(), 1..3),
             relays in proptest::collection::vec(any_relay(), 0..10),
         ) -> PoolParams {
             PoolParams {
@@ -155,7 +152,7 @@ mod tests {
                 cost,
                 margin: RationalNumber { numerator: margin, denominator: 100 },
                 reward_account: [&[0xF0], &reward_account[..]].concat().into(),
-                owners: owners.into_iter().map(|h| h.into()).collect(),
+                owners,
                 relays,
                 metadata: None,
             }

--- a/crates/amaru-kernel/src/cardano/pool_params.rs
+++ b/crates/amaru-kernel/src/cardano/pool_params.rs
@@ -20,7 +20,7 @@ use crate::{
     utils::cbor::SerialisedAsSet,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PoolParams {
     pub id: PoolId,
     pub vrf: Hash<VRF_KEY>,

--- a/crates/amaru-kernel/src/cardano/pool_params.rs
+++ b/crates/amaru-kernel/src/cardano/pool_params.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeSet;
-
 use crate::{
     Hash, Lovelace, PoolId, PoolMetadata, RationalNumber, Relay, RewardAccount, cbor,
     size::{KEY, VRF_KEY},
@@ -28,7 +26,18 @@ pub struct PoolParams {
     pub cost: Lovelace,
     pub margin: RationalNumber,
     pub reward_account: RewardAccount,
-    pub owners: BTreeSet<Hash<KEY>>,
+    // NOTE: Small set too small for BTreeSet
+    //
+    // A BTreeSet allocates in nodes of ~400 bytes which can contain multiple elements. So when a
+    // set would typically be small; a BTreeSet can easily kill us memory-wise; especially when
+    // found in an object that gets reproduced many many times. Using a BTreeSet makes every pool
+    // params 400 bytes bigger; even if most will have a single owner.
+    //
+    // Plus, if the set is small anyway, doing a binary search to find elements is cheap.
+    //
+    // Here, nothing guarantees that the set is small but we know that at worse, it cannot contain
+    // much more than 500 elements due to the transaction max size.
+    pub owners: Vec<Hash<KEY>>,
     pub relays: Vec<Relay>,
     pub metadata: Option<PoolMetadata>,
 }

--- a/crates/amaru-kernel/src/cardano/script_context.rs
+++ b/crates/amaru-kernel/src/cardano/script_context.rs
@@ -40,7 +40,7 @@ impl<'a> ScriptContext<'a> {
             tx_info.inputs.get(redeemer_key.index as usize).and_then(|output_ref| match &output_ref.output.datum {
                 MemoizedDatum::None => None,
                 MemoizedDatum::Hash(hash) => tx_info.data.0.get(hash).copied(),
-                MemoizedDatum::Inline(data) => Some(data.as_ref()),
+                MemoizedDatum::Inline(data) => Some(data.as_ref().as_ref()),
             })
         } else {
             None

--- a/crates/amaru-kernel/src/cardano/transaction_body.rs
+++ b/crates/amaru-kernel/src/cardano/transaction_body.rs
@@ -65,7 +65,7 @@ pub struct TransactionBody {
 
     pub network: Option<Network>,
 
-    pub collateral_return: Option<MemoizedTransactionOutput>,
+    pub collateral_return: Option<Box<MemoizedTransactionOutput>>,
 
     pub total_collateral: Option<Lovelace>,
 

--- a/crates/amaru-kernel/src/cardano/tx_info.rs
+++ b/crates/amaru-kernel/src/cardano/tx_info.rs
@@ -202,7 +202,7 @@ impl<'a> TxInfo<'a> {
                 let output_ref = utxos.resolve_input(input).ok_or(TxInfoTranslationError::MissingInput(*input))?;
 
                 if let Some(script) = output_ref.output.script.as_ref() {
-                    scripts.insert(script.script_hash(), BorrowedScript::from(script));
+                    scripts.insert(script.script_hash(), BorrowedScript::from(script.as_ref()));
                 };
 
                 Ok(output_ref)

--- a/crates/amaru-kernel/src/traits/has_ownership.rs
+++ b/crates/amaru-kernel/src/traits/has_ownership.rs
@@ -71,9 +71,8 @@ impl HasOwnership for Certificate {
             | Self::RegDRepCert(stake_credential, _, _)
             | Self::UnRegDRepCert(stake_credential, _)
             | Self::UpdateDRepCert(stake_credential, _) => *stake_credential,
-            Self::PoolRegistration { operator: id, .. } | Self::PoolRetirement(id, _) => {
-                StakeCredential::AddrKeyhash(*id)
-            }
+            Self::PoolRetirement(id, _) => StakeCredential::AddrKeyhash(*id),
+            Self::PoolRegistration(params) => StakeCredential::AddrKeyhash(params.id),
         }
     }
 }

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -1095,7 +1095,7 @@ impl NodePoolParams {
             cost: self.cost,
             margin: self.margin,
             reward_account: self.reward_account,
-            owners: self.owners,
+            owners: self.owners.into_iter().collect(),
             relays: self.relays,
             metadata: self.metadata,
         }

--- a/crates/amaru-ledger/src/context.rs
+++ b/crates/amaru-ledger/src/context.rs
@@ -255,10 +255,14 @@ pub trait DRepsSlice {
         &mut self,
         drep: StakeCredential,
         registration: DRepRegistration,
-        anchor: Option<Anchor>,
+        anchor: Option<Box<Anchor>>,
     ) -> Result<(), RegisterError<DRepRegistration, StakeCredential>>;
 
-    fn update(&mut self, drep: StakeCredential, anchor: Option<Anchor>) -> Result<(), UpdateError<StakeCredential>>;
+    fn update(
+        &mut self,
+        drep: StakeCredential,
+        anchor: Option<Box<Anchor>>,
+    ) -> Result<(), UpdateError<StakeCredential>>;
 
     fn unregister(&mut self, drep: StakeCredential, refund: Lovelace, pointer: CertificatePointer);
 }
@@ -298,7 +302,7 @@ pub trait CommitteeSlice {
     fn resign(
         &mut self,
         cc_member: StakeCredential,
-        anchor: Option<Anchor>,
+        anchor: Option<Box<Anchor>>,
     ) -> Result<(), UnregisterError<CCMember, StakeCredential>>;
 }
 
@@ -425,7 +429,7 @@ where
     for (script_hash, location) in known_scripts {
         let lookup = |input| {
             UtxoSlice::lookup(context, input)
-                .and_then(|output| output.script.as_ref())
+                .and_then(|output| output.script.as_deref())
                 .unwrap_or_else(|| unreachable!("no script at expected location: {location:?}"))
         };
 
@@ -455,7 +459,7 @@ where
                 .and_then(|output| match &output.datum {
                     MemoizedDatum::None => None,
                     MemoizedDatum::Hash(..) => None,
-                    MemoizedDatum::Inline(data) => Some(data),
+                    MemoizedDatum::Inline(data) => Some(data.as_ref()),
                 })
                 .unwrap_or_else(|| unreachable!("no datum at expected location: {location:?}"))
         };

--- a/crates/amaru-ledger/src/context/default/validation.rs
+++ b/crates/amaru-ledger/src/context/default/validation.rs
@@ -286,7 +286,7 @@ impl DRepsSlice for DefaultValidationContext {
         &mut self,
         drep: StakeCredential,
         registration: DRepRegistration,
-        anchor: Option<Anchor>,
+        anchor: Option<Box<Anchor>>,
     ) -> Result<(), RegisterError<DRepRegistration, StakeCredential>> {
         let _span = trace_span!(
             ledger::transaction::CERTIFICATE_DREP_REGISTRATION,
@@ -304,7 +304,11 @@ impl DRepsSlice for DefaultValidationContext {
         Ok(())
     }
 
-    fn update(&mut self, drep: StakeCredential, anchor: Option<Anchor>) -> Result<(), UpdateError<StakeCredential>> {
+    fn update(
+        &mut self,
+        drep: StakeCredential,
+        anchor: Option<Box<Anchor>>,
+    ) -> Result<(), UpdateError<StakeCredential>> {
         let _span = trace_span!(ledger::transaction::CERTIFICATE_DREP_UPDATE, drep = format!("{drep:?}"));
         if let Some(a) = &anchor {
             _span.record("anchor_url", &a.url);
@@ -362,7 +366,7 @@ impl CommitteeSlice for DefaultValidationContext {
     fn resign(
         &mut self,
         cc_member: StakeCredential,
-        anchor: Option<Anchor>,
+        anchor: Option<Box<Anchor>>,
     ) -> Result<(), UnregisterError<CCMember, StakeCredential>> {
         let _span =
             trace_span!(ledger::transaction::CERTIFICATE_COMMITTEE_RESIGN, cc_member = format!("{cc_member:?}"));

--- a/crates/amaru-ledger/src/epoch_transition/pools_updates.rs
+++ b/crates/amaru-ledger/src/epoch_transition/pools_updates.rs
@@ -232,7 +232,8 @@ mod tests {
                     let pending_certificate = || {
                         prop_oneof![
                             (1..3u64).prop_map(move |offset| Retirement(Epoch::from(epoch as u64) + offset)),
-                            any_pool_params().prop_map(move |params| Registration(PoolParams { id, ..params }))
+                            any_pool_params()
+                                .prop_map(move |params| PoolCertificate::from(PoolParams { id, ..params }))
                         ]
                     };
                     vec(pending_certificate(), 0..3)
@@ -264,7 +265,7 @@ mod tests {
             for certificate in &self.log {
                 match certificate {
                     Registration(params) => {
-                        current = Some(params.clone());
+                        current = Some(params.as_ref().clone());
                         retiring = false;
                     }
                     Retirement(at) => retiring = at <= &epoch,
@@ -296,7 +297,7 @@ mod tests {
 
                 let pool_id = pool.id();
                 for certificate in updates {
-                    pool.pending_certificates.append_certificate(certificate);
+                    pool.pending_certificates.append(certificate);
                 }
 
                 let before_tick = pool.clone();
@@ -356,7 +357,7 @@ mod tests {
 
             let mut pool = Pool::new(registered_at, deposit, initial_params);
             let pool_id = pool.id();
-            pool.pending_certificates = PoolCertificates::default().with_retirement(epoch);
+            pool.pending_certificates = PoolCertificates::default().with(epoch);
 
             let mut pools_updates = PoolsEpochTransitionUpdates::default();
             pools_updates.tick_pool(epoch, pool);
@@ -376,8 +377,7 @@ mod tests {
 
         // A retirement scheduled for a distant epoch, then a re-registration effective sooner. The
         // re-registration cancels the retirement, so the pool must survive the retirement epoch.
-        pool.pending_certificates =
-            PoolCertificates::default().with_retirement(Epoch::from(617)).with_registration(updated_params.clone());
+        pool.pending_certificates = PoolCertificates::default().with(Epoch::from(617)).with(updated_params.clone());
 
         let mut at_615 = PoolsEpochTransitionUpdates::default();
         at_615.tick_pool(Epoch::from(615), pool);
@@ -407,10 +407,10 @@ mod tests {
         pool_params_b.reward_account = reward_account;
 
         let mut pool_a = Pool::new(run_strategy(any_certificate_pointer(u64::MAX)), deposit_a, pool_params_a);
-        pool_a.pending_certificates.append_retirement(Epoch::from(0));
+        pool_a.pending_certificates.append(Epoch::from(0));
 
         let mut pool_b = Pool::new(run_strategy(any_certificate_pointer(u64::MAX)), deposit_b, pool_params_b);
-        pool_b.pending_certificates.append_retirement(Epoch::from(0));
+        pool_b.pending_certificates.append(Epoch::from(0));
 
         let mut pools_updates = PoolsEpochTransitionUpdates::default();
         let pending_a = pool_a.pending_certificates.pending_after(Epoch::from(0));

--- a/crates/amaru-ledger/src/epoch_transition/pools_updates/pool_certificates.rs
+++ b/crates/amaru-ledger/src/epoch_transition/pools_updates/pool_certificates.rs
@@ -50,25 +50,12 @@ impl<'b, C> cbor::decode::Decode<'b, C> for PoolCertificates {
 }
 
 impl PoolCertificates {
-    pub fn append_certificate(&mut self, certificate: PoolCertificate) {
-        self.0.push(certificate);
+    pub fn append(&mut self, certificate: impl Into<PoolCertificate>) {
+        self.0.push(certificate.into());
     }
 
-    pub fn append_registration(&mut self, params: PoolParams) {
-        self.0.push(PoolCertificate::Registration(params));
-    }
-
-    pub fn append_retirement(&mut self, epoch: Epoch) {
-        self.0.push(PoolCertificate::Retirement(epoch))
-    }
-
-    pub fn with_registration(mut self, params: PoolParams) -> Self {
-        self.0.push(PoolCertificate::Registration(params));
-        self
-    }
-
-    pub fn with_retirement(mut self, epoch: Epoch) -> Self {
-        self.0.push(PoolCertificate::Retirement(epoch));
+    pub fn with(mut self, certificate: impl Into<PoolCertificate>) -> Self {
+        self.0.push(certificate.into());
         self
     }
 
@@ -129,8 +116,26 @@ impl PoolCertificates {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum PoolCertificate {
-    Registration(PoolParams),
+    Registration(Box<PoolParams>),
     Retirement(Epoch),
+}
+
+impl From<PoolParams> for PoolCertificate {
+    fn from(params: PoolParams) -> Self {
+        Self::Registration(Box::new(params))
+    }
+}
+
+impl From<Box<PoolParams>> for PoolCertificate {
+    fn from(params: Box<PoolParams>) -> Self {
+        Self::Registration(params)
+    }
+}
+
+impl From<Epoch> for PoolCertificate {
+    fn from(epoch: Epoch) -> Self {
+        Self::Retirement(epoch)
+    }
 }
 
 impl<C> cbor::encode::Encode<C> for PoolCertificate {
@@ -224,7 +229,7 @@ mod tests {
     use super::*;
 
     pub fn any_pool_certificate(epoch: Epoch) -> impl Strategy<Value = PoolCertificate> {
-        prop_oneof![Just(Retirement(epoch)), any_pool_params().prop_map(Registration)]
+        prop_oneof![Just(Retirement(epoch)), any_pool_params().prop_map(PoolCertificate::from)]
     }
 
     pub fn any_pool_certificates() -> impl Strategy<Value = PoolCertificates> {

--- a/crates/amaru-ledger/src/rules.rs
+++ b/crates/amaru-ledger/src/rules.rs
@@ -108,8 +108,8 @@ fn prepare_certificate<'a>(context: &mut impl PreparationContext<'a>, certificat
             context.require_pool(pool_key_hash);
         }
 
-        Certificate::PoolRegistration { operator: pool_key_hash, .. }
-        | Certificate::PoolRetirement(pool_key_hash, _) => context.require_pool(pool_key_hash),
+        Certificate::PoolRegistration(params) => context.require_pool(&params.id),
+        Certificate::PoolRetirement(pool_id, _) => context.require_pool(pool_id),
 
         Certificate::StakeVoteDeleg(credential, pool_key_hash, drep)
         | Certificate::StakeVoteRegDeleg(credential, pool_key_hash, drep, _) => {

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/certificates.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/certificates.rs
@@ -159,18 +159,11 @@ where
     };
 
     match certificate {
-        Certificate::PoolRegistration {
-            operator: id,
-            vrf_keyhash: vrf,
-            pledge,
-            cost,
-            margin,
-            reward_account,
-            pool_owners: owners,
-            relays,
-            pool_metadata: metadata,
-        } => {
-            context.require_vkey_witness(id);
+        Certificate::PoolRegistration(params) => {
+            let PoolParams { id, cost, reward_account, owners, .. } = params.as_ref();
+
+            context.require_vkey_witness(*id);
+
             // https://github.com/IntersectMBO/cardano-ledger/blob/master/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs#L250-L256
             // The Haskell node requires both the owners and the operators, which may be the same pkh.
             // TODO: We need coverage for this branch, we have none in either conformance tests or unit tests.
@@ -179,7 +172,7 @@ where
             }
 
             let reward_account_network =
-                parse_reward_account(&reward_account).ok_or(InvalidCertificates::PoolMalformedRewardAccount)?.1;
+                parse_reward_account(reward_account).ok_or(InvalidCertificates::PoolMalformedRewardAccount)?.1;
 
             if reward_account_network != network {
                 return Err(InvalidCertificates::PoolWrongNetwork {
@@ -188,19 +181,17 @@ where
                 });
             }
 
-            if cost < protocol_parameters.min_pool_cost {
+            if cost < &protocol_parameters.min_pool_cost {
                 return Err(InvalidCertificates::PoolCostTooLow {
-                    provided: cost,
+                    provided: *cost,
                     minimum: protocol_parameters.min_pool_cost,
                 });
             }
 
             // TODO: Have `register` return this information
-            let is_new_pool = !context.exists(id);
+            let is_new_pool = !context.exists(*id);
 
-            let params = PoolParams { id, vrf, pledge, cost, margin, reward_account, owners, relays, metadata };
-
-            PoolsSlice::register(context, params, pointer, protocol_parameters.stake_pool_deposit);
+            PoolsSlice::register(context, *params, pointer, protocol_parameters.stake_pool_deposit);
 
             if is_new_pool {
                 context.produce_lovelace(protocol_parameters.stake_pool_deposit);
@@ -463,12 +454,12 @@ where
     use Certificate::*;
 
     match certificate {
-        PoolRegistration { operator: id, .. } => {
+        PoolRegistration(params) => {
             // TODO: Have tests covering local state changes in certificate accounting
             //
             // See note below.
-            if !local_pools_slice.contains(&id) && !context.exists(id) {
-                local_pools_slice.insert(id);
+            if !local_pools_slice.contains(&params.id) && !context.exists(params.id) {
+                local_pools_slice.insert(params.id);
                 protocol_parameters.stake_pool_deposit as i64
             } else {
                 0

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/inputs.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/inputs.rs
@@ -69,7 +69,7 @@ where
             match &output.datum {
                 MemoizedDatum::Inline(data) => context.acknowledge_datum(data.hash(), *reference_input),
                 MemoizedDatum::Hash(hash) => {
-                    context.allow_supplemental_datum(*hash);
+                    context.allow_supplemental_datum(*hash.as_ref());
                 }
                 MemoizedDatum::None => (),
             };

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
@@ -181,7 +181,7 @@ where
         collateral::execute(
             context,
             transaction_body.collateral.as_deref(),
-            transaction_body.collateral_return.as_ref(),
+            transaction_body.collateral_return.as_deref(),
             transaction_body.total_collateral,
             transaction_body.fee,
             protocol_parameters,
@@ -198,7 +198,7 @@ where
             context,
             protocol_parameters,
             network,
-            mem::take(&mut transaction_body.collateral_return).map(|x| vec![x]).unwrap_or_default(),
+            mem::take(&mut transaction_body.collateral_return).map(|x| vec![*x]).unwrap_or_default(),
             SupplementalDatumPolicy::Disallow,
             |_context, _index, _value| {
                 if is_valid {

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/outputs.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/outputs.rs
@@ -90,7 +90,7 @@ where
         if matches!(supplemental_datum_policy, SupplementalDatumPolicy::Allow)
             && let MemoizedDatum::Hash(hash) = &output.datum
         {
-            context.allow_supplemental_datum(*hash);
+            context.allow_supplemental_datum(*hash.as_ref());
         }
 
         if let Some(script) = output.script.as_ref() {

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/scripts.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/scripts.rs
@@ -292,7 +292,7 @@ fn partition_scripts(
 
         let mut require_datum_preimage = || match datum {
             MemoizedDatum::Hash(hash) => {
-                required_datums.insert(*hash);
+                required_datums.insert(*hash.as_ref());
             }
             MemoizedDatum::Inline(..) | MemoizedDatum::None => {}
         };

--- a/crates/amaru-ledger/src/state/volatile.rs
+++ b/crates/amaru-ledger/src/state/volatile.rs
@@ -15,7 +15,7 @@
 use std::collections::VecDeque;
 
 use amaru_kernel::{
-    Anchor, CertificatePointer, DRep, DRepRegistration, Epoch, Lovelace, Point, PoolId, ProposalId, StakeCredential,
+    CertificatePointer, DRep, DRepRegistration, Epoch, Lovelace, Point, PoolId, ProposalId, StakeCredential,
     TransactionInput,
 };
 
@@ -66,7 +66,7 @@ pub type CommitteeMemberBind<'a> = Bind<&'a StakeCredential, &'a Empty, &'a Epoc
 /// A DRep's accumulated binding: the metadata anchor, plus the registration record. The registration
 /// is the queryable value; the anchor is updated independently of registration, so an anchor-only
 /// update is a bind-only (`value: None`) change that composes onto the registration from below.
-pub type DRepBind<'a> = Bind<&'a Anchor, &'a Empty, &'a DRepRegistration>;
+pub type DRepBind<'a> = Bind<&'a Empty, &'a Empty, &'a DRepRegistration>;
 
 /// An outward-facing store API to query the volatile as a store.
 pub trait VolatileState {

--- a/crates/amaru-ledger/src/state/volatile/aggregate.rs
+++ b/crates/amaru-ledger/src/state/volatile/aggregate.rs
@@ -15,7 +15,7 @@
 use std::{collections::BTreeSet, sync::Arc};
 
 use amaru_kernel::{
-    Anchor, CertificatePointer, DRep, DRepRegistration, Lovelace, MemoizedTransactionOutput, PoolId, ProposalId,
+    CertificatePointer, DRep, DRepRegistration, Lovelace, MemoizedTransactionOutput, PoolId, ProposalId,
     StakeCredential, TransactionInput,
 };
 
@@ -38,7 +38,7 @@ type Accounts = IndexedBind<StakeCredential, (PoolId, CertificatePointer), (DRep
 
 /// The window's DReps, indexed by credential so each one's per-fragment history is retracted exactly
 /// on stabilization and folded on read. See [`IndexedBind`].
-type DReps = IndexedBind<StakeCredential, Anchor, Empty, DRepRegistration>;
+type DReps = IndexedBind<StakeCredential, Empty, Empty, DRepRegistration>;
 
 /// The window's constitutional committee, indexed by cold credential so each member's hot-key
 /// history is retracted exactly on stabilization. A member may rotate their hot key (produce then
@@ -146,7 +146,7 @@ impl VolatileAggregate {
         self.pools.extend(pools);
         self.withdrawals.extend(withdrawals.iter().cloned());
         self.proposals.extend(proposals.keys().cloned());
-        self.dreps.extend(dreps);
+        self.dreps.extend_with(dreps, |bind| bind.map_left(|_| Empty));
         self.committee.extend(committee);
         self.accounts.extend(accounts);
 

--- a/crates/amaru-ledger/src/state/volatile/aggregate/indexed_bind.rs
+++ b/crates/amaru-ledger/src/state/volatile/aggregate/indexed_bind.rs
@@ -67,9 +67,29 @@ impl<K: Ord, L, R, V> IndexedBind<K, L, R, V> {
         }
     }
 
+    /// Like [`Self::extend`] but allows transforming a bind when indexing.
+    pub fn extend_with<Lsrc, Rsrc, Vsrc>(
+        &mut self,
+        diff: &DiffBind<K, Lsrc, Rsrc, Vsrc>,
+        with: impl Fn(Bind<Lsrc, Rsrc, Vsrc>) -> Bind<L, R, V>,
+    ) where
+        K: ToOwned<Owned = K>,
+        Lsrc: ToOwned<Owned = Lsrc>,
+        Rsrc: ToOwned<Owned = Rsrc>,
+        Vsrc: ToOwned<Owned = Vsrc>,
+    {
+        for (key, bind) in &diff.registered {
+            push_front_or_insert(&mut self.index, key, Existence::Exists(with(bind.to_owned())));
+        }
+
+        for key in &diff.unregistered {
+            push_front_or_insert(&mut self.index, key, Existence::Gone);
+        }
+    }
+
     /// Retract the oldest fragment's contribution for every key it touched, popping the front of
     /// each deque and dropping the key once its history empties.
-    pub fn remove(&mut self, diff: &DiffBind<K, L, R, V>) -> bool {
+    pub fn remove<Lany, Rany, Vany>(&mut self, diff: &DiffBind<K, Lany, Rany, Vany>) -> bool {
         let mut all_present = true;
 
         for key in diff.registered.keys().chain(diff.unregistered.iter()) {

--- a/crates/amaru-ledger/src/state/volatile/bind.rs
+++ b/crates/amaru-ledger/src/state/volatile/bind.rs
@@ -45,6 +45,21 @@ impl<L, R, V> Bind<L, R, V> {
         Bind { left: self.left.as_refs(), right: self.right.as_refs(), value: self.value.as_ref() }
     }
 
+    /// Map on the left-hand binding
+    pub fn map_left<A>(self, to: impl FnOnce(L) -> A) -> Bind<A, R, V> {
+        Bind { left: self.left.map(to), right: self.right, value: self.value }
+    }
+
+    /// Map on the right-hand binding
+    pub fn map_right<A>(self, to: impl FnOnce(R) -> A) -> Bind<L, A, V> {
+        Bind { left: self.left, right: self.right.map(to), value: self.value }
+    }
+
+    /// Map on the bind value
+    pub fn map<A>(self, to: impl FnOnce(V) -> A) -> Bind<L, R, A> {
+        Bind { left: self.left, right: self.right, value: self.value.map(to) }
+    }
+
     /// Absorb a more recent update in place.
     /// A `Set`/`Reset` overrides, `Unchanged` keeps what's here, and a `value: Some(...)` supersedes wholesale.
     pub fn then(&mut self, newer: Self) {

--- a/crates/amaru-ledger/src/state/volatile/existence.rs
+++ b/crates/amaru-ledger/src/state/volatile/existence.rs
@@ -50,6 +50,15 @@ impl<T> Existence<T> {
         }
     }
 
+    #[inline]
+    pub fn map<A>(self, to: impl FnOnce(T) -> A) -> Existence<A> {
+        match self {
+            Self::Exists(v) => Existence::Exists(to(v)),
+            Self::Gone => Existence::Gone,
+            Self::Unknown => Existence::Unknown,
+        }
+    }
+
     /// Return this verdict when it is conclusive, otherwise lazily fall back to an older one.
     pub fn or_else(self, older: impl FnOnce() -> Self) -> Self {
         match self {

--- a/crates/amaru-ledger/src/state/volatile/fragment.rs
+++ b/crates/amaru-ledger/src/state/volatile/fragment.rs
@@ -56,7 +56,7 @@ pub struct VolatileFragment {
     pub utxo: DiffSet<TransactionInput, Arc<MemoizedTransactionOutput>>,
     pub pools: DiffEpochReg<PoolId, Arc<(PoolParams, CertificatePointer, Lovelace)>>,
     pub accounts: DiffBind<StakeCredential, (PoolId, CertificatePointer), (DRep, CertificatePointer), Lovelace>,
-    pub dreps: DiffBind<StakeCredential, Anchor, Empty, DRepRegistration>,
+    pub dreps: DiffBind<StakeCredential, Box<Anchor>, Empty, DRepRegistration>,
     pub dreps_deregistrations: BTreeMap<StakeCredential, CertificatePointer>,
     pub committee: DiffSet<StakeCredential, StakeCredential>,
     pub withdrawals: BTreeSet<StakeCredential>,
@@ -233,7 +233,7 @@ pub(crate) fn add_accounts(
 // ------------------------------------------------------------------------------------------- DReps
 
 pub(crate) fn add_dreps(
-    iterator: impl Iterator<Item = (StakeCredential, Bind<Anchor, Empty, DRepRegistration>)>,
+    iterator: impl Iterator<Item = (StakeCredential, Bind<Box<Anchor>, Empty, DRepRegistration>)>,
 ) -> impl Iterator<Item = (dreps::Key, dreps::Value)> {
     iterator.map(move |(credential, Bind { left: anchor, right: _, value: registration }): (_, Bind<_, Empty, _>)| {
         (credential, (anchor, registration))

--- a/crates/amaru-ledger/src/state/volatile/resettable.rs
+++ b/crates/amaru-ledger/src/state/volatile/resettable.rs
@@ -38,6 +38,15 @@ impl<A> From<Option<A>> for Resettable<A> {
 }
 
 impl<A> Resettable<A> {
+    /// Map a function onto the value if any.
+    pub fn map<B>(self, to: impl FnOnce(A) -> B) -> Resettable<B> {
+        match self {
+            Self::Set(a) => Resettable::Set(to(a)),
+            Self::Reset => Resettable::Reset,
+            Self::Unchanged => Resettable::Unchanged,
+        }
+    }
+
     /// Apply this change to `value`, returning the previous content when a change occurred.
     ///
     /// - `Unchanged` => returns `None` and leaves `value` as-is
@@ -45,9 +54,9 @@ impl<A> Resettable<A> {
     /// - `Reset`     => sets `value` to `None` and returns the old `Option<A>`
     pub fn set_or_reset(self, value: &mut Option<A>) -> Option<A> {
         match self {
-            Resettable::Set(new) => Option::replace(value, new),
-            Resettable::Reset => mem::take(value),
-            Resettable::Unchanged => None,
+            Self::Set(new) => Option::replace(value, new),
+            Self::Reset => mem::take(value),
+            Self::Unchanged => None,
         }
     }
 
@@ -64,9 +73,9 @@ impl<A> Resettable<A> {
     /// case.
     pub fn into_option(self, when_unchanged: Option<A>) -> Option<A> {
         match self {
-            Resettable::Set(value) => Some(value),
-            Resettable::Reset => None,
-            Resettable::Unchanged => when_unchanged,
+            Self::Set(value) => Some(value),
+            Self::Reset => None,
+            Self::Unchanged => when_unchanged,
         }
     }
 

--- a/crates/amaru-ledger/src/state/volatile/view/iter_pools.rs
+++ b/crates/amaru-ledger/src/state/volatile/view/iter_pools.rs
@@ -91,13 +91,13 @@ impl<'volatile, DBIter: Iterator<Item = (PoolId, Pool)>> Iterator for IterPools<
             // Pool is already registered, and has some updates.
             if let Some(update) = self.registrations.remove(&pool_id) {
                 for (pool_params, _, _) in update.iter() {
-                    pool.pending_certificates.append_registration(pool_params.clone());
+                    pool.pending_certificates.append(pool_params.clone());
                 }
             }
 
             // Pool has announced its retirement.
             if let Some(retirement_epoch) = self.retirements.remove(&pool_id) {
-                pool.pending_certificates.append_retirement(retirement_epoch)
+                pool.pending_certificates.append(retirement_epoch)
             }
 
             return Some((pool_id, pool));
@@ -109,12 +109,12 @@ impl<'volatile, DBIter: Iterator<Item = (PoolId, Pool)>> Iterator for IterPools<
 
             let mut pool = Pool::new(registration.1, registration.2, registration.0.clone());
             if let Some(re_registration) = re_registration {
-                pool.pending_certificates.append_registration(re_registration.0.clone());
+                pool.pending_certificates.append(re_registration.0.clone());
             }
 
             // Pool has announced its retirement.
             if let Some(retirement_epoch) = self.retirements.remove(&pool_id) {
-                pool.pending_certificates.append_retirement(retirement_epoch)
+                pool.pending_certificates.append(retirement_epoch)
             }
 
             return Some((pool_id, pool));
@@ -146,10 +146,7 @@ mod tests {
     static STABLE: LazyLock<BTreeMap<u8, (PoolId, Pool)>> = LazyLock::new(|| {
         let row = |ix| {
             let (current_params, registered_at, deposit) = mock_pool(ix);
-            (
-                mock_pool_id(ix),
-                Pool { registered_at, deposit, current_params, pending_certificates: Default::default() },
-            )
+            (mock_pool_id(ix), Pool::new(registered_at, deposit, current_params))
         };
 
         (0..MAX_POOLS).map(|ix| (ix, row(ix))).collect()
@@ -195,15 +192,15 @@ mod tests {
                     .iter()
                     .map(|(ix, row)| {
                         let (current_params, registered_at, deposit) = mock_pool(*ix);
-                        let mut pending_certificates = PoolCertificates::default();
+                        let mut pool = Pool::new(registered_at, deposit, current_params);
                         for event in row.iter() {
                             match event {
-                                Event::Registration => pending_certificates.append_registration(mock_pool_params(*ix)),
-                                Event::LateRetirement => pending_certificates.append_retirement(epoch + 10),
-                                Event::ImminentRetirement => pending_certificates.append_retirement(epoch + 1),
+                                Event::Registration => pool.pending_certificates.append(mock_pool_params(*ix)),
+                                Event::LateRetirement => pool.pending_certificates.append(epoch + 10),
+                                Event::ImminentRetirement => pool.pending_certificates.append(epoch + 1),
                             }
                         }
-                        (mock_pool_id(*ix), Pool { registered_at, deposit, current_params, pending_certificates })
+                        (mock_pool_id(*ix), pool)
                     })
                     .collect::<Vec<(PoolId, Pool)>>()
                     .into_iter(),
@@ -374,7 +371,7 @@ mod tests {
             // parameters and yet, preserve the late retirement as well. There's no diff strategy on
             // pool updates, we just replace the pool object entirely; and must therefore include
             // the late retirement.
-            updated: &[(0, Pool { pending_certificates: PoolCertificates::default().with_retirement(Epoch::from(110)), ..stable(0) })],
+            updated: &[(0, Pool { pending_certificates: PoolCertificates::default().with(Epoch::from(110)), ..stable(0) })],
             retired: &[]
         };
         "update in stable, late retirement in volatile"
@@ -410,7 +407,7 @@ mod tests {
         },
         NextEpochExpectations {
             seen: &[0],
-            updated: &[(0, Pool { pending_certificates: PoolCertificates::default().with_retirement(Epoch::from(110)), ..stable(0) })],
+            updated: &[(0, Pool { pending_certificates: PoolCertificates::default().with(Epoch::from(110)), ..stable(0) })],
             retired: &[]
         };
         "imminent retirement in stable, late retirement in volatile"

--- a/crates/amaru-ledger/src/store/columns/dreps.rs
+++ b/crates/amaru-ledger/src/store/columns/dreps.rs
@@ -20,14 +20,14 @@ use crate::state::volatile::Resettable;
 /// Iterator used to browse rows from the DRep column. Meant to be referenced using qualified imports.
 pub type Iter<'a, 'b> = IterBorrow<'a, 'b, Key, Option<Row>>;
 
-pub type Value = (Resettable<Anchor>, Option<DRepRegistration>);
+pub type Value = (Resettable<Box<Anchor>>, Option<DRepRegistration>);
 
 pub type Key = StakeCredential;
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct Row {
     pub deposit: Lovelace,
-    pub anchor: Option<Anchor>,
+    pub anchor: Option<Box<Anchor>>,
     pub registered_at: CertificatePointer,
     pub valid_until: Epoch,
 }
@@ -77,7 +77,7 @@ pub mod tests {
         ) -> Row {
             Row {
                 deposit,
-                anchor,
+                anchor: anchor.map(Box::new),
                 registered_at,
                 valid_until,
             }

--- a/crates/amaru-ledger/src/store/columns/pools.rs
+++ b/crates/amaru-ledger/src/store/columns/pools.rs
@@ -112,7 +112,7 @@ pub mod tests {
             let row_extended: Row = cbor::decode(&bytes_extended).unwrap();
 
             let mut pending_certificates = row.pending_certificates.clone();
-            pending_certificates.append_certificate(certificate);
+            pending_certificates.append(certificate);
             let expected = Row {
                 pending_certificates,
                 ..row

--- a/crates/amaru-ledger/src/store/columns/utxo.rs
+++ b/crates/amaru-ledger/src/store/columns/utxo.rs
@@ -74,7 +74,7 @@ pub mod tests {
             #[expect(clippy::expect_used)]
             let memoized = MemoizedPlutusData::new(pd).expect("PlutusData encoding should never fail");
 
-            MemoizedDatum::Inline(memoized)
+            MemoizedDatum::from(memoized)
         })
     }
 

--- a/crates/amaru-ledger/src/summary/governance.rs
+++ b/crates/amaru-ledger/src/summary/governance.rs
@@ -37,7 +37,7 @@ pub struct GovernanceSummary {
 #[derive(Debug, serde::Serialize)]
 #[cfg_attr(test, derive(Clone))]
 pub struct DRepState {
-    pub metadata: Option<Anchor>,
+    pub metadata: Option<Box<Anchor>>,
     pub valid_until: Option<Epoch>,
     pub voting_stake: Lovelace,
     #[serde(skip)]

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -632,7 +632,7 @@ mod test {
                 margin: RationalNumber { numerator: 1, denominator: 1 },
                 // 0xF0 discriminates a script stake address on a test network.
                 reward_account: [&[0xF0], &[tag; 28][..]].concat().into(),
-                owners: BTreeSet::new(),
+                owners: Vec::new(),
                 relays: Vec::new(),
                 metadata: None,
             },

--- a/crates/amaru-ledger/src/summary/stake_distribution.rs
+++ b/crates/amaru-ledger/src/summary/stake_distribution.rs
@@ -436,7 +436,7 @@ pub mod tests {
         ) -> DRepState {
             DRepState {
                 valid_until: Some(Epoch::from(valid_until)),
-                metadata,
+                metadata: metadata.map(Box::new),
                 voting_stake,
                 registered_at,
             }

--- a/crates/amaru-plutus/src/script_context/mod.rs
+++ b/crates/amaru-plutus/src/script_context/mod.rs
@@ -105,8 +105,8 @@ pub mod test_vectors {
     use std::{collections::BTreeMap, sync::LazyLock};
 
     use amaru_kernel::{
-        Address, MemoizedDatum, MemoizedTransactionOutput, MemoizedValue, TransactionInput, Value, include_json,
-        utils::serde::hex_to_bytes,
+        Address, Hash, MemoizedDatum, MemoizedPlutusData, MemoizedTransactionOutput, MemoizedValue, TransactionInput,
+        Value, include_json, size::DATUM, utils::serde::hex_to_bytes,
     };
     use serde::Deserialize;
 
@@ -251,13 +251,15 @@ pub mod test_vectors {
                             Field::Datum => {
                                 assert_only_datum_or_hash(&datum).map_err(serde::de::Error::custom)?;
                                 let string: String = map.next_value()?;
-                                datum = MemoizedDatum::Inline(string.try_into().map_err(serde::de::Error::custom)?);
+                                datum = MemoizedDatum::from(
+                                    MemoizedPlutusData::try_from(string).map_err(serde::de::Error::custom)?,
+                                );
                             }
                             Field::DatumHash => {
                                 assert_only_datum_or_hash(&datum).map_err(serde::de::Error::custom)?;
                                 let string: String = map.next_value()?;
                                 let bytes: Vec<u8> = hex::decode(string).map_err(serde::de::Error::custom)?;
-                                datum = MemoizedDatum::Hash(bytes.as_slice().into())
+                                datum = MemoizedDatum::from(Hash::<DATUM>::from(bytes.as_slice()))
                             }
                             Field::Script => {
                                 unimplemented!("script in UTxO not yet supported");

--- a/crates/amaru-plutus/src/script_context/v1.rs
+++ b/crates/amaru-plutus/src/script_context/v1.rs
@@ -15,8 +15,8 @@
 use std::{borrow::Cow, collections::BTreeMap};
 
 use amaru_kernel::{
-    Address, Certificate as PallasCertificate, Hash, MemoizedDatum, MemoizedTransactionOutput, PlutusData,
-    StakePayload, TransactionInput, size::DATUM,
+    Address, Certificate, Hash, MemoizedDatum, MemoizedTransactionOutput, PlutusData, PoolParams, StakePayload,
+    TransactionInput, size::DATUM,
 };
 
 use crate::{
@@ -130,7 +130,7 @@ where
 }
 
 #[allow(clippy::wildcard_enum_match_arm)]
-impl<const V: u8> ToPlutusData<V> for PallasCertificate
+impl<const V: u8> ToPlutusData<V> for Certificate
 where
     PlutusVersion<V>: IsKnownPlutusVersion + IsPrePlutusVersion3,
 {
@@ -161,33 +161,36 @@ where
     /// It is actually not possible (by the ledger serialization) logic to construct a Certificate with a `Pointer`, so this can be hardcoded to `Constr(0, [cred])`
     fn to_plutus_data(&self) -> Result<PlutusData, PlutusDataError> {
         match self {
-            PallasCertificate::StakeRegistration(stake_credential) => {
+            Certificate::StakeRegistration(stake_credential) => {
                 constr!(0, [constr!(0, [stake_credential])?])
             }
-            PallasCertificate::Reg(stake_credential, _) => {
+            Certificate::Reg(stake_credential, _) => {
                 constr!(0, [constr!(0, [stake_credential])?])
             }
-            PallasCertificate::StakeDeregistration(stake_credential) => {
+            Certificate::StakeDeregistration(stake_credential) => {
                 constr!(1, [constr!(0, [stake_credential])?])
             }
-            PallasCertificate::UnReg(stake_credential, _) => {
+            Certificate::UnReg(stake_credential, _) => {
                 constr!(1, [constr!(0, [stake_credential])?])
             }
-            PallasCertificate::StakeDelegation(stake_credential, hash) => {
+            Certificate::StakeDelegation(stake_credential, hash) => {
                 constr!(2, [constr!(0, [stake_credential])?, hash])
             }
-            PallasCertificate::PoolRegistration {
-                operator,
-                vrf_keyhash,
-                pledge: _,
-                cost: _,
-                margin: _,
-                reward_account: _,
-                pool_owners: _,
-                relays: _,
-                pool_metadata: _,
-            } => constr!(3, [operator, vrf_keyhash]),
-            PallasCertificate::PoolRetirement(hash, epoch) => constr!(4, [hash, epoch]),
+            Certificate::PoolRegistration(params) => {
+                let PoolParams {
+                    id,
+                    vrf,
+                    pledge: _,
+                    cost: _,
+                    margin: _,
+                    reward_account: _,
+                    owners: _,
+                    relays: _,
+                    metadata: _,
+                } = params.as_ref();
+                constr!(3, [id, vrf])
+            }
+            Certificate::PoolRetirement(hash, epoch) => constr!(4, [hash, epoch]),
             certificate => {
                 Err(PlutusDataError::unsupported_version(format!("illegal certificate type: {certificate:?}"), V))
             }
@@ -204,7 +207,7 @@ impl ToPlutusData<1> for MemoizedTransactionOutput {
                 self.address,
                 self.value.as_ref(),
                 match &self.datum {
-                    MemoizedDatum::Hash(hash) => Some(*hash),
+                    MemoizedDatum::Hash(hash) => Some(*hash.as_ref()),
                     _ => None::<Hash<DATUM>>,
                 },
             ]

--- a/crates/amaru-plutus/src/script_context/v3.rs
+++ b/crates/amaru-plutus/src/script_context/v3.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 
 use amaru_kernel::{
     Address, Certificate, Constitution, CostModels, DRep, DRepVotingThresholds, ExUnitPrices, ExUnits,
-    GovernanceAction, MemoizedTransactionOutput, PlutusData, PoolVotingThresholds, Proposal, ProposalId,
+    GovernanceAction, MemoizedTransactionOutput, PlutusData, PoolParams, PoolVotingThresholds, Proposal, ProposalId,
     ProtocolParamUpdate, RationalNumber, StakeAddress, StakeCredential, StakePayload, TransactionInput, Vote, Voter,
 };
 use num::Integer;
@@ -162,17 +162,20 @@ impl ToPlutusData<3> for Certificate {
             Certificate::UnRegDRepCert(drep_credential, deposit) => {
                 constr_v3!(6, [drep_credential, deposit])
             }
-            Certificate::PoolRegistration {
-                operator,
-                vrf_keyhash,
-                pledge: _,
-                cost: _,
-                margin: _,
-                reward_account: _,
-                pool_owners: _,
-                relays: _,
-                pool_metadata: _,
-            } => constr_v3!(7, [operator, vrf_keyhash]),
+            Certificate::PoolRegistration(params) => {
+                let PoolParams {
+                    id,
+                    vrf,
+                    pledge: _,
+                    cost: _,
+                    margin: _,
+                    reward_account: _,
+                    owners: _,
+                    relays: _,
+                    metadata: _,
+                } = params.as_ref();
+                constr_v3!(7, [id, vrf])
+            }
             Certificate::PoolRetirement(pool_keyhash, epoch) => {
                 constr_v3!(8, [pool_keyhash, epoch])
             }

--- a/crates/amaru-plutus/src/to_plutus_data.rs
+++ b/crates/amaru-plutus/src/to_plutus_data.rs
@@ -132,7 +132,7 @@ where
         match self {
             MemoizedDatum::None => constr!(0),
             MemoizedDatum::Hash(hash) => constr!(1, [hash]),
-            MemoizedDatum::Inline(data) => constr!(2, [data.as_ref()]),
+            MemoizedDatum::Inline(data) => constr!(2, [data.as_ref().as_ref()]),
         }
     }
 }
@@ -230,6 +230,16 @@ where
                 constr!(1, [hash])
             }
         }
+    }
+}
+
+impl<A, const V: u8> ToPlutusData<V> for Box<A>
+where
+    PlutusVersion<V>: IsKnownPlutusVersion,
+    A: ToPlutusData<V>,
+{
+    fn to_plutus_data(&self) -> Result<PlutusData, PlutusDataError> {
+        self.as_ref().to_plutus_data()
     }
 }
 

--- a/crates/amaru-stores/src/lib.rs
+++ b/crates/amaru-stores/src/lib.rs
@@ -125,7 +125,7 @@ pub mod tests {
 
         if drep_row.anchor.is_none() {
             drep_row.anchor =
-                Some(Anchor { url: "https://example.com".to_string(), content_hash: Hash::from([0u8; 32]) });
+                Some(Box::new(Anchor { url: "https://example.com".to_string(), content_hash: Hash::from([0u8; 32]) }));
         }
         let anchor = drep_row.anchor.clone().expect("Expected anchor to be Some");
         let deposit = drep_row.deposit;
@@ -378,7 +378,7 @@ pub mod tests {
 
         assert_eq!(
             store.pool(&fixture.pool_params.id)?.expect("Expected pool row").pending_certificates,
-            PoolCertificates::default().with_retirement(fixture.pool_epoch),
+            PoolCertificates::default().with(fixture.pool_epoch),
             "Expected pool to be scheduled for removal"
         );
 

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/pools.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/pools.rs
@@ -14,7 +14,7 @@
 
 use amaru_kernel::Epoch;
 use amaru_ledger::{
-    epoch_transition::pools_updates::PoolCertificate,
+    epoch_transition::pools_updates::{PoolCertificate, PoolCertificates},
     store::{
         StoreError,
         columns::{
@@ -57,8 +57,13 @@ pub fn add<DB>(db: &Transaction<'_, DB>, rows: impl Iterator<Item = Value>) -> R
             // TODO: We might want to define a MERGE OPERATOR to speed this up if
             // necessary.
             let params = match db.get(as_key(&PREFIX, pool)).map_err(|err| StoreError::Internal(err.into()))? {
-                None => as_value(Row::new(registered_at, deposit, params)),
-                Some(existing_params) => Row::extend(existing_params, PoolCertificate::Registration(params)),
+                None => as_value(Row {
+                    registered_at,
+                    deposit,
+                    current_params: params,
+                    pending_certificates: PoolCertificates::default(),
+                }),
+                Some(existing_params) => Row::extend(existing_params, PoolCertificate::from(params)),
             };
 
             db.put(as_key(&PREFIX, pool), params).map_err(|err| StoreError::Internal(err.into()))?;

--- a/crates/amaru/src/cardano_node/mempack.rs
+++ b/crates/amaru/src/cardano_node/mempack.rs
@@ -37,7 +37,7 @@ pub fn decode_transaction_output(bytes: &[u8]) -> Result<MemoizedTransactionOutp
             true,
             decode_compact_address(&mut decoder)?,
             decode_compact_value(&mut decoder)?,
-            MemoizedDatum::Hash(decoder.hash32()?),
+            MemoizedDatum::from(decoder.hash32()?),
             None,
         ),
         2 => {
@@ -56,7 +56,7 @@ pub fn decode_transaction_output(bytes: &[u8]) -> Result<MemoizedTransactionOutp
                 true,
                 decode_address28(&mut decoder, stake)?,
                 Value::Coin(decode_compact_coin(&mut decoder)?),
-                MemoizedDatum::Hash(decoder.packed_hash32()?),
+                MemoizedDatum::from(decoder.packed_hash32()?),
                 None,
             )
         }
@@ -64,7 +64,7 @@ pub fn decode_transaction_output(bytes: &[u8]) -> Result<MemoizedTransactionOutp
             false,
             decode_compact_address(&mut decoder)?,
             decode_compact_value(&mut decoder)?,
-            MemoizedDatum::Inline(decode_inline_plutus_data(&mut decoder)?),
+            MemoizedDatum::from(decode_inline_plutus_data(&mut decoder)?),
             None,
         ),
         5 => make_transaction_output(
@@ -339,8 +339,8 @@ fn decode_compact_value(decoder: &mut Decoder<'_>) -> Result<Value, String> {
 fn decode_datum(decoder: &mut Decoder<'_>) -> Result<MemoizedDatum, String> {
     match decoder.tag()? {
         0 => Ok(MemoizedDatum::None),
-        1 => Ok(MemoizedDatum::Hash(decoder.hash32()?)),
-        2 => Ok(MemoizedDatum::Inline(decode_inline_plutus_data(decoder)?)),
+        1 => Ok(MemoizedDatum::from(decoder.hash32()?)),
+        2 => Ok(MemoizedDatum::from(decode_inline_plutus_data(decoder)?)),
         other => Err(format!("unsupported datum tag {other}")),
     }
 }


### PR DESCRIPTION
I noticed the memory footprint of the volatile when 3x for the pools after removing Pallas; this was because I replaced a (small) `Vec` with a `BTreeSet`. This is now fixed.

I also took the opportunity to remove some duplication between the pool params and certificates and, to box a few optional fields that should really be boxed. That reduces the memory footprint across the board without introducing much delays (even improving lookups and merges in some cases). 

### Before

#### mainnet RSS 

~1700MB

#### `volatile_bench`

```
memory usage (volatile footprint)
├─ accounts=1349MB
├─ committee=793MB
├─ dreps=652MB
├─ mixed=212MB
├─ pools=965MB
├─ proposals=26MB
├─ utxo=978MB
├─ votes=389MB
╰─ withdrawals=430MB
```

### After

#### mainnet RSS

~1300MB

#### `volatile_bench`

```
memory usage (volatile footprint)
├─ accounts=1349MB
├─ committee=794MB
├─ dreps=502MB
├─ mixed=143MB
├─ pools=314MB
├─ proposals=29MB
├─ utxo=830MB
├─ votes=308MB
╰─ withdrawals=433MB
 ```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced memory usage across critical-path Cardano data structures.
  * Improved handling of pool registration, governance anchors, scripts, datums, and collateral outputs.
  * Strengthened serialization and deserialization consistency for transactions and Plutus script contexts.

* **Refactor**
  * Streamlined pool certificate and state-update handling for more consistent processing.
  * Added safer data transformation support across ledger state operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->