### PR TITLE
fix: track the leader reward accounts before they possibly change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Other guiding principles:
 - **amaru-ledger**: debit the treasury when enacted withdrawals are paid out at the epoch boundary ([#1118][])
 - **amaru-ledger**: preserve the `Ratified` status of proposals pruned during ratification ([#1118][])
 - **amaru-kernel**: reduce memory footprint of various types on the critical path.
+- **amaru-ledger**: when a leader changes it reward account, the rewards owed to the previous account must return to the treasury ([#1125](https://github.com/pragma-org/amaru/pull/1125)).
 
 ## [v10.11.20260730](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260730)
 

--- a/crates/amaru-ledger/src/epoch_transition/rewards_state.rs
+++ b/crates/amaru-ledger/src/epoch_transition/rewards_state.rs
@@ -153,6 +153,13 @@ pub struct Rewards<STEP: KnownRewardState + Clone> {
     /// shares this map rather than copying it.
     accounts: Arc<BTreeMap<StakeCredential, Lovelace>>,
 
+    /// Credentials credited a *leader* reward, as named by the stake distribution the rewards were
+    /// computed from. A pool's reward account is an arbitrary stake credential the protocol never
+    /// requires to be registered, and the pool may have changed or dropped it since; so this is the
+    /// only record of who is actually owed the leader reward, and payability has to be resolved
+    /// against it rather than against the pool registry as it stands when the rewards are paid out.
+    leader_recipients: Arc<BTreeSet<StakeCredential>>,
+
     /// The accounts whose rewards are unclaimed because they were no longer registered at the epoch
     /// boundary. For `Effective` this is the set of such account keys (their amounts stay in
     /// `accounts` and are summed back into the treasury); for `Computed` it is `()`. Rolling an
@@ -161,18 +168,28 @@ pub struct Rewards<STEP: KnownRewardState + Clone> {
     unclaimed: STEP::UnclaimedRewards,
 }
 
+impl<STEP: KnownRewardState + Clone> Rewards<STEP> {
+    /// The credentials credited a leader reward, against which payability must be resolved. See
+    /// the note on the field itself.
+    pub fn leader_recipients(&self) -> &BTreeSet<StakeCredential> {
+        &self.leader_recipients
+    }
+}
+
 impl Rewards<Computed> {
     pub fn new(
         delta_reserves: Lovelace,
         delta_treasury: Lovelace,
         total_rewards: Lovelace,
         accounts: BTreeMap<StakeCredential, Lovelace>,
+        leader_recipients: BTreeSet<StakeCredential>,
     ) -> Self {
         Self {
             delta_reserves,
             delta_treasury,
             total_rewards,
             accounts: Arc::new(accounts),
+            leader_recipients: Arc::new(leader_recipients),
             unclaimed: (),
             step: PhantomData,
         }
@@ -208,6 +225,7 @@ impl Rewards<Effective> {
             delta_treasury: computed_rewards.delta_treasury,
             total_rewards: computed_rewards.total_rewards,
             accounts,
+            leader_recipients: computed_rewards.leader_recipients,
             unclaimed: Arc::new(unclaimed),
         }
     }
@@ -249,6 +267,7 @@ impl Rewards<Effective> {
             delta_treasury: self.delta_treasury,
             total_rewards: self.total_rewards,
             accounts: self.accounts,
+            leader_recipients: self.leader_recipients,
             unclaimed: (),
         }
     }
@@ -277,8 +296,14 @@ mod test {
 
         let delta_reserves = 1_000;
         let delta_treasury = 7;
-        let computed_rewards =
-            Rewards::<Computed>::new(delta_reserves, delta_treasury, accounts.values().sum(), accounts);
+        let leader_recipients = BTreeSet::from([registered]);
+        let computed_rewards = Rewards::<Computed>::new(
+            delta_reserves,
+            delta_treasury,
+            accounts.values().sum(),
+            accounts,
+            leader_recipients.clone(),
+        );
         let effective_rewards = Rewards::<Effective>::new(computed_rewards.clone(), BTreeSet::from([unregistered]));
 
         // The still-registered account is paid its reward; the unregistered one is not (its reward
@@ -287,10 +312,12 @@ mod test {
         assert_eq!(effective_rewards.reward_of(&unregistered), 0);
         assert_eq!(effective_rewards.delta_reserves(), delta_reserves);
         assert_eq!(effective_rewards.delta_treasury(), delta_treasury + 42);
+        assert_eq!(effective_rewards.leader_recipients(), &leader_recipients);
 
         // Rolling back drops the unclaimed markers, restoring the original computed rewards.
         let rolled_back = effective_rewards.clone().to_computed();
         assert_eq!(rolled_back, computed_rewards, "rollback");
+        assert_eq!(rolled_back.leader_recipients(), &leader_recipients);
     }
 
     /// Unregistered credentials that are owed no reward are dropped: they cannot change what is paid
@@ -301,7 +328,7 @@ mod test {
         let rewardless = StakeCredential::ScriptHash(Hash::from([2u8; 28]));
 
         let accounts = BTreeMap::from([(rewarded, 42)]);
-        let computed_rewards = Rewards::<Computed>::new(1_000, 7, 42, accounts);
+        let computed_rewards = Rewards::<Computed>::new(1_000, 7, 42, accounts, Default::default());
 
         // The same credentials repeated, as chaining the unregistration sources may well do.
         let unregistered = [rewarded, rewardless, rewarded, rewardless];

--- a/crates/amaru-ledger/src/epoch_transition/rewards_state.rs
+++ b/crates/amaru-ledger/src/epoch_transition/rewards_state.rs
@@ -153,12 +153,13 @@ pub struct Rewards<STEP: KnownRewardState + Clone> {
     /// shares this map rather than copying it.
     accounts: Arc<BTreeMap<StakeCredential, Lovelace>>,
 
-    /// Credentials credited a *leader* reward, as named by the stake distribution the rewards were
-    /// computed from. A pool's reward account is an arbitrary stake credential the protocol never
-    /// requires to be registered, and the pool may have changed or dropped it since; so this is the
-    /// only record of who is actually owed the leader reward, and payability has to be resolved
-    /// against it rather than against the pool registry as it stands when the rewards are paid out.
-    leader_recipients: Arc<BTreeSet<StakeCredential>>,
+    /// Known (paid) pools owners at the time the rewards were calculated that received non-zero
+    /// rewards.
+    ///
+    /// A pool's reward account is an arbitrary stake credential the protocol never requires to be
+    /// registered, and the pool may have changed or dropped it between the moment the rewards were
+    /// computed and the moment they need to be paid;
+    pools_owners: Arc<BTreeSet<StakeCredential>>,
 
     /// The accounts whose rewards are unclaimed because they were no longer registered at the epoch
     /// boundary. For `Effective` this is the set of such account keys (their amounts stay in
@@ -169,10 +170,10 @@ pub struct Rewards<STEP: KnownRewardState + Clone> {
 }
 
 impl<STEP: KnownRewardState + Clone> Rewards<STEP> {
-    /// The credentials credited a leader reward, against which payability must be resolved. See
+    /// The credentials credited a pool owner, against which payability must be resolved. See
     /// the note on the field itself.
-    pub fn leader_recipients(&self) -> &BTreeSet<StakeCredential> {
-        &self.leader_recipients
+    pub fn pools_owners(&self) -> BTreeSet<&StakeCredential> {
+        self.pools_owners.iter().collect()
     }
 }
 
@@ -182,17 +183,29 @@ impl Rewards<Computed> {
         delta_treasury: Lovelace,
         total_rewards: Lovelace,
         accounts: BTreeMap<StakeCredential, Lovelace>,
-        leader_recipients: BTreeSet<StakeCredential>,
+        pools_owners: BTreeSet<StakeCredential>,
     ) -> Self {
         Self {
             delta_reserves,
             delta_treasury,
             total_rewards,
             accounts: Arc::new(accounts),
-            leader_recipients: Arc::new(leader_recipients),
+            pools_owners: Arc::new(pools_owners),
             unclaimed: (),
             step: PhantomData,
         }
+    }
+
+    // Resolve all accounts that have received rewards but aren't payable because they no longer
+    // exist or have never existed. This can happen because of two reasons:
+    //
+    // - The account was simply unregistered.
+    // - The account was configured as pool owner but was never registered.
+    pub fn unclaimed_rewards(
+        &self,
+        unreachable_accounts: impl IntoIterator<Item = StakeCredential>,
+    ) -> BTreeSet<StakeCredential> {
+        unreachable_accounts.into_iter().filter(|credential| self.accounts.contains_key(credential)).collect()
     }
 }
 
@@ -210,22 +223,14 @@ impl Rewards<Effective> {
     ///
     /// What we hold onto is thus bounded by the rewarded accounts rather than by the number of
     /// accounts that are unreachable at the end of the epoch.
-    pub fn new(
-        computed_rewards: Rewards<Computed>,
-        unreachable_accounts: impl IntoIterator<Item = StakeCredential>,
-    ) -> Self {
-        let accounts = computed_rewards.accounts;
-
-        let unclaimed =
-            unreachable_accounts.into_iter().filter(|credential| accounts.contains_key(credential)).collect();
-
+    pub fn new(computed_rewards: Rewards<Computed>, unclaimed: BTreeSet<StakeCredential>) -> Self {
         Self {
             step: PhantomData,
             delta_reserves: computed_rewards.delta_reserves,
             delta_treasury: computed_rewards.delta_treasury,
             total_rewards: computed_rewards.total_rewards,
-            accounts,
-            leader_recipients: computed_rewards.leader_recipients,
+            accounts: computed_rewards.accounts,
+            pools_owners: computed_rewards.pools_owners,
             unclaimed: Arc::new(unclaimed),
         }
     }
@@ -238,7 +243,7 @@ impl Rewards<Effective> {
 
     /// Total amount of rewards that couldn't be paid to accounts because they unregistered between
     /// the moment the rewards were calculated and the moment they needed to be paid out.
-    pub fn unclaimed_rewards(&self) -> Lovelace {
+    pub fn total_unclaimed_rewards(&self) -> Lovelace {
         self.unclaimed.iter().filter_map(|account| self.accounts.get(account)).sum()
     }
 
@@ -255,7 +260,7 @@ impl Rewards<Effective> {
     /// Amount to be paid to the treasury, including the rewards left unclaimed by accounts that
     /// unregistered during the epoch.
     pub fn delta_treasury(&self) -> Lovelace {
-        self.delta_treasury + self.unclaimed_rewards()
+        self.delta_treasury + self.total_unclaimed_rewards()
     }
 
     /// Roll an effective rewards summary back to a computed one by dropping the unclaimed markers.
@@ -267,7 +272,7 @@ impl Rewards<Effective> {
             delta_treasury: self.delta_treasury,
             total_rewards: self.total_rewards,
             accounts: self.accounts,
-            leader_recipients: self.leader_recipients,
+            pools_owners: self.pools_owners,
             unclaimed: (),
         }
     }
@@ -296,13 +301,13 @@ mod test {
 
         let delta_reserves = 1_000;
         let delta_treasury = 7;
-        let leader_recipients = BTreeSet::from([registered]);
+        let pools_owners = BTreeSet::from([registered]);
         let computed_rewards = Rewards::<Computed>::new(
             delta_reserves,
             delta_treasury,
             accounts.values().sum(),
             accounts,
-            leader_recipients.clone(),
+            pools_owners.clone(),
         );
         let effective_rewards = Rewards::<Effective>::new(computed_rewards.clone(), BTreeSet::from([unregistered]));
 
@@ -312,12 +317,12 @@ mod test {
         assert_eq!(effective_rewards.reward_of(&unregistered), 0);
         assert_eq!(effective_rewards.delta_reserves(), delta_reserves);
         assert_eq!(effective_rewards.delta_treasury(), delta_treasury + 42);
-        assert_eq!(effective_rewards.leader_recipients(), &leader_recipients);
+        assert_eq!(effective_rewards.pools_owners(), pools_owners.iter().collect());
 
         // Rolling back drops the unclaimed markers, restoring the original computed rewards.
         let rolled_back = effective_rewards.clone().to_computed();
         assert_eq!(rolled_back, computed_rewards, "rollback");
-        assert_eq!(rolled_back.leader_recipients(), &leader_recipients);
+        assert_eq!(rolled_back.pools_owners(), pools_owners.iter().collect());
     }
 
     /// Unregistered credentials that are owed no reward are dropped: they cannot change what is paid
@@ -331,11 +336,10 @@ mod test {
         let computed_rewards = Rewards::<Computed>::new(1_000, 7, 42, accounts, Default::default());
 
         // The same credentials repeated, as chaining the unregistration sources may well do.
-        let unregistered = [rewarded, rewardless, rewarded, rewardless];
+        let unclaimed = computed_rewards.unclaimed_rewards([rewarded, rewardless, rewarded, rewardless]);
+        let effective_rewards = Rewards::<Effective>::new(computed_rewards, unclaimed);
 
-        let effective_rewards = Rewards::<Effective>::new(computed_rewards, unregistered);
-
-        assert_eq!(effective_rewards.unclaimed_rewards(), 42);
+        assert_eq!(effective_rewards.total_unclaimed_rewards(), 42);
         assert_eq!(effective_rewards.reward_of(&rewarded), 0);
         assert_eq!(*effective_rewards.unclaimed, BTreeSet::from([rewarded]));
     }

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -424,15 +424,10 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
                 // the ledger if we don't.
                 let computed_rewards = computed_rewards.ok_or(StateError::RewardsSummaryNotReady)?;
 
-                // Payability is resolved against the credentials the rewards computation actually
-                // credited leader rewards to; the pool registry as it stands now may no longer name
-                // them. The clone is required: `unclaimed` is a lazy iterator only consumed inside
-                // `Rewards::<Effective>::new`, which moves `computed_rewards`, so it cannot borrow
-                // from it.
-                let pools_rewards_accounts = computed_rewards.leader_recipients().clone();
-                let unclaimed = volatile_view.iter_unreachable_accounts(pools_rewards_accounts)?;
+                let unclaimed_rewards = computed_rewards
+                    .unclaimed_rewards(volatile_view.iter_unreachable_accounts(computed_rewards.pools_owners())?);
 
-                let effective_rewards = Rewards::<Effective>::new(computed_rewards, unclaimed);
+                let effective_rewards = Rewards::<Effective>::new(computed_rewards, unclaimed_rewards);
 
                 (db.pots()?.treasury + effective_rewards.delta_treasury(), Some(effective_rewards))
             } else {

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -23,8 +23,8 @@ use std::{
 
 use amaru_kernel::{
     Block, Epoch, EraHistory, EraHistoryError, GlobalParameters, HasTransactionId, Hash, Hasher, NetworkName, Point,
-    PoolId, ProtocolParameters, Slot, Tip, Transaction, TransactionId, TransactionPointer, expect_stake_credential,
-    protocol_version, to_cbor, utils::string::display_collection,
+    PoolId, ProtocolParameters, Slot, Tip, Transaction, TransactionId, TransactionPointer, protocol_version, to_cbor,
+    utils::string::display_collection,
 };
 use amaru_metrics::ledger::LedgerMetrics;
 use amaru_observability::{debug_span, info, info_span, trace, warn};
@@ -404,18 +404,7 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
             // Compute the updates to perform on pools at the epoch boundary. This uses information
             // from both the immutable store and the volatile database, since we compute the updates
             // before they are "stable" and safe to store.
-            //
-            // It also tells us the reward account of every pool, which the rewards below need to
-            // tell apart the leader rewards that can no longer be paid.
-            let mut pools_rewards_accounts = BTreeSet::new();
-            let pools_updates = PoolsEpochTransitionUpdates::new(
-                volatile_view.iter_pools()?.inspect(|(_, pool)| {
-                    // Capture the reward account *before* any pending update is folded in, so that we remember
-                    // the one the epoch that just ended paid its leader rewards to.
-                    pools_rewards_accounts.insert(expect_stake_credential(&pool.current_params.reward_account));
-                }),
-                next_epoch,
-            );
+            let pools_updates = PoolsEpochTransitionUpdates::new(volatile_view.iter_pools()?, next_epoch);
 
             // NOTE: No rewards during epoch transition?
             //
@@ -435,6 +424,12 @@ impl<S: Store, HS: HistoricalStores + Send> State<S, HS> {
                 // the ledger if we don't.
                 let computed_rewards = computed_rewards.ok_or(StateError::RewardsSummaryNotReady)?;
 
+                // Payability is resolved against the credentials the rewards computation actually
+                // credited leader rewards to; the pool registry as it stands now may no longer name
+                // them. The clone is required: `unclaimed` is a lazy iterator only consumed inside
+                // `Rewards::<Effective>::new`, which moves `computed_rewards`, so it cannot borrow
+                // from it.
+                let pools_rewards_accounts = computed_rewards.leader_recipients().clone();
                 let unclaimed = volatile_view.iter_unreachable_accounts(pools_rewards_accounts)?;
 
                 let effective_rewards = Rewards::<Effective>::new(computed_rewards, unclaimed);

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -1095,7 +1095,7 @@ mod tests {
     fn reward_balance_folds_in_the_pending_overlay_credit_during_the_straddle() {
         let mut db = VolatileDB::default();
         let accounts = BTreeMap::from([(cred(1), 5_000_000)]);
-        let computed = Rewards::<Computed>::new(0, 0, accounts.values().sum(), accounts);
+        let computed = Rewards::<Computed>::new(0, 0, accounts.values().sum(), accounts, Default::default());
         let effective = Rewards::<Effective>::new(computed, BTreeSet::new());
 
         // The pending boundary credit is added on top of the stable base.
@@ -1134,7 +1134,7 @@ mod tests {
     #[test_case(None, None => Existence::Unknown; "untouched everywhere defers to the stable store")]
     fn resolve_committee_precedence(draining: Option<CommitteeAct>, current: Option<CommitteeAct>) -> Existence<bool> {
         let mut db = VolatileDB::default();
-        let computed = Rewards::<Computed>::new(0, 0, 0, BTreeMap::new());
+        let computed = Rewards::<Computed>::new(0, 0, 0, BTreeMap::new(), Default::default());
         let effective = Rewards::<Effective>::new(computed, BTreeSet::new());
         if let Some(act) = draining {
             db.push_back(committee_block(10, act));
@@ -1227,7 +1227,8 @@ mod tests {
     /// Effective boundary rewards crediting a single account, to give the overlay non-trivial,
     /// observable state (its pending reward credit surfaces through `resolve_account`).
     fn effective_reward(credential: StakeCredential, amount: u64) -> Rewards<Effective> {
-        let computed = Rewards::<Computed>::new(0, 0, amount, BTreeMap::from([(credential, amount)]));
+        let computed =
+            Rewards::<Computed>::new(0, 0, amount, BTreeMap::from([(credential, amount)]), Default::default());
         Rewards::<Effective>::new(computed, BTreeSet::new())
     }
 

--- a/crates/amaru-ledger/src/state/volatile/overlay.rs
+++ b/crates/amaru-ledger/src/state/volatile/overlay.rs
@@ -434,8 +434,13 @@ mod test {
     /// Effective rewards where `credential(1)` is still registered while `credential(2)` unregistered during
     /// the epoch, so its rewards are unclaimed and returned to the treasury.
     fn effective_rewards() -> Rewards<Effective> {
-        let computed =
-            Rewards::<Computed>::new(1_000, 7, 142, BTreeMap::from([(credential(1), 100), (credential(2), 42)]));
+        let computed = Rewards::<Computed>::new(
+            1_000,
+            7,
+            142,
+            BTreeMap::from([(credential(1), 100), (credential(2), 42)]),
+            Default::default(),
+        );
         Rewards::<Effective>::new(computed, BTreeSet::from([credential(2)]))
     }
 }

--- a/crates/amaru-ledger/src/state/volatile/view.rs
+++ b/crates/amaru-ledger/src/state/volatile/view.rs
@@ -141,7 +141,7 @@ impl<'volatile, 'db, DB: ReadStore> VolatileView<'volatile, 'db, DB> {
     #[expect(clippy::panic)]
     pub fn iter_unreachable_accounts(
         &mut self,
-        pools_rewards_accounts: BTreeSet<StakeCredential>,
+        pools_owners: BTreeSet<&'_ StakeCredential>,
     ) -> Result<impl Iterator<Item = StakeCredential>, StoreError> {
         let AccountVolatileView { mut registered, mut unregistered } = match mem::take(&mut self.accounts) {
             None => {
@@ -162,7 +162,7 @@ impl<'volatile, 'db, DB: ReadStore> VolatileView<'volatile, 'db, DB> {
             self.db.iter_recently_unregistered_accounts()?,
             &mut registered,
             &mut unregistered,
-            pools_rewards_accounts,
+            pools_owners,
         ))
     }
 
@@ -198,10 +198,10 @@ mod test {
         let volatile = VolatileDB::default();
         let mut view = VolatileView::new(&volatile, &stable);
 
-        let pool_reward_accounts = BTreeSet::from([credential(1), credential(2)]);
+        let pool_reward_accounts = [credential(1), credential(2)];
 
         assert_eq!(
-            unreachable_accounts(&mut view, pool_reward_accounts),
+            unreachable_accounts(&mut view, pool_reward_accounts.iter().collect()),
             BTreeSet::from([credential(2)]),
             "credential(1) has an account and is payable; credential(2) never had one",
         );
@@ -218,9 +218,12 @@ mod test {
         let volatile = VolatileDB::default();
         let mut view = VolatileView::new(&volatile, &stable);
 
-        let leader_reward_accounts = BTreeSet::from([credential(1)]);
+        let leader_reward_accounts = [credential(1)];
 
-        assert_eq!(unreachable_accounts(&mut view, leader_reward_accounts), BTreeSet::from([credential(1)]));
+        assert_eq!(
+            unreachable_accounts(&mut view, leader_reward_accounts.iter().collect()),
+            BTreeSet::from(leader_reward_accounts),
+        );
     }
 
     /// Accounts registered when the stake distribution was taken are covered by the unregistration
@@ -260,10 +263,10 @@ mod test {
 
         let mut view = VolatileView::new(&volatile, &stable);
 
-        let pool_reward_accounts = BTreeSet::from([credential(1), credential(5)]);
+        let pool_reward_accounts = [credential(1), credential(5)];
 
         assert_eq!(
-            unreachable_accounts(&mut view, pool_reward_accounts),
+            unreachable_accounts(&mut view, pool_reward_accounts.iter().collect()),
             BTreeSet::from([credential(2), credential(4)])
         );
     }
@@ -274,7 +277,7 @@ mod test {
     /// and any repetition don't matter.
     fn unreachable_accounts(
         view: &mut VolatileView<'_, '_, Stable>,
-        pool_reward_accounts: BTreeSet<StakeCredential>,
+        pool_reward_accounts: BTreeSet<&StakeCredential>,
     ) -> BTreeSet<StakeCredential> {
         view.iter_unreachable_accounts(pool_reward_accounts).unwrap().collect()
     }

--- a/crates/amaru-ledger/src/state/volatile/view.rs
+++ b/crates/amaru-ledger/src/state/volatile/view.rs
@@ -132,9 +132,10 @@ impl<'volatile, 'db, DB: ReadStore> VolatileView<'volatile, 'db, DB> {
     ///   that allows us to recover this information.
     ///
     /// - Pool leaders: pools are paid on their pool's reward account, an arbitrary stake credential
-    ///   which the protocol never requires to be registered so a pool can earn a reward payable to a
-    ///   credential that has never had an account at all. Such an account may be missing despite no
-    ///   unregistration to have ever been recorded .
+    ///   which the protocol never requires to be registered, as named by the stake distribution the
+    ///   rewards were computed from. The pool may have changed or dropped that account since, and
+    ///   the credential may never have had an account at all. So such an account may be missing
+    ///   despite no unregistration to have ever been recorded.
     ///
     /// IMPORTANT: Yields accounts in no particular order.
     #[expect(clippy::panic)]
@@ -204,6 +205,22 @@ mod test {
             BTreeSet::from([credential(2)]),
             "credential(1) has an account and is payable; credential(2) never had one",
         );
+    }
+
+    /// A pool can change or drop its reward account between the stake distribution snapshot and the
+    /// payout: the credential owed the leader reward is then named by no pool in the registry, and
+    /// if it was deregistered long enough ago, its unregistration marker has been pruned too. As
+    /// long as it is fed in as a leader reward account, it is still yielded as unreachable: neither
+    /// the registry nor the unregistration index is needed to catch it.
+    #[test]
+    fn leader_reward_accounts_no_longer_named_by_any_pool_are_unclaimed() {
+        let stable = Stable { accounts: BTreeSet::new(), recently_unregistered: BTreeSet::new() };
+        let volatile = VolatileDB::default();
+        let mut view = VolatileView::new(&volatile, &stable);
+
+        let leader_reward_accounts = BTreeSet::from([credential(1)]);
+
+        assert_eq!(unreachable_accounts(&mut view, leader_reward_accounts), BTreeSet::from([credential(1)]));
     }
 
     /// Accounts registered when the stake distribution was taken are covered by the unregistration

--- a/crates/amaru-ledger/src/state/volatile/view/iter_unreachable_accounts.rs
+++ b/crates/amaru-ledger/src/state/volatile/view/iter_unreachable_accounts.rs
@@ -19,15 +19,15 @@ use amaru_kernel::StakeCredential;
 /// Similar to [`crate::state::volatile::IterPools`], but for accounts; It provides an unordered
 /// iterator over recently unregistered accounts in an epoch that patches a read-only stable store
 /// with pending updates such as registrations or de-registrations.
-pub(crate) struct IterUnreachableAccounts<'volatile, F, I> {
+pub(crate) struct IterUnreachableAccounts<'volatile, 'pools, F, I> {
     account_exists: Box<F>,
     iter_recently_unregistered_accounts: Option<I>,
     registrations: BTreeSet<&'volatile StakeCredential>,
     deregistrations: BTreeSet<&'volatile StakeCredential>,
-    pools_rewards_accounts: BTreeSet<StakeCredential>,
+    pools_rewards_accounts: BTreeSet<&'pools StakeCredential>,
 }
 
-impl<'volatile, F, I> IterUnreachableAccounts<'volatile, F, I>
+impl<'volatile, 'pools, F, I> IterUnreachableAccounts<'volatile, 'pools, F, I>
 where
     F: Fn(&StakeCredential) -> bool,
     I: Iterator<Item = StakeCredential>,
@@ -37,7 +37,7 @@ where
         iter_recently_unregistered_accounts: I,
         registrations: &mut BTreeSet<&'volatile StakeCredential>,
         deregistrations: &mut BTreeSet<&'volatile StakeCredential>,
-        pools_rewards_accounts: BTreeSet<StakeCredential>,
+        pools_rewards_accounts: BTreeSet<&'pools StakeCredential>,
     ) -> Self {
         Self {
             account_exists: Box::new(account_exists),
@@ -49,7 +49,7 @@ where
     }
 }
 
-impl<'volatile, F, I> Iterator for IterUnreachableAccounts<'volatile, F, I>
+impl<'volatile, 'pools, F, I> Iterator for IterUnreachableAccounts<'volatile, 'pools, F, I>
 where
     F: Fn(&StakeCredential) -> bool,
     I: Iterator<Item = StakeCredential>,
@@ -83,7 +83,7 @@ where
                 continue;
             }
 
-            if self.account_exists.as_ref()(&account) {
+            if self.account_exists.as_ref()(account) {
                 // Here we need not to check for de-registrations because we have already
                 // removed the recently unregistered accounts from the pools_rewards_accounts
                 // just above.
@@ -92,7 +92,7 @@ where
 
             // We already check that the account was not registered recently; so if it's
             // also not in the stable store, it's definitely not there.
-            return Some(account);
+            return Some(*account);
         }
 
         None

--- a/crates/amaru-ledger/src/store/epoch_transition.rs
+++ b/crates/amaru-ledger/src/store/epoch_transition.rs
@@ -62,7 +62,7 @@ pub fn pay_rewards<'store>(
             }
 
             let expected_total_rewards = effective_rewards.total_rewards();
-            let actual_total_rewards = rewards_paid + effective_rewards.unclaimed_rewards();
+            let actual_total_rewards = rewards_paid + effective_rewards.total_unclaimed_rewards();
 
             // Technically, if we did everything *right*, there should be no accounts with rewards that
             // cannot be paid out (i.e. accounts that no longer exists). This has been taken care of during

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -107,7 +107,7 @@ the system at a certain point in time. We always take snapshots _at the end of e
 certain mutations are applied to the system.
 */
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use amaru_kernel::{
     Epoch, GlobalParameters, Lovelace, PoolId, ProtocolParameters, StakeCredential, expect_stake_credential,
@@ -327,6 +327,9 @@ pub struct RewardsSummary {
 
     /// Per-account rewards, determined from their relative stake and their delegatee.
     accounts: BTreeMap<StakeCredential, Lovelace>,
+
+    /// Credentials credited a leader reward, as named by the stake distribution's pool parameters.
+    leader_recipients: BTreeSet<StakeCredential>,
 }
 
 impl RewardsSummary {
@@ -369,11 +372,14 @@ impl RewardsSummary {
 
         let mut accounts: BTreeMap<StakeCredential, Lovelace> = BTreeMap::new();
 
+        let mut leader_recipients: BTreeSet<StakeCredential> = BTreeSet::new();
+
         let mut pools: BTreeMap<PoolId, PoolRewards> = BTreeMap::new();
 
         let mut effective_rewards = stake_distribution.pools.iter().fold(0, |effective_rewards, (pool_id, pool)| {
             let pool_rewards = RewardsSummary::apply_leader_rewards(
                 &mut accounts,
+                &mut leader_recipients,
                 &mut blocks_per_pool,
                 blocks_count,
                 available_rewards,
@@ -431,6 +437,7 @@ impl RewardsSummary {
             effective_rewards,
             pots,
             accounts,
+            leader_recipients,
         })
     }
 
@@ -513,6 +520,7 @@ impl RewardsSummary {
     #[expect(clippy::too_many_arguments)]
     fn apply_leader_rewards(
         accounts: &mut BTreeMap<StakeCredential, Lovelace>,
+        leader_recipients: &mut BTreeSet<StakeCredential>,
         blocks_per_pool: &mut BTreeMap<PoolId, u64>,
         blocks_count: u64,
         available_rewards: Lovelace,
@@ -541,11 +549,12 @@ impl RewardsSummary {
             // *owners* and the performance against its *delegators*. So a pool can perfectly well
             // earn a leader reward payable to a credential that has no account, in which case the
             // reward is unclaimed and goes to the treasury instead. That is settled at the epoch
-            // boundary, from the reward accounts collected while ticking the pools.
-            accounts
-                .entry(expect_stake_credential(&pool.parameters.reward_account))
-                .and_modify(|rewards| *rewards += rewards_leader)
-                .or_insert(rewards_leader);
+            // boundary, against the recipients recorded here: the pool may change or drop its
+            // reward account before the payout, so the registry as it stands then no longer knows
+            // who was owed the reward.
+            let credential = expect_stake_credential(&pool.parameters.reward_account);
+            leader_recipients.insert(credential);
+            accounts.entry(credential).and_modify(|rewards| *rewards += rewards_leader).or_insert(rewards_leader);
         }
 
         PoolRewards { leader: rewards_leader, pot: rewards_pot }
@@ -560,6 +569,16 @@ impl RewardsSummary {
     pub fn delta_treasury(&self) -> Lovelace {
         self.treasury_tax
     }
+
+    /// Rewards owed to each credential, whether or not that credential still has an account.
+    pub fn accounts(&self) -> &BTreeMap<StakeCredential, Lovelace> {
+        &self.accounts
+    }
+
+    /// Total rewards actually given out, across all credentials.
+    pub fn effective_rewards(&self) -> Lovelace {
+        self.effective_rewards
+    }
 }
 
 impl From<RewardsSummary> for Rewards<Computed> {
@@ -569,6 +588,7 @@ impl From<RewardsSummary> for Rewards<Computed> {
             summary.delta_treasury(),
             summary.effective_rewards,
             summary.accounts,
+            summary.leader_recipients,
         )
     }
 }
@@ -586,7 +606,7 @@ mod test {
     #[test]
     fn a_leader_reward_is_credited_to_an_unregistered_reward_account() {
         let pool = pool(1);
-        let accounts = apply_leader_rewards(&pool, &stake_distribution(&pool, BTreeMap::new()));
+        let (accounts, _) = apply_leader_rewards(&pool, &stake_distribution(&pool, BTreeMap::new()));
         assert!(accounts.contains_key(&credential(1)));
     }
 
@@ -600,9 +620,47 @@ mod test {
             AccountState { balance: STAKE, pool: Some(pool.parameters.id), drep: None },
         )]);
 
-        let accounts = apply_leader_rewards(&pool, &stake_distribution(&pool, delegators));
+        let (accounts, _) = apply_leader_rewards(&pool, &stake_distribution(&pool, delegators));
 
         assert!(accounts.contains_key(&credential(1)));
+    }
+
+    /// Crediting a leader reward also records its recipient, so that payability can later be
+    /// resolved against the credentials actually owed a reward rather than against the pool
+    /// registry as it stands at payout time.
+    #[test]
+    fn a_leader_reward_records_its_recipient() {
+        let pool = pool(1);
+        let (_, leader_recipients) = apply_leader_rewards(&pool, &stake_distribution(&pool, BTreeMap::new()));
+        assert_eq!(leader_recipients, BTreeSet::from([credential(1)]));
+    }
+
+    /// A pool earning no leader reward records no recipient: anything else would be a wasted
+    /// database lookup at the epoch boundary.
+    #[test]
+    fn a_pool_earning_no_leader_reward_records_no_recipient() {
+        let pool = pool(1);
+        let stake_distribution = stake_distribution(&pool, BTreeMap::new());
+
+        let mut accounts = BTreeMap::new();
+        let mut leader_recipients = BTreeSet::new();
+        let mut blocks_per_pool = BTreeMap::new();
+
+        let rewards = RewardsSummary::apply_leader_rewards(
+            &mut accounts,
+            &mut leader_recipients,
+            &mut blocks_per_pool,
+            1,
+            1_000_000_000,
+            STAKE,
+            &stake_distribution,
+            &pool,
+            &MAINNET_DEFAULT_PROTOCOL_PARAMETERS,
+        );
+
+        assert_eq!(rewards.leader, 0, "a pool with no block should earn no leader reward");
+        assert!(leader_recipients.is_empty());
+        assert!(accounts.is_empty());
     }
 
     // HELPERS
@@ -651,16 +709,19 @@ mod test {
         }
     }
 
-    /// Credit a leader reward to `pool`, and report which accounts were credited.
+    /// Credit a leader reward to `pool`, and report which accounts were credited and which
+    /// recipients were recorded.
     fn apply_leader_rewards(
         pool: &PoolState,
         stake_distribution: &StakeDistribution,
-    ) -> BTreeMap<StakeCredential, Lovelace> {
+    ) -> (BTreeMap<StakeCredential, Lovelace>, BTreeSet<StakeCredential>) {
         let mut accounts = BTreeMap::new();
+        let mut leader_recipients = BTreeSet::new();
         let mut blocks_per_pool = BTreeMap::from([(pool.parameters.id, 1)]);
 
         let rewards = RewardsSummary::apply_leader_rewards(
             &mut accounts,
+            &mut leader_recipients,
             &mut blocks_per_pool,
             1,
             1_000_000_000,
@@ -671,6 +732,6 @@ mod test {
         );
 
         assert!(rewards.leader > 0, "the fixture should reward the leader");
-        accounts
+        (accounts, leader_recipients)
     }
 }


### PR DESCRIPTION
This PR makes sure that we return rewards to the treasure when they are associated to an account, at computation time, that a pool does not use anymore at distribution time. This fixes the rewards discrepancy observed on `mainnet`  between epochs `642` and `643`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved reward handling when pool leaders change reward accounts.
  * Rewards owed to previous leader accounts can now be correctly identified and returned to the treasury.
  * Added tracking for leader reward recipients, including accounts no longer associated with an active pool.

* **Bug Fixes**
  * Corrected unclaimed reward calculations and payment validation for unreachable reward accounts.
  * Added coverage for reward accounts no longer referenced by any pool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->