### PR TITLE
fix: only send new tip from track peers for truly new headers from peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Other guiding principles:
 ### Fixed
 
 - **amaru-ledger**: reject governance proposals whose previous action does not match the enacted root nor an in-flight proposal of the same purpose. ([#1090][], [#932][])
+- **amaru-consensus**: make sure that a header previously ingested, with its block validated cannot be sent to the `select_chain` stage.
 
 ## [v10.11.20260806](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260807)
 

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -79,9 +79,9 @@ pub const HEIGHT_RECHECK_INTERVAL: Duration = Duration::from_millis(200);
 ///
 /// `TrackPeers::try_roll_forward` runs protocol checks (parent, consecutive height, monotonic
 /// slot, clock skew) and Praos validation via ledger `validate_header`. On success it advances
-/// the peer tip, stores the header if new, and notifies `downstream` with [`NewTip`]. If
-/// `RequestNext` was not already sent (e.g. after a height defer is released), it is sent after
-/// success.
+/// the peer tip, stores the header with its nonces, and notifies `downstream` with [`NewTip`]
+/// when the header was not in the store yet. If `RequestNext` was not already sent (e.g. after a
+/// height defer is released), it is sent after success.
 ///
 /// # Deferral
 ///
@@ -382,7 +382,8 @@ impl TrackPeers {
     /// returned, together with the nonces to store alongside it.
     ///
     /// Note: a header can already sit in the chain store without carrying any nonces, as is the
-    /// case for headers imported during bootstrap. Those still need to be validated.
+    /// case for headers imported during bootstrap. Those still need to be validated, but they are
+    /// not forwarded downstream again (see `TrackPeers::try_roll_forward`).
     #[expect(clippy::too_many_arguments)]
     async fn validate_header(
         &mut self,
@@ -659,18 +660,52 @@ impl TrackPeers {
         let header_tip = header.tip();
         let current = header_tip.point();
         let header_parent = header.parent_hash();
-        match validated {
+        let parent_of_new_header = if let Some((parent, nonces)) = validated {
+            // A header can already be in the store without carrying nonces, as is the case for
+            // headers imported during bootstrap. Such a header may have had its block validated
+            // by the startup recovery already, and chain selection only accepts tips whose block
+            // has no validity verdict yet, so only headers new to the store are forwarded.
+            let is_new = !store.has_header(&current.hash()).await;
+
+            // the header and its nonces are stored atomically, so that stored nonces always
+            // denote a fully validated header, and follow-up headers can be validated
+            store
+                .store_validated_header(&header, &nonces)
+                .or_terminate_with(eff, async |e| {
+                    let error = ConsensusError::StoreHeaderFailed(header.hash(), e);
+                    error!(
+                        consensus::perf::header::LIFECYCLE,
+                        peer = peer.clone(),
+                        header_hash = current.hash(),
+                        error = %error,
+                        outcome = HeaderLifecycleOutcome::StoreHeaderError.as_str()
+                    );
+                    record_header_rejected(eff, HeaderLifecycleOutcome::StoreHeaderError).await;
+                })
+                .await;
+
+            is_new.then_some(parent)
+        } else {
+            None
+        };
+
+        let slot_start_to_header_micros = self.slot_start_to_header_micros(header_tip.slot(), received_at);
+        eff.external(Performance::record_header_announcement(
+            peer.clone(),
+            header_tip,
+            header_parent,
+            received_at,
+            slot_start_to_header_micros,
+        ))
+        .await;
+
+        match parent_of_new_header {
+            Some(parent) => {
+                tracing::debug!(%peer, %current, highest = %tip.point(), "roll forward with new header");
+                eff.send(&self.downstream, NewTip { tip: header_tip, parent, trace_context }).await;
+            }
             None => {
                 tracing::debug!(%peer, %current, highest = %tip.point(), "roll forward, header already stored");
-                let slot_start_to_header_micros = self.slot_start_to_header_micros(header_tip.slot(), received_at);
-                eff.external(Performance::record_header_announcement(
-                    peer.clone(),
-                    header_tip,
-                    header_parent,
-                    received_at,
-                    slot_start_to_header_micros,
-                ))
-                .await;
                 debug!(
                     consensus::perf::header::LIFECYCLE,
                     peer = peer.clone(),
@@ -678,35 +713,6 @@ impl TrackPeers {
                     outcome = HeaderLifecycleOutcome::DuplicateHeader.as_str()
                 );
                 record_header_rejected(eff, HeaderLifecycleOutcome::DuplicateHeader).await;
-            }
-            Some((parent, nonces)) => {
-                // the header and its nonces are stored atomically, so that stored nonces always
-                // denote a fully validated header, and follow-up headers can be validated
-                store
-                    .store_validated_header(&header, &nonces)
-                    .or_terminate_with(eff, async |e| {
-                        let error = ConsensusError::StoreHeaderFailed(header.hash(), e);
-                        error!(
-                            consensus::perf::header::LIFECYCLE,
-                            peer = peer.clone(),
-                            header_hash = current.hash(),
-                            error = %error,
-                            outcome = HeaderLifecycleOutcome::StoreHeaderError.as_str()
-                        );
-                        record_header_rejected(eff, HeaderLifecycleOutcome::StoreHeaderError).await;
-                    })
-                    .await;
-                let slot_start_to_header_micros = self.slot_start_to_header_micros(header_tip.slot(), received_at);
-                eff.external(Performance::record_header_announcement(
-                    peer.clone(),
-                    header_tip,
-                    header_parent,
-                    received_at,
-                    slot_start_to_header_micros,
-                ))
-                .await;
-                tracing::debug!(%peer, %current, highest = %tip.point(), "roll forward with new header");
-                eff.send(&self.downstream, NewTip { tip: header_tip, parent, trace_context }).await;
             }
         }
 

--- a/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
@@ -168,6 +168,10 @@ pub fn te_get_nonces(at_stage: &str, hash: HeaderHash) -> TraceEntry {
     TraceEntry::suspend(Effect::external(at_stage, Box::new(GetNoncesEffect::new(hash))))
 }
 
+pub fn te_has_header(at_stage: &str, hash: HeaderHash) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(at_stage, Box::new(HasHeaderEffect::new(hash))))
+}
+
 pub fn te_load_header(at_stage: &str, hash: HeaderHash) -> TraceEntry {
     TraceEntry::suspend(Effect::external(at_stage, Box::new(LoadHeaderEffect::new(hash))))
 }

--- a/crates/amaru-consensus/src/stages/track_peers/tests.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/tests.rs
@@ -38,9 +38,9 @@ use crate::{
                 HEIGHT_RECHECK_INTERVAL, SIM_INITIAL_CLOCK_SECS, build_store, build_store_with_nonces,
                 height_recheck_schedule_id, make_block_header, new_tip, schedule_id_at, setup, setup_base,
                 setup_with_ledger_tip_until_sleeping, slot_start_to_header_micros, te_clear_peer_availability,
-                te_clock, te_clock_suspend, te_get_nonces, te_load_header, te_load_tip, te_record_header_announcement,
-                te_record_rollback, te_schedule, te_store_validated_header, te_validate_header, test_prep,
-                test_prep_with_max_peer_lead, tm_volatile_tip,
+                te_clock, te_clock_suspend, te_get_nonces, te_has_header, te_load_header, te_load_tip,
+                te_record_header_announcement, te_record_rollback, te_schedule, te_store_validated_header,
+                te_validate_header, test_prep, test_prep_with_max_peer_lead, tm_volatile_tip,
             },
         },
     },
@@ -404,11 +404,11 @@ fn test_roll_forward_known_peer_header_already_stored() {
 
 /// A header imported during bootstrap is present in the chain store but has no evolved nonces.
 /// When re-received from a peer, its nonces must still be computed (via `validate_header`) so
-/// that descendant headers can be validated. Nonce absence means the header was never fully
-/// validated, so it is treated like a new header: stored with its nonces and propagated
-/// downstream.
+/// that descendant headers can be validated. It is not propagated downstream though: the block of
+/// an already-stored header may have been validated by the startup recovery, and chain selection
+/// only accepts tips whose block has no validity verdict yet.
 #[test]
-fn test_roll_forward_stored_header_missing_nonces_revalidates() {
+fn test_roll_forward_stored_header_missing_nonces_revalidates_without_forwarding() {
     let prep = test_prep();
     let peer = Peer::new("peer1");
     let parent = &prep.headers[0];
@@ -439,6 +439,7 @@ fn test_roll_forward_stored_header_missing_nonces_revalidates() {
             te_send("tp-1", &prep.handler, RequestNext).into(),
             te_get_nonces("tp-1", header.hash()).into(),
             te_validate_header("tp-1", header.clone()).into(),
+            te_has_header("tp-1", header.hash()).into(),
             te_store_validated_header("tp-1", header.clone()).into(),
             te_record_header_announcement(
                 "tp-1",
@@ -449,11 +450,11 @@ fn test_roll_forward_stored_header_missing_nonces_revalidates() {
                 slot_start_to_header_micros(&header.tip(), received_at),
             )
             .into(),
-            te_send("tp-1", "downstream", new_tip(header.tip(), parent.point())).into(),
+            te_header_rejected("duplicate header").into(),
             te_state("tp-1", &expected).into(),
         ],
     );
-    logs.assert_and_remove(Level::DEBUG, &["roll forward", "new header"]).assert_no_remaining_at([
+    logs.assert_and_remove(Level::DEBUG, &["roll forward", "already stored"]).assert_no_remaining_at([
         Level::INFO,
         Level::WARN,
         Level::ERROR,
@@ -490,6 +491,7 @@ fn test_roll_forward_known_peer_new_header_forwards_tip() {
             te_send("tp-1", &prep.handler, RequestNext).into(),
             te_get_nonces("tp-1", header.hash()).into(),
             te_validate_header("tp-1", header.clone()).into(),
+            te_has_header("tp-1", header.hash()).into(),
             te_store_validated_header("tp-1", header.clone()).into(),
             te_record_header_announcement(
                 "tp-1",
@@ -812,6 +814,7 @@ fn test_roll_forward_header_slot_near_future_defers() {
             tm_state::<TrackPeers>("tp-1", |s| s.deferred.len() == 1, "clock skew deferred"),
             te_input("tp-1", &TrackPeersMsg::RecheckLedgerHeight).into(),
             te_validate_header("tp-1", header.clone()).into(),
+            te_has_header("tp-1", header.hash()).into(),
             te_store_validated_header("tp-1", header.clone()).into(),
             tm_state::<TrackPeers>("tp-1", |s| s.deferred.is_empty(), "processed after recheck"),
         ],
@@ -1153,6 +1156,7 @@ fn test_height_defer_recheck_when_ledger_advances() {
             te_clock_suspend("tp-1").into(),
             te_get_nonces("tp-1", header.hash()).into(),
             te_validate_header("tp-1", header.clone()).into(),
+            te_has_header("tp-1", header.hash()).into(),
             te_store_validated_header("tp-1", header.clone()).into(),
             te_send("tp-1", "downstream", new_tip(header.tip(), Point::Origin)).into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
@@ -1292,10 +1296,12 @@ fn test_pipelined_stake_defer_and_wake_sequence() {
             te_clock_suspend("tp-1").into(),
             te_get_nonces("tp-1", h1.hash()).into(),
             te_validate_header("tp-1", h1.clone()).into(),
+            te_has_header("tp-1", h1.hash()).into(),
             te_store_validated_header("tp-1", h1.clone()).into(),
             te_send("tp-1", "downstream", new_tip(h1.tip(), parent.point())).into(),
             te_get_nonces("tp-1", h2.hash()).into(),
             te_validate_header("tp-1", h2.clone()).into(),
+            te_has_header("tp-1", h2.hash()).into(),
             te_store_validated_header("tp-1", h2.clone()).into(),
             te_send("tp-1", "downstream", new_tip(h2.tip(), h1.point())).into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),


### PR DESCRIPTION
This PR fixes a consequence of #1087 (validation of already stored headers). It is possible on bootstrap to have headers with no associated nonces. In that case we should not consider those headers as "new" in `track_peers` and not send them to `select_chain` because that stage will see their block as already validated and stop.

We prevent this by avoiding to send downstream headers that are already stored, whether they have, or not, associated nonces in the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of previously stored and bootstrap-imported headers during peer tracking.
  * Prevented duplicate headers from being forwarded unnecessarily.
  * Ensured stored headers are revalidated correctly while preserving duplicate-header metrics and logging.
  * Improved processing of new and deferred headers by checking whether they are already present before storage.

* **Tests**
  * Expanded coverage for duplicate headers, header presence checks, revalidation, and deferred header processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->