### PR TITLE
prune performance tracking when no longer relevant

### DIFF
--- a/crates/amaru-consensus/src/performance/effects.rs
+++ b/crates/amaru-consensus/src/performance/effects.rs
@@ -115,8 +115,8 @@ impl Performance {
         ForgetPeerEffect { peer }
     }
 
-    pub fn prune_below(min_height: BlockHeight) -> PruneBelowEffect {
-        PruneBelowEffect { min_height }
+    pub fn prune_below(min_height: BlockHeight, now: Instant) -> PruneBelowEffect {
+        PruneBelowEffect { min_height, now }
     }
 
     pub fn select_peers_for_fetch(params: SelectPeersParams) -> SelectPeersForFetchEffect {
@@ -346,13 +346,15 @@ impl ExternalEffectAPI for ForgetPeerEffect {
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PruneBelowEffect {
     pub(crate) min_height: BlockHeight,
+    pub(crate) now: Instant,
 }
 
 impl ExternalEffect for PruneBelowEffect {
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
         Self::wrap_sync({
             let perf = require_perf(&resources);
-            enqueue(&perf, PerformanceOp::PruneBelow { effect: *self });
+            let meter = optional_meter(&resources);
+            enqueue(&perf, PerformanceOp::PruneBelow { effect: *self, meter });
         })
     }
 }

--- a/crates/amaru-consensus/src/performance/header.rs
+++ b/crates/amaru-consensus/src/performance/header.rs
@@ -16,7 +16,7 @@
 
 use std::collections::BTreeMap;
 
-use amaru_kernel::{HeaderHash, Peer, Tip};
+use amaru_kernel::{BlockHeight, HeaderHash, Peer, Tip};
 use amaru_metrics::{Meter, MetricRecorder, consensus::ConsensusMetrics};
 use amaru_observability::debug;
 use amaru_pure_stage::Instant;
@@ -56,6 +56,8 @@ struct HeaderLifecycle {
     peer: Peer,
     /// Interval from virtual slot start to header reception, computed by the announcing stage.
     slot_start_to_header_micros: u64,
+    /// Block height of the header (for immutable-horizon pruning).
+    height: BlockHeight,
     /// Time when the header was first received from an upstream peer.
     received_at: Instant,
     /// Time when its block was first requested, if it was requested.
@@ -65,8 +67,8 @@ struct HeaderLifecycle {
 }
 
 impl HeaderLifecycle {
-    fn new(peer: Peer, slot_start_to_header_micros: u64, received_at: Instant) -> Self {
-        Self { peer, slot_start_to_header_micros, received_at, requested_at: None, downloaded_at: None }
+    fn new(peer: Peer, slot_start_to_header_micros: u64, height: BlockHeight, received_at: Instant) -> Self {
+        Self { peer, slot_start_to_header_micros, height, received_at, requested_at: None, downloaded_at: None }
     }
 }
 
@@ -159,9 +161,21 @@ impl HeaderPerformance {
         received_at: Instant,
         slot_start_to_header_micros: u64,
     ) {
-        self.lifecycles
-            .entry(tip.hash())
-            .or_insert_with(|| HeaderLifecycle::new(peer, slot_start_to_header_micros, received_at));
+        self.lifecycles.entry(tip.hash()).or_insert_with(|| {
+            HeaderLifecycle::new(peer, slot_start_to_header_micros, tip.block_height(), received_at)
+        });
+    }
+
+    /// Close open lifecycles (and any matching fork switch) for headers that have fallen behind
+    /// the immutable horizon (`height < min_height`). Emits `HeaderLifecycleOutcome::Pruned`.
+    pub fn apply_prune_below(&mut self, min_height: BlockHeight, now: Instant, meter: Option<&Meter>) {
+        let to_prune: Vec<HeaderHash> =
+            self.lifecycles.iter().filter(|(_, lc)| lc.height < min_height).map(|(h, _)| *h).collect();
+        for hash in to_prune {
+            // Not a sync-path decision; always include the slot-start interval when available.
+            self.emit_lifecycle(&hash, HeaderLifecycleOutcome::Pruned, now, false, meter);
+            self.close_fork(&hash, ForkSwitchOutcome::AbandonedBlock, now, meter);
+        }
     }
 
     /// The fetch stage requested the blocks for these headers: record their request time.

--- a/crates/amaru-consensus/src/performance/mod.rs
+++ b/crates/amaru-consensus/src/performance/mod.rs
@@ -136,7 +136,7 @@ pub(crate) enum PerformanceOp {
     RecordKeepaliveRtt { effect: RecordKeepaliveRttEffect },
     ClearPeerAvailability { effect: ClearPeerAvailabilityEffect },
     ForgetPeer { effect: ForgetPeerEffect },
-    PruneBelow { effect: PruneBelowEffect },
+    PruneBelow { effect: PruneBelowEffect, meter: Option<Arc<Meter>> },
     SelectPeersForFetch { effect: SelectPeersForFetchEffect, reply: oneshot::Sender<FetchPeerSet> },
     PeerCoversFragment { effect: PeerCoversFragmentEffect, reply: oneshot::Sender<bool> },
     DirectClaimants { effect: DirectClaimantsEffect, reply: oneshot::Sender<Vec<(Peer, Instant, ClaimKind)>> },
@@ -281,8 +281,9 @@ fn dispatch(peers: &mut PeerPerformance, headers: &mut HeaderPerformance, op: Pe
         PerformanceOp::ForgetPeer { effect } => {
             peers.apply_forget_peer(&effect.peer);
         }
-        PerformanceOp::PruneBelow { effect } => {
+        PerformanceOp::PruneBelow { effect, meter } => {
             peers.apply_prune_below(effect.min_height);
+            headers.apply_prune_below(effect.min_height, effect.now, meter.as_deref());
         }
         PerformanceOp::SelectPeersForFetch { effect, reply } => {
             let result = peers.apply_select_peers_for_fetch(effect.params);

--- a/crates/amaru-consensus/src/performance/tests.rs
+++ b/crates/amaru-consensus/src/performance/tests.rs
@@ -440,6 +440,18 @@ fn slot_start_metric_omitted_while_syncing() {
     assert_eq!(headers.lifecycle_count(), 0);
 }
 
+#[test]
+fn prune_below_closes_open_lifecycles_as_pruned() {
+    let mut headers = HeaderPerformance::new();
+    headers.apply_header_received(peer("alice"), tip(1, 1), t(1), 0);
+    headers.apply_header_received(peer("alice"), tip(5, 5), t(2), 0);
+    assert_eq!(headers.lifecycle_count(), 2);
+    headers.apply_prune_below(BlockHeight::from(5), t(3), None);
+    assert_eq!(headers.lifecycle_count(), 1);
+    headers.apply_prune_below(BlockHeight::from(6), t(4), None);
+    assert_eq!(headers.lifecycle_count(), 0);
+}
+
 // ---------------------------------------------------------------------------
 // Resource handle + external effects (smoke)
 // ---------------------------------------------------------------------------

--- a/crates/amaru-consensus/src/stages/adopt_chain/mod.rs
+++ b/crates/amaru-consensus/src/stages/adopt_chain/mod.rs
@@ -22,7 +22,10 @@ use amaru_protocols::{manager::ManagerMessage, store_effects::Store};
 use amaru_pure_stage::{Effects, Instant, OrTerminateWith, StageRef};
 use tracing::Instrument;
 
-use crate::stages::{block_source::BlockSourceMsg, select_chain::cmp_tip};
+use crate::{
+    performance::Performance,
+    stages::{block_source::BlockSourceMsg, select_chain::cmp_tip},
+};
 
 /// The AdoptChain stage decides whether (and how) to adopt a newly validated
 /// chain tip as the node's new best chain, updating the persistent chain store
@@ -50,6 +53,9 @@ use crate::stages::{block_source::BlockSourceMsg, select_chain::cmp_tip};
 ///   2. `ManagerMessage::NewTip(tip)` — to the downstream manager/peer layer.
 ///   3. `BlockSourceMsg::AdoptedTip(tip)` — to block_source (so it can adjust
 ///      its tip distance / fetch window for the newly adopted chain).
+/// - During `drag_anchor_forward`: `Performance::prune_below(tip.height - k, now)` so
+///   peer availability claims and open header lifecycles below the immutable horizon are dropped
+///   (header entries emit `HeaderLifecycleOutcome::Pruned`).
 /// - Finally, `current_best_tip` is updated in the returned state.
 ///
 /// Early exits (no adoption, no sends, no anchor drag, no logging of "adopted"):
@@ -203,14 +209,13 @@ pub async fn stage(mut state: AdoptChain, msg: AdoptChainMsg, eff: Effects<Adopt
                 .await;
         }
 
-        drag_anchor_forward(&store, &msg, state.consensus_security_param)
+        let now = drag_anchor_forward(&store, &msg, state.consensus_security_param, &eff)
             .or_terminate_with(&eff, async |error| {
                 tracing::error!(error = %error, tip = %msg, "failed to drag anchor forward");
             })
             .await;
 
         // do not print every single block while catching up
-        let now = eff.clock().await;
         if now.saturating_since(state.last_printed) >= Duration::from_secs(1) {
             info!(
                 consensus::tip::ADOPT,
@@ -273,12 +278,23 @@ enum AdoptTipResult {
 /// blocks behind the adopted tip. The walk along the best chain runs in a single
 /// store effect against a consistent snapshot; only the resulting anchor write
 /// is a separate effect. Only moves the anchor forward, never backward.
-async fn drag_anchor_forward(store: &Store, tip: &Tip, consensus_security_param: u64) -> Result<(), StoreError> {
+///
+/// After the anchor update (if any), prunes performance maps at the immutable horizon
+/// (`tip.height - k`): peer claims below that height, and open header lifecycles as `Pruned`.
+/// Returns the clock reading used for that prune (also suitable for adoption logging).
+async fn drag_anchor_forward(
+    store: &Store,
+    tip: &Tip,
+    consensus_security_param: u64,
+    eff: &Effects<AdoptChainMsg>,
+) -> Result<Instant, StoreError> {
     let target_height = tip.block_height() - consensus_security_param;
     if let Some(new_anchor) = store.find_anchor_at_height(target_height).await {
         store.set_anchor_hash(&new_anchor).await?;
     }
-    Ok(())
+    let now = eff.clock().await;
+    eff.external(Performance::prune_below(target_height, now)).await;
+    Ok(now)
 }
 
 #[cfg(test)]

--- a/crates/amaru-consensus/src/stages/adopt_chain/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/adopt_chain/test_setup.rs
@@ -142,9 +142,17 @@ pub fn register_guards() -> DeserializerGuards {
         amaru_pure_stage::register_effect_deserializer::<NextBestChainEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<FindAncestorOnBestChainEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<FindAnchorAtHeightEffect>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<crate::performance::PruneBelowEffect>().boxed(),
         amaru_pure_stage::register_data_deserializer::<Option<(Point, NonEmptyVec<Point>)>>().boxed(),
         amaru_pure_stage::register_data_deserializer::<Option<HeaderHash>>().boxed(),
     ]
+}
+
+pub fn te_prune_below(at_stage: &str, min_height: BlockHeight, now: amaru_pure_stage::Instant) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(
+        at_stage,
+        Box::new(crate::performance::Performance::prune_below(min_height, now)),
+    ))
 }
 
 pub fn test_prep(consensus_security_param: u64) -> TestPrep {
@@ -177,6 +185,9 @@ pub fn setup(prep: &TestPrep, msg: AdoptChainMsg) -> (SimulationRunning, Deseria
     // No global_epoch_offset: adopt_chain only needs relative sim time for the 1s log throttle.
     let mut network = SimulationBuilder::default().with_trace_buffer(TraceBuffer::new_shared(100, 1000000));
     network.resources().put::<ResourceHeaderStore>(prep.store.clone());
+    network
+        .resources()
+        .put::<crate::performance::ResourcePerformance>(std::sync::Arc::new(crate::performance::Performance::new()));
 
     let ac = network.stage("ac", stage);
     let ac = network.wire_up(ac, prep.state.clone());

--- a/crates/amaru-consensus/src/stages/adopt_chain/tests.rs
+++ b/crates/amaru-consensus/src/stages/adopt_chain/tests.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
+
 use amaru_kernel::{HeaderHash, NonEmptyVec, ORIGIN_HASH};
 use amaru_ouroboros::MempoolMsg;
 use amaru_ouroboros_traits::BaseReadChainStore;
-use amaru_pure_stage::trace_buffer::TerminationReason;
+use amaru_pure_stage::{Instant, trace_buffer::TerminationReason};
 use test_setup::{
     assert_trace, setup, te_find_ancestor_on_best_chain, te_load_header, te_terminate, te_terminated, test_prep,
 };
@@ -24,10 +26,15 @@ use tracing::Level;
 use super::*;
 use crate::stages::{
     adopt_chain::test_setup::{
-        te_clock, te_find_anchor_at_height, te_roll_forward_chain, te_send, te_set_anchor_hash, te_switch_to_fork,
+        te_clock, te_find_anchor_at_height, te_prune_below, te_roll_forward_chain, te_send, te_set_anchor_hash,
+        te_switch_to_fork,
     },
     test_utils::{te_input, te_state},
 };
+
+fn sim_clock() -> Instant {
+    Instant::at_offset(Duration::ZERO, Duration::ZERO)
+}
 
 /// Incoming tip not in store -> terminate.
 #[test]
@@ -136,6 +143,7 @@ fn test_extension_adopts_and_sends() {
             te_find_anchor_at_height("ac-1", BlockHeight::new(2)),
             te_set_anchor_hash("ac-1", prep.headers.h1.hash()),
             te_clock("ac-1"),
+            te_prune_below("ac-1", tip.block_height() - 2, sim_clock()),
             te_send("ac-1", "mempool", MempoolMsg::NewTip(tip)),
             te_send("ac-1", "downstream", ManagerMessage::new_tip(tip)),
             te_send("ac-1", "block_source", BlockSourceMsg::AdoptedTip(tip)),
@@ -187,6 +195,7 @@ fn test_fork_switch_adopts_and_sends() {
             te_find_anchor_at_height("ac-1", BlockHeight::new(2)),
             te_set_anchor_hash("ac-1", prep.headers.h1.hash()),
             te_clock("ac-1"),
+            te_prune_below("ac-1", tip.block_height() - 2, sim_clock()),
             te_send("ac-1", "mempool", MempoolMsg::NewTip(tip)),
             te_send("ac-1", "downstream", ManagerMessage::new_tip(tip)),
             te_send("ac-1", "block_source", BlockSourceMsg::AdoptedTip(tip)),
@@ -231,6 +240,7 @@ fn test_fork_switch_opcert_hacked() {
             te_switch_to_fork("ac-1", prep.headers.h1.point(), NonEmptyVec::singleton(prep.headers.h2.point())),
             te_find_anchor_at_height("ac-1", BlockHeight::new(1)),
             te_clock("ac-1"),
+            te_prune_below("ac-1", tip.block_height() - 2, sim_clock()),
             te_send("ac-1", "mempool", MempoolMsg::NewTip(tip)),
             te_send("ac-1", "downstream", ManagerMessage::new_tip(tip)),
             te_send("ac-1", "block_source", BlockSourceMsg::AdoptedTip(tip)),

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -26,7 +26,10 @@ use amaru_pure_stage::{Effects, Instant, ScheduleId, StageRef};
 use rand::{SeedableRng, rngs::StdRng, seq::IteratorRandom};
 use tracing::Instrument;
 
-use crate::effects::{GenerateRandomSeed, Ledger, LedgerOps};
+use crate::{
+    effects::{GenerateRandomSeed, Ledger, LedgerOps},
+    performance::Performance,
+};
 
 const STATIC_PEER_BAN_PERIOD: Duration = Duration::from_secs(10);
 
@@ -292,8 +295,15 @@ impl PeerSelection {
 }
 
 impl PeerSelection {
+    /// Whether this peer still has a usable connection (inbound or established outbound).
+    fn peer_still_connected(&self, peer: &Peer) -> bool {
+        self.inbound_peers.contains_key(peer) || matches!(self.outbound_peers.get(peer), Some(PeerState::Connected(_)))
+    }
+
     async fn ban_peer(&mut self, peer: Peer, eff: &Effects<PeerSelectionMsg>) {
         let is_static = self.static_peers.contains(&peer);
+
+        eff.external(Performance::forget_peer(peer.clone())).await;
 
         let mut send_remove = false;
         if let Some(peer_state) = self.inbound_peers.remove(&peer) {
@@ -312,6 +322,13 @@ impl PeerSelection {
         }
 
         self.cool_down(peer, eff, is_static).await;
+    }
+
+    /// Drop availability claims when a peer has no remaining live connections (scores kept).
+    async fn clear_availability_if_gone(&self, peer: &Peer, eff: &Effects<PeerSelectionMsg>) {
+        if !self.peer_still_connected(peer) {
+            eff.external(Performance::clear_peer_availability(peer.clone())).await;
+        }
     }
 
     async fn cool_down(&mut self, peer: Peer, eff: &Effects<PeerSelectionMsg>, is_static: bool) {
@@ -570,20 +587,25 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
             }
         }
         PeerSelectionMsg::Disconnected(peer, conn_id, ConnectionDirection::Inbound, _) => {
-            let _span = debug_span!(
-                amaru::protocols::peer_selection::peer::DISCONNECTED,
-                peer = &peer,
-                conn_id = conn_id.as_u64(),
-                direction = ConnectionDirection::Inbound,
-            )
-            .entered();
-            if let Entry::Occupied(entry) = state.inbound_peers.entry(peer)
-                && entry.get().id == conn_id
             {
-                entry.remove();
+                let _span = debug_span!(
+                    amaru::protocols::peer_selection::peer::DISCONNECTED,
+                    peer = &peer,
+                    conn_id = conn_id.as_u64(),
+                    direction = ConnectionDirection::Inbound,
+                )
+                .entered();
+                if let Entry::Occupied(entry) = state.inbound_peers.entry(peer.clone())
+                    && entry.get().id == conn_id
+                {
+                    entry.remove();
+                }
             }
+            state.clear_availability_if_gone(&peer, &eff).await;
         }
-        PeerSelectionMsg::Disconnected(_, _, ConnectionDirection::Outbound, will_retry) if will_retry => {}
+        PeerSelectionMsg::Disconnected(peer, _, ConnectionDirection::Outbound, true) => {
+            eff.external(Performance::clear_peer_availability(peer)).await;
+        }
         PeerSelectionMsg::Disconnected(peer, conn_id, ConnectionDirection::Outbound, _) => {
             if let Entry::Occupied(entry) = state.outbound_peers.entry(peer.clone())
                 && let PeerState::Connected(conn) = entry.get()
@@ -591,18 +613,20 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
             {
                 let span = debug_span!(
                     amaru::protocols::peer_selection::peer::DISCONNECTED,
-                    peer = peer,
+                    peer = peer.clone(),
                     conn_id = conn_id.as_u64(),
                     direction = ConnectionDirection::Outbound,
                 )
                 .entered();
                 entry.remove();
                 drop(span);
+                state.clear_availability_if_gone(&peer, &eff).await;
                 state.regulate_peers(&eff).await;
             }
         }
         PeerSelectionMsg::ConnectFailed(peer) => {
             state.outbound_peers.remove(&peer);
+            state.clear_availability_if_gone(&peer, &eff).await;
             state.regulate_peers(&eff).await;
         }
         PeerSelectionMsg::LedgerCheckCandidates(candidates) => {

--- a/crates/amaru-consensus/src/stages/peer_selection/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/test_setup.rs
@@ -128,7 +128,20 @@ pub fn register_guards() -> DeserializerGuards {
         amaru_pure_stage::register_data_deserializer::<ManagerMessage>().boxed(),
         amaru_pure_stage::register_data_deserializer::<ScheduleId>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<GenerateRandomSeed>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<crate::performance::ClearPeerAvailabilityEffect>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<crate::performance::ForgetPeerEffect>().boxed(),
     ]
+}
+
+pub fn te_forget_peer(at_stage: &str, peer: Peer) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(at_stage, Box::new(crate::performance::Performance::forget_peer(peer))))
+}
+
+pub fn te_clear_peer_availability(at_stage: &str, peer: Peer) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(
+        at_stage,
+        Box::new(crate::performance::Performance::clear_peer_availability(peer)),
+    ))
 }
 
 pub fn setup(prep: &TestPrep, msg: PeerSelectionMsg) -> (SimulationRunning, DeserializerGuards, Logs) {
@@ -171,7 +184,11 @@ fn setup_preload_with_mode(
             network.preload(&ps, messages).unwrap();
             network
         },
-        |_resources| {},
+        |resources| {
+            resources.put::<crate::performance::ResourcePerformance>(std::sync::Arc::new(
+                crate::performance::Performance::new(),
+            ));
+        },
         |running| {
             running.use_virtual_child_stages(true);
 

--- a/crates/amaru-consensus/src/stages/peer_selection/tests.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/tests.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeSet;
 
 use amaru_ouroboros::{ConnectionDirection, ConnectionId};
 use amaru_protocols::manager::ManagerMessage;
-use amaru_pure_stage::trace_match::{assert_trace_contains, tm_send_match};
+use amaru_pure_stage::trace_match::{assert_trace_contains, assert_trace_does_not_contain, tm_send_match};
 use tracing::Level;
 
 use super::*;
@@ -27,8 +27,9 @@ use crate::stages::{
     peer_selection::test_setup::{
         TestPrep, cooldown_duration, cooldown_instant, first_schedule_id, first_static_schedule_id,
         peer_selection_stage, second_schedule_id_at, setup, setup_preload, setup_preload_until_sleeping, sim_at,
-        static_cooldown_instant, te_cancel_schedule, te_clock, te_clock_suspend, te_random_seed, te_schedule, te_send,
-        test_prep, test_prep_with_snapshot, tm_add_stage_starts_with, with_single_cooldown,
+        static_cooldown_instant, te_cancel_schedule, te_clear_peer_availability, te_clock, te_clock_suspend,
+        te_forget_peer, te_random_seed, te_schedule, te_send, test_prep, test_prep_with_snapshot,
+        tm_add_stage_starts_with, with_single_cooldown,
     },
     test_utils::{assert_trace, te_input, te_state, tm_state},
 };
@@ -249,6 +250,7 @@ fn test_add_peer_during_cooldown_cancels_timer() {
         &[
             te_state("ps-1", &state),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())),
+            te_forget_peer("ps-1", p.clone()),
             te_clock_suspend("ps-1"),
             te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid),
             te_state("ps-1", &after_ban),
@@ -284,6 +286,7 @@ fn test_adversarial_outbound_connected() {
         &[
             te_state("ps-1", &state),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())),
+            te_forget_peer("ps-1", p.clone()),
             te_clock_suspend("ps-1"),
             te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid),
             te_state("ps-1", &after),
@@ -347,6 +350,7 @@ fn test_check_cooldowns_before_due_does_not_lift_ban() {
         &[
             te_state("ps-1", &state),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())),
+            te_forget_peer("ps-1", p.clone()),
             te_clock_suspend("ps-1"),
             te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid0),
             te_state("ps-1", &after_ban),
@@ -438,7 +442,15 @@ fn test_disconnected_inbound() {
         s
     };
     let (running, _guards, mut logs) = setup_preload(&prep, [msg.clone()]);
-    assert_trace(&running, &[te_state("ps-1", &state), te_input("ps-1", &msg), te_state("ps-1", &after)]);
+    assert_trace(
+        &running,
+        &[
+            te_state("ps-1", &state),
+            te_input("ps-1", &msg),
+            te_clear_peer_availability("ps-1", p.clone()),
+            te_state("ps-1", &after),
+        ],
+    );
     logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 
@@ -451,8 +463,16 @@ fn test_disconnected_outbound_connecting_schedules_cooldown() {
     state_conn.outbound_peers.insert(p.clone(), PeerState::Connecting);
     let msg = PeerSelectionMsg::Disconnected(p.clone(), ConnectionId::initial(), ConnectionDirection::Outbound, true);
     let (running, _guards, mut logs) = setup_preload(&prep, [msg.clone()]);
-    // will_retry == true is a no-op: no cool-down, no regulation.
-    assert_trace(&running, &[te_state("ps-1", &state), te_input("ps-1", &msg), te_state("ps-1", &state)]);
+    // will_retry == true: no cool-down, no regulation; still clear availability claims.
+    assert_trace(
+        &running,
+        &[
+            te_state("ps-1", &state),
+            te_input("ps-1", &msg),
+            te_clear_peer_availability("ps-1", p.clone()),
+            te_state("ps-1", &state),
+        ],
+    );
     logs.assert_no_remaining_at([Level::WARN, Level::ERROR]);
 }
 
@@ -484,10 +504,12 @@ fn test_adversarial_twice_extends_cooldown_single_timer() {
         &[
             te_state("ps-1", &state),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())),
+            te_forget_peer("ps-1", p.clone()),
             te_clock_suspend("ps-1"),
             te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid0),
             te_state("ps-1", &after_first),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())),
+            te_forget_peer("ps-1", p.clone()),
             te_clock_suspend("ps-1"),
             te_state("ps-1", &after_second),
             te_clock(cooldown_instant()),
@@ -760,6 +782,8 @@ fn test_disconnected_outbound_peer_also_in_inbound() {
             ),
         ],
     );
+    // Still inbound ⇒ claims must not be cleared.
+    assert_trace_does_not_contain(&running, &[te_clear_peer_availability("ps-1", p).into()]);
 
     logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
@@ -836,10 +860,12 @@ fn test_second_cooldown_does_not_schedule_again() {
         &[
             te_state("ps-1", &prep.state),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p1.clone())),
+            te_forget_peer("ps-1", p1.clone()),
             te_clock_suspend("ps-1"),
             te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid),
             te_state("ps-1", &after_first),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p2.clone())),
+            te_forget_peer("ps-1", p2.clone()),
             te_clock_suspend("ps-1"),
             te_state("ps-1", &after_second),
             te_clock(cooldown_instant()),

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -493,6 +493,20 @@ impl TrackPeers {
         self.deferred.retain(|d| d.conn_id != conn_id);
     }
 
+    /// True if this peer still has an upstream session or deferred work.
+    fn peer_still_tracked(&self, peer: &Peer) -> bool {
+        self.upstream.values().any(|pp| match pp {
+            PerPeer::Connecting { peer: p } | PerPeer::Established { peer: p, .. } => p == peer,
+        }) || self.deferred.iter().any(|d| &d.peer == peer)
+    }
+
+    /// Drop availability claims when the peer has no remaining sessions (scores kept).
+    async fn clear_availability_if_gone(&self, peer: &Peer, eff: &Effects<TrackPeersMsg>) {
+        if !self.peer_still_tracked(peer) {
+            eff.external(Performance::clear_peer_availability(peer.clone())).await;
+        }
+    }
+
     /// Try to defer this header validation due to missing stake distribution.
     /// Returns true if deferred (and not adversarial).
     /// Rejects (returns false to let caller do adversarial) if the missing dist is >1 epoch ahead.
@@ -729,6 +743,7 @@ impl TrackPeers {
             Terminated => {
                 tracing::info!(%peer, %conn_id, "chainsync terminated, purging connection state");
                 self.purge_connection(conn_id);
+                self.clear_availability_if_gone(&peer, &eff).await;
             }
             IntersectFound(current, tip) => {
                 let current_tip = Store::new(eff.clone()).load_tip(&current.hash()).await;
@@ -746,6 +761,7 @@ impl TrackPeers {
                 tracing::info!(%peer, highest = %tip.point(), reason = "intersect not found", "stopping chainsync");
                 eff.send(&handler, chainsync::InitiatorMessage::Done).await;
                 self.purge_connection(conn_id);
+                self.clear_availability_if_gone(&peer, &eff).await;
             }
             RollForward(header_content, tip) => {
                 let peer_clone = peer.clone();

--- a/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
@@ -255,9 +255,17 @@ fn register_guards() -> DeserializerGuards {
         amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordHeaderRejectedEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordIntersectionEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordRollbackEffect>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<crate::performance::ClearPeerAvailabilityEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<amaru_protocols::metrics_effects::RecordMetricsEffect>()
             .boxed(),
     ]
+}
+
+pub fn te_clear_peer_availability(at_stage: &str, peer: Peer) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(
+        at_stage,
+        Box::new(crate::performance::Performance::clear_peer_availability(peer)),
+    ))
 }
 
 pub fn setup(

--- a/crates/amaru-consensus/src/stages/track_peers/tests.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/tests.rs
@@ -37,10 +37,10 @@ use crate::{
             test_setup::{
                 HEIGHT_RECHECK_INTERVAL, SIM_INITIAL_CLOCK_SECS, build_store, build_store_with_nonces,
                 height_recheck_schedule_id, make_block_header, new_tip, schedule_id_at, setup, setup_base,
-                setup_with_ledger_tip_until_sleeping, slot_start_to_header_micros, te_clock, te_clock_suspend,
-                te_get_nonces, te_load_header, te_load_tip, te_record_header_announcement, te_record_rollback,
-                te_schedule, te_store_validated_header, te_validate_header, test_prep, test_prep_with_max_peer_lead,
-                tm_volatile_tip,
+                setup_with_ledger_tip_until_sleeping, slot_start_to_header_micros, te_clear_peer_availability,
+                te_clock, te_clock_suspend, te_get_nonces, te_load_header, te_load_tip, te_record_header_announcement,
+                te_record_rollback, te_schedule, te_store_validated_header, te_validate_header, test_prep,
+                test_prep_with_max_peer_lead, tm_volatile_tip,
             },
         },
     },
@@ -143,7 +143,12 @@ fn test_terminated_purges_upstream_and_deferred() {
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
     assert_trace_contains(
         &running,
-        &[te_state("tp-1", &state).into(), te_input("tp-1", &msg).into(), te_state("tp-1", &expected).into()],
+        &[
+            te_state("tp-1", &state).into(),
+            te_input("tp-1", &msg).into(),
+            te_clear_peer_availability("tp-1", peer).into(),
+            te_state("tp-1", &expected).into(),
+        ],
     );
     logs.assert_and_remove(Level::INFO, &["chainsync terminated"]).assert_no_remaining_at([
         Level::INFO,
@@ -172,13 +177,15 @@ fn test_terminated_only_purges_matching_connection() {
     });
 
     let mut expected = prep.state.clone();
-    expected.insert_peer(peer, conn_b, prep.headers[0].tip(), prep.headers[0].tip());
+    expected.insert_peer(peer.clone(), conn_b, prep.headers[0].tip(), prep.headers[0].tip());
 
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
     assert_trace_contains(
         &running,
         &[te_state("tp-1", &state).into(), te_input("tp-1", &msg).into(), te_state("tp-1", &expected).into()],
     );
+    // Other connection still tracked for this peer ⇒ no clear_peer_availability.
+    assert_trace_does_not_contain(&running, &[te_clear_peer_availability("tp-1", peer).into()]);
     logs.assert_and_remove(Level::INFO, &["chainsync terminated"]).assert_no_remaining_at([
         Level::INFO,
         Level::WARN,


### PR DESCRIPTION
- peers are removed when banned
- headers for which blocks are not fetched are pruned when older than
  anchor

Skip-changelog

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>