### PR TITLE
add performance edr

### DIFF
--- a/crates/amaru-consensus/src/performance/effects.rs
+++ b/crates/amaru-consensus/src/performance/effects.rs
@@ -16,6 +16,10 @@
 //!
 //! Stages use factory methods on [`Performance`] and pass the result to `eff.external(...)`.
 //! Each effect is enqueued as a [`PerformanceOp`] on the worker thread.
+//!
+//! Header/fork telemetry is produced on the worker as pure [`HeaderTelemetry`] values and
+//! **emitted here** on the pure-stage effect executor. That keeps OpenTelemetry export (which may
+//! drop or lag under resource/connectivity pressure) off the performance worker.
 
 // wrap_sync type safety requires this -- clippy be damned
 #![expect(clippy::unit_arg)]
@@ -28,8 +32,8 @@ use amaru_pure_stage::{BoxFuture, ExternalEffect, ExternalEffectAPI, Instant, Re
 use tokio::sync::oneshot;
 
 use super::{
-    ClaimKind, FetchPeerSet, HeaderLifecycleOutcome, PeerScores, PeerSnapshot, Performance, PerformanceOp,
-    ResourcePerformance, SelectPeersParams,
+    ClaimKind, FetchPeerSet, HeaderLifecycleOutcome, HeaderPerformance, HeaderTelemetry, PeerScores, PeerSnapshot,
+    Performance, PerformanceOp, ResourcePerformance, SelectPeersParams,
 };
 
 fn require_perf(resources: &Resources) -> ResourcePerformance {
@@ -57,6 +61,16 @@ async fn enqueue_query<T: Send + 'static>(
     {
         reply_rx.await.expect("performance worker dropped reply")
     }
+}
+
+/// Await worker telemetry, then emit on this (effect-executor) path.
+async fn enqueue_and_emit_telemetry(
+    perf: &Performance,
+    meter: Option<Arc<amaru_metrics::Meter>>,
+    make: impl FnOnce(oneshot::Sender<Vec<HeaderTelemetry>>) -> PerformanceOp,
+) {
+    let events = enqueue_query(perf, make).await;
+    HeaderTelemetry::emit_all(&events, meter.as_deref());
 }
 
 // ---------------------------------------------------------------------------
@@ -351,10 +365,10 @@ pub struct PruneBelowEffect {
 
 impl ExternalEffect for PruneBelowEffect {
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            let meter = optional_meter(&resources);
-            enqueue(&perf, PerformanceOp::PruneBelow { effect: *self, meter });
+        let perf = require_perf(&resources);
+        let meter = optional_meter(&resources);
+        Self::wrap(async move {
+            enqueue_and_emit_telemetry(&perf, meter, |reply| PerformanceOp::PruneBelow { effect: *self, reply }).await
         })
     }
 }
@@ -516,9 +530,9 @@ pub struct RecordHeaderRejectedEffect {
 impl ExternalEffect for RecordHeaderRejectedEffect {
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
         Self::wrap_sync({
-            let perf = require_perf(&resources);
+            // NOTE: No worker state; emit directly on the effect path (never on the performance thread).
             let meter = optional_meter(&resources);
-            enqueue(&perf, PerformanceOp::RecordHeaderRejected { effect: *self, meter });
+            HeaderPerformance::apply_header_rejected(self.outcome).emit(meter.as_deref());
         })
     }
 }
@@ -535,10 +549,14 @@ pub struct RecordHeaderAbandonedEffect {
 
 impl ExternalEffect for RecordHeaderAbandonedEffect {
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            let meter = optional_meter(&resources);
-            enqueue(&perf, PerformanceOp::RecordHeaderAbandoned { effect: *self, meter });
+        let perf = require_perf(&resources);
+        let meter = optional_meter(&resources);
+        Self::wrap(async move {
+            enqueue_and_emit_telemetry(&perf, meter, |reply| PerformanceOp::RecordHeaderAbandoned {
+                effect: *self,
+                reply,
+            })
+            .await
         })
     }
 }
@@ -555,10 +573,11 @@ pub struct RecordForkStartedEffect {
 
 impl ExternalEffect for RecordForkStartedEffect {
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            let meter = optional_meter(&resources);
-            enqueue(&perf, PerformanceOp::RecordForkStarted { effect: *self, meter });
+        let perf = require_perf(&resources);
+        let meter = optional_meter(&resources);
+        Self::wrap(async move {
+            enqueue_and_emit_telemetry(&perf, meter, |reply| PerformanceOp::RecordForkStarted { effect: *self, reply })
+                .await
         })
     }
 }
@@ -577,10 +596,11 @@ pub struct RecordBlockValidEffect {
 
 impl ExternalEffect for RecordBlockValidEffect {
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            let meter = optional_meter(&resources);
-            enqueue(&perf, PerformanceOp::RecordBlockValid { effect: *self, meter });
+        let perf = require_perf(&resources);
+        let meter = optional_meter(&resources);
+        Self::wrap(async move {
+            enqueue_and_emit_telemetry(&perf, meter, |reply| PerformanceOp::RecordBlockValid { effect: *self, reply })
+                .await
         })
     }
 }
@@ -600,10 +620,11 @@ pub struct RecordBlockPrunedEffect {
 
 impl ExternalEffect for RecordBlockPrunedEffect {
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            let meter = optional_meter(&resources);
-            enqueue(&perf, PerformanceOp::RecordBlockPruned { effect: *self, meter });
+        let perf = require_perf(&resources);
+        let meter = optional_meter(&resources);
+        Self::wrap(async move {
+            enqueue_and_emit_telemetry(&perf, meter, |reply| PerformanceOp::RecordBlockPruned { effect: *self, reply })
+                .await
         })
     }
 }

--- a/crates/amaru-consensus/src/performance/header.rs
+++ b/crates/amaru-consensus/src/performance/header.rs
@@ -13,6 +13,11 @@
 // limitations under the License.
 
 //! Per-header lifecycle timing for network-health events and metrics.
+//!
+//! State transitions are pure: methods return [`HeaderTelemetry`] payloads. OpenTelemetry events
+//! and metrics are **not** emitted here — the performance worker must not run export paths that
+//! may drop or block under resource/connectivity pressure. Callers (external-effect handlers on
+//! the stage executor) invoke [`HeaderTelemetry::emit`].
 
 use std::collections::BTreeMap;
 
@@ -21,10 +26,10 @@ use amaru_metrics::{Meter, MetricRecorder, consensus::ConsensusMetrics};
 use amaru_observability::debug;
 use amaru_pure_stage::Instant;
 
-/// Tracks the processing of headers to emit a single `perf.header.lifecycle` event per header when
-/// its block reaches a terminal state (adopted, invalidated, abandoned, or pruned). The event covers
-/// the virtual slot start followed by the four network-health processing points of a header's
-/// lifecycle and carries the intervals between them:
+/// Tracks the processing of headers to produce a single `perf.header.lifecycle` telemetry payload
+/// per header when its block reaches a terminal state (adopted, invalidated, abandoned, or pruned).
+/// The payload covers the virtual slot start followed by the four network-health processing points
+/// of a header's lifecycle and the intervals between them:
 ///
 /// - `slot_start_to_header_micros`: from the virtual beginning of the slot to the header's
 ///   reception (computed by stages via era history; omitted when the node is still syncing).
@@ -36,11 +41,9 @@ use amaru_pure_stage::Instant;
 /// timings to that peer (TUI / `perf.header.lifecycle`). Later announcements of the same hash do not
 /// overwrite the first announcer or the slot-start interval.
 ///
-/// Fork switches are tracked independently and emitted as `perf.fork.switch`.
+/// Fork switches are tracked independently and surface as `perf.fork.switch` telemetry.
 ///
-/// OTel events and metrics are emitted from this type when terminal outcomes are recorded
-/// (optional `Meter` from pure-stage resources).
-/// Owned by the performance worker thread.
+/// Owned by the performance worker thread; emission of returned telemetry happens off that thread.
 #[derive(Debug, Default)]
 pub struct HeaderPerformance {
     /// The lifecycle timestamps of each header whose block has not yet reached a terminal state.
@@ -133,12 +136,127 @@ pub enum ForkSwitchOutcome {
 }
 
 impl ForkSwitchOutcome {
-    fn as_str(self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::AbandonedBlock => "abandoned",
             Self::InvalidBlock => "invalid",
             Self::ValidBlock => "valid",
             Self::Superseded => "superseded_fork",
+        }
+    }
+}
+
+/// Telemetry produced by a header/fork state transition.
+///
+/// Emit via [`HeaderTelemetry::emit`] on the external-effect path (not on the performance worker).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HeaderTelemetry {
+    /// Closed or rejected header lifecycle (`perf.header.lifecycle`).
+    Lifecycle {
+        hash: Option<HeaderHash>,
+        /// First announcer peer when a tracked lifecycle is closed; `None` for reception rejections.
+        peer: Option<Peer>,
+        outcome: HeaderLifecycleOutcome,
+        /// Omitted while syncing or when no tracked lifecycle exists.
+        slot_start_to_header_micros: Option<u64>,
+        block_fetch_wait_micros: Option<u64>,
+        block_fetch_micros: Option<u64>,
+        forward_micros: Option<u64>,
+    },
+    /// Closed fork switch (`perf.fork.switch`).
+    ForkSwitch { hash: HeaderHash, outcome: ForkSwitchOutcome, duration_micros: u64 },
+}
+
+impl HeaderTelemetry {
+    /// Emit the corresponding tracing event and optional metric.
+    ///
+    /// Safe to call where OTel/export layers may drop or lag; must not run on the performance
+    /// worker thread.
+    pub fn emit(&self, meter: Option<&Meter>) {
+        match self {
+            Self::Lifecycle {
+                hash,
+                peer,
+                outcome,
+                slot_start_to_header_micros,
+                block_fetch_wait_micros,
+                block_fetch_micros,
+                forward_micros,
+            } => {
+                match (hash, peer) {
+                    (Some(hash), Some(peer)) => {
+                        debug!(
+                            consensus::perf::header::LIFECYCLE,
+                            peer = peer,
+                            header_hash = hash,
+                            outcome = outcome.as_str(),
+                            slot_start_to_header_micros = @slot_start_to_header_micros,
+                            block_fetch_wait_micros = @block_fetch_wait_micros,
+                            block_fetch_micros = @block_fetch_micros,
+                            forward_micros = @forward_micros
+                        );
+                    }
+                    (Some(hash), None) => {
+                        debug!(
+                            consensus::perf::header::LIFECYCLE,
+                            header_hash = hash,
+                            outcome = outcome.as_str(),
+                            slot_start_to_header_micros = @slot_start_to_header_micros,
+                            block_fetch_wait_micros = @block_fetch_wait_micros,
+                            block_fetch_micros = @block_fetch_micros,
+                            forward_micros = @forward_micros
+                        );
+                    }
+                    _ => {
+                        debug!(consensus::perf::header::LIFECYCLE, outcome = outcome.as_str());
+                    }
+                }
+                record_metric(
+                    meter,
+                    ConsensusMetrics::HeaderLifecycle {
+                        outcome: outcome.as_str().to_string(),
+                        slot_start_to_header_micros: *slot_start_to_header_micros,
+                        block_fetch_wait_micros: *block_fetch_wait_micros,
+                        block_fetch_micros: *block_fetch_micros,
+                        forward_micros: *forward_micros,
+                    },
+                );
+            }
+            Self::ForkSwitch { hash, outcome, duration_micros } => {
+                debug!(
+                    consensus::perf::fork::SWITCH,
+                    header_hash = hash,
+                    outcome = outcome.as_str(),
+                    duration_micros = @duration_micros
+                );
+                record_metric(
+                    meter,
+                    ConsensusMetrics::ForkSwitch {
+                        outcome: outcome.as_str().to_string(),
+                        duration_micros: *duration_micros,
+                    },
+                );
+            }
+        }
+    }
+
+    /// Emit a batch of telemetry events.
+    pub fn emit_all(events: &[Self], meter: Option<&Meter>) {
+        for event in events {
+            event.emit(meter);
+        }
+    }
+
+    /// Rejected header with no tracked lifecycle (no durations, no hash, no peer).
+    pub fn rejected(outcome: HeaderLifecycleOutcome) -> Self {
+        Self::Lifecycle {
+            hash: None,
+            peer: None,
+            outcome,
+            slot_start_to_header_micros: None,
+            block_fetch_wait_micros: None,
+            block_fetch_micros: None,
+            forward_micros: None,
         }
     }
 }
@@ -167,15 +285,17 @@ impl HeaderPerformance {
     }
 
     /// Close open lifecycles (and any matching fork switch) for headers that have fallen behind
-    /// the immutable horizon (`height < min_height`). Emits `HeaderLifecycleOutcome::Pruned`.
-    pub fn apply_prune_below(&mut self, min_height: BlockHeight, now: Instant, meter: Option<&Meter>) {
+    /// the immutable horizon (`height < min_height`). Returns `Pruned` (and fork) telemetry.
+    pub fn apply_prune_below(&mut self, min_height: BlockHeight, now: Instant) -> Vec<HeaderTelemetry> {
         let to_prune: Vec<HeaderHash> =
             self.lifecycles.iter().filter(|(_, lc)| lc.height < min_height).map(|(h, _)| *h).collect();
+        let mut out = Vec::new();
         for hash in to_prune {
             // Not a sync-path decision; always include the slot-start interval when available.
-            self.emit_lifecycle(&hash, HeaderLifecycleOutcome::Pruned, now, false, meter);
-            self.close_fork(&hash, ForkSwitchOutcome::AbandonedBlock, now, meter);
+            out.extend(self.close_lifecycle(&hash, HeaderLifecycleOutcome::Pruned, now, false));
+            out.extend(self.close_fork(&hash, ForkSwitchOutcome::AbandonedBlock, now));
         }
+        out
     }
 
     /// The fetch stage requested the blocks for these headers: record their request time.
@@ -195,34 +315,36 @@ impl HeaderPerformance {
     }
 
     /// Header rejected on reception (duplicate, undecodable, invalid, store error, …).
-    /// Emits a lifecycle event/metric with no duration fields; does not require a tracked lifecycle.
-    pub fn apply_header_rejected(&self, outcome: HeaderLifecycleOutcome, meter: Option<&Meter>) {
-        emit_rejected(outcome, meter);
+    /// Does not require a tracked lifecycle; telemetry has no duration fields.
+    pub fn apply_header_rejected(outcome: HeaderLifecycleOutcome) -> HeaderTelemetry {
+        HeaderTelemetry::rejected(outcome)
     }
 
     /// A received header that is abandoned because its block depends on an invalid block.
-    pub fn apply_header_abandoned(&mut self, hash: &HeaderHash, now: Instant, meter: Option<&Meter>) {
+    pub fn apply_header_abandoned(&mut self, hash: &HeaderHash, now: Instant) -> Vec<HeaderTelemetry> {
         // Not a sync-path decision; always include the slot-start interval when available.
-        self.emit_lifecycle(hash, HeaderLifecycleOutcome::AbandonedBlock, now, false, meter);
+        self.close_lifecycle(hash, HeaderLifecycleOutcome::AbandonedBlock, now, false)
     }
 
     /// A fork has been detected: start tracking the time it takes to switch to it. If a previous
-    /// fork switch is still in progress, record it as superseded.
-    pub fn apply_fork_started(&mut self, tip: Tip, started_at: Instant, meter: Option<&Meter>) {
+    /// fork switch is still in progress, return it as superseded telemetry.
+    pub fn apply_fork_started(&mut self, tip: Tip, started_at: Instant) -> Vec<HeaderTelemetry> {
+        let mut out = Vec::new();
         if let Some(previous) = self.fork_switch.take() {
-            emit_fork_switch(&previous.hash, ForkSwitchOutcome::Superseded, started_at, previous.started_at, meter);
+            out.push(fork_telemetry(&previous.hash, ForkSwitchOutcome::Superseded, started_at, previous.started_at));
         }
         self.fork_switch = Some(ForkSwitch { hash: tip.hash(), started_at });
+        out
     }
 
-    /// The block for a header has been validated and adopted: emit its lifecycle event and the
-    /// fork-switch event if it was waiting on this header.
+    /// The block for a header has been validated and adopted.
     ///
     /// When `syncing` is true, `slot_start_to_header_micros` is omitted (not meaningful while
     /// catching up far behind the network tip).
-    pub fn apply_block_valid(&mut self, hash: &HeaderHash, now: Instant, syncing: bool, meter: Option<&Meter>) {
-        self.emit_lifecycle(hash, HeaderLifecycleOutcome::ValidBlock, now, syncing, meter);
-        self.close_fork(hash, ForkSwitchOutcome::ValidBlock, now, meter);
+    pub fn apply_block_valid(&mut self, hash: &HeaderHash, now: Instant, syncing: bool) -> Vec<HeaderTelemetry> {
+        let mut out = self.close_lifecycle(hash, HeaderLifecycleOutcome::ValidBlock, now, syncing);
+        out.extend(self.close_fork(hash, ForkSwitchOutcome::ValidBlock, now));
+        out
     }
 
     /// A header has been pruned after a block validation.
@@ -237,15 +359,15 @@ impl HeaderPerformance {
         invalid: bool,
         now: Instant,
         syncing: bool,
-        meter: Option<&Meter>,
-    ) {
+    ) -> Vec<HeaderTelemetry> {
         let (header_outcome, fork_outcome) = if invalid {
             (HeaderLifecycleOutcome::InvalidBlock, ForkSwitchOutcome::InvalidBlock)
         } else {
             (HeaderLifecycleOutcome::AbandonedBlock, ForkSwitchOutcome::AbandonedBlock)
         };
-        self.emit_lifecycle(hash, header_outcome, now, syncing, meter);
-        self.close_fork(hash, fork_outcome, now, meter);
+        let mut out = self.close_lifecycle(hash, header_outcome, now, syncing);
+        out.extend(self.close_fork(hash, fork_outcome, now));
+        out
     }
 
     /// Number of headers currently tracked (tests / diagnostics).
@@ -270,18 +392,18 @@ impl HeaderPerformance {
 }
 
 impl HeaderPerformance {
-    /// Emit a `perf.header.lifecycle` event for a header reaching a terminal state.
-    /// Record the corresponding metric, and drop its tracking record.
-    fn emit_lifecycle(
+    /// Close a lifecycle if present; return zero or one telemetry payload.
+    ///
+    /// When `syncing` is true, `slot_start_to_header_micros` is omitted from the payload.
+    fn close_lifecycle(
         &mut self,
         hash: &HeaderHash,
         outcome: HeaderLifecycleOutcome,
         now: Instant,
         syncing: bool,
-        meter: Option<&Meter>,
-    ) {
+    ) -> Vec<HeaderTelemetry> {
         let Some(lifecycle) = self.lifecycles.remove(hash) else {
-            return;
+            return Vec::new();
         };
 
         let slot_start_to_header_micros = (!syncing).then_some(lifecycle.slot_start_to_header_micros);
@@ -293,35 +415,24 @@ impl HeaderPerformance {
             .map(|(requested_at, downloaded_at)| duration_micros(requested_at, downloaded_at));
         let forward_micros = duration_micros(lifecycle.received_at, now);
 
-        debug!(
-            consensus::perf::header::LIFECYCLE,
-            peer = lifecycle.peer.clone(),
-            header_hash = hash,
-            outcome = outcome.as_str(),
-            slot_start_to_header_micros = @slot_start_to_header_micros,
-            block_fetch_wait_micros = @block_fetch_wait_micros,
-            block_fetch_micros = @block_fetch_micros,
-            forward_micros = @forward_micros
-        );
-
-        record_metric(
-            meter,
-            ConsensusMetrics::HeaderLifecycle {
-                outcome: outcome.as_str().to_string(),
-                slot_start_to_header_micros,
-                block_fetch_wait_micros,
-                block_fetch_micros,
-                forward_micros: Some(forward_micros),
-            },
-        );
+        vec![HeaderTelemetry::Lifecycle {
+            hash: Some(*hash),
+            peer: Some(lifecycle.peer),
+            outcome,
+            slot_start_to_header_micros,
+            block_fetch_wait_micros,
+            block_fetch_micros,
+            forward_micros: Some(forward_micros),
+        }]
     }
 
-    fn close_fork(&mut self, hash: &HeaderHash, outcome: ForkSwitchOutcome, now: Instant, meter: Option<&Meter>) {
+    fn close_fork(&mut self, hash: &HeaderHash, outcome: ForkSwitchOutcome, now: Instant) -> Vec<HeaderTelemetry> {
         if self.fork_switch.as_ref().is_some_and(|fork| &fork.hash == hash)
             && let Some(fork) = self.fork_switch.take()
         {
-            emit_fork_switch(&fork.hash, outcome, now, fork.started_at, meter);
+            return vec![fork_telemetry(&fork.hash, outcome, now, fork.started_at)];
         }
+        Vec::new()
     }
 }
 
@@ -330,40 +441,8 @@ fn duration_micros(started: Instant, now: Instant) -> u64 {
     now.saturating_since(started).as_micros() as u64
 }
 
-fn emit_rejected(outcome: HeaderLifecycleOutcome, meter: Option<&Meter>) {
-    debug!(consensus::perf::header::LIFECYCLE, outcome = outcome.as_str());
-    record_metric(
-        meter,
-        ConsensusMetrics::HeaderLifecycle {
-            outcome: outcome.as_str().to_string(),
-            slot_start_to_header_micros: None,
-            block_fetch_wait_micros: None,
-            block_fetch_micros: None,
-            forward_micros: None,
-        },
-    );
-}
-
-/// Emit a `perf.fork.switch` event for a fork switch that started at `started_at` and ended now,
-/// and record the matching metric when a meter is available.
-fn emit_fork_switch(
-    hash: &HeaderHash,
-    outcome: ForkSwitchOutcome,
-    now: Instant,
-    started_at: Instant,
-    meter: Option<&Meter>,
-) {
-    let duration = duration_micros(started_at, now);
-    debug!(
-        consensus::perf::fork::SWITCH,
-        header_hash = hash,
-        outcome = outcome.as_str(),
-        duration_micros = @duration
-    );
-    record_metric(
-        meter,
-        ConsensusMetrics::ForkSwitch { outcome: outcome.as_str().to_string(), duration_micros: duration },
-    );
+fn fork_telemetry(hash: &HeaderHash, outcome: ForkSwitchOutcome, now: Instant, started_at: Instant) -> HeaderTelemetry {
+    HeaderTelemetry::ForkSwitch { hash: *hash, outcome, duration_micros: duration_micros(started_at, now) }
 }
 
 fn record_metric(meter: Option<&Meter>, metric: ConsensusMetrics) {

--- a/crates/amaru-consensus/src/performance/mod.rs
+++ b/crates/amaru-consensus/src/performance/mod.rs
@@ -26,7 +26,9 @@
 //! Channel depth is monitored: WARN (rate-limited) when the queue exceeds normally expected
 //! depth, ERROR + panic when it grows beyond reasonable bounds.
 //!
-//! OTel events and metrics are emitted inside the worker when terminal outcomes are recorded.
+//! Terminal header/fork transitions produce [`HeaderTelemetry`] on the worker; OpenTelemetry
+//! events and metrics are emitted only on the external-effect path so export drops or lag cannot
+//! stall or couple to performance state updates.
 
 mod effects;
 mod header;
@@ -43,10 +45,9 @@ use std::{
 };
 
 use amaru_kernel::Peer;
-use amaru_metrics::Meter;
 use amaru_pure_stage::Instant;
 pub use effects::*;
-pub use header::{ForkSwitchOutcome, HeaderLifecycleOutcome, HeaderPerformance};
+pub use header::{ForkSwitchOutcome, HeaderLifecycleOutcome, HeaderPerformance, HeaderTelemetry};
 use parking_lot::Mutex;
 pub use peer::{BlockClaim, ClaimKind, FetchPeerSet, PeerPerformance, PeerScores, PeerSnapshot, SelectPeersParams};
 use tokio::{
@@ -127,6 +128,8 @@ impl fmt::Debug for Performance {
 }
 
 /// All operations accepted by the performance worker, wrapping the corresponding effect payloads.
+///
+/// Ops that close header/fork state reply with [`HeaderTelemetry`] for emission off this thread.
 pub(crate) enum PerformanceOp {
     RecordIntersection { effect: RecordIntersectionEffect },
     RecordHeaderAnnouncement { effect: RecordHeaderAnnouncementEffect },
@@ -136,7 +139,7 @@ pub(crate) enum PerformanceOp {
     RecordKeepaliveRtt { effect: RecordKeepaliveRttEffect },
     ClearPeerAvailability { effect: ClearPeerAvailabilityEffect },
     ForgetPeer { effect: ForgetPeerEffect },
-    PruneBelow { effect: PruneBelowEffect, meter: Option<Arc<Meter>> },
+    PruneBelow { effect: PruneBelowEffect, reply: oneshot::Sender<Vec<HeaderTelemetry>> },
     SelectPeersForFetch { effect: SelectPeersForFetchEffect, reply: oneshot::Sender<FetchPeerSet> },
     PeerCoversFragment { effect: PeerCoversFragmentEffect, reply: oneshot::Sender<bool> },
     DirectClaimants { effect: DirectClaimantsEffect, reply: oneshot::Sender<Vec<(Peer, Instant, ClaimKind)>> },
@@ -145,11 +148,10 @@ pub(crate) enum PerformanceOp {
     Scores { effect: ScoresEffect, reply: oneshot::Sender<PeerScores> },
     Snapshot { effect: SnapshotEffect, reply: oneshot::Sender<Option<PeerSnapshot>> },
     RecordRollback { effect: RecordRollbackEffect },
-    RecordHeaderRejected { effect: RecordHeaderRejectedEffect, meter: Option<Arc<Meter>> },
-    RecordHeaderAbandoned { effect: RecordHeaderAbandonedEffect, meter: Option<Arc<Meter>> },
-    RecordForkStarted { effect: RecordForkStartedEffect, meter: Option<Arc<Meter>> },
-    RecordBlockValid { effect: RecordBlockValidEffect, meter: Option<Arc<Meter>> },
-    RecordBlockPruned { effect: RecordBlockPrunedEffect, meter: Option<Arc<Meter>> },
+    RecordHeaderAbandoned { effect: RecordHeaderAbandonedEffect, reply: oneshot::Sender<Vec<HeaderTelemetry>> },
+    RecordForkStarted { effect: RecordForkStartedEffect, reply: oneshot::Sender<Vec<HeaderTelemetry>> },
+    RecordBlockValid { effect: RecordBlockValidEffect, reply: oneshot::Sender<Vec<HeaderTelemetry>> },
+    RecordBlockPruned { effect: RecordBlockPrunedEffect, reply: oneshot::Sender<Vec<HeaderTelemetry>> },
 }
 
 impl Performance {
@@ -281,9 +283,10 @@ fn dispatch(peers: &mut PeerPerformance, headers: &mut HeaderPerformance, op: Pe
         PerformanceOp::ForgetPeer { effect } => {
             peers.apply_forget_peer(&effect.peer);
         }
-        PerformanceOp::PruneBelow { effect, meter } => {
+        PerformanceOp::PruneBelow { effect, reply } => {
             peers.apply_prune_below(effect.min_height);
-            headers.apply_prune_below(effect.min_height, effect.now, meter.as_deref());
+            let telemetry = headers.apply_prune_below(effect.min_height, effect.now);
+            let _ = reply.send(telemetry);
         }
         PerformanceOp::SelectPeersForFetch { effect, reply } => {
             let result = peers.apply_select_peers_for_fetch(effect.params);
@@ -316,20 +319,21 @@ fn dispatch(peers: &mut PeerPerformance, headers: &mut HeaderPerformance, op: Pe
         PerformanceOp::RecordRollback { effect } => {
             peers.apply_rollback(effect.peer, effect.point, effect.parent, effect.at);
         }
-        PerformanceOp::RecordHeaderRejected { effect, meter } => {
-            headers.apply_header_rejected(effect.outcome, meter.as_deref());
+        PerformanceOp::RecordHeaderAbandoned { effect, reply } => {
+            let telemetry = headers.apply_header_abandoned(&effect.hash, effect.now);
+            let _ = reply.send(telemetry);
         }
-        PerformanceOp::RecordHeaderAbandoned { effect, meter } => {
-            headers.apply_header_abandoned(&effect.hash, effect.now, meter.as_deref());
+        PerformanceOp::RecordForkStarted { effect, reply } => {
+            let telemetry = headers.apply_fork_started(effect.tip, effect.started_at);
+            let _ = reply.send(telemetry);
         }
-        PerformanceOp::RecordForkStarted { effect, meter } => {
-            headers.apply_fork_started(effect.tip, effect.started_at, meter.as_deref());
+        PerformanceOp::RecordBlockValid { effect, reply } => {
+            let telemetry = headers.apply_block_valid(&effect.hash, effect.now, effect.syncing);
+            let _ = reply.send(telemetry);
         }
-        PerformanceOp::RecordBlockValid { effect, meter } => {
-            headers.apply_block_valid(&effect.hash, effect.now, effect.syncing, meter.as_deref());
-        }
-        PerformanceOp::RecordBlockPruned { effect, meter } => {
-            headers.apply_block_pruned(&effect.hash, effect.invalid, effect.now, effect.syncing, meter.as_deref());
+        PerformanceOp::RecordBlockPruned { effect, reply } => {
+            let telemetry = headers.apply_block_pruned(&effect.hash, effect.invalid, effect.now, effect.syncing);
+            let _ = reply.send(telemetry);
         }
     }
 }

--- a/crates/amaru-consensus/src/performance/tests.rs
+++ b/crates/amaru-consensus/src/performance/tests.rs
@@ -410,34 +410,53 @@ fn blocks_requested_and_downloaded_then_valid_closes_lifecycle() {
     headers.apply_blocks_requested(&[hash(1)], t(2));
     headers.apply_block_downloaded(&hash(1), t(3));
     assert_eq!(headers.lifecycle_count(), 1);
-    headers.apply_block_valid(&hash(1), t(4), false, None);
+    let telemetry = headers.apply_block_valid(&hash(1), t(4), false);
     assert_eq!(headers.lifecycle_count(), 0);
+    assert_eq!(telemetry.len(), 1);
+    assert!(matches!(
+        &telemetry[0],
+        super::HeaderTelemetry::Lifecycle {
+            outcome: HeaderLifecycleOutcome::ValidBlock,
+            slot_start_to_header_micros: Some(500),
+            ..
+        }
+    ));
 }
 
 #[test]
 fn header_rejected_does_not_require_lifecycle_entry() {
-    let headers = HeaderPerformance::new();
-    headers.apply_header_rejected(HeaderLifecycleOutcome::DuplicateHeader, None);
-    assert_eq!(headers.lifecycle_count(), 0);
+    let telemetry = HeaderPerformance::apply_header_rejected(HeaderLifecycleOutcome::DuplicateHeader);
+    assert!(matches!(
+        telemetry,
+        super::HeaderTelemetry::Lifecycle { outcome: HeaderLifecycleOutcome::DuplicateHeader, hash: None, .. }
+    ));
 }
 
 #[test]
 fn fork_started_and_closed_on_valid_block() {
     let mut headers = HeaderPerformance::new();
     headers.apply_header_received(peer("alice"), tip(1, 1), t(1), 0);
-    headers.apply_fork_started(tip(1, 1), t(1), None);
+    assert!(headers.apply_fork_started(tip(1, 1), t(1)).is_empty());
     assert!(headers.has_fork_switch(&hash(1)));
-    headers.apply_block_valid(&hash(1), t(2), false, None);
+    let telemetry = headers.apply_block_valid(&hash(1), t(2), false);
     assert!(!headers.has_fork_switch(&hash(1)));
+    assert_eq!(telemetry.len(), 2); // lifecycle + fork switch
 }
 
 #[test]
 fn slot_start_metric_omitted_while_syncing() {
     let mut headers = HeaderPerformance::new();
     headers.apply_header_received(peer("alice"), tip(1, 1), t(1), 42_000);
-    // Syncing path still closes the lifecycle; metric emission is covered via OTel/meter in production.
-    headers.apply_block_valid(&hash(1), t(2), true, None);
+    let telemetry = headers.apply_block_valid(&hash(1), t(2), true);
     assert_eq!(headers.lifecycle_count(), 0);
+    assert!(matches!(
+        &telemetry[0],
+        super::HeaderTelemetry::Lifecycle {
+            outcome: HeaderLifecycleOutcome::ValidBlock,
+            slot_start_to_header_micros: None,
+            ..
+        }
+    ));
 }
 
 #[test]
@@ -446,9 +465,11 @@ fn prune_below_closes_open_lifecycles_as_pruned() {
     headers.apply_header_received(peer("alice"), tip(1, 1), t(1), 0);
     headers.apply_header_received(peer("alice"), tip(5, 5), t(2), 0);
     assert_eq!(headers.lifecycle_count(), 2);
-    headers.apply_prune_below(BlockHeight::from(5), t(3), None);
+    let pruned = headers.apply_prune_below(BlockHeight::from(5), t(3));
     assert_eq!(headers.lifecycle_count(), 1);
-    headers.apply_prune_below(BlockHeight::from(6), t(4), None);
+    assert_eq!(pruned.len(), 1);
+    assert!(matches!(&pruned[0], super::HeaderTelemetry::Lifecycle { outcome: HeaderLifecycleOutcome::Pruned, .. }));
+    headers.apply_prune_below(BlockHeight::from(6), t(4));
     assert_eq!(headers.lifecycle_count(), 0);
 }
 

--- a/engineering-decision-records/029-consensus-performance-resource.md
+++ b/engineering-decision-records/029-consensus-performance-resource.md
@@ -1,0 +1,128 @@
+---
+type: architecture
+status: accepted
+---
+
+# Consensus performance resource
+
+## Context
+
+[EDR-024][edr-peer-handling] sketched a shared `PeerPerformanceResource` fed by chainsync, blockfetch, and keepalive, and consumed by block-source selection and peer churn.
+[EDR-026][edr-tracing] requires network-health observability at four processing points per header (first reception, first block request, first block reception, local adoption), plus fork-switch timing.
+[EDR-007][edr-observability] / [EDR-015][edr-metrics] govern how those observations surface as spans, events, and metrics.
+
+Consensus stages already form a pipelined pure-stage graph with deliberate back-pressure ([EDR-011][edr-simulation]).
+Performance state is **cross-cutting**: many stages produce samples, few stages consume rankings, and the same semantic event (e.g. “header announced”) may update multiple aspectx (e.g. peer availability and header lifecycle).
+Putting that state into stage messages would introduce new high-rate information flows to the stage graph, creating cycles and capacity coupling that would be difficult to design such that deadlock cannot occur.
+
+## Decision
+
+### Shared resource, not a pure-stage stage
+
+Performance state lives in a pure-stage **resource** (`ResourcePerformance`), not as another stage in the back-pressured graph.
+
+Stages interact only via `ExternalEffect`s constructed on `Performance` (e.g. `eff.external(Performance::record_header_announcement(...)).await`).
+Recording effects enqueue work and complete immediately from the stage’s point of view; query effects (e.g. `select_peers_for_fetch`) await a oneshot reply.
+
+State is owned by a dedicated **worker thread** (Tokio `current_thread` runtime + unbounded op channel).
+That thread is an explicit secondary actor **outside** pure-stage capacity control: it serialises mutations of `PeerPerformance` and `HeaderPerformance` without holding locks on multi-thread runtime workers.
+
+**Why not a pure-stage stage?**
+pure-stage solves *bounded* information flow with rigorous back-pressure; designing acyclic bounded graphs is inherent cost of that guarantee.
+Performance data are already bounded indirectly (they are derived from stage traffic that *is* back-pressured).
+Folding them into inter-stage messages would add cycles and capacity coupling for information that is not the target of those resource bounds.
+Crossing the boundary with `ExternalEffect` keeps the stage graph simple while still making every probe point visible in simulation traces ([EDR-011][edr-simulation]).
+
+**Why not drop under load?**
+Peer scores and claims drive fetch selection; losing them silently is not “graceful degradation” the way losing export of OpenTelemetry is.
+Queue depth is monitored: sustained growth is a design/capacity failure and must fail loudly, not drop ops.
+Telemetry emission that could block the worker (OTLP export) should remain decoupled from op processing so the worker stays within its latency budget.
+
+**Why one resource for peers and headers?**
+Several probe points are intrinsically dual-purpose.
+A single semantic event (“header announced”, “block delivered”, …) updates peer claims/scores *and* header lifecycle timestamps, keeping call sites few and consistent.
+Splitting queues or stages would force dual instrumentation for the same domain event.
+
+### Two logical maps, one worker
+
+| Component | Role |
+| --- | --- |
+| `PeerPerformance` | Per-peer **claims** (intersection / header / block delivery on the parent chain) and **scores** (EWMAs of header lag, block response time, bandwidth; counters for fetch success/timeout; keepalive RTT). |
+| `HeaderPerformance` | Open **header lifecycles** (received / requested / downloaded) until a terminal outcome; optional in-progress **fork switch**. |
+
+Unit tests exercise these types directly without spawning the worker.
+Integration and stage tests install `ResourcePerformance` and assert effect traces.
+
+### Event-oriented API
+
+Stages emit domain events, not low-level map mutations, currently:
+
+- **Peer / chain tips:** `record_intersection`, `record_header_announcement`, `record_rollback`, `record_block_delivery`, `record_fetch_failure`
+- **Header lifecycle / forks:** `record_blocks_requested`, `record_block_valid`, `record_block_pruned`, `record_header_abandoned`, `record_header_rejected`, `record_fork_started`
+- **Peer lifecycle:** `clear_peer_availability` (disconnect / no remaining live connection; scores kept), `forget_peer` (ban; scores and claims removed)
+- **Horizon:** `prune_below(min_height, now)`
+- **Queries:** `select_peers_for_fetch`, `peer_covers_fragment`, `direct_claimants`, `rank_peers_for_churn`, `scores`, `snapshot`
+
+Timestamps use pure-stage `Instant` so simulation remains deterministic ([EDR-014][edr-time] for wall-clock vs monotonic concerns at the node boundary).
+
+### Fetch selection and scoring
+
+`fetch_blocks` selects covering peers via `select_peers_for_fetch` (coverage from claims, ranked by a score to be tuned over time).
+If coverage is weak or the set is empty, the stage may fall back to all eligible connections.
+
+### Lifecycle terminalisation and pruning
+
+Header lifecycles must always reach a terminal outcome so the map won't grow without bound and so network-health observations close:
+
+| Outcome | When |
+| --- | --- |
+| `ValidBlock` / `InvalidBlock` / `AbandonedBlock` | Chain selection / validation / better chain |
+| Rejected header variants | Undecodable, invalid, duplicate, store error (often without a prior open lifecycle) |
+| `Pruned` | Header height falls below the immutable horizon |
+
+The immutable horizon is `tip.height − k` after anchor drag in `adopt_chain` (`drag_anchor_forward`).
+Peer maps are also cleaned on connection end (`clear_peer_availability` when no live connection remains) and on adversarial ban (`forget_peer`).
+
+### Relation to tracing and metrics
+
+[EDR-026][edr-tracing] spans (`perf.header.forward`, `perf.blocks.fetch`, `perf.fork.switch`, …) remain the span-based story for distributed traces and operator debugging.
+The performance resource complements that with:
+
+- **decision state** (who can serve what; ranked peer sets);
+- **closed lifecycle events/metrics** (`perf.header.lifecycle` intervals, fork-switch outcomes) emitted from the worker when a lifecycle terminates, using the optional metrics meter from resources ([EDR-015][edr-metrics]).
+
+Spans answer “what path did this header take?”; the resource answers “given everything we have seen so far, whom do we ask next?” and ensures every accepted header is accounted for even when never adopted.
+Probe points should stay aligned: the same stage moments that open/close [EDR-026][edr-tracing] spans are the natural places to record performance events, avoiding divergent instrumentation.
+
+## Consequences
+
+- Consensus stages depend on `ResourcePerformance` being installed in pure-stage `Resources` (production and stage tests).
+- Simulation tests assert performance effects in stage traces (`te_*` / `assert_trace*`); peer/header logic is also unit-tested without the worker.
+- Op queue depth is a capacity invariant of the node design, not a soft buffer to shed load.
+- Dropping the last `Performance` handle joins the worker after the channel closes; teardown should avoid doing that join on a multi-thread Tokio worker under a deep queue.
+- Ranking and churn algorithms can evolve inside `PeerPerformance` without reshaping the stage graph, as long as the event/query API remains stable.
+- Until keepalive RTT and churn ranking are wired (below), peer quality is incomplete relative to the network-spec intent described in [EDR-024][edr-peer-handling] (latency + bandwidth-based selection).
+
+## Future work
+
+1. **Keepalive RTT tracking** — call `record_keepalive_rtt` from the keepalive mini-protocol handler; fold `keepalive_rtt_ewma` into fetch ranking and churn badness (and into bandwidth estimation where response time includes RTT).
+2. **Churn** — peer selection should demote/promote using `rank_peers_for_churn` (or successor) on a schedule, not only react to adversarial bans.
+3. **Scoring policy** — replace provisional EWMA heuristics with an explicit, testable policy (document knobs; avoid silent retunes).
+5. **Horizon / dual-connection edge cases** — keep pruning and clear/forget rules aligned with multi-connection peers (inbound+outbound) so availability is cleared only when no usable connection remains.
+
+## Discussion points
+
+Captured mainly from review of the performance-resource PR ([#1127](https://github.com/pragma-org/amaru/pull/1127)):
+
+- **Stage vs resource:** a dedicated pure-stage for peer performance would make selection logic “simulatable as a stage,” but would also pull decision-critical data into the back-pressured graph and add cycles.
+  The chosen compromise is: pure maps unit-testable + effect traces in stage simulation + worker as the serialised owner of live state.
+- **Two queues (header vs peer):** considered for isolating “droppable” telemetry from “must not drop” peer data.
+  Rejected in favour of one op stream and a hard capacity invariant: if the node cannot digest performance ops, the design is wrong.
+  Header and peer updates also share inputs, so splitting would duplicate probe points.
+
+[edr-observability]: ./007-observability.md
+[edr-simulation]: ./011-deterministic-simulation-testing.md
+[edr-time]: ./014-time-in-amaru.md
+[edr-metrics]: ./015-recording-cardano-metrics.md
+[edr-peer-handling]: ./024-peer-handling-infrastructure.md
+[edr-tracing]: ./026-tracing-span-design.md

--- a/engineering-decision-records/030-consensus-performance-resource.md
+++ b/engineering-decision-records/030-consensus-performance-resource.md
@@ -89,7 +89,9 @@ Peer maps are also cleaned on connection end (`clear_peer_availability` when no 
 The performance resource complements that with:
 
 - **decision state** (who can serve what; ranked peer sets);
-- **closed lifecycle events/metrics** (`perf.header.lifecycle` intervals, fork-switch outcomes) emitted from the worker when a lifecycle terminates, using the optional metrics meter from resources ([EDR-015][edr-metrics]).
+- **closed lifecycle telemetry** (`perf.header.lifecycle` intervals, fork-switch outcomes): the worker produces pure payloads when a lifecycle terminates; the external-effect handler emits tracing events and optional metrics ([EDR-015][edr-metrics]) on the stage effect executor.
+
+OpenTelemetry export may drop or lag under resource or connectivity pressure. That must not stall the performance worker or couple export failure modes to peer/header state. Therefore **no OTel/metric emission runs on the performance thread**.
 
 Spans answer “what path did this header take?”; the resource answers “given everything we have seen so far, whom do we ask next?” and ensures every accepted header is accounted for even when never adopted.
 Probe points should stay aligned: the same stage moments that open/close [EDR-026][edr-tracing] spans are the natural places to record performance events, avoiding divergent instrumentation.
@@ -108,7 +110,7 @@ Probe points should stay aligned: the same stage moments that open/close [EDR-02
 1. **Keepalive RTT tracking** — call `record_keepalive_rtt` from the keepalive mini-protocol handler; fold `keepalive_rtt_ewma` into fetch ranking and churn badness (and into bandwidth estimation where response time includes RTT).
 2. **Churn** — peer selection should demote/promote using `rank_peers_for_churn` (or successor) on a schedule, not only react to adversarial bans.
 3. **Scoring policy** — replace provisional EWMA heuristics with an explicit, testable policy (document knobs; avoid silent retunes).
-5. **Horizon / dual-connection edge cases** — keep pruning and clear/forget rules aligned with multi-connection peers (inbound+outbound) so availability is cleared only when no usable connection remains.
+4. **Horizon / dual-connection edge cases** — keep pruning and clear/forget rules aligned with multi-connection peers (inbound+outbound) so availability is cleared only when no usable connection remains.
 
 ## Discussion points
 


### PR DESCRIPTION
also move OTel emission from `performance` thread into the pure-stage effect handler, so that the `performance` thread cannot be blocked (and fall behind) during observability network bandwidth issues

Skip-changelog

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>