### PR TITLE
use Performance resource to select peers for fetch_blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Other guiding principles:
 - **amaru**: add `amaru mithril sync` to download verified Mithril immutable files and replay their blocks directly into the chain and ledger stores.
 - **amaru**: add `amaru node rm --wipe-all-dbs` to remove the ledger and chain databases resolved from the selected network.
 - **amaru-tui**: `node run` now launches a feature-rich TUI that feeds from the emitted traces and metrics to provide an out-of-the-box dashboard for Amaru. Can be disabled with `--no-tui`.
+- **amaru-consensus**: add basic peer performance tracking to select up to three peers whenever fetching blocks. ([#1093](https://github.com/pragma-org/amaru/issues/1093))
 
 ### Changed
 

--- a/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
@@ -24,12 +24,13 @@ use amaru_pure_stage::{Effects, OrTerminateWith, ScheduleId, StageRef, TryInStag
 use tracing::Instrument;
 
 use crate::{
-    performance::Performance,
+    performance::{Performance, SelectPeersParams},
     stages::{block_source::BlockSourceMsg, peer_selection::PeerSelectionMsg, select_chain::SelectChainMsg},
 };
 
 // TODO make configurable
 const MAX_MISSING_BLOCKS_PER_BATCH: usize = 25;
+const MAX_FETCH_PEERS: usize = 3;
 
 /// Block fetch coordinator stage.
 ///
@@ -51,8 +52,9 @@ const MAX_MISSING_BLOCKS_PER_BATCH: usize = 25;
 /// ## Input messages and behaviour
 /// - `NewTip(tip, parent)`: Update tracked block_height, assert no outstanding missing,
 ///   delegate to `request_missing_blocks` which queries store for gaps and (if any)
-///   sends `ManagerMessage::FetchBlocks` (with cr=child ref for replies) then schedules
-///   a `Timeout(req_id)`.
+///   selects covering peers via `Performance::select_peers_for_fetch`, sends
+///   `ManagerMessage::FetchBlocks` (peer list or all-connections fallback when selection is
+///   weak) then schedules a `Timeout(req_id)`.
 /// - `RecoverStoredBlocks { from, to }`: Startup recovery only, where `from` is the ledger tip and
 ///   `to` the best stored candidate. Walks the stored headers from `to` back down to `from` and
 ///   replays them downstream for re-validation (using `ancestors_between` + `has_block` checks),
@@ -62,14 +64,14 @@ const MAX_MISSING_BLOCKS_PER_BATCH: usize = 25;
 ///   on fail). Any valid body during an active batch is scored via `record_block_delivery`
 ///   (including concurrent multi-peer stragglers). Ordering checks against current `missing`
 ///   cursor (parent + first point); out-of-order bodies are dropped after scoring. On match:
-///   store block, send downstream, `shift_one_block`; if empty, clear state, cancel timeout,
-///   signal `FetchNextFrom` upstream.
+///   credit the peer as a contributor (fair timeout), store block, send downstream,
+///   `shift_one_block`; if empty, clear state, cancel timeout, signal `FetchNextFrom` upstream.
 /// - `Timeout(req_id)`: If matches current, log warn (unless paused for no peers),
-///   `record_fetch_failure` for peers still in the timeout set, clear missing/timeout,
-///   signal `FetchNextFrom(boundary)` upstream to retry.
-/// - `PeersAsked(req_id, peers)`: Union the manager-contacted set into the timeout set, excluding
-///   peers already settled for this request (so a late `PeersAsked` cannot re-add a peer that
-///   already sent `NoBlocks`).
+///   `record_fetch_failure` for contacted peers that neither settled (`NoBlocks`) nor contributed
+///   an accepted block, clear missing/timeout, signal `FetchNextFrom(boundary)` upstream to retry.
+/// - `PeersAsked(req_id, peers)`: Set the timeout set to manager-contacted peers, excluding peers
+///   already settled for this request (so a late `PeersAsked` cannot re-add a peer that already
+///   sent `NoBlocks`).
 /// - `NoBlocks(req_id, peer)`: Mark the peer settled, `record_fetch_failure` once, and drop them
 ///   from the timeout set.
 /// - `NoPeersAvailable(req_id)`: If matches current, log INFO that fetch is paused; leave the
@@ -103,7 +105,10 @@ const MAX_MISSING_BLOCKS_PER_BATCH: usize = 25;
 ///
 /// ## External interactions (which stages it talks to)
 /// - **select_chain (upstream)**: receives `NewTip`/`RecoverStoredBlocks`; sends `SelectChainMsg::FetchNextFrom(point)` on batch done, no-work, timeout, or recovery complete.
-/// - **manager**: sends `ManagerMessage::FetchBlocks {from, through, id, cr: cleanup_replies}` to initiate block fetches (replies flow back via provided child ref).
+/// - **manager**: sends `ManagerMessage::FetchBlocks {from, through, id, cr, peers}` to initiate block fetches
+///   (replies flow back via provided child ref). `peers` is `Some(selected)` from Performance when
+///   selection is strong, or `None` (all initiating connections) when the performance map has no
+///   covering peers (cold start / empty map fallback).
 /// - **downstream** (typically validate_block_input via contramap in build): sends `(Tip, parent_Point, block_height)` for each block (newly fetched or recovered stored).
 /// - **block_source** (via child only): `BlockReceived {peer, tip}` for every header seen in replies (even stragglers/old).
 /// - **peer_selection**: `Adversarial(peer)` on body-hash mismatch (main) or header decode failure (child).
@@ -131,10 +136,12 @@ pub struct FetchBlocks {
     trace_context: Option<TraceContext>,
     /// When the current fetch batch was requested (for peer delivery timing).
     fetch_started_at: Option<amaru_pure_stage::Instant>,
-    /// Peers still at risk of timeout failure for the current batch.
+    /// Peers contacted for the current batch and still at risk of timeout failure.
     fetch_peers: BTreeSet<Peer>,
     /// Peers already scored for this batch (e.g. `NoBlocks`); never re-added by a late `PeersAsked`.
     fetch_settled: BTreeSet<Peer>,
+    /// Peers that delivered at least one accepted (ordered) block in the current batch.
+    fetch_contributors: BTreeSet<Peer>,
 }
 
 impl FetchBlocks {
@@ -161,6 +168,7 @@ impl FetchBlocks {
             fetch_started_at: None,
             fetch_peers: BTreeSet::new(),
             fetch_settled: BTreeSet::new(),
+            fetch_contributors: BTreeSet::new(),
         }
     }
 
@@ -343,14 +351,38 @@ impl FetchBlocks {
         let requested: Vec<HeaderHash> = missing.missing_points().into_iter().map(|point| point.hash()).collect();
         self.missing = Some(missing);
 
+        let selected = eff
+            .external(Performance::select_peers_for_fetch(SelectPeersParams {
+                need: requested.clone(),
+                max_peers: MAX_FETCH_PEERS,
+                now,
+            }))
+            .await;
+        let peers_for_manager = if selected.weak || selected.peers.is_empty() {
+            tracing::debug!(
+                weak = selected.weak,
+                "no covering peers selected; falling back to all initiating connections"
+            );
+            None
+        } else {
+            Some(selected.peers)
+        };
+        self.fetch_peers.clear();
+        self.fetch_settled.clear();
+        self.fetch_contributors.clear();
+
         eff.send(
             &self.manager,
-            ManagerMessage::FetchBlocks { from, through, id: self.req_id, cr: self.cleanup_replies.clone() },
+            ManagerMessage::FetchBlocks {
+                from,
+                through,
+                id: self.req_id,
+                cr: self.cleanup_replies.clone(),
+                peers: peers_for_manager,
+            },
         )
         .await;
         self.fetch_started_at = Some(now);
-        self.fetch_peers.clear();
-        self.fetch_settled.clear();
         eff.external(Performance::record_blocks_requested(requested, now)).await;
         let timeout = eff.schedule_after(FetchBlocksMsg::Timeout(self.req_id), Duration::from_secs(5)).await;
         self.timeout = Some(timeout);
@@ -409,6 +441,9 @@ impl FetchBlocks {
             return;
         }
 
+        // Accepted ordered body: do not count this peer as a timeout failure.
+        self.fetch_contributors.insert(peer.clone());
+
         store
             .store_block(&point.hash(), &network_block.raw_block())
             .or_terminate_with(&eff, async |error| {
@@ -431,6 +466,7 @@ impl FetchBlocks {
             self.fetch_started_at = None;
             self.fetch_peers.clear();
             self.fetch_settled.clear();
+            self.fetch_contributors.clear();
             if let Some(timeout) = self.timeout.take() {
                 eff.cancel_schedule(timeout).await;
             }
@@ -442,13 +478,8 @@ impl FetchBlocks {
         if req_id != self.req_id || self.missing.is_none() {
             return;
         }
-        // Union contacted peers into the timeout set; never re-add peers already settled
-        // (e.g. NoBlocks arrived before this message — no ordering guarantee across stages).
-        for peer in peers {
-            if !self.fetch_settled.contains(&peer) {
-                self.fetch_peers.insert(peer);
-            }
-        }
+        // Contacted set from the manager; exclude peers already settled (e.g. NoBlocks raced ahead).
+        self.fetch_peers = peers.into_iter().filter(|p| !self.fetch_settled.contains(p)).collect();
     }
 
     pub async fn no_blocks(&mut self, req_id: u64, peer: Peer, eff: Effects<FetchBlocksMsg>) {
@@ -473,6 +504,7 @@ impl FetchBlocks {
         self.no_peers_pause = true;
         self.fetch_peers.clear();
         self.fetch_settled.clear();
+        self.fetch_contributors.clear();
     }
 
     pub async fn timeout(&mut self, req_id: u64, eff: Effects<FetchBlocksMsg>) {
@@ -480,15 +512,17 @@ impl FetchBlocks {
             return;
         }
 
-        let peers: Vec<Peer> = std::mem::take(&mut self.fetch_peers).into_iter().collect();
+        let asked = std::mem::take(&mut self.fetch_peers);
+        let contributors = std::mem::take(&mut self.fetch_contributors);
         self.fetch_settled.clear();
         if self.no_peers_pause {
             tracing::debug!(%req_id, "retrying block fetch after no-peers pause");
         } else {
             tracing::warn!(%req_id, "timeout fetching blocks");
-            if !peers.is_empty() {
+            let failed: Vec<Peer> = asked.into_iter().filter(|p| !contributors.contains(p)).collect();
+            if !failed.is_empty() {
                 let now = eff.clock().await;
-                eff.external(Performance::record_fetch_failure(peers, now)).await;
+                eff.external(Performance::record_fetch_failure(failed, now)).await;
             }
         }
         match self.missing.as_ref().map(|m| m.boundary()) {

--- a/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
@@ -144,6 +144,8 @@ pub fn register_guards() -> DeserializerGuards {
         amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordBlocksRequestedEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordBlockDeliveryEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordFetchFailureEffect>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<crate::performance::SelectPeersForFetchEffect>().boxed(),
+        amaru_pure_stage::register_data_deserializer::<crate::performance::FetchPeerSet>().boxed(),
         amaru_pure_stage::register_data_deserializer::<(Vec<HeaderHash>, bool)>().boxed(),
         amaru_pure_stage::register_data_deserializer::<Option<Vec<amaru_kernel::Tip>>>().boxed(),
         amaru_pure_stage::register_data_deserializer::<Result<Option<MissingBlocks>, StoreError>>().boxed(),
@@ -172,12 +174,20 @@ pub fn test_prep() -> TestPrep {
 }
 
 pub fn setup(prep: &TestPrep, msg: FetchBlocksMsg) -> (SimulationRunning, DeserializerGuards, Logs) {
-    setup_preload(prep, [msg])
+    setup_with_overrides(prep, [msg], |_| {})
 }
 
 pub fn setup_preload(
     prep: &TestPrep,
     messages: impl IntoIterator<Item = FetchBlocksMsg>,
+) -> (SimulationRunning, DeserializerGuards, Logs) {
+    setup_with_overrides(prep, messages, |_| {})
+}
+
+pub fn setup_with_overrides(
+    prep: &TestPrep,
+    messages: impl IntoIterator<Item = FetchBlocksMsg>,
+    overrides: impl FnOnce(&mut SimulationRunning),
 ) -> (SimulationRunning, DeserializerGuards, Logs) {
     let guards = register_guards();
 
@@ -196,10 +206,7 @@ pub fn setup_preload(
                 crate::performance::Performance::new(),
             ));
         },
-        |_running| {
-            // No additional external effect overrides needed for basic fetch_blocks tests.
-            // Virtual child stages are enabled by default in run_simulation.
-        },
+        overrides,
     )
 }
 
@@ -254,6 +261,17 @@ pub fn te_record_blocks_requested(at_stage: &str, hashes: Vec<HeaderHash>, reque
     TraceEntry::suspend(Effect::external(
         at_stage,
         Box::new(crate::performance::Performance::record_blocks_requested(hashes, requested_at)),
+    ))
+}
+
+pub fn te_select_peers_for_fetch(at_stage: &str, need: Vec<HeaderHash>, max_peers: usize, now: Instant) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(
+        at_stage,
+        Box::new(crate::performance::Performance::select_peers_for_fetch(crate::performance::SelectPeersParams {
+            need,
+            max_peers,
+            now,
+        })),
     ))
 }
 

--- a/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
@@ -18,20 +18,25 @@ use amaru_kernel::{BlockHeight, IsHeader, Peer};
 use amaru_ouroboros_traits::MissingBlocks;
 use amaru_protocols::manager::ManagerMessage;
 use amaru_pure_stage::{
-    Instant, ScheduleIds, assert_trace_contains, tm_add_stage, trace_buffer::TerminationReason,
-    trace_match::tm_wire_stage_state,
+    Instant, ScheduleIds, assert_trace_contains, simulation::running::OverrideResult, tm_add_stage,
+    trace_buffer::TerminationReason, trace_match::tm_wire_stage_state,
 };
 use tracing::Level;
 
 use super::*;
-use crate::stages::{
-    fetch_blocks::test_setup::{
-        TestPrep, make_block_header, setup, te_ancestors_between, te_cancel_schedule, te_clock, te_find_missing_blocks,
-        te_has_block, te_load_header, te_record_block_delivery, te_record_blocks_requested, te_record_fetch_failure,
-        te_schedule, te_store_block, test_peer, test_prep,
-    },
-    test_utils::{
-        assert_trace, start_in_era, te_clock_read, te_input, te_send, te_state, te_terminate, te_terminated, tm_state,
+use crate::{
+    performance::FetchPeerSet,
+    stages::{
+        fetch_blocks::test_setup::{
+            TestPrep, make_block_header, setup, setup_with_overrides, te_ancestors_between, te_cancel_schedule,
+            te_clock, te_find_missing_blocks, te_has_block, te_load_header, te_record_block_delivery,
+            te_record_blocks_requested, te_record_fetch_failure, te_schedule, te_select_peers_for_fetch,
+            te_store_block, test_peer, test_prep,
+        },
+        test_utils::{
+            assert_trace, start_in_era, te_clock_read, te_input, te_send, te_state, te_terminate, te_terminated,
+            tm_state,
+        },
     },
 };
 
@@ -179,6 +184,7 @@ fn test_recover_stored_blocks_fetches_the_whole_gap_after_the_replayed_prefix() 
             // The tail of the replay path is the batch to fetch, so no second search of the store.
             te_has_block("fb-1", prep.headers.h2.hash()),
             te_clock_read("fb-1"),
+            te_select_peers_for_fetch("fb-1", vec![prep.headers.h2.hash(), h3.hash()], 3, requested_at),
             te_send(
                 "fb-1",
                 "manager",
@@ -187,6 +193,7 @@ fn test_recover_stored_blocks_fetches_the_whole_gap_after_the_replayed_prefix() 
                     through: h3.point(),
                     id: 1,
                     cr: prep.cleanup_replies.clone(),
+                    peers: None,
                 },
             ),
             te_record_blocks_requested("fb-1", vec![prep.headers.h2.hash(), h3.hash()], requested_at),
@@ -209,6 +216,7 @@ fn test_recover_stored_blocks_fetches_the_whole_gap_after_the_replayed_prefix() 
     logs.assert_and_remove(Level::DEBUG, &["recovering stored blocks"])
         .assert_and_remove(Level::DEBUG, &["validating stored block"])
         .assert_and_remove(Level::DEBUG, &["requesting blocks"])
+        .assert_and_remove(Level::DEBUG, &["no covering peers selected"])
         .assert_and_remove(Level::WARN, &["timeout fetching blocks"])
         .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
@@ -252,6 +260,7 @@ fn test_new_tip_blocks_to_fetch() {
             te_input("fb-1", &msg),
             te_find_missing_blocks("fb-1", tip.hash(), 25),
             te_clock_read("fb-1"),
+            te_select_peers_for_fetch("fb-1", vec![prep.headers.h1.hash(), prep.headers.h2.hash()], 3, requested_at),
             te_send(
                 "fb-1",
                 "manager",
@@ -260,6 +269,7 @@ fn test_new_tip_blocks_to_fetch() {
                     through: prep.headers.h2.point(),
                     id: 1,
                     cr: prep.cleanup_replies.clone(),
+                    peers: None,
                 },
             ),
             te_record_blocks_requested("fb-1", vec![prep.headers.h1.hash(), prep.headers.h2.hash()], requested_at),
@@ -272,6 +282,7 @@ fn test_new_tip_blocks_to_fetch() {
         ],
     );
     logs.assert_and_remove(Level::DEBUG, &["requesting blocks"])
+        .assert_and_remove(Level::DEBUG, &["no covering peers selected"])
         .assert_and_remove(Level::WARN, &["timeout fetching blocks"])
         .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
@@ -298,6 +309,7 @@ fn test_block_received() {
     let expected = {
         let mut state = prep.state.clone();
         state.missing = Some(MissingBlocks::new(prep.headers.h1.point(), vec![prep.headers.h2.point()]));
+        state.fetch_contributors.insert(test_peer());
         state
     };
     let raw = TestPrep::raw_block(&prep.headers.h1);
@@ -520,6 +532,7 @@ fn test_timeout_records_fetch_failure_for_asked_peers() {
         state.trace_context = None;
         state.fetch_started_at = None;
         state.fetch_peers.clear();
+        state.fetch_contributors.clear();
         state
     };
     assert_trace_contains(
@@ -530,6 +543,107 @@ fn test_timeout_records_fetch_failure_for_asked_peers() {
             te_record_fetch_failure("fb-1", vec![peer], failed_at).into(),
             te_send("fb-1", "upstream", SelectChainMsg::fetch_next_from(prep.headers.h0.point())).into(),
             te_state("fb-1", &expected).into(),
+        ],
+    );
+    logs.assert_and_remove(Level::WARN, &["timeout fetching blocks"]).assert_no_remaining_at([
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
+}
+
+#[test]
+fn test_strong_selection_passes_peers_to_manager() {
+    use std::collections::BTreeSet;
+
+    use crate::performance::SelectPeersForFetchEffect;
+
+    let prep = test_prep();
+    prep.store_headers(&[&prep.headers.h0, &prep.headers.h1, &prep.headers.h2]);
+    prep.set_anchor(prep.headers.h0.hash());
+
+    let selected = Peer::new("alice");
+    let tip = prep.headers.h2.tip();
+    let parent = prep.headers.h1.point();
+    let msg = FetchBlocksMsg::new_tip(tip, parent);
+    let selected_clone = selected.clone();
+    let (running, _guards, mut logs) = setup_with_overrides(&prep, [msg.clone()], move |running| {
+        running.override_external_effect::<SelectPeersForFetchEffect>(usize::MAX, move |_| {
+            OverrideResult::handled(FetchPeerSet { peers: vec![selected_clone.clone()], weak: false })
+        });
+    });
+
+    let requested_at = Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time);
+    assert_trace_contains(
+        &running,
+        &[
+            te_input("fb-1", &msg).into(),
+            te_find_missing_blocks("fb-1", tip.hash(), 25).into(),
+            te_clock_read("fb-1").into(),
+            te_select_peers_for_fetch("fb-1", vec![prep.headers.h1.hash(), prep.headers.h2.hash()], 3, requested_at)
+                .into(),
+            te_send(
+                "fb-1",
+                "manager",
+                ManagerMessage::FetchBlocks {
+                    from: prep.headers.h1.point(),
+                    through: prep.headers.h2.point(),
+                    id: 1,
+                    cr: prep.cleanup_replies.clone(),
+                    peers: Some(vec![selected]),
+                },
+            )
+            .into(),
+            te_record_blocks_requested("fb-1", vec![prep.headers.h1.hash(), prep.headers.h2.hash()], requested_at)
+                .into(),
+            // fetch_peers is filled only by PeersAsked, not by selection prefill.
+            te_state_match_fetch_peers(&BTreeSet::new()),
+        ],
+    );
+    // Sim advances the 5s timeout after the request; ignore that tail.
+    logs.assert_and_remove(Level::DEBUG, &["requesting blocks"])
+        .assert_and_remove(Level::WARN, &["timeout fetching blocks"])
+        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+fn te_state_match_fetch_peers(
+    expected: &std::collections::BTreeSet<Peer>,
+) -> amaru_pure_stage::trace_match::TraceMatch<'static> {
+    let expected = expected.clone();
+    tm_state("fb-1", move |s: &FetchBlocks| s.fetch_peers == expected, "state with selected fetch_peers")
+}
+
+#[test]
+fn test_timeout_skips_fetch_failure_for_contributors() {
+    use std::collections::BTreeSet;
+
+    let mut prep = test_prep();
+    let schedule_id = prep.schedule_at(Duration::from_secs(5));
+    let good = test_peer();
+    let bad = Peer::new("silent");
+    prep.state = {
+        let mut state = prep.state_with_request(
+            MissingBlocks::new(prep.headers.h0.point(), vec![prep.headers.h1.point()]),
+            1,
+            schedule_id,
+        );
+        state.fetch_peers = BTreeSet::from([good.clone(), bad.clone()]);
+        state.fetch_contributors = BTreeSet::from([good]);
+        state.fetch_started_at = Some(Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time));
+        state.trace_context = Some(Default::default());
+        state
+    };
+
+    let msg = FetchBlocksMsg::Timeout(1);
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    let failed_at = Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time);
+    assert_trace_contains(
+        &running,
+        &[
+            te_input("fb-1", &msg).into(),
+            te_clock_read("fb-1").into(),
+            te_record_fetch_failure("fb-1", vec![bad], failed_at).into(),
+            te_send("fb-1", "upstream", SelectChainMsg::fetch_next_from(prep.headers.h0.point())).into(),
         ],
     );
     logs.assert_and_remove(Level::WARN, &["timeout fetching blocks"]).assert_no_remaining_at([

--- a/crates/amaru-protocols/src/manager/mod.rs
+++ b/crates/amaru-protocols/src/manager/mod.rs
@@ -72,8 +72,11 @@ pub enum ManagerMessage {
     Disconnect(Peer, ConnectionId),
     /// Start listening for incoming connections on the given socket address.
     Listen(SocketAddr),
-    /// Fetch all blocks on the given chain fragment
-    FetchBlocks { from: Point, through: Point, cr: StageRef<Blocks>, id: u64 },
+    /// Fetch blocks on the given chain fragment.
+    ///
+    /// When `peers` is `Some`, only those peers' initiating connections are asked.
+    /// When `None`, every initiating connection is asked (cold-start / empty-selection fallback).
+    FetchBlocks { from: Point, through: Point, cr: StageRef<Blocks>, id: u64, peers: Option<Vec<Peer>> },
     /// Advertise this new tip to all downstream peers.
     NewTip(Tip, TraceContext),
     /// INTERNAL message sent by the connector stage after a connection attempt completes.
@@ -576,23 +579,37 @@ impl Manager {
         through: Point,
         cr: StageRef<Blocks>,
         id: u64,
+        peers: Option<Vec<Peer>>,
         eff: &Effects<ManagerMessage>,
     ) {
-        tracing::debug!(?from, ?through, "fetching blocks");
-        let mut peers = Vec::new();
-        for conn in self.connections.values() {
-            if !conn.may_initiate {
-                continue;
+        tracing::debug!(?from, ?through, ?peers, "fetching blocks");
+        let mut contacted = Vec::new();
+        match peers {
+            None => {
+                for conn in self.connections.values() {
+                    if !conn.may_initiate {
+                        continue;
+                    }
+                    contacted.push(conn.peer.clone());
+                    eff.send(&conn.stage, ConnectionMessage::FetchBlocks { from, through, cr: cr.clone(), id }).await;
+                }
             }
-            peers.push(conn.peer.clone());
-            eff.send(&conn.stage, ConnectionMessage::FetchBlocks { from, through, cr: cr.clone(), id }).await;
+            Some(wanted) => {
+                for peer in wanted {
+                    let Some(conn) = self.connections.values().find(|c| c.may_initiate && c.peer == peer) else {
+                        continue;
+                    };
+                    contacted.push(peer);
+                    eff.send(&conn.stage, ConnectionMessage::FetchBlocks { from, through, cr: cr.clone(), id }).await;
+                }
+            }
         }
-        if peers.is_empty() {
+        if contacted.is_empty() {
             tracing::debug!(%id, "no connections available to fetch blocks");
             eff.send(&cr, Blocks::NoPeersAvailable(id)).await;
         } else {
-            tracing::debug!(%id, sent = peers.len(), "fetch blocks request sent to connections");
-            eff.send(&cr, Blocks::PeersAsked(id, peers)).await;
+            tracing::debug!(%id, sent = contacted.len(), "fetch blocks request sent to connections");
+            eff.send(&cr, Blocks::PeersAsked(id, contacted)).await;
         }
     }
 }
@@ -650,8 +667,8 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
                     eff.send(&conn.stage, ConnectionMessage::NewTip(tip, trace_context.clone())).await;
                 }
             }
-            ManagerMessage::FetchBlocks { from, through, cr, id } => {
-                manager.fetch_blocks(from, through, cr, id, &eff).await;
+            ManagerMessage::FetchBlocks { from, through, cr, id, peers } => {
+                manager.fetch_blocks(from, through, cr, id, peers, &eff).await;
             }
             ManagerMessage::ConnectionResult(peer, conn_id) => {
                 manager.connection_result(peer, conn_id, &eff).await;

--- a/crates/amaru-protocols/src/tests/chainsync_stage.rs
+++ b/crates/amaru-protocols/src/tests/chainsync_stage.rs
@@ -113,7 +113,13 @@ async fn start_next_fetch(state: &mut StoreFetchedBlocks, eff: &Effects<StoreFet
     state.current = Some(PendingFetch { id, remaining_points: batch.expected_points, handler: batch.handler });
     eff.send(
         &state.manager,
-        ManagerMessage::FetchBlocks { from: batch.from, through: batch.through, cr: state.blocks.clone(), id },
+        ManagerMessage::FetchBlocks {
+            from: batch.from,
+            through: batch.through,
+            cr: state.blocks.clone(),
+            id,
+            peers: None,
+        },
     )
     .await;
 }


### PR DESCRIPTION
Use the Performance resource to select upstream peers for fetching blocks.

fixes #1093

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Block fetching can now select up to three high-performing peers for each request.
  * Requests fall back to all eligible connections when peer selection is unavailable or insufficient.

* **Bug Fixes**
  * Improved timeout handling by avoiding failure attribution to peers that successfully contributed blocks.
  * Enhanced tracking of contacted and contributing peers during block retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->