### PR TITLE
wire up peer performance for headers & blocks

### DIFF
--- a/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Duration;
+use std::{collections::BTreeSet, time::Duration};
 
 use amaru_kernel::{
     BlockHeader, BlockHeight, HeaderHash, IsHeader, ORIGIN_HASH, Peer, Point, Tip, cardano::network_block::NetworkBlock,
@@ -59,12 +59,19 @@ const MAX_MISSING_BLOCKS_PER_BATCH: usize = 25;
 ///   falling back to `request_missing_blocks` on first gap. Terminates on store errors, and on an
 ///   origin `from`, which means the ledger was never bootstrapped.
 /// - `Block(peer, network_block)`: Decode + basic integrity (body_hash match → adversarial
-///   on fail), ordering checks against current `missing` cursor (parent + first point;
-///   stragglers logged and dropped). On match: store block, send `(Tip, parent_boundary, block_height)`
-///   downstream, `shift_one_block` on cursor; if now empty, clear state, cancel timeout,
+///   on fail). Any valid body during an active batch is scored via `record_block_delivery`
+///   (including concurrent multi-peer stragglers). Ordering checks against current `missing`
+///   cursor (parent + first point); out-of-order bodies are dropped after scoring. On match:
+///   store block, send downstream, `shift_one_block`; if empty, clear state, cancel timeout,
 ///   signal `FetchNextFrom` upstream.
-/// - `Timeout(req_id)`: If matches current, log error (unless paused for no peers), clear
-///   missing/timeout, signal `FetchNextFrom(boundary)` upstream to retry (no direct peer penalty here).
+/// - `Timeout(req_id)`: If matches current, log warn (unless paused for no peers),
+///   `record_fetch_failure` for peers still in the timeout set, clear missing/timeout,
+///   signal `FetchNextFrom(boundary)` upstream to retry.
+/// - `PeersAsked(req_id, peers)`: Union the manager-contacted set into the timeout set, excluding
+///   peers already settled for this request (so a late `PeersAsked` cannot re-add a peer that
+///   already sent `NoBlocks`).
+/// - `NoBlocks(req_id, peer)`: Mark the peer settled, `record_fetch_failure` once, and drop them
+///   from the timeout set.
 /// - `NoPeersAvailable(req_id)`: If matches current, log INFO that fetch is paused; leave the
 ///   5s timeout armed so retry is rate-limited without ERROR.
 ///
@@ -72,8 +79,9 @@ const MAX_MISSING_BLOCKS_PER_BATCH: usize = 25;
 /// - **cleanup_replies** (dynamic, `StageRef<Blocks>`, lazily `ensure_child`'d on every
 ///   message; factory creates `Cleanup` with self-ref + block_source/peer_selection):
 ///   - Receives `Blocks` replies routed by manager (because `cr` passed in FetchBlocks).
-///   - `NoBlocks(_)`: ignored (timeout will handle).
+///   - `NoBlocks(id, peer)`: forward `FetchBlocksMsg::NoBlocks(id, peer)` for active ids.
 ///   - `NoPeersAvailable(id)`: forward `FetchBlocksMsg::NoPeersAvailable(id)` to parent.
+///   - `PeersAsked(id, peers)`: forward `FetchBlocksMsg::PeersAsked(id, peers)` to parent.
 ///   - `Block(id, peer, nb)`: decode header (adversarial on fail + return), ALWAYS
 ///     `BlockSourceMsg::BlockReceived {peer, tip}` (for stats/selection), forward as
 ///     `FetchBlocksMsg::Block` to parent ONLY if id >= curr_id (straggler filter),
@@ -123,6 +131,10 @@ pub struct FetchBlocks {
     trace_context: Option<TraceContext>,
     /// When the current fetch batch was requested (for peer delivery timing).
     fetch_started_at: Option<amaru_pure_stage::Instant>,
+    /// Peers still at risk of timeout failure for the current batch.
+    fetch_peers: BTreeSet<Peer>,
+    /// Peers already scored for this batch (e.g. `NoBlocks`); never re-added by a late `PeersAsked`.
+    fetch_settled: BTreeSet<Peer>,
 }
 
 impl FetchBlocks {
@@ -147,6 +159,8 @@ impl FetchBlocks {
             block_height: BlockHeight::from(0),
             trace_context: Default::default(),
             fetch_started_at: None,
+            fetch_peers: BTreeSet::new(),
+            fetch_settled: BTreeSet::new(),
         }
     }
 
@@ -335,6 +349,8 @@ impl FetchBlocks {
         )
         .await;
         self.fetch_started_at = Some(now);
+        self.fetch_peers.clear();
+        self.fetch_settled.clear();
         eff.external(Performance::record_blocks_requested(requested, now)).await;
         let timeout = eff.schedule_after(FetchBlocksMsg::Timeout(self.req_id), Duration::from_secs(5)).await;
         self.timeout = Some(timeout);
@@ -360,10 +376,28 @@ impl FetchBlocks {
             tracing::warn!(expected = %header.header().header_body.block_body_hash, actual = %block.body_hash(), "block body hash mismatch");
             return;
         }
+
         let Some(missing) = self.missing.as_mut() else {
             tracing::debug!(%peer, "received straggler block");
             return;
         };
+
+        // Credit peer delivery for any valid body while a batch is active (including concurrent
+        // multi-peer stragglers that fail the ordering checks below).
+        let now = eff.clock().await;
+        let response = self.fetch_started_at.map(|started| now.saturating_since(started)).unwrap_or(Duration::ZERO);
+        let bytes = network_block.raw_block().len() as u64;
+        eff.external(Performance::record_block_delivery(
+            peer.clone(),
+            point.hash(),
+            header.block_height(),
+            header.parent_hash(),
+            now,
+            response,
+            bytes,
+        ))
+        .await;
+
         if header.parent_hash() != Some(missing.boundary().hash()) {
             // this happens for stragglers when fetching from multiple peers
             tracing::debug!(expected = %missing.boundary().hash(), actual = %header.parent_hash().unwrap_or(ORIGIN_HASH), "block parent hash mismatch");
@@ -374,22 +408,6 @@ impl FetchBlocks {
             tracing::warn!(%expected, actual = ?point, "block point mismatch");
             return;
         }
-
-        let now = eff.clock().await;
-        let response = self.fetch_started_at.map(|started| now.saturating_since(started)).unwrap_or(Duration::ZERO);
-        let bytes = network_block.raw_block().len() as u64;
-        let height = header.block_height();
-        let parent = header.parent_hash();
-        eff.external(Performance::record_block_delivery(
-            peer.clone(),
-            point.hash(),
-            height,
-            parent,
-            now,
-            response,
-            bytes,
-        ))
-        .await;
 
         store
             .store_block(&point.hash(), &network_block.raw_block())
@@ -411,11 +429,39 @@ impl FetchBlocks {
             self.missing = None;
             self.no_peers_pause = false;
             self.fetch_started_at = None;
+            self.fetch_peers.clear();
+            self.fetch_settled.clear();
             if let Some(timeout) = self.timeout.take() {
                 eff.cancel_schedule(timeout).await;
             }
             self.fetch_next_from(eff, point).await;
         }
+    }
+
+    pub async fn peers_asked(&mut self, req_id: u64, peers: Vec<Peer>, _eff: Effects<FetchBlocksMsg>) {
+        if req_id != self.req_id || self.missing.is_none() {
+            return;
+        }
+        // Union contacted peers into the timeout set; never re-add peers already settled
+        // (e.g. NoBlocks arrived before this message — no ordering guarantee across stages).
+        for peer in peers {
+            if !self.fetch_settled.contains(&peer) {
+                self.fetch_peers.insert(peer);
+            }
+        }
+    }
+
+    pub async fn no_blocks(&mut self, req_id: u64, peer: Peer, eff: Effects<FetchBlocksMsg>) {
+        if req_id != self.req_id || self.missing.is_none() {
+            return;
+        }
+        if !self.fetch_settled.insert(peer.clone()) {
+            // Already scored for this request (duplicate NoBlocks).
+            return;
+        }
+        self.fetch_peers.remove(&peer);
+        let now = eff.clock().await;
+        eff.external(Performance::record_fetch_failure(vec![peer], now)).await;
     }
 
     pub async fn no_peers_available(&mut self, req_id: u64, _eff: Effects<FetchBlocksMsg>) {
@@ -425,6 +471,8 @@ impl FetchBlocks {
 
         tracing::info!(%req_id, "block fetching paused due to no upstream peers");
         self.no_peers_pause = true;
+        self.fetch_peers.clear();
+        self.fetch_settled.clear();
     }
 
     pub async fn timeout(&mut self, req_id: u64, eff: Effects<FetchBlocksMsg>) {
@@ -432,10 +480,16 @@ impl FetchBlocks {
             return;
         }
 
+        let peers: Vec<Peer> = std::mem::take(&mut self.fetch_peers).into_iter().collect();
+        self.fetch_settled.clear();
         if self.no_peers_pause {
             tracing::debug!(%req_id, "retrying block fetch after no-peers pause");
         } else {
             tracing::warn!(%req_id, "timeout fetching blocks");
+            if !peers.is_empty() {
+                let now = eff.clock().await;
+                eff.external(Performance::record_fetch_failure(peers, now)).await;
+            }
         }
         match self.missing.as_ref().map(|m| m.boundary()) {
             None => (),
@@ -443,6 +497,7 @@ impl FetchBlocks {
                 self.timeout = None;
                 self.missing = None;
                 self.no_peers_pause = false;
+                self.fetch_started_at = None;
                 self.fetch_next_from(eff, from).await;
             }
         }
@@ -470,10 +525,22 @@ impl DownloadedBlock {
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum FetchBlocksMsg {
-    NewTip { tip: Tip, parent: Point, trace_context: TraceContext },
-    RecoverStoredBlocks { from: Point, to: HeaderHash, trace_context: TraceContext },
+    NewTip {
+        tip: Tip,
+        parent: Point,
+        trace_context: TraceContext,
+    },
+    RecoverStoredBlocks {
+        from: Point,
+        to: HeaderHash,
+        trace_context: TraceContext,
+    },
     Block(Peer, NetworkBlock),
     Timeout(u64),
+    /// Peers the manager asked for the current request id (for timeout failure scoring).
+    PeersAsked(u64, Vec<Peer>),
+    /// Peer reported no blocks in the requested range.
+    NoBlocks(u64, Peer),
     NoPeersAvailable(u64),
 }
 
@@ -500,6 +567,8 @@ pub async fn stage(mut state: FetchBlocks, msg: FetchBlocksMsg, eff: Effects<Fet
         }
         FetchBlocksMsg::Block(peer, block) => state.block(peer, block, eff).await,
         FetchBlocksMsg::Timeout(req_id) => state.timeout(req_id, eff).await,
+        FetchBlocksMsg::PeersAsked(req_id, peers) => state.peers_asked(req_id, peers, eff).await,
+        FetchBlocksMsg::NoBlocks(req_id, peer) => state.no_blocks(req_id, peer, eff).await,
         FetchBlocksMsg::NoPeersAvailable(req_id) => state.no_peers_available(req_id, eff).await,
     }
     state
@@ -528,10 +597,18 @@ impl Cleanup {
 /// TODO: keep block hashes in LRU to deduplicate incoming blocks without validation or ordering assumption
 async fn cleanup_replies(mut state: Cleanup, msg: Blocks, eff: Effects<Blocks>) -> Cleanup {
     match msg {
-        // completely ignore empty responses, fetch stage will deal with timeouts
-        Blocks::NoBlocks(_) => {}
+        Blocks::NoBlocks(id, peer) => {
+            if id >= state.curr_id {
+                eff.send(&state.fetch, FetchBlocksMsg::NoBlocks(id, peer)).await;
+            }
+        }
         Blocks::NoPeersAvailable(id) => {
             eff.send(&state.fetch, FetchBlocksMsg::NoPeersAvailable(id)).await;
+        }
+        Blocks::PeersAsked(id, peers) => {
+            if id >= state.curr_id {
+                eff.send(&state.fetch, FetchBlocksMsg::PeersAsked(id, peers)).await;
+            }
         }
         Blocks::Block(id, peer, network_block) => {
             let header = match network_block.decode_header() {

--- a/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
@@ -143,6 +143,7 @@ pub fn register_guards() -> DeserializerGuards {
         amaru_pure_stage::register_effect_deserializer::<AncestorsBetweenEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordBlocksRequestedEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordBlockDeliveryEffect>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordFetchFailureEffect>().boxed(),
         amaru_pure_stage::register_data_deserializer::<(Vec<HeaderHash>, bool)>().boxed(),
         amaru_pure_stage::register_data_deserializer::<Option<Vec<amaru_kernel::Tip>>>().boxed(),
         amaru_pure_stage::register_data_deserializer::<Result<Option<MissingBlocks>, StoreError>>().boxed(),
@@ -171,6 +172,13 @@ pub fn test_prep() -> TestPrep {
 }
 
 pub fn setup(prep: &TestPrep, msg: FetchBlocksMsg) -> (SimulationRunning, DeserializerGuards, Logs) {
+    setup_preload(prep, [msg])
+}
+
+pub fn setup_preload(
+    prep: &TestPrep,
+    messages: impl IntoIterator<Item = FetchBlocksMsg>,
+) -> (SimulationRunning, DeserializerGuards, Logs) {
     let guards = register_guards();
 
     run_simulation(
@@ -179,7 +187,7 @@ pub fn setup(prep: &TestPrep, msg: FetchBlocksMsg) -> (SimulationRunning, Deseri
         |mut network| {
             let fb = network.stage("fb", stage);
             let fb = network.wire_up(fb, prep.state.clone());
-            network.preload(&fb, [msg]).unwrap();
+            network.preload(&fb, messages).unwrap();
             network
         },
         |resources| {
@@ -265,5 +273,12 @@ pub fn te_record_block_delivery(
         Box::new(crate::performance::Performance::record_block_delivery(
             peer, hash, height, parent, at, response, bytes,
         )),
+    ))
+}
+
+pub fn te_record_fetch_failure(at_stage: &str, peers: Vec<Peer>, at: Instant) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(
+        at_stage,
+        Box::new(crate::performance::Performance::record_fetch_failure(peers, at)),
     ))
 }

--- a/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
@@ -14,7 +14,7 @@
 
 use std::time::Duration;
 
-use amaru_kernel::{BlockHeight, IsHeader};
+use amaru_kernel::{BlockHeight, IsHeader, Peer};
 use amaru_ouroboros_traits::MissingBlocks;
 use amaru_protocols::manager::ManagerMessage;
 use amaru_pure_stage::{
@@ -27,8 +27,8 @@ use super::*;
 use crate::stages::{
     fetch_blocks::test_setup::{
         TestPrep, make_block_header, setup, te_ancestors_between, te_cancel_schedule, te_clock, te_find_missing_blocks,
-        te_has_block, te_load_header, te_record_block_delivery, te_record_blocks_requested, te_schedule,
-        te_store_block, test_peer, test_prep,
+        te_has_block, te_load_header, te_record_block_delivery, te_record_blocks_requested, te_record_fetch_failure,
+        te_schedule, te_store_block, test_peer, test_prep,
     },
     test_utils::{
         assert_trace, start_in_era, te_clock_read, te_input, te_send, te_state, te_terminate, te_terminated, tm_state,
@@ -201,6 +201,7 @@ fn test_recover_stored_blocks_fetches_the_whole_gap_after_the_replayed_prefix() 
                 state.missing = None;
                 state.timeout = None;
                 state.trace_context = None;
+                state.fetch_started_at = None;
                 state
             }),
         ],
@@ -241,6 +242,7 @@ fn test_new_tip_blocks_to_fetch() {
         state.missing = None;
         state.timeout = None;
         state.trace_context = None;
+        state.fetch_started_at = None;
         state
     };
     assert_trace(
@@ -486,6 +488,156 @@ fn test_timeout_stale_is_ignored() {
 
     assert_trace_contains(&running, &[te_input("fb-1", &msg).into(), te_state("fb-1", &prep.state).into()]);
 
+    logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_timeout_records_fetch_failure_for_asked_peers() {
+    use std::collections::BTreeSet;
+
+    let mut prep = test_prep();
+    let schedule_id = prep.schedule_at(Duration::from_secs(5));
+    let peer = test_peer();
+    prep.state = {
+        let mut state = prep.state_with_request(
+            MissingBlocks::new(prep.headers.h0.point(), vec![prep.headers.h1.point()]),
+            1,
+            schedule_id,
+        );
+        state.fetch_peers = BTreeSet::from([peer.clone()]);
+        state.fetch_started_at = Some(Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time));
+        state.trace_context = Some(Default::default());
+        state
+    };
+
+    let msg = FetchBlocksMsg::Timeout(1);
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    let failed_at = Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time);
+    let expected = {
+        let mut state = prep.state.clone();
+        state.missing = None;
+        state.timeout = None;
+        state.trace_context = None;
+        state.fetch_started_at = None;
+        state.fetch_peers.clear();
+        state
+    };
+    assert_trace_contains(
+        &running,
+        &[
+            te_input("fb-1", &msg).into(),
+            te_clock_read("fb-1").into(),
+            te_record_fetch_failure("fb-1", vec![peer], failed_at).into(),
+            te_send("fb-1", "upstream", SelectChainMsg::fetch_next_from(prep.headers.h0.point())).into(),
+            te_state("fb-1", &expected).into(),
+        ],
+    );
+    logs.assert_and_remove(Level::WARN, &["timeout fetching blocks"]).assert_no_remaining_at([
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
+}
+
+#[test]
+fn test_no_blocks_records_fetch_failure() {
+    use std::collections::BTreeSet;
+
+    let mut prep = test_prep();
+    let peer = test_peer();
+    let other = Peer::new("other");
+    prep.state = {
+        let mut state = prep.state_with_request(
+            MissingBlocks::new(prep.headers.h0.point(), vec![prep.headers.h1.point()]),
+            1,
+            prep.schedule_at(Duration::from_secs(5)),
+        );
+        state.fetch_peers = BTreeSet::from([peer.clone(), other.clone()]);
+        state
+    };
+
+    let msg = FetchBlocksMsg::NoBlocks(1, peer.clone());
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    let failed_at = Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time);
+    let expected = {
+        let mut state = prep.state.clone();
+        state.fetch_peers.remove(&peer);
+        state.fetch_settled.insert(peer.clone());
+        state
+    };
+    assert_trace_contains(
+        &running,
+        &[
+            te_input("fb-1", &msg).into(),
+            te_clock_read("fb-1").into(),
+            te_record_fetch_failure("fb-1", vec![peer], failed_at).into(),
+            te_state("fb-1", &expected).into(),
+        ],
+    );
+    logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_peers_asked_stores_peer_set() {
+    use std::collections::BTreeSet;
+
+    let mut prep = test_prep();
+    let peer = test_peer();
+    prep.state = prep.state_with_request(
+        MissingBlocks::new(prep.headers.h0.point(), vec![prep.headers.h1.point()]),
+        1,
+        prep.schedule_at(Duration::from_secs(5)),
+    );
+
+    let msg = FetchBlocksMsg::PeersAsked(1, vec![peer.clone()]);
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    let expected = {
+        let mut state = prep.state.clone();
+        state.fetch_peers = BTreeSet::from([peer]);
+        state
+    };
+    assert_trace_contains(&running, &[te_input("fb-1", &msg).into(), te_state("fb-1", &expected).into()]);
+    logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+/// Regression: `NoBlocks` may arrive before `PeersAsked` (no cross-stage order). A late
+/// `PeersAsked` must not put a settled peer back into the timeout set (would double-count
+/// `fetch_timeouts` on batch timeout).
+#[test]
+fn test_peers_asked_does_not_resurrect_no_blocks_peer() {
+    use std::collections::BTreeSet;
+
+    use crate::stages::fetch_blocks::test_setup::setup_preload;
+
+    let mut prep = test_prep();
+    let alice = test_peer();
+    let bob = Peer::new("bob");
+    prep.state = prep.state_with_request(
+        MissingBlocks::new(prep.headers.h0.point(), vec![prep.headers.h1.point()]),
+        1,
+        prep.schedule_at(Duration::from_secs(5)),
+    );
+
+    let no_blocks = FetchBlocksMsg::NoBlocks(1, alice.clone());
+    let peers_asked = FetchBlocksMsg::PeersAsked(1, vec![alice.clone(), bob.clone()]);
+    let (running, _guards, mut logs) = setup_preload(&prep, [no_blocks.clone(), peers_asked.clone()]);
+    let failed_at = Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time);
+    let expected = {
+        let mut state = prep.state.clone();
+        state.fetch_settled = BTreeSet::from([alice.clone()]);
+        state.fetch_peers = BTreeSet::from([bob]);
+        state
+    };
+    assert_trace_contains(
+        &running,
+        &[
+            te_input("fb-1", &no_blocks).into(),
+            te_clock_read("fb-1").into(),
+            te_record_fetch_failure("fb-1", vec![alice], failed_at).into(),
+            te_input("fb-1", &peers_asked).into(),
+            te_state("fb-1", &expected).into(),
+        ],
+    );
     logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -474,7 +474,7 @@ impl TrackPeers {
         current: Point,
         tip: Tip,
         store: &Store,
-    ) -> Result<(), ConsensusError> {
+    ) -> Result<Tip, ConsensusError> {
         let Some(current_tip) = store.load_tip(&current.hash()).await else {
             return Err(ConsensusError::UnknownPoint(current.hash()));
         };
@@ -484,7 +484,7 @@ impl TrackPeers {
         };
         *current_ref = current_tip;
         *highest_ref = tip;
-        Ok(())
+        Ok(current_tip)
     }
 
     /// Remove all per-connection state for a chainsync session. Idempotent.
@@ -858,10 +858,21 @@ impl TrackPeers {
                     eff.send(&handler, chainsync::InitiatorMessage::RequestNext).await;
 
                     let store = Store::new(eff.clone()).with_trace_context(&trace_context);
-                    if let Err(error) = self.roll_backward(&peer, conn_id, current, tip, &store).await {
-                        tracing::error!(%error, %peer, "chain_sync.roll_backward.failed");
-                        self.purge_connection(conn_id);
-                        eff.send(&self.peer_selection, PeerSelectionMsg::Adversarial(peer, trace_context)).await;
+                    match self.roll_backward(&peer, conn_id, current, tip, &store).await {
+                        Ok(current_tip) => {
+                            let parent = store
+                                .load_header(&current_tip.hash())
+                                .await
+                                .and_then(|h| h.parent_hash())
+                                .filter(|p| *p != ORIGIN_HASH);
+                            let now = eff.clock().await;
+                            eff.external(Performance::record_rollback(peer, current_tip, parent, now)).await;
+                        }
+                        Err(error) => {
+                            tracing::error!(%error, %peer, "chain_sync.roll_backward.failed");
+                            self.purge_connection(conn_id);
+                            eff.send(&self.peer_selection, PeerSelectionMsg::Adversarial(peer, trace_context)).await;
+                        }
                     }
                 }
                 .instrument(span)

--- a/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
@@ -168,6 +168,23 @@ pub fn te_get_nonces(at_stage: &str, hash: HeaderHash) -> TraceEntry {
     TraceEntry::suspend(Effect::external(at_stage, Box::new(GetNoncesEffect::new(hash))))
 }
 
+pub fn te_load_header(at_stage: &str, hash: HeaderHash) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(at_stage, Box::new(LoadHeaderEffect::new(hash))))
+}
+
+pub fn te_record_rollback(
+    at_stage: &str,
+    peer: Peer,
+    point: Tip,
+    parent: Option<HeaderHash>,
+    at: Instant,
+) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(
+        at_stage,
+        Box::new(crate::performance::Performance::record_rollback(peer, point, parent, at)),
+    ))
+}
+
 pub fn te_store_validated_header(at_stage: &str, header: BlockHeader) -> TraceEntry {
     TraceEntry::suspend(Effect::external(
         at_stage,
@@ -237,6 +254,7 @@ fn register_guards() -> DeserializerGuards {
         amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordHeaderAnnouncementEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordHeaderRejectedEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordIntersectionEffect>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordRollbackEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<amaru_protocols::metrics_effects::RecordMetricsEffect>()
             .boxed(),
     ]

--- a/crates/amaru-consensus/src/stages/track_peers/tests.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/tests.rs
@@ -31,15 +31,16 @@ use crate::{
     errors::ConsensusError,
     stages::{
         peer_selection::PeerSelectionMsg,
-        test_utils::{start_in_era, te_input, te_send, te_state, tm_state},
+        test_utils::{start_in_era, te_clock_read, te_input, te_send, te_state, tm_state},
         track_peers::{
             TrackPeers, TrackPeersMsg,
             test_setup::{
                 HEIGHT_RECHECK_INTERVAL, SIM_INITIAL_CLOCK_SECS, build_store, build_store_with_nonces,
                 height_recheck_schedule_id, make_block_header, new_tip, schedule_id_at, setup, setup_base,
                 setup_with_ledger_tip_until_sleeping, slot_start_to_header_micros, te_clock, te_clock_suspend,
-                te_get_nonces, te_load_tip, te_record_header_announcement, te_schedule, te_store_validated_header,
-                te_validate_header, test_prep, test_prep_with_max_peer_lead, tm_volatile_tip,
+                te_get_nonces, te_load_header, te_load_tip, te_record_header_announcement, te_record_rollback,
+                te_schedule, te_store_validated_header, te_validate_header, test_prep, test_prep_with_max_peer_lead,
+                tm_volatile_tip,
             },
         },
     },
@@ -882,8 +883,9 @@ fn test_roll_backward_updates_peer() {
     state.insert_peer(peer.clone(), prep.conn_id, Tip::origin(), Tip::origin());
 
     let mut expected = prep.state.clone();
-    expected.insert_peer(peer, prep.conn_id, header.tip(), tip);
+    expected.insert_peer(peer.clone(), prep.conn_id, header.tip(), tip);
 
+    let now = Instant::at_offset(Duration::from_secs(SIM_INITIAL_CLOCK_SECS), start_in_era().relative_time);
     let (running, _guards, mut logs) =
         setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(slice::from_ref(header)));
     assert_trace_contains(
@@ -893,6 +895,9 @@ fn test_roll_backward_updates_peer() {
             te_input("tp-1", &msg).into(),
             te_send("tp-1", &prep.handler, RequestNext).into(),
             te_load_tip("tp-1", current.hash()).into(),
+            te_load_header("tp-1", current.hash()).into(),
+            te_clock_read("tp-1").into(),
+            te_record_rollback("tp-1", peer, header.tip(), header.parent_hash(), now).into(),
             te_state("tp-1", &expected).into(),
         ],
     );

--- a/crates/amaru-protocols/src/blockfetch/initiator.rs
+++ b/crates/amaru-protocols/src/blockfetch/initiator.rs
@@ -44,8 +44,12 @@ pub fn initiator() -> Miniprotocol<State, BlockFetchInitiator, Initiator> {
 
 #[derive(PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 pub enum Blocks {
-    NoBlocks(u64),
+    /// Peer responded that it has no blocks in the requested range.
+    NoBlocks(u64, Peer),
+    /// Manager found no initiating connections for this request id.
     NoPeersAvailable(u64),
+    /// Peers to which the manager dispatched this fetch request (for performance scoring).
+    PeersAsked(u64, Vec<Peer>),
     Block(u64, Peer, NetworkBlock),
     Done(u64),
 }
@@ -53,8 +57,9 @@ pub enum Blocks {
 impl std::fmt::Debug for Blocks {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::NoBlocks(id) => f.debug_tuple("NoBlocks").field(id).finish(),
+            Self::NoBlocks(id, peer) => f.debug_tuple("NoBlocks").field(id).field(peer).finish(),
             Self::NoPeersAvailable(id) => f.debug_tuple("NoPeersAvailable").field(id).finish(),
+            Self::PeersAsked(id, peers) => f.debug_tuple("PeersAsked").field(id).field(peers).finish(),
             Self::Block(id, peer, block) => {
                 f.debug_tuple("Block").field(id).field(peer).field(&debug_bytes(block.as_slice(), 80)).finish()
             }
@@ -127,7 +132,7 @@ impl StageState<State, Initiator> for BlockFetchInitiator {
                 InitiatorResult::Initialize => None,
                 InitiatorResult::NoBlocks => {
                     let (_, _, id, cr, _) = self.queue.pop_front().expect("queue must not be empty");
-                    eff.send(&cr, Blocks::NoBlocks(id)).await;
+                    eff.send(&cr, Blocks::NoBlocks(id, self.peer.clone())).await;
                     self.queue.front()
                 }
                 InitiatorResult::Block(body) => {

--- a/crates/amaru-protocols/src/manager/mod.rs
+++ b/crates/amaru-protocols/src/manager/mod.rs
@@ -579,19 +579,20 @@ impl Manager {
         eff: &Effects<ManagerMessage>,
     ) {
         tracing::debug!(?from, ?through, "fetching blocks");
-        let mut sent = 0;
+        let mut peers = Vec::new();
         for conn in self.connections.values() {
             if !conn.may_initiate {
                 continue;
             }
+            peers.push(conn.peer.clone());
             eff.send(&conn.stage, ConnectionMessage::FetchBlocks { from, through, cr: cr.clone(), id }).await;
-            sent += 1;
         }
-        if sent == 0 {
+        if peers.is_empty() {
             tracing::debug!(%id, "no connections available to fetch blocks");
             eff.send(&cr, Blocks::NoPeersAvailable(id)).await;
         } else {
-            tracing::debug!(%id, sent, "fetch blocks request sent to connections");
+            tracing::debug!(%id, sent = peers.len(), "fetch blocks request sent to connections");
+            eff.send(&cr, Blocks::PeersAsked(id, peers)).await;
         }
     }
 }

--- a/crates/amaru-protocols/src/tests/chainsync_stage.rs
+++ b/crates/amaru-protocols/src/tests/chainsync_stage.rs
@@ -143,7 +143,7 @@ pub(super) async fn store_fetched_blocks(
             state.queue.push_back(batch);
             start_next_fetch(&mut state, &eff).await;
         }
-        StoreFetchedBlocksMessage::Blocks(Blocks::NoBlocks(id)) => {
+        StoreFetchedBlocksMessage::Blocks(Blocks::NoBlocks(id, _peer)) => {
             if !matches!(state.current.as_ref(), Some(current) if current.id == id) {
                 return state;
             }
@@ -151,6 +151,7 @@ pub(super) async fn store_fetched_blocks(
             assert!(current.remaining_points.is_empty(), "expected blocks for request {id}, got no blocks");
             advance_after_fetch(&mut state, current.handler, &eff).await;
         }
+        StoreFetchedBlocksMessage::Blocks(Blocks::PeersAsked(..)) => {}
         StoreFetchedBlocksMessage::Blocks(Blocks::NoPeersAvailable(id)) => {
             panic!("unexpected NoPeersAvailable for request {id}: test expects connected peers");
         }


### PR DESCRIPTION
Wire up PeerPerformance inputs into the Performance resource.

Skip-changelog

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved block fetching to track contacted peers and handle empty responses more accurately.
  - Fetch timeouts and delivery failures are now attributed to the relevant peers.
  - Valid blocks, including late-arriving blocks, are captured for performance monitoring.
  - Improved rollback processing records performance data and distinguishes recoverable issues from adversarial behavior.

- **Reliability**
  - Fetch state is cleaned up consistently when requests complete, pause, or time out.
  - Peer availability and request outcomes are reported more accurately across the networking flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->