### PR TITLE
feat: added simple script to test e2e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Other guiding principles:
 
 ## v10.11.20260806 _[unreleased; planned for 2026-08-06]_
 
+### Added
+
+- **amaru**: add `amaru node rm --wipe-all-dbs` to remove the ledger and chain databases resolved from the selected network.
+
 ### Changed
 
 - **amaru-consensus**: skip the validation of headers whose evolved nonces are already stored, to avoid unnecessary rechecks when getting the same header from different peers. ([#1087][])

--- a/crates/amaru/src/bin/amaru/cmd/node/mod.rs
+++ b/crates/amaru/src/bin/amaru/cmd/node/mod.rs
@@ -16,6 +16,7 @@ use amaru::lifecycle::Runnable;
 use clap::Subcommand;
 
 pub(crate) mod bootstrap;
+pub(crate) mod rm;
 pub(crate) mod run;
 
 #[derive(Debug, Subcommand)]
@@ -35,6 +36,9 @@ pub(crate) enum NodeCommand {
     /// It imports snapshots, bootstrap headers and bootstrap nonces in one step.
     #[clap(verbatim_doc_comment)]
     Bootstrap(bootstrap::Args),
+
+    /// Remove the node's ledger and chain databases.
+    Rm(rm::Args),
 }
 
 impl NodeCommand {
@@ -42,6 +46,7 @@ impl NodeCommand {
         match self {
             Self::Run(args) => run::runnable(args),
             Self::Bootstrap(args) => bootstrap::runnable(args),
+            Self::Rm(args) => rm::runnable(args),
         }
     }
 }

--- a/crates/amaru/src/bin/amaru/cmd/node/rm.rs
+++ b/crates/amaru/src/bin/amaru/cmd/node/rm.rs
@@ -1,0 +1,93 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    error::Error,
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use amaru::{
+    default_chain_dir, default_ledger_dir,
+    lifecycle::{Runnable, RuntimeKind},
+};
+use amaru_kernel::NetworkName;
+use clap::Parser;
+use tracing::info;
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    /// Confirm removal of all node databases.
+    #[arg(long, required = true)]
+    wipe_all_dbs: bool,
+
+    /// Path of the chain on-disk storage.
+    #[arg(
+        long,
+        value_name = amaru::value_names::DIRECTORY,
+        env = amaru::env_vars::CHAIN_DIR,
+    )]
+    chain_dir: Option<PathBuf>,
+
+    /// Path of the ledger on-disk storage.
+    #[arg(
+        long,
+        value_name = amaru::value_names::DIRECTORY,
+        env = amaru::env_vars::LEDGER_DIR,
+    )]
+    ledger_dir: Option<PathBuf>,
+
+    /// Network whose node databases should be removed.
+    #[arg(
+        long,
+        value_name = amaru::value_names::NETWORK,
+        env = amaru::env_vars::NETWORK,
+    )]
+    network: NetworkName,
+}
+
+pub(crate) fn runnable(args: Args) -> Runnable {
+    Runnable::exit_on_signal(RuntimeKind::Simple, move || run(args))
+}
+
+async fn run(args: Args) -> Result<(), Box<dyn Error>> {
+    let Args { wipe_all_dbs, chain_dir, ledger_dir, network } = args;
+    if !wipe_all_dbs {
+        return Err("refusing to remove node databases without --wipe-all-dbs".into());
+    }
+
+    let ledger_dir = ledger_dir.unwrap_or_else(|| default_ledger_dir(network).into());
+    let chain_dir = chain_dir.unwrap_or_else(|| default_chain_dir(network).into());
+
+    info!(
+        _command = "node rm",
+        chain_dir = %chain_dir.display(),
+        ledger_dir = %ledger_dir.display(),
+        network = %network,
+        "running",
+    );
+
+    remove_database(&ledger_dir)?;
+    remove_database(&chain_dir)?;
+
+    Ok(())
+}
+
+fn remove_database(path: &Path) -> Result<(), io::Error> {
+    match fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(io::Error::new(err.kind(), format!("failed to remove {}: {err}", path.display()))),
+    }
+}

--- a/crates/amaru/tests/conformance/stake-distributions/Makefile
+++ b/crates/amaru/tests/conformance/stake-distributions/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help zst unzst list download upload check-aws-env check-network-dir
+.PHONY: help zst unzst list download upload check-env check-aws-env check-network-dir
 
 THIS_MAKEFILE := $(lastword $(MAKEFILE_LIST))
 
@@ -6,6 +6,8 @@ NETWORKS := preview preprod mainnet
 NETWORK := $(notdir $(CURDIR))
 IS_NETWORK_DIR := $(filter $(NETWORK),$(NETWORKS))
 BUCKET := cardano-stake-distributions/$(NETWORK)
+DEFAULT_ENDPOINT := https://bd7a351a104d485dcc8b921c273db90c.r2.cloudflarestorage.com
+ENDPOINT ?= $(DEFAULT_ENDPOINT)
 
 help:
 	@if [ -z "$(IS_NETWORK_DIR)" ]; then \
@@ -48,15 +50,17 @@ unzst: check-network-dir ## Uncompress individual .json.zst files using zstd com
 		zstd -d -f -q --rm "$$file"; \
 	done
 
-check-aws-env:
+check-env:
 	@test -n "$(ENDPOINT)" || { echo "Missing ENDPOINT"; exit 1; }
+
+check-aws-env: check-env
 	@test -n "$(AWS_ACCESS_KEY_ID)" || { echo "Missing AWS_ACCESS_KEY_ID"; exit 1; }
 	@test -n "$(AWS_SECRET_ACCESS_KEY)" || { echo "Missing AWS_SECRET_ACCESS_KEY"; exit 1; }
 
 list: check-network-dir check-aws-env ## List all objects in the network-specific S3 bucket
 	@aws s3 ls --recursive --human-readable --summarize --endpoint-url "$(ENDPOINT)" "s3://$(BUCKET)/"
 
-download: check-network-dir check-aws-env ## Download missing 'epoch_*.json.zst' fixtures from the network-specific S3 bucket
+download: check-network-dir check-env ## Download missing 'epoch_*.json.zst' fixtures from the network-specific S3 bucket
 	@remote_files=$$(aws s3 ls --recursive --endpoint-url "$(ENDPOINT)" "s3://$(BUCKET)/" | awk '{print $$4}' | sed 's@^[^/]*/@@' | grep '^epoch_.*\.json\.zst$$' || true); \
 	if [ -z "$$remote_files" ]; then \
 		echo "No epoch_*.json.zst files found in s3://$(BUCKET)/"; \

--- a/scripts/run-until-then-test
+++ b/scripts/run-until-then-test
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $0 [--force] <bootstrap_epoch> <last_test_epoch>
+
+Bootstrap Amaru, synchronize far enough to retain ledger snapshots through
+last_test_epoch, and compare snapshots from bootstrap_epoch through
+last_test_epoch with Haskell-node stake-distribution fixtures. Stable ledger
+snapshots trail epoch transitions by two epochs, so the node runs through
+last_test_epoch + 2. Use --force to delete existing ledger and chain databases
+for the selected network.
+
+Environment:
+  AMARU_NETWORK                Network to test (default: preprod)
+  BUILD_PROFILE                Cargo profile (default: test)
+  PUBLIC_ENDPOINT              Public fixture URL
+EOF
+}
+
+force=false
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --force)
+      force=true
+      shift
+      ;;
+    --help | -h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Error: unknown option '$1'." >&2
+      usage >&2
+      exit 1
+      ;;
+    *) break ;;
+  esac
+done
+
+if [ "$#" -ne 2 ]; then
+  usage >&2
+  exit 1
+fi
+
+if ! [[ "$1" =~ ^[0-9]+$ && "$2" =~ ^[0-9]+$ ]]; then
+  echo "Error: bootstrap_epoch and target_epoch must be non-negative integers." >&2
+  exit 1
+fi
+
+bootstrap_epoch=$((10#$1))
+target_epoch=$((10#$2))
+run_until_epoch=$((target_epoch + 2))
+
+if (( target_epoch <= bootstrap_epoch )); then
+  echo "Error: target_epoch must be greater than bootstrap_epoch." >&2
+  exit 1
+fi
+
+network="${AMARU_NETWORK:-preprod}"
+build_profile="${BUILD_PROFILE:-test}"
+public_endpoint="${PUBLIC_ENDPOINT:-https://pub-8631964439fd4bc4a92eeb26c8dda3b1.r2.dev}"
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Error: required command '$command_name' is not available." >&2
+    exit 1
+  fi
+}
+
+require_command cargo
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+cd "$repo_root"
+
+ledger_dir="ledger.${network}.db"
+chain_dir="chain.${network}.db"
+fixtures_dir="crates/amaru/tests/conformance/stake-distributions/${network}"
+require_command curl
+echo "==> Downloading missing $network E2E fixtures for epochs $bootstrap_epoch through $target_epoch"
+epoch="$bootstrap_epoch"
+while (( epoch <= target_epoch )); do
+  fixture="$fixtures_dir/epoch_${epoch}.json.zst"
+  json_fixture="${fixture%.zst}"
+  if [ ! -f "$fixture" ] && [ ! -f "$json_fixture" ]; then
+    curl -fsSL -o "$fixture" "$public_endpoint/${network}/epoch_${epoch}.json.zst"
+  fi
+  epoch=$((epoch + 1))
+done
+
+if [ "$force" = "true" ]; then
+  echo "==> Removing existing $network node databases"
+  AMARU_NETWORK="$network" \
+  AMARU_LEDGER_DIR="$ledger_dir" \
+  AMARU_CHAIN_DIR="$chain_dir" \
+  cargo run --profile "$build_profile" --locked --bin amaru -- node rm --wipe-all-dbs
+fi
+
+echo "==> Bootstrapping $network at epoch $bootstrap_epoch"
+AMARU_NETWORK="$network" \
+AMARU_LEDGER_DIR="$ledger_dir" \
+AMARU_CHAIN_DIR="$chain_dir" \
+cargo run --profile "$build_profile" --locked --bin amaru -- node bootstrap --epoch "$bootstrap_epoch"
+
+echo "==> Running $network until epoch $run_until_epoch to retain snapshots through epoch $target_epoch"
+AMARU_NETWORK="$network" \
+AMARU_LEDGER_DIR="$ledger_dir" \
+AMARU_CHAIN_DIR="$chain_dir" \
+AMARU_MAX_EXTRA_LEDGER_SNAPSHOTS=all \
+AMARU_UPSTREAM_PEERS="${AMARU_UPSTREAM_PEERS:-1}" \
+AMARU_TRACE="${AMARU_TRACE:-amaru=info}" \
+"$script_dir/run-until" "$build_profile" "$run_until_epoch"
+
+echo "==> Validating $network ledger snapshots with available E2E fixtures"
+test_filter="compare_${network}_stake_distribution_with_haskell_node"
+env AMARU_NETWORK="$network" cargo test --profile "$build_profile" --locked -p amaru --test summary "$test_filter"

--- a/scripts/run-until-then-test
+++ b/scripts/run-until-then-test
@@ -85,16 +85,34 @@ ledger_dir="ledger.${network}.db"
 chain_dir="chain.${network}.db"
 fixtures_dir="crates/amaru/tests/conformance/stake-distributions/${network}"
 require_command curl
-echo "==> Downloading missing $network E2E fixtures for epochs $bootstrap_epoch through $target_epoch"
-epoch="$bootstrap_epoch"
-while (( epoch <= target_epoch )); do
-  fixture="$fixtures_dir/epoch_${epoch}.json.zst"
-  json_fixture="${fixture%.zst}"
-  if [ ! -f "$fixture" ] && [ ! -f "$json_fixture" ]; then
-    curl -fsSL -o "$fixture" "$public_endpoint/${network}/epoch_${epoch}.json.zst"
+
+download_fixtures() {
+  local epoch="$bootstrap_epoch"
+  local fixture
+  local json_fixture
+
+  echo "==> Downloading missing $network E2E fixtures for epochs $bootstrap_epoch through $target_epoch"
+  while (( epoch <= target_epoch )); do
+    fixture="$fixtures_dir/epoch_${epoch}.json.zst"
+    json_fixture="${fixture%.zst}"
+    if [ ! -f "$fixture" ] && [ ! -f "$json_fixture" ]; then
+      curl -fsSL -o "$fixture" "$public_endpoint/${network}/epoch_${epoch}.json.zst"
+    fi
+    epoch=$((epoch + 1))
+  done
+}
+
+fixtures_pid=""
+stop_fixture_download() {
+  if [ -n "$fixtures_pid" ] && kill -0 "$fixtures_pid" 2>/dev/null; then
+    kill "$fixtures_pid" 2>/dev/null || true
+    wait "$fixtures_pid" || true
   fi
-  epoch=$((epoch + 1))
-done
+}
+
+download_fixtures &
+fixtures_pid=$!
+trap stop_fixture_download EXIT
 
 if [ "$force" = "true" ]; then
   echo "==> Removing existing $network node databases"
@@ -118,6 +136,11 @@ AMARU_MAX_EXTRA_LEDGER_SNAPSHOTS=all \
 AMARU_UPSTREAM_PEERS="${AMARU_UPSTREAM_PEERS:-1}" \
 AMARU_TRACE="${AMARU_TRACE:-amaru=info}" \
 "$script_dir/run-until" "$build_profile" "$run_until_epoch"
+
+echo "==> Waiting for $network E2E fixture downloads"
+wait "$fixtures_pid"
+fixtures_pid=""
+trap - EXIT
 
 echo "==> Validating $network ledger snapshots with available E2E fixtures"
 test_filter="compare_${network}_stake_distribution_with_haskell_node"


### PR DESCRIPTION
Added a simple script that:

* bootstrap
* run amaru the necessary time
* download necessary test fixtures
* run them

This is convenient to easily bootstrap from a known set of snapshots and validate the chain then behave as expected.

A new command `amaru node rm --wipe-all-dbs` has been introduced to help with that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `amaru node rm --wipe-all-dbs` to remove a node’s ledger and chain databases.
  * Added a workflow for running Amaru through a target epoch and validating stake distributions.
* **Improvements**
  * Improved processing-time and throughput reporting with fractional-second precision.
  * Added configurable endpoint support and validation for stake-distribution fixture downloads.
* **Documentation**
  * Documented the new database-removal command in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->