### PR TITLE
Introduce GovActionsDoNotExist Logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Other guiding principles:
 - **amaru-node**: `Telemetry::install` embedder helper for fmt / JSON / OTLP (metrics + traces + logs) using the same env knobs as the product binary.
 - **amaru-observability**: structured logging for complex values: schema transport preserves JSON primitives and encodes other values as CBOR (`record_bytes`); JSON traces get nested objects/arrays, OTEL logs get nested `AnyValue` maps/lists, OTEL spans upgrade homogeneous CBOR arrays to `Value::Array` (with CBOR diagnostic fallback otherwise), and console logs use CBOR diagnostic notation. ([#1182](https://github.com/pragma-org/amaru/pull/1182))
 - **amaru**: stake-distribution conformance tests no longer partition `#[ignore]` vs active cases from `ledger.<network>.db` at build time (watching that live DB rebuilt `amaru` on every node write). Fixture directories are still watched so tests regenerate when snapshots change; each test soft-skips with a warning when the matching local ledger snapshot is missing.
+- **amaru-ledger**: validate the governance actions a transaction votes on actually exist, counting proposals submitted earlier in the same block. ([#1139][], [#924][])
 
 ### Fixed
 
@@ -294,6 +295,7 @@ Other guiding principles:
 [#909]: https://github.com/pragma-org/amaru/issues/909
 [#912]: https://github.com/pragma-org/amaru/issues/912
 [#915]: https://github.com/pragma-org/amaru/issues/915
+[#924]: https://github.com/pragma-org/amaru/issues/924
 [#928]: https://github.com/pragma-org/amaru/issues/928
 [#929]: https://github.com/pragma-org/amaru/issues/929
 [#932]: https://github.com/pragma-org/amaru/issues/932
@@ -348,3 +350,4 @@ Other guiding principles:
 [#1101]: https://github.com/pragma-org/amaru/pull/1101
 [#1109]: https://github.com/pragma-org/amaru/pull/1109
 [#1118]: https://github.com/pragma-org/amaru/pull/1118
+[#1139]: https://github.com/pragma-org/amaru/pull/1139

--- a/crates/amaru-ledger/src/context.rs
+++ b/crates/amaru-ledger/src/context.rs
@@ -328,10 +328,9 @@ pub struct ProposalState {
 }
 
 pub trait ProposalsSlice {
-    /// Whether an active proposal `id` exists AND shares `kind`'s governance purpose (same
-    /// [`ProposalKind`] discriminant). Folds block-start proposals together with ones acknowledged
-    /// earlier in the block.
-    fn exists(&self, id: &ProposalId, kind: &ProposalKind) -> bool;
+    /// Check whether a proposal exists. If the `kind` is specified, it must also match and be part
+    /// of the same lineage.
+    fn exists(&self, id: &ProposalId, kind: Option<ProposalKind>) -> bool;
 
     /// The current governance roots, i.e. the latest enacted action per category.
     fn roots(&self) -> &ProposalsRoots;

--- a/crates/amaru-ledger/src/context/default/validation.rs
+++ b/crates/amaru-ledger/src/context/default/validation.rs
@@ -375,21 +375,19 @@ impl CommitteeSlice for DefaultValidationContext {
 }
 
 impl ProposalsSlice for DefaultValidationContext {
-    fn exists(&self, id: &ProposalId, kind: &ProposalKind) -> bool {
-        let target = mem::discriminant(kind);
-
+    // Check whether a proposal exists. If the `kind` is specified, it must also match and be part
+    // of the same lineage.
+    fn exists(&self, id: &ProposalId, kind: Option<ProposalKind>) -> bool {
         // block-start proposals
-        if let Some(existing) = self.proposals.get(id)
-            && mem::discriminant(existing) == target
-        {
-            return true;
+        if let Some(existing) = self.proposals.get(id) {
+            return kind.is_none_or(|kind| mem::discriminant(existing) == mem::discriminant(&kind));
         }
 
         // proposals acknowledged earlier in this block
-        if let Some(existing) = self.state.proposals.get(id)
-            && mem::discriminant(&ProposalKind::from(&existing.0.gov_action)) == target
-        {
-            return true;
+        if let Some(existing) = self.state.proposals.get(id) {
+            return kind.is_none_or(|kind| {
+                mem::discriminant(&ProposalKind::from(&existing.0.gov_action)) == mem::discriminant(&kind)
+            });
         }
 
         false

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/fixture.rs
@@ -32,6 +32,7 @@ use crate::{
             InvalidVKeyWitness, InvalidValidityInterval, InvalidWithdrawals, PhaseOneError,
             outputs::{InvalidOutput, InvalidOutputs},
             proposals::InvalidProposals,
+            voting_procedures::InvalidVotingProcedures,
         },
     },
 };
@@ -248,6 +249,7 @@ pub(super) enum Predicate {
     ConwayTxRefScriptsSizeTooBig,
     ConwayWdrlNotDelegatedToDRep,
     FeeTooSmallUTxO,
+    GovActionsDoNotExist,
     IncorrectDepositDELEG,
     IncorrectTotalCollateralField,
     ConwayTreasuryValueMismatch,
@@ -346,6 +348,9 @@ impl From<PhaseOneError> for Predicate {
             }
             PhaseOneError::Proposals(InvalidProposals::InvalidPrevGovActionId { .. }) => {
                 Predicate::InvalidPrevGovActionId
+            }
+            PhaseOneError::VotingProcedures(InvalidVotingProcedures::GovActionsDoNotExist(_)) => {
+                Predicate::GovActionsDoNotExist
             }
             PhaseOneError::ValueNotPreserved(_) => Predicate::ValueNotConservedUTxO,
             PhaseOneError::Certificates(InvalidCertificates::StakeCredentialInvalidPoolDelegation(ref e)) => match e {

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
@@ -51,6 +51,7 @@ pub mod vkey_witness;
 pub use vkey_witness::InvalidVKeyWitness;
 
 pub mod voting_procedures;
+pub use voting_procedures::InvalidVotingProcedures;
 
 pub mod withdrawals;
 pub use withdrawals::InvalidWithdrawals;
@@ -96,6 +97,9 @@ pub enum PhaseOneError {
 
     #[error("invalid proposals: {0}")]
     Proposals(#[from] proposals::InvalidProposals),
+
+    #[error("invalid voting procedures: {0}")]
+    VotingProcedures(#[from] InvalidVotingProcedures),
 
     #[error("invalid transaction metadata: {0}")]
     Metadata(#[from] InvalidTransactionMetadata),
@@ -283,7 +287,7 @@ where
         })?;
 
         debug_span!(ledger::rules::phase_one::VOTES)
-            .in_scope(|| voting_procedures::execute(context, mem::take(&mut transaction_body.votes)));
+            .in_scope(|| voting_procedures::execute(context, mem::take(&mut transaction_body.votes)))?;
     } else {
         debug_span!(ledger::rules::phase_one::CERTIFICATES).in_scope(|| {
             certificates::count_lovelace(context, protocol_parameters, mem::take(&mut transaction_body.certificates))

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/proposals.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/proposals.rs
@@ -135,7 +135,7 @@ where
     if !matches!(kind, ProposalKind::Orphan) {
         let parent = proposal.parent();
         let follows_root = parent == context.roots().root_of(kind);
-        let follows_in_flight = matches!(parent, Some(id) if context.exists(id, &kind));
+        let follows_in_flight = matches!(parent, Some(id) if context.exists(id, Some(kind)));
         if !follows_root && !follows_in_flight {
             return Err(InvalidProposals::InvalidPrevGovActionId { parent: parent.cloned() });
         }

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/voting_procedures.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/voting_procedures.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use amaru_kernel::{
     HasOwnership, MemoizedDatum, NonEmptyKeyValuePairs, ProposalId, RedeemerTag, RequiredScript, StakeCredential,
@@ -21,15 +21,31 @@ use amaru_kernel::{
 
 use crate::context::{ProposalsSlice, WitnessSlice};
 
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidVotingProcedures {
+    #[error("governance actions do not exist: {0:?}")]
+    GovActionsDoNotExist(BTreeSet<ProposalId>),
+}
+
 pub(crate) fn execute<C>(
     context: &mut C,
     voting_procedures: Option<NonEmptyKeyValuePairs<Voter, NonEmptyKeyValuePairs<ProposalId, VotingProcedure>>>,
-) where
+) -> Result<(), InvalidVotingProcedures>
+where
     C: WitnessSlice + ProposalsSlice,
 {
     if let Some(voting_procedures) = voting_procedures {
+        let mut unknown_proposals = BTreeSet::new();
+
+        // TODO: remove this intermediate collect using itertools::sorted_by_key
         voting_procedures.into_iter().collect::<BTreeMap<_, _>>().into_iter().enumerate().for_each(
             |(index, (voter, votes))| {
+                for (proposal_id, _) in votes.iter() {
+                    if !ProposalsSlice::exists(context, proposal_id, None) {
+                        unknown_proposals.insert(*proposal_id);
+                    }
+                }
+
                 match voter.owner() {
                     StakeCredential::ScriptHash(hash) => {
                         context.require_script_witness(RequiredScript {
@@ -44,8 +60,14 @@ pub(crate) fn execute<C>(
 
                 votes.into_iter().for_each(|(proposal_id, ballot)| {
                     context.vote(proposal_id, voter.clone(), ballot.vote, ballot.anchor);
-                })
+                });
             },
         );
+
+        if !unknown_proposals.is_empty() {
+            return Err(InvalidVotingProcedures::GovActionsDoNotExist(unknown_proposals));
+        }
     }
+
+    Ok(())
 }

--- a/crates/amaru-ledger/tests/data/phase-one/fail/GovActionsDoNotExist/0.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/GovActionsDoNotExist/0.json
@@ -1,0 +1,50 @@
+{
+  "title": "vote cast on a governance action absent from the proposals state",
+  "description": "A registered DRep naming a proposal id that no proposal in state carries.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "8258207ae12fe7076ec75319e0ecac782bcb6d828bb6a4baa49eada7116b47a80d449200",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [
+      {
+        "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "deposit": 500000000,
+        "registeredAt": {
+          "transaction": {
+            "slot": 0,
+            "transactionIndex": 0
+          },
+          "certificateIndex": 0
+        },
+        "validUntil": 1000
+      }
+    ],
+    "committee": [],
+    "proposals": [
+      "8258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b00"
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d90102818258207ae12fe7076ec75319e0ecac782bcb6d828bb6a4baa49eada7116b47a80d4492000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18202581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a1825820bbd665a051206b767522b19427cced4e0420a050852f7ba1c875c9ec1e4983e1008201f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258405c8b74a8926ec66661779cff7512c53ef14cc243fb20907a1a62c841f9fdaef6d409301c96944bdbd5f355b077894b773717722e8fd7764a1c5fd1020f56540ff5f6",
+  "expected": {
+    "predicate": "GovActionsDoNotExist"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/fail/GovActionsDoNotExist/1.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/GovActionsDoNotExist/1.json
@@ -1,0 +1,37 @@
+{
+  "title": "vote cast on a governance action whose index does not match any proposal",
+  "description": "A proposal id sharing the seeded proposal's transaction id but naming a different action index.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820c25d414957cf674b477d9bec7c295a653f02aee955828f9ebec7a4ece7891f2900",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": ["93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"],
+    "accounts": [],
+    "dreps": [],
+    "committee": [],
+    "proposals": [
+      "8258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b00"
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820c25d414957cf674b477d9bec7c295a653f02aee955828f9ebec7a4ece7891f29000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18204581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018201f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258406d6fd3a60b8e7a94ebd0dda9f809aa4adc4c3ea24c4c29b58aae7b7a7c70f0f8543d7c8efb406a5e37ca38d3c340c681aa8e7a7ef5837327d8ecb29d58aba60bf5f6",
+  "expected": {
+    "predicate": "GovActionsDoNotExist"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/fail/GovActionsDoNotExist/2.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/GovActionsDoNotExist/2.json
@@ -1,0 +1,43 @@
+{
+  "title": "vote cast by a committee member on a governance action that does not exist",
+  "description": "An authorized committee hot key naming an absent proposal id.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "82582033e3dfb56c093ef6a5e0a85e186f6c4cba64004d1c21d06d868e1168672b9cdc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "committee": [
+      {
+        "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
+        "hotCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "validUntil": 200
+      }
+    ],
+    "proposals": [
+      "8258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b00"
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d901028182582033e3dfb56c093ef6a5e0a85e186f6c4cba64004d1c21d06d868e1168672b9cdc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a1825820bbd665a051206b767522b19427cced4e0420a050852f7ba1c875c9ec1e4983e1008201f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258407c0b8db38f40877a619d45a2da54831f6d6bec42d67d3fa70b4db8a1dca933eaf07e1adf533e05e439c404f15d57cba594cc6bc2155bfc7552d79526896e3002f5f6",
+  "expected": {
+    "predicate": "GovActionsDoNotExist"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/fail/GovActionsDoNotExist/3.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/GovActionsDoNotExist/3.json
@@ -1,0 +1,50 @@
+{
+  "title": "vote cast on two governance actions of which only one exists",
+  "description": "A single voter casting one ballot on the seeded proposal and one on an absent id.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "8258202b648a1f906db52cc04eac0a58116b1ed17c7bacab29a2f592d325b12281cafc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [
+      {
+        "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "deposit": 500000000,
+        "registeredAt": {
+          "transaction": {
+            "slot": 0,
+            "transactionIndex": 0
+          },
+          "certificateIndex": 0
+        },
+        "validUntil": 1000
+      }
+    ],
+    "committee": [],
+    "proposals": [
+      "8258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b00"
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d90102818258202b648a1f906db52cc04eac0a58116b1ed17c7bacab29a2f592d325b12281cafc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18202581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a28258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b008201f6825820bbd665a051206b767522b19427cced4e0420a050852f7ba1c875c9ec1e4983e1008201f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840f608a4bbfed1cf60d841586def7f826ba2d65241612d4b5e0512a1285024aae057abf43a3e38db8e57cbe23fe3b95f09a6633030139959a72bcda8f2122c5e0df5f6",
+  "expected": {
+    "predicate": "GovActionsDoNotExist"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/scenarios/00044-pass-vote-cast-by-a-script-credential-drep.json
+++ b/crates/amaru-ledger/tests/data/phase-one/scenarios/00044-pass-vote-cast-by-a-script-credential-drep.json
@@ -15,12 +15,12 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
-    "dreps": [],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    "proposals": [
+      {
+        "id": { "transactionId": "7E2B9D5F1A3C7E5B9D1F3A5C7E9B1D3F5A7C9E1B3D5F7A9C1E3B5D7F9A1C3E5B", "proposalIndex": 0 },
+        "govAction": "8301f6820a01"
+      }
+    ]
   },
   "point": {
     "slot": 0,

--- a/crates/amaru-ledger/tests/data/rules-conformance.failures.toml
+++ b/crates/amaru-ledger/tests/data/rules-conformance.failures.toml
@@ -29,7 +29,6 @@
 # PassEpoch event that this harness skips, so the empty prev-gov-action-id can't be rejected here.
 "conway/fail-gov-empty-prevgovid-after-the-first-constitution-was-enacted/0" = "Expected failure, got success"
 "conway/fail-gov-expired-gov-actions/0" = "Expected failure, got success"
-"conway/fail-gov-non-existent-gov-actions/0" = "Expected failure, got success"
 "conway/fail-gov-policy-is-respected-by-proposals/0" = "Expected failure, got success"
 "conway/fail-gov-votersdonotexist/0" = "Expected failure, got success"
 "conway/fail-govcert-resigning-a-non-cc-key/0" = "Expected failure, got success"


### PR DESCRIPTION
Closes #924.

This PR introduces logic to validate that gov actions which are being voted on actually exist at the time of voting. It is also my first use of the new GitHub stacks feature!

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Governance votes now reject references to nonexistent governance actions.
  - Validation recognizes proposals created earlier in the same block.
  - Missing governance actions are reported clearly, including when a transaction references multiple unavailable actions.
  - Existing proposal-kind checks remain enforced when applicable.

- **Tests**
  - Added coverage for missing actions across DRep and committee voting scenarios.
  - Updated conformance expectations and voting scenarios to reflect the corrected validation behavior.

- **Documentation**
  - Added a changelog entry describing the governance-action validation update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->