### PR TITLE
Implement VoteOnExpiredGovAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Other guiding principles:
 - **amaru-ledger**: resolve and control CC member cold credentials following ratification or in-flight proposals.
 - **amaru-ledger**: disallow voters not relevant to the target proposals.
 - **amaru**: use definite decoding for Conway bytes
+- **amaru-ledger**: reject votes cast on governance actions that have expired. ([#1143][], [#926][])
 
 ## v10.11.20260813 _[unreleased; planned for 2026-08-13]_
 
@@ -326,6 +327,7 @@ Other guiding principles:
 [#915]: https://github.com/pragma-org/amaru/issues/915
 [#923]: https://github.com/pragma-org/amaru/issues/923
 [#924]: https://github.com/pragma-org/amaru/issues/924
+[#926]: https://github.com/pragma-org/amaru/issues/926
 [#928]: https://github.com/pragma-org/amaru/issues/928
 [#929]: https://github.com/pragma-org/amaru/issues/929
 [#931]: https://github.com/pragma-org/amaru/issues/931
@@ -383,3 +385,4 @@ Other guiding principles:
 [#1118]: https://github.com/pragma-org/amaru/pull/1118
 [#1138]: https://github.com/pragma-org/amaru/pull/1138
 [#1139]: https://github.com/pragma-org/amaru/pull/1139
+[#1143]: https://github.com/pragma-org/amaru/pull/1143

--- a/crates/amaru-ledger/benches/state/volatile_db/common/scenario.rs
+++ b/crates/amaru-ledger/benches/state/volatile_db/common/scenario.rs
@@ -18,7 +18,7 @@ use amaru_kernel::{
     CertificatePointer, Epoch, MAINNET_DEFAULT_PROTOCOL_PARAMETERS, Pots, ProposalPointer, StakeCredential,
 };
 use amaru_ledger::{
-    context::PreparationContext,
+    context::{PreparationContext, ProposalState},
     epoch_transition::GovernanceActivity,
     state::volatile::{AnchoredVolatileFragment, VolatileDB, VolatileFragment, VolatileSequence},
     store::{self, ReadStore},
@@ -404,7 +404,14 @@ fn step_fragment_dreps(fragment: &mut VolatileFragment, rng: &mut impl rand::Rng
 fn step_fragment_proposals(fragment: &mut VolatileFragment, rng: &mut impl rand::Rng, _ix: usize) -> usize {
     let proposal_id = fixture::comparable_proposal_id(rng);
 
-    fragment.proposals.insert(proposal_id, Arc::new((fixture::proposal(rng), ProposalPointer::default())));
+    fragment.proposals.insert(
+        proposal_id,
+        Arc::new(ProposalState {
+            proposed_in: ProposalPointer::default(),
+            valid_until: Epoch::default(),
+            proposal: fixture::proposal(rng),
+        }),
+    );
 
     Scenario::Proposals.per_item_size()
 }

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -663,7 +663,7 @@ fn import_proposals(
                                 },
                                 proposal_index,
                             },
-                            valid_until: proposal.proposed_in + protocol_parameters.gov_action_lifetime,
+                            valid_until: proposal.expires_after,
                             proposal: proposal.procedure.clone(),
                         },
                     ))

--- a/crates/amaru-ledger/src/context.rs
+++ b/crates/amaru-ledger/src/context.rs
@@ -341,15 +341,29 @@ pub struct ProposalState {
     pub proposal: Proposal,
 }
 
+/// [`ProposalState`] with its payload reduced to a [`ProposalSlim`], as the volatile window and the
+/// validation context carry it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProposalStateSlim {
+    pub action: ProposalSlim,
+    pub valid_until: Epoch,
+}
+
+impl From<&ProposalState> for ProposalStateSlim {
+    fn from(state: &ProposalState) -> Self {
+        Self { action: ProposalSlim::from(&state.proposal.gov_action), valid_until: state.valid_until }
+    }
+}
+
 pub trait ProposalsSlice {
     /// A slim view of a known proposal, whether it comes from the ledger state or was acknowledged
     /// earlier in the block.
-    fn lookup(&self, id: &ProposalId) -> Option<ProposalSlim>;
+    fn lookup(&self, id: &ProposalId) -> Option<ProposalStateSlim>;
 
     /// The current governance roots, i.e. the latest enacted action per category.
     fn roots(&self) -> &ProposalsRoots;
 
-    fn acknowledge(&mut self, id: ProposalId, pointer: ProposalPointer, proposal: Proposal);
+    fn acknowledge(&mut self, id: ProposalId, state: ProposalState);
 
     fn vote(&mut self, proposal: ProposalId, voter: Voter, vote: Vote, anchor: Option<Anchor>);
 }

--- a/crates/amaru-ledger/src/context/default/preparation.rs
+++ b/crates/amaru-ledger/src/context/default/preparation.rs
@@ -27,7 +27,7 @@ use crate::{
     context::{
         AccountState, CCMember, ContextHydratationError, DefaultValidationContext, PreparationContext,
         PrepareAccountsSlice, PrepareCommitteeSlice, PrepareDRepsSlice, PreparePoolsSlice, PrepareProposalsSlice,
-        PrepareUtxoSlice, UnresolvedInputPolicy,
+        PrepareUtxoSlice, ProposalStateSlim, UnresolvedInputPolicy,
     },
     state::volatile::{Bind, Existence, VolatileDB, VolatileState},
     store::ReadStore,
@@ -479,15 +479,17 @@ fn resolve_committee<'block, 'volatile>(
     })
 }
 
-/// The materialized [`ProposalState`] for each existing id, layering the ongoing block over the
-/// volatile DB over the stable store; a `Gone` tombstone (boundary pruning) skips the stale
-/// stable entry. A proposal still in the volatile window was proposed within the last `k` blocks,
-/// so its expiry is derived from its own pointer rather than read from a not-yet-written row.
+/// The [`ProposalStateSlim`] for each existing id, layering the ongoing block over the volatile DB over
+/// the stable store; a `Gone` tombstone (boundary pruning) skips the stale stable entry.
+///
+/// Expiry is read from whichever layer answers, never re-derived: it is stamped once at submission
+/// from the lifetime in force then, so a later change to `gov_action_lifetime` must neither extend
+/// nor shorten an action already on the chain.
 pub fn resolve_proposals(
     volatile: &impl VolatileState<Proposal = <VolatileDB as VolatileState>::Proposal>,
     db: &impl ReadStore,
     mut keys: impl Iterator<Item = ProposalId>,
-) -> Result<BTreeMap<ProposalId, ProposalSlim>, ContextHydratationError> {
+) -> Result<BTreeMap<ProposalId, ProposalStateSlim>, ContextHydratationError> {
     debug_span!(ledger::validation_context::proposals::HYDRATE).in_scope(|| {
         let mut from_volatile = 0;
         let mut from_db = 0;
@@ -509,7 +511,13 @@ pub fn resolve_proposals(
                 Existence::Unknown => {
                     if let Some(row) = db.proposal(&id).map_err(ContextHydratationError::ResolveProposals)? {
                         from_db += 1;
-                        proposals.insert(id, ProposalSlim::from(&row.proposal.gov_action));
+                        proposals.insert(
+                            id,
+                            ProposalStateSlim {
+                                action: ProposalSlim::from(&row.proposal.gov_action),
+                                valid_until: row.valid_until,
+                            },
+                        );
                     }
 
                     Ok(proposals)

--- a/crates/amaru-ledger/src/context/default/validation.rs
+++ b/crates/amaru-ledger/src/context/default/validation.rs
@@ -22,8 +22,7 @@ use std::{
 use amaru_kernel::{
     Anchor, Ballot, BallotId, CertificatePointer, ConstitutionalCommitteeMemberStatus, DRep, DRepRegistration, Epoch,
     GovernanceAction, Hash, Lovelace, MemoizedPlutusData, MemoizedScript, MemoizedTransactionOutput, Mint, PoolId,
-    PoolParams, Proposal, ProposalId, ProposalPointer, ProposalSlim, ProposalsRoots, RequiredScript, StakeCredential,
-    TransactionInput, Value, Vote, Voter,
+    PoolParams, ProposalId, ProposalsRoots, RequiredScript, StakeCredential, TransactionInput, Value, Vote, Voter,
     cardano::value::Balance,
     size::{DATUM, KEY, SCRIPT},
 };
@@ -31,8 +30,8 @@ use amaru_kernel::{
 use crate::{
     context::{
         AccountState, AccountsSlice, BalanceSlice, CCMember, CommitteeSlice, DRepsSlice, DelegateError, PoolsSlice,
-        PotsSlice, ProposalsSlice, RegisterError, UnregisterError, UpdateError, UtxoSlice, ValidationContext,
-        WitnessSlice, blanket_known_datums, blanket_known_scripts,
+        PotsSlice, ProposalState, ProposalStateSlim, ProposalsSlice, RegisterError, UnregisterError, UpdateError,
+        UtxoSlice, ValidationContext, WitnessSlice, blanket_known_datums, blanket_known_scripts,
     },
     state::volatile::{BindError, Existence, VolatileFragment},
 };
@@ -44,7 +43,7 @@ pub struct DefaultValidationContext {
     accounts: BTreeMap<StakeCredential, AccountState>,
     dreps: BTreeMap<StakeCredential, DRepRegistration>,
     committee: BTreeMap<StakeCredential, CCMember>,
-    proposals: BTreeMap<ProposalId, ProposalSlim>,
+    proposals: BTreeMap<ProposalId, ProposalStateSlim>,
     proposals_roots: ProposalsRoots,
     treasury: Lovelace,
     state: VolatileFragment,
@@ -65,7 +64,7 @@ impl DefaultValidationContext {
         accounts: BTreeMap<StakeCredential, AccountState>,
         dreps: BTreeMap<StakeCredential, DRepRegistration>,
         committee: BTreeMap<StakeCredential, CCMember>,
-        proposals: BTreeMap<ProposalId, ProposalSlim>,
+        proposals: BTreeMap<ProposalId, ProposalStateSlim>,
         proposals_roots: ProposalsRoots,
         treasury: Lovelace,
     ) -> Self {
@@ -373,18 +372,18 @@ impl CommitteeSlice for DefaultValidationContext {
 }
 
 impl ProposalsSlice for DefaultValidationContext {
-    fn lookup(&self, id: &ProposalId) -> Option<ProposalSlim> {
+    fn lookup(&self, id: &ProposalId) -> Option<ProposalStateSlim> {
         self.proposals
             .get(id)
             .copied()
-            .or_else(|| self.state.proposals.get(id).map(|entry| ProposalSlim::from(&entry.0.gov_action)))
+            .or_else(|| self.state.proposals.get(id).map(|state| ProposalStateSlim::from(state.as_ref())))
     }
 
     fn roots(&self) -> &ProposalsRoots {
         &self.proposals_roots
     }
 
-    fn acknowledge(&mut self, id: ProposalId, pointer: ProposalPointer, proposal: Proposal) {
+    fn acknowledge(&mut self, id: ProposalId, state: ProposalState) {
         // NOTE: Candidate CC Members
         //
         // Members present in pending proposals are seen and accessible for various operations
@@ -392,7 +391,7 @@ impl ProposalsSlice for DefaultValidationContext {
         // be overridden by certificates also present in the transaction. And they are removed when
         // the fragment (and proposals) go out of the volatile and the proposals become available to
         // the store anyway.
-        if let GovernanceAction::UpdateCommittee(_, _, added, _) = &proposal.gov_action {
+        if let GovernanceAction::UpdateCommittee(_, _, added, _) = &state.proposal.gov_action {
             for (cold_credential, _) in added.iter() {
                 if !matches!(self.state.committee.get(cold_credential), Existence::Exists(..)) {
                     self.state
@@ -403,7 +402,7 @@ impl ProposalsSlice for DefaultValidationContext {
             }
         }
 
-        self.state.proposals.insert(id, Arc::new((proposal, pointer)));
+        self.state.proposals.insert(id, Arc::new(state));
     }
 
     fn vote(&mut self, proposal: ProposalId, voter: Voter, vote: Vote, anchor: Option<Anchor>) {

--- a/crates/amaru-ledger/src/rules/transaction/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/fixture.rs
@@ -24,7 +24,7 @@ use amaru_kernel::{
 use serde::Deserialize;
 
 use crate::{
-    context::{AccountState, CCMember, DelegateError},
+    context::{AccountState, CCMember, DelegateError, ProposalStateSlim},
     epoch_transition::GovernanceActivity,
     rules::{
         WithPosition,
@@ -69,7 +69,7 @@ pub(super) struct InitialState {
     #[serde(deserialize_with = "deserialize_committee", default)]
     pub(super) committee: BTreeMap<StakeCredential, CCMember>,
     #[serde(deserialize_with = "deserialize_proposals", default)]
-    pub(super) proposals: BTreeMap<ProposalId, ProposalSlim>,
+    pub(super) proposals: BTreeMap<ProposalId, ProposalStateSlim>,
     #[serde(default)]
     pub(super) proposals_roots: ProposalsRoots,
     #[serde(default)]
@@ -168,12 +168,14 @@ where
         .collect())
 }
 
-fn deserialize_proposals<'de, D>(deserializer: D) -> Result<BTreeMap<ProposalId, ProposalSlim>, D::Error>
+fn deserialize_proposals<'de, D>(deserializer: D) -> Result<BTreeMap<ProposalId, ProposalStateSlim>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let entries = Vec::<(ProposalId, ProposalSlim)>::deserialize(deserializer)?;
-    Ok(entries.into_iter().collect())
+    Ok(Vec::<(ProposalId, ProposalSlim, Epoch)>::deserialize(deserializer)?
+        .into_iter()
+        .map(|(id, action, valid_until)| (id, ProposalStateSlim { action, valid_until }))
+        .collect())
 }
 
 /// A row of the constitutional committee, keyed by cold credential. `hotCredential` is absent for a
@@ -304,6 +306,7 @@ pub(super) enum Predicate {
     ValidationTagMismatch { description: TagMismatchDescription },
     ValueNotConservedUTxO,
     VotersDoNotExist,
+    VotingOnExpiredGovAction,
     WithdrawalsNotInRewardsCERTS,
     WrongNetworkInTxBody,
     WrongNetworkInTxOutput,
@@ -413,6 +416,9 @@ impl From<PhaseOneError> for Predicate {
             }
             PhaseOneError::VotingProcedures(InvalidVotingProcedures::UnknownVoter(_)) => Predicate::VotersDoNotExist,
             PhaseOneError::VotingProcedures(InvalidVotingProcedures::DisallowedVoter(_)) => Predicate::DisallowedVoters,
+            PhaseOneError::VotingProcedures(InvalidVotingProcedures::VotingOnExpiredGovAction(_)) => {
+                Predicate::VotingOnExpiredGovAction
+            }
             PhaseOneError::ValueNotPreserved(_) => Predicate::ValueNotConservedUTxO,
             PhaseOneError::Certificates(InvalidCertificates::StakeCredentialInvalidPoolDelegation(ref e)) => match e {
                 DelegateError::UnknownSource(_) => Predicate::StakeCredentialInvalidPoolDelegation,
@@ -464,7 +470,10 @@ impl From<PhaseOneError> for Predicate {
             | PhaseOneError::Withdrawals(_)
             | PhaseOneError::Scripts(_)
             | PhaseOneError::Collateral(_)
-            | PhaseOneError::Proposals(_) => unreachable!("no predicate mapping yet for {err}"),
+            | PhaseOneError::Proposals(_)
+            | PhaseOneError::VotingProcedures(InvalidVotingProcedures::EraHistory(_)) => {
+                unreachable!("no predicate mapping yet for {err}")
+            }
         }
     }
 }

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
@@ -289,6 +289,8 @@ where
             voting_procedures::execute(
                 context,
                 protocol_parameters.protocol_version,
+                era_history,
+                pointer,
                 mem::take(&mut transaction_body.votes),
             )
         })?;

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/proposals.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/proposals.rs
@@ -21,7 +21,7 @@ use amaru_kernel::{
 };
 use thiserror::Error;
 
-use crate::context::{AccountsSlice, BalanceSlice, ProposalsSlice, WitnessSlice};
+use crate::context::{AccountsSlice, BalanceSlice, ProposalState, ProposalsSlice, WitnessSlice};
 
 #[derive(Debug, Error)]
 pub enum InvalidProposals {
@@ -110,7 +110,10 @@ where
 
         let pointer = ProposalPointer { transaction: transaction.1, proposal_index };
         let id = ProposalId { transaction_id: *transaction.0, proposal_index: proposal_index as u32 };
-        context.acknowledge(id, pointer, proposal)
+        let valid_until = era_history.slot_to_epoch(transaction.1.slot, transaction.1.slot)?
+            + protocol_parameters.gov_action_lifetime;
+
+        context.acknowledge(id, ProposalState { proposed_in: pointer, valid_until, proposal })
     }
 
     Ok(())
@@ -162,7 +165,7 @@ where
             let follows_root = parent == context.roots().root_of(kind);
             let follows_in_flight = parent
                 .and_then(|id| ProposalsSlice::lookup(context, id))
-                .is_some_and(|in_flight| in_flight.same_lineage(kind));
+                .is_some_and(|in_flight| in_flight.action.same_lineage(kind));
             if !follows_root && !follows_in_flight {
                 return Err(InvalidProposals::InvalidPrevGovActionId { parent: parent.cloned() });
             }
@@ -276,7 +279,7 @@ where
         return None;
     }
 
-    match parent.and_then(|id| context.lookup(id)) {
+    match parent.and_then(|id| context.lookup(id)).map(|in_flight| in_flight.action) {
         Some(ProposalSlim::HardFork(previous_version)) => Some(previous_version),
         // The lineage check in `validate_proposal` runs first, and rejects any parent that is
         // neither the hard fork root nor a hard fork proposal still in flight.

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/voting_procedures.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/voting_procedures.rs
@@ -15,14 +15,14 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use amaru_kernel::{
-    HasOwnership, MemoizedDatum, NonEmptyKeyValuePairs, ProposalId, ProposalSlim, ProtocolVersion, RedeemerTag,
-    RequiredScript, StakeCredential, Voter, VotingProcedure, protocol_version::PROTOCOL_VERSION_11,
-    utils::string::display_map,
+    Epoch, EraHistory, HasOwnership, MemoizedDatum, NonEmptyKeyValuePairs, ProposalId, ProposalSlim, ProtocolVersion,
+    RedeemerTag, RequiredScript, StakeCredential, TransactionPointer, Voter, VotingProcedure,
+    protocol_version::PROTOCOL_VERSION_11, utils::string::display_map,
 };
 use itertools::Itertools;
 use thiserror::Error;
 
-use crate::context::{CommitteeSlice, DRepsSlice, PoolsSlice, ProposalsSlice, WitnessSlice};
+use crate::context::{CommitteeSlice, DRepsSlice, PoolsSlice, ProposalStateSlim, ProposalsSlice, WitnessSlice};
 
 #[derive(Debug, Error)]
 pub enum InvalidVotingProcedures {
@@ -34,19 +34,34 @@ pub enum InvalidVotingProcedures {
 
     #[error("governance actions do not exist: {0:?}")]
     GovActionsDoNotExist(BTreeSet<ProposalId>),
+
+    #[error("votes cast on governance actions that have expired: {}", display_map(.0))]
+    VotingOnExpiredGovAction(BTreeMap<Voter, ProposalId>),
+
+    #[error("era history error: {0}")]
+    EraHistory(#[from] amaru_kernel::EraHistoryError),
 }
 
 pub(crate) fn execute<C>(
     context: &mut C,
     protocol_version: ProtocolVersion,
+    era_history: &EraHistory,
+    pointer: TransactionPointer,
     voting_procedures: Option<NonEmptyKeyValuePairs<Voter, NonEmptyKeyValuePairs<ProposalId, VotingProcedure>>>,
 ) -> Result<(), InvalidVotingProcedures>
 where
     C: WitnessSlice + ProposalsSlice + CommitteeSlice + DRepsSlice + PoolsSlice,
 {
     if let Some(voting_procedures) = voting_procedures {
+        // NOTE: Some conformance tests fail this check because the Haskell imp tests run on a
+        // synthetic test chain whose epoch/slot mapping differs from our era_history. Our
+        // slot_to_epoch computes a different current epoch, so an action they expect to have expired
+        // still reads as live here.
+        let current_epoch = era_history.slot_to_epoch(pointer.slot, pointer.slot)?;
+
         let mut unknown_voters = BTreeSet::new();
         let mut unknown_proposals = BTreeSet::new();
+        let mut expired_proposals = BTreeMap::new();
         let mut disallowed_voters = BTreeMap::new();
 
         voting_procedures.into_iter().sorted_by_key(|(k, _)| *k).enumerate().for_each(|(index, (voter, votes))| {
@@ -61,16 +76,25 @@ where
                         unknown_proposals.insert(*proposal_id);
                     }
                     Some(proposal) => {
-                        if !is_allowed_voter(&voter, &proposal) {
-                            disallowed_voters.insert(voter, proposal);
+                        if is_expired(&proposal, current_epoch) {
+                            expired_proposals.insert(voter, *proposal_id);
+                            return;
+                        }
+
+                        if !is_allowed_voter(&voter, &proposal.action) {
+                            disallowed_voters.insert(voter, proposal.action);
                             return;
                         }
                     }
                 }
             }
 
-            if !(unknown_voters.is_empty() && disallowed_voters.is_empty() && unknown_proposals.is_empty()) {
-                return; // Skip validations after if any proposal or voter is invalid;
+            if !(unknown_voters.is_empty()
+                && disallowed_voters.is_empty()
+                && unknown_proposals.is_empty()
+                && expired_proposals.is_empty())
+            {
+                return;
             }
 
             match voter.owner() {
@@ -98,12 +122,21 @@ where
             return Err(InvalidVotingProcedures::GovActionsDoNotExist(unknown_proposals));
         }
 
+        if !expired_proposals.is_empty() {
+            return Err(InvalidVotingProcedures::VotingOnExpiredGovAction(expired_proposals));
+        }
+
         if !disallowed_voters.is_empty() {
             return Err(InvalidVotingProcedures::DisallowedVoter(disallowed_voters));
         }
     }
 
     Ok(())
+}
+
+/// Whether the proposal is past the last epoch in which a vote on it still counts.
+fn is_expired(proposal: &ProposalStateSlim, current_epoch: Epoch) -> bool {
+    proposal.valid_until < current_epoch
 }
 
 /// Whether a voter has any say over this kind of governance action

--- a/crates/amaru-ledger/src/snapshot.rs
+++ b/crates/amaru-ledger/src/snapshot.rs
@@ -75,26 +75,21 @@ pub fn committee_members(
 
 /// A governance proposal's block-start state from a snapshot. `proposed_in` is synthesized to the
 /// start of its proposing epoch, the only position a NewEpochState records.
+///
+/// The expiry is the one the snapshot recorded, not `proposed_in + gov_action_lifetime`: the two
+/// agree only if the lifetime never changed since the action was submitted.
 pub fn proposal_state(
     proposal: NewEpochProposalState,
     era_history: &EraHistory,
-    protocol_parameters: &ProtocolParameters,
 ) -> Result<(ProposalId, ProposalState), EraHistoryError> {
-    let NewEpochProposalState { id, procedure, proposed_in, .. } = proposal;
+    let NewEpochProposalState { id, procedure, proposed_in, expires_after, .. } = proposal;
 
     let proposed_in_pointer = ProposalPointer {
         transaction: TransactionPointer { slot: era_history.epoch_bounds(proposed_in)?.start, transaction_index: 0 },
         proposal_index: id.proposal_index as usize,
     };
 
-    Ok((
-        id,
-        ProposalState {
-            proposed_in: proposed_in_pointer,
-            valid_until: proposed_in + protocol_parameters.gov_action_lifetime,
-            proposal: procedure,
-        },
-    ))
+    Ok((id, ProposalState { proposed_in: proposed_in_pointer, valid_until: expires_after, proposal: procedure }))
 }
 
 /// The governance roots, the latest enacted action per category, as of the snapshot.

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -348,7 +348,7 @@ impl<S: Store, HS: HistoricalStores + Send + Sync + 'static> State<S, HS> {
 
                 // Persist changes for this block
                 let StoreUpdate { point: stable_point, issuer: stable_issuer, fees, donations, add, remove, withdrawals } =
-                    now_stable.into_store_update(immutable_epoch, protocol_parameters);
+                    now_stable.into_store_update();
 
                 self.stable.lock().unwrap()
                     .with_transaction(|batch| {

--- a/crates/amaru-ledger/src/state/volatile/aggregate.rs
+++ b/crates/amaru-ledger/src/state/volatile/aggregate.rs
@@ -19,11 +19,13 @@ use std::{
 
 use amaru_kernel::{
     CertificatePointer, ConstitutionalCommitteeMemberStatus, DRep, DRepRegistration, Epoch, Lovelace,
-    MemoizedTransactionOutput, PoolId, Proposal, ProposalId, ProposalPointer, ProposalSlim, StakeCredential,
-    TransactionInput,
+    MemoizedTransactionOutput, PoolId, ProposalId, StakeCredential, TransactionInput,
 };
 
-use crate::state::volatile::{AccountBind, CommitteeMemberBind, DRepBind, DiffSet, Empty, Existence, VolatileFragment};
+use crate::{
+    context::{ProposalState, ProposalStateSlim},
+    state::volatile::{AccountBind, CommitteeMemberBind, DRepBind, DiffSet, Empty, Existence, VolatileFragment},
+};
 
 mod indexed_bind;
 pub use indexed_bind::IndexedBind;
@@ -65,7 +67,7 @@ pub struct VolatileAggregate {
     dreps: DReps,
     committee: Committee,
     withdrawals: BTreeSet<StakeCredential>,
-    proposals: BTreeMap<ProposalId, Arc<(Proposal, ProposalPointer)>>,
+    proposals: BTreeMap<ProposalId, Arc<ProposalState>>,
     fees: Lovelace,
     donations: Lovelace,
 }
@@ -117,9 +119,9 @@ impl VolatileAggregate {
 
     /// This aggregate's view of a governance proposal. Proposals are add-only in a block, so this is
     /// `Exists` or `Unknown`; pruning only happens at the boundary.
-    pub fn resolve_proposal(&self, id: &ProposalId) -> Existence<ProposalSlim> {
+    pub fn resolve_proposal(&self, id: &ProposalId) -> Existence<ProposalStateSlim> {
         match self.proposals.get(id) {
-            Some(entry) => Existence::Exists(ProposalSlim::from(&entry.0.gov_action)),
+            Some(state) => Existence::Exists(ProposalStateSlim::from(state.as_ref())),
             None => Existence::Unknown,
         }
     }

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -19,11 +19,12 @@ use std::{
 
 use amaru_kernel::{
     Epoch, EraHistory, GlobalParameters, Hash, Lovelace, MemoizedTransactionOutput,
-    PREPROD_DEFAULT_PROTOCOL_PARAMETERS, Point, PoolId, Pots, ProposalId, ProposalSlim, ProposalsRoots,
-    ProtocolParameters, StakeCredential, TransactionInput, size::SCRIPT,
+    PREPROD_DEFAULT_PROTOCOL_PARAMETERS, Point, PoolId, Pots, ProposalId, ProposalsRoots, ProtocolParameters,
+    StakeCredential, TransactionInput, size::SCRIPT,
 };
 
 use crate::{
+    context::ProposalStateSlim,
     epoch_transition::{
         Computed, Effective, GovernanceActivity, GovernanceUpdates, PoolsEpochTransitionUpdates, Rewards, RewardsState,
     },
@@ -173,7 +174,7 @@ impl VolatileState for VolatileDB {
     }
 
     // ----------------------------------------------------------------------------------- Proposals
-    type Proposal = Existence<ProposalSlim>;
+    type Proposal = Existence<ProposalStateSlim>;
     /// Resolve a governance proposal across the volatile layers, precedence `current -> overlay
     /// (pruning) -> draining`. A proposal pruned at the boundary is `Gone`; `Unknown` means consult
     /// the stable store.

--- a/crates/amaru-ledger/src/state/volatile/fragment.rs
+++ b/crates/amaru-ledger/src/state/volatile/fragment.rs
@@ -19,11 +19,12 @@ use std::{
 
 use amaru_kernel::{
     Anchor, Ballot, BallotId, CertificatePointer, ConstitutionalCommitteeMemberStatus, DRep, DRepRegistration, Epoch,
-    Lovelace, MemoizedTransactionOutput, Point, PoolId, PoolParams, Proposal, ProposalId, ProposalPointer,
-    ProtocolParameters, Slot, StakeCredential, TransactionInput,
+    Lovelace, MemoizedTransactionOutput, Point, PoolId, PoolParams, ProposalId, Slot, StakeCredential,
+    TransactionInput,
 };
 
 use crate::{
+    context::ProposalState,
     state::volatile::{Bind, Empty},
     store::{self, columns::*},
 };
@@ -60,7 +61,7 @@ pub struct VolatileFragment {
     pub dreps_deregistrations: BTreeMap<StakeCredential, CertificatePointer>,
     pub committee: DiffBind<StakeCredential, ConstitutionalCommitteeMemberStatus, Epoch, Empty>,
     pub withdrawals: BTreeSet<StakeCredential>,
-    pub proposals: BTreeMap<ProposalId, Arc<(Proposal, ProposalPointer)>>,
+    pub proposals: BTreeMap<ProposalId, Arc<ProposalState>>,
     pub votes: DiffSet<BallotId, Ballot>,
     pub fees: Lovelace,
     pub donations: Lovelace,
@@ -97,8 +98,6 @@ impl AnchoredVolatileFragment {
     #[allow(clippy::type_complexity)]
     pub fn into_store_update(
         self,
-        epoch: Epoch,
-        protocol_parameters: &ProtocolParameters,
     ) -> StoreUpdate<
         impl Iterator<Item = accounts::Key>,
         store::Columns<
@@ -120,8 +119,6 @@ impl AnchoredVolatileFragment {
             impl Iterator<Item = ()>,
         >,
     > {
-        let gov_action_lifetime = protocol_parameters.gov_action_lifetime;
-
         let Self {
             fragment:
                 VolatileFragment {
@@ -152,7 +149,7 @@ impl AnchoredVolatileFragment {
                 accounts: add_accounts(accounts.registered.into_iter()),
                 dreps: add_dreps(dreps.registered.into_iter()),
                 cc_members: add_committee(committee.registered.into_iter()),
-                proposals: add_proposals(proposals.into_iter(), epoch + gov_action_lifetime),
+                proposals: add_proposals(proposals.into_iter()),
                 votes: votes.produced.into_iter(),
             },
             remove: store::Columns {
@@ -269,11 +266,10 @@ pub(crate) fn add_committee(
 // --------------------------------------------------------------------------------------- Proposals
 
 pub(crate) fn add_proposals(
-    iterator: impl Iterator<Item = (ProposalId, Arc<(Proposal, ProposalPointer)>)>,
-    expiration: Epoch,
+    iterator: impl Iterator<Item = (ProposalId, Arc<ProposalState>)>,
 ) -> impl Iterator<Item = (proposals::Key, proposals::Value)> {
-    iterator.map(move |(proposal_id, value)| {
-        let (proposal, proposed_in) = Arc::unwrap_or_clone(value);
-        (proposal_id, proposals::Value { proposed_in, valid_until: expiration, proposal })
+    iterator.map(|(proposal_id, value)| {
+        let ProposalState { proposed_in, valid_until, proposal } = Arc::unwrap_or_clone(value);
+        (proposal_id, proposals::Value { proposed_in, valid_until, proposal })
     })
 }

--- a/crates/amaru-ledger/src/state/volatile/series.rs
+++ b/crates/amaru-ledger/src/state/volatile/series.rs
@@ -15,15 +15,17 @@
 use std::{collections::VecDeque, mem};
 
 use amaru_kernel::{
-    Lovelace, MemoizedTransactionOutput, Point, PoolId, Pots, ProposalId, ProposalSlim, StakeCredential,
-    TransactionInput,
+    Lovelace, MemoizedTransactionOutput, Point, PoolId, Pots, ProposalId, StakeCredential, TransactionInput,
 };
 use amaru_observability::debug_span;
 
-use crate::state::{
-    AnchoredVolatileFragment,
-    volatile::{
-        AccountBind, CommitteeMemberBind, DRepBind, Existence, VolatileAggregate, VolatileSequence, VolatileState,
+use crate::{
+    context::ProposalStateSlim,
+    state::{
+        AnchoredVolatileFragment,
+        volatile::{
+            AccountBind, CommitteeMemberBind, DRepBind, Existence, VolatileAggregate, VolatileSequence, VolatileState,
+        },
     },
 };
 
@@ -72,7 +74,7 @@ impl VolatileState for VolatileSeries {
     }
 
     // ----------------------------------------------------------------------------------- Proposals
-    type Proposal = Existence<ProposalSlim>;
+    type Proposal = Existence<ProposalStateSlim>;
     fn resolve_proposal(&self, id: &ProposalId) -> Self::Proposal {
         self.aggregate.resolve_proposal(id)
     }

--- a/crates/amaru-ledger/src/state/volatile/view.rs
+++ b/crates/amaru-ledger/src/state/volatile/view.rs
@@ -18,12 +18,10 @@ use std::{
     sync::Arc,
 };
 
-use amaru_kernel::{
-    CertificatePointer, Epoch, Lovelace, PoolId, PoolParams, Proposal, ProposalId, ProposalPointer, ProposalsRootsRc,
-    StakeCredential,
-};
+use amaru_kernel::{CertificatePointer, Lovelace, PoolId, PoolParams, ProposalId, ProposalsRootsRc, StakeCredential};
 
 use crate::{
+    context::ProposalState,
     state::{
         VolatileDB,
         volatile::{DiffBind, DiffEpochReg, VolatileSequence, VolatileState, fragment::add_proposals},
@@ -43,11 +41,9 @@ mod iter_unreachable_accounts;
 /// context.
 #[derive(Debug)]
 pub struct VolatileView<'volatile, 'store, DB: ReadStore> {
-    epoch: Epoch,
-    proposal_lifetime: u64,
     db: &'store DB,
     pools: Option<DiffEpochReg<PoolId, &'volatile (PoolParams, CertificatePointer, Lovelace)>>,
-    proposals: BTreeMap<&'volatile ProposalId, &'volatile Arc<(Proposal, ProposalPointer)>>,
+    proposals: BTreeMap<&'volatile ProposalId, &'volatile Arc<ProposalState>>,
     accounts: Option<AccountVolatileView<'volatile>>,
     volatile_donations: Lovelace,
 }
@@ -87,8 +83,6 @@ impl<'volatile, 'db, DB: ReadStore> VolatileView<'volatile, 'db, DB> {
         };
 
         Self {
-            epoch: volatile.epoch(),
-            proposal_lifetime: volatile.protocol_parameters().gov_action_lifetime,
             db: stable,
             accounts: Some(accounts),
             pools: Some(pools),
@@ -117,10 +111,7 @@ impl<'volatile, 'db, DB: ReadStore> VolatileView<'volatile, 'db, DB> {
     ///
     /// IMPORTANT: Yields proposals in no particular order.
     pub fn iter_proposals(&self) -> Result<impl Iterator<Item = (ProposalId, proposals::Row)>, StoreError> {
-        Ok(self.db.iter_proposals()?.chain(add_proposals(
-            self.proposals.iter().map(|(k, v)| (*(*k), (*v).clone())),
-            self.epoch + self.proposal_lifetime,
-        )))
+        Ok(self.db.iter_proposals()?.chain(add_proposals(self.proposals.iter().map(|(k, v)| (*(*k), (*v).clone())))))
     }
 
     /// Provides an iterator for accounts on top of the stable store, tracking accounts that are "no

--- a/crates/amaru-ledger/tests/data/transaction/README.md
+++ b/crates/amaru-ledger/tests/data/transaction/README.md
@@ -84,19 +84,23 @@ it is made up of the following fields:
 - `dreps`: `[{ credential, deposit, registeredAt, validUntil }]`, with the same
   `credential` encoding, a `registeredAt` certificate pointer, and a `validUntil`
   epoch.
-- `committee`: `[{ coldCredential, hotCredential?, validUntil? }]`, the constitutional
+- `committee`: `[{ coldCredential, status?, validUntil? }]`, the constitutional
   committee keyed by cold credential, both credentials hex-encoded CBOR of a
-  `StakeCredential`. `hotCredential` is absent for a member that has never authorized
-  one or has resigned; `validUntil` is absent for a member holding no term, which is
-  still a state a member can authorize a hot credential from. Note that a vote
-  identifies its committee member by *hot* credential.
-- `proposals`: `[[id, kind]]`, the in-flight governance proposals seeding the
-  block-start proposal set. `id` is a governance action id (see below); `kind` is
-  the lineage the proposal belongs to, one of `ProtocolParameters`, `HardFork`,
-  `ConstitutionalCommittee`, `Constitution` or `Orphan` — the last for the actions
-  that chain to nothing, `Information` and `TreasuryWithdrawals`. Only the lineage
-  matters here, so the action itself is not spelled out. Use `[]` when none are
-  seeded.
+  `StakeCredential`. `status` is the hot credential the member authorized, or
+  `"resigned"`; it is absent for a member that has never authorized one. `validUntil`
+  is absent for a member holding no term, which is still a state a member can
+  authorize a hot credential from. Note that a vote identifies its committee member
+  by *hot* credential.
+- `proposals`: `[[id, kind, validUntil]]`, the in-flight governance proposals
+  seeding the block-start proposal set. `id` is a governance action id (see below);
+  `kind` is the lineage the proposal belongs to, one of `ProtocolParameters`,
+  `ProtocolParameters(security-group)`, `HardFork(<major>.<minor>)`,
+  `ConstitutionalCommittee`, `Constitution`, `Information` or `TreasuryWithdrawals`
+  (`Orphan` also names the latter two, which chain to nothing). Beyond what the
+  lineage carries, the action itself is not spelled out. `validUntil` is the last
+  epoch a vote on the proposal still counts, i.e. the epoch it was proposed in plus
+  `governanceActionLifetime`.
+  Use `[]` when none are seeded.
 - `proposalsRoots`: `{ protocolParameters?, hardFork?, constitutionalCommittee?, constitution? }`,
   the latest enacted governance action id per purpose, each a governance action id
   (see below). Use `{}` when none are enacted; absent purposes default to none.

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00044-pass-vote-cast-by-a-script-credential-drep.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00044-pass-vote-cast-by-a-script-credential-drep.json
@@ -30,7 +30,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00132-pass-gov-hardfork-initiation-follows-in-flight.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00132-pass-gov-hardfork-initiation-follows-in-flight.json
@@ -22,7 +22,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "a829a847676b9e2c0ddd470708741dcff03b1769b4dc5ee8632be1817e892ee3", "proposalIndex": 0 }, "HardFork(10.1)"]
+      [{ "transactionId": "a829a847676b9e2c0ddd470708741dcff03b1769b4dc5ee8632be1817e892ee3", "proposalIndex": 0 }, "HardFork(10.1)", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00136-pass-gov-new-constitution-follows-in-flight.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00136-pass-gov-new-constitution-follows-in-flight.json
@@ -22,7 +22,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "a829a847676b9e2c0ddd470708741dcff03b1769b4dc5ee8632be1817e892ee3", "proposalIndex": 0 }, "Constitution"]
+      [{ "transactionId": "a829a847676b9e2c0ddd470708741dcff03b1769b4dc5ee8632be1817e892ee3", "proposalIndex": 0 }, "Constitution", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00140-pass-gov-parameter-change-follows-in-flight.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00140-pass-gov-parameter-change-follows-in-flight.json
@@ -22,7 +22,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "a829a847676b9e2c0ddd470708741dcff03b1769b4dc5ee8632be1817e892ee3", "proposalIndex": 0 }, "ProtocolParameters"]
+      [{ "transactionId": "a829a847676b9e2c0ddd470708741dcff03b1769b4dc5ee8632be1817e892ee3", "proposalIndex": 0 }, "ProtocolParameters", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00144-pass-gov-update-committee-follows-in-flight.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00144-pass-gov-update-committee-follows-in-flight.json
@@ -22,7 +22,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "a829a847676b9e2c0ddd470708741dcff03b1769b4dc5ee8632be1817e892ee3", "proposalIndex": 0 }, "ConstitutionalCommittee"]
+      [{ "transactionId": "a829a847676b9e2c0ddd470708741dcff03b1769b4dc5ee8632be1817e892ee3", "proposalIndex": 0 }, "ConstitutionalCommittee", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00149-fail-parameter-change-proposal-chaining-to-a-parent-of-a-different-purpose.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00149-fail-parameter-change-proposal-chaining-to-a-parent-of-a-different-purpose.json
@@ -22,7 +22,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "a829a847676b9e2c0ddd470708741dcff03b1769b4dc5ee8632be1817e892ee3", "proposalIndex": 0 }, "Constitution"]
+      [{ "transactionId": "a829a847676b9e2c0ddd470708741dcff03b1769b4dc5ee8632be1817e892ee3", "proposalIndex": 0 }, "Constitution", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00152-pass-vote-cast-by-an-authorized-committee-hot-key.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00152-pass-vote-cast-by-an-authorized-committee-hot-key.json
@@ -23,7 +23,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00153-pass-vote-cast-by-an-authorized-committee-hot-script-credential.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00153-pass-vote-cast-by-an-authorized-committee-hot-script-credential.json
@@ -23,7 +23,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00154-pass-vote-cast-by-an-unelected-committee-member-with-an-authorized-hot-key-v10.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00154-pass-vote-cast-by-an-unelected-committee-member-with-an-authorized-hot-key-v10.json
@@ -23,7 +23,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00155-pass-vote-cast-by-a-drep-whose-registration-has-expired.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00155-pass-vote-cast-by-a-drep-whose-registration-has-expired.json
@@ -30,7 +30,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00156-pass-vote-cast-by-a-registered-drep-key-credential.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00156-pass-vote-cast-by-a-registered-drep-key-credential.json
@@ -30,7 +30,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00157-pass-vote-cast-by-a-registered-stake-pool.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00157-pass-vote-cast-by-a-registered-stake-pool.json
@@ -19,7 +19,7 @@
       "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00158-fail-vote-cast-by-a-drep-key-credential-that-is-not-registered.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00158-fail-vote-cast-by-a-drep-key-credential-that-is-not-registered.json
@@ -16,7 +16,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00159-fail-vote-cast-by-a-drep-script-credential-that-is-not-registered.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00159-fail-vote-cast-by-a-drep-script-credential-that-is-not-registered.json
@@ -16,7 +16,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00160-fail-vote-cast-by-a-credential-registered-as-a-stake-account-but-not-as-a-drep.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00160-fail-vote-cast-by-a-credential-registered-as-a-stake-account-but-not-as-a-drep.json
@@ -22,7 +22,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00161-fail-vote-cast-by-a-committee-hot-key-with-an-empty-committee.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00161-fail-vote-cast-by-a-committee-hot-key-with-an-empty-committee.json
@@ -16,7 +16,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00162-fail-vote-cast-by-a-committee-hot-key-the-member-has-rotated-away-from.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00162-fail-vote-cast-by-a-committee-hot-key-the-member-has-rotated-away-from.json
@@ -23,7 +23,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00163-fail-vote-cast-by-a-committee-hot-key-of-a-member-that-authorized-none.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00163-fail-vote-cast-by-a-committee-hot-key-of-a-member-that-authorized-none.json
@@ -23,7 +23,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00164-fail-vote-cast-by-a-committee-members-cold-credential-instead-of-its-hot-one.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00164-fail-vote-cast-by-a-committee-members-cold-credential-instead-of-its-hot-one.json
@@ -23,7 +23,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00165-fail-vote-cast-by-a-committee-hot-script-credential-that-no-member-authorized.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00165-fail-vote-cast-by-a-committee-hot-script-credential-that-no-member-authorized.json
@@ -23,7 +23,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00166-fail-vote-cast-by-a-stake-pool-that-is-not-registered.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00166-fail-vote-cast-by-a-stake-pool-that-is-not-registered.json
@@ -16,7 +16,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00167-pass-vote-cast-by-a-committee-hot-key-authorized-earlier-in-the-same-transaction.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00167-pass-vote-cast-by-a-committee-hot-key-authorized-earlier-in-the-same-transaction.json
@@ -23,7 +23,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00168-pass-vote-cast-by-a-committee-hot-key-rotated-to-earlier-in-the-same-transaction.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00168-pass-vote-cast-by-a-committee-hot-key-rotated-to-earlier-in-the-same-transaction.json
@@ -23,7 +23,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00169-fail-vote-cast-by-a-committee-hot-key-whose-member-resigned-earlier-in-the-same-transaction.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00169-fail-vote-cast-by-a-committee-hot-key-whose-member-resigned-earlier-in-the-same-transaction.json
@@ -23,7 +23,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00170-fail-vote-cast-by-a-committee-hot-key-rotated-away-from-earlier-in-the-same-transaction.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00170-fail-vote-cast-by-a-committee-hot-key-rotated-away-from-earlier-in-the-same-transaction.json
@@ -23,7 +23,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00171-fail-vote-cast-by-an-unelected-committee-member-with-an-authorized-hot-key-v11.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00171-fail-vote-cast-by-an-unelected-committee-member-with-an-authorized-hot-key-v11.json
@@ -29,7 +29,7 @@
       }
     ],
     "proposals": [
-      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan"]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Orphan", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00172-fail-vote-cast-by-a-committee-member-on-a-committee-update.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00172-fail-vote-cast-by-a-committee-member-on-a-committee-update.json
@@ -23,10 +23,7 @@
       }
     ],
     "proposals": [
-      [
-        { "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 },
-        "ConstitutionalCommittee"
-      ]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "ConstitutionalCommittee", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00173-fail-vote-cast-by-a-stake-pool-on-a-new-constitution.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00173-fail-vote-cast-by-a-stake-pool-on-a-new-constitution.json
@@ -19,10 +19,7 @@
       "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
     ],
     "proposals": [
-      [
-        { "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 },
-        "Constitution"
-      ]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Constitution", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00174-fail-vote-cast-by-a-stake-pool-on-a-treasury-withdrawal.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00174-fail-vote-cast-by-a-stake-pool-on-a-treasury-withdrawal.json
@@ -19,10 +19,7 @@
       "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
     ],
     "proposals": [
-      [
-        { "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 },
-        "TreasuryWithdrawals"
-      ]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "TreasuryWithdrawals", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00175-fail-vote-cast-by-a-stake-pool-on-a-parameter-change-outside-the-security-group.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00175-fail-vote-cast-by-a-stake-pool-on-a-parameter-change-outside-the-security-group.json
@@ -19,10 +19,7 @@
       "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
     ],
     "proposals": [
-      [
-        { "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 },
-        "ProtocolParameters"
-      ]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "ProtocolParameters", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00176-pass-vote-committee-new-constitution.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00176-pass-vote-committee-new-constitution.json
@@ -23,10 +23,7 @@
       }
     ],
     "proposals": [
-      [
-        { "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 },
-        "Constitution"
-      ]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Constitution", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00177-pass-vote-committee-treasury-withdrawals.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00177-pass-vote-committee-treasury-withdrawals.json
@@ -23,10 +23,7 @@
       }
     ],
     "proposals": [
-      [
-        { "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 },
-        "TreasuryWithdrawals"
-      ]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "TreasuryWithdrawals", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00178-pass-vote-drep-no-confidence.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00178-pass-vote-drep-no-confidence.json
@@ -30,10 +30,7 @@
       }
     ],
     "proposals": [
-      [
-        { "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 },
-        "ConstitutionalCommittee"
-      ]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "ConstitutionalCommittee", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00179-pass-vote-drep-treasury-withdrawals.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00179-pass-vote-drep-treasury-withdrawals.json
@@ -30,10 +30,7 @@
       }
     ],
     "proposals": [
-      [
-        { "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 },
-        "TreasuryWithdrawals"
-      ]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "TreasuryWithdrawals", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00180-pass-vote-stake-pool-hard-fork-initiation.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00180-pass-vote-stake-pool-hard-fork-initiation.json
@@ -19,10 +19,7 @@
       "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
     ],
     "proposals": [
-      [
-        { "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 },
-        "HardFork(11.0)"
-      ]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "HardFork(11.0)", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00181-pass-vote-stake-pool-update-committee.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00181-pass-vote-stake-pool-update-committee.json
@@ -19,10 +19,7 @@
       "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
     ],
     "proposals": [
-      [
-        { "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 },
-        "ConstitutionalCommittee"
-      ]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "ConstitutionalCommittee", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00182-pass-vote-stake-pool-parameter-change-security-group.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00182-pass-vote-stake-pool-parameter-change-security-group.json
@@ -19,10 +19,7 @@
       "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
     ],
     "proposals": [
-      [
-        { "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 },
-        "ProtocolParameters(security-group)"
-      ]
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "ProtocolParameters(security-group)", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00202-fail-gov-hardfork-initiation-repeating-the-in-flight-version.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00202-fail-gov-hardfork-initiation-repeating-the-in-flight-version.json
@@ -23,7 +23,7 @@
     ],
     "dreps": [],
     "proposals": [
-      [{ "transactionId": "a829a847676b9e2c0ddd470708741dcff03b1769b4dc5ee8632be1817e892ee3", "proposalIndex": 0 }, "HardFork(10.1)"]
+      [{ "transactionId": "a829a847676b9e2c0ddd470708741dcff03b1769b4dc5ee8632be1817e892ee3", "proposalIndex": 0 }, "HardFork(10.1)", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00203-fail-gov-hardfork-initiation-chains-two-majors.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00203-fail-gov-hardfork-initiation-chains-two-majors.json
@@ -26,7 +26,7 @@
     ],
     "dreps": [],
     "proposals": [
-      [{ "transactionId": "a829a847676b9e2c0ddd470708741dcff03b1769b4dc5ee8632be1817e892ee3", "proposalIndex": 0 }, "HardFork(10.0)"]
+      [{ "transactionId": "a829a847676b9e2c0ddd470708741dcff03b1769b4dc5ee8632be1817e892ee3", "proposalIndex": 0 }, "HardFork(10.0)", 6]
     ]
   },
   "point": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00221-fail-vote-cast-on-a-governance-action-absent-from-the-proposals-state.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00221-fail-vote-cast-on-a-governance-action-absent-from-the-proposals-state.json
@@ -33,7 +33,7 @@
     ],
     "committee": [],
     "proposals": [
-      "8258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b00"
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 6]
     ],
     "governanceActivity": {
       "consecutiveDormantEpochs": 0

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00221-fail-vote-cast-on-a-governance-action-absent-from-the-proposals-state.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00221-fail-vote-cast-on-a-governance-action-absent-from-the-proposals-state.json
@@ -15,8 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
     "dreps": [
       {
         "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
@@ -31,13 +29,9 @@
         "validUntil": 1000
       }
     ],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 6]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 0,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00222-fail-vote-cast-on-a-governance-action-whose-index-does-not-match-any-proposal.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00222-fail-vote-cast-on-a-governance-action-whose-index-does-not-match-any-proposal.json
@@ -18,15 +18,9 @@
     "pools": [
       "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
     ],
-    "accounts": [],
-    "dreps": [],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 6]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 0,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00222-fail-vote-cast-on-a-governance-action-whose-index-does-not-match-any-proposal.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00222-fail-vote-cast-on-a-governance-action-whose-index-does-not-match-any-proposal.json
@@ -15,12 +15,14 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": ["93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"],
+    "pools": [
+      "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
+    ],
     "accounts": [],
     "dreps": [],
     "committee": [],
     "proposals": [
-      "8258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b00"
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 6]
     ],
     "governanceActivity": {
       "consecutiveDormantEpochs": 0

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00223-fail-vote-cast-by-a-committee-member-on-a-governance-action-that-does-not-exist.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00223-fail-vote-cast-by-a-committee-member-on-a-governance-action-that-does-not-exist.json
@@ -15,9 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
-    "dreps": [],
     "committee": [
       {
         "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
@@ -27,10 +24,7 @@
     ],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 6]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 0,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00223-fail-vote-cast-by-a-committee-member-on-a-governance-action-that-does-not-exist.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00223-fail-vote-cast-by-a-committee-member-on-a-governance-action-that-does-not-exist.json
@@ -26,7 +26,7 @@
       }
     ],
     "proposals": [
-      "8258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b00"
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 6]
     ],
     "governanceActivity": {
       "consecutiveDormantEpochs": 0

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00224-fail-vote-cast-on-two-governance-actions-of-which-only-one-exists.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00224-fail-vote-cast-on-two-governance-actions-of-which-only-one-exists.json
@@ -33,7 +33,7 @@
     ],
     "committee": [],
     "proposals": [
-      "8258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b00"
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 6]
     ],
     "governanceActivity": {
       "consecutiveDormantEpochs": 0

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00224-fail-vote-cast-on-two-governance-actions-of-which-only-one-exists.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00224-fail-vote-cast-on-two-governance-actions-of-which-only-one-exists.json
@@ -15,8 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
     "dreps": [
       {
         "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
@@ -31,13 +29,9 @@
         "validUntil": 1000
       }
     ],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 6]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 0,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00225-fail-yes-vote-cast-by-a-registered-drep-key-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00225-fail-yes-vote-cast-by-a-registered-drep-key-credential-on-an-expired-governance-action.json
@@ -15,8 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
     "dreps": [
       {
         "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
@@ -31,13 +29,9 @@
         "validUntil": 1000
       }
     ],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00225-fail-yes-vote-cast-by-a-registered-drep-key-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00225-fail-yes-vote-cast-by-a-registered-drep-key-credential-on-an-expired-governance-action.json
@@ -1,0 +1,50 @@
+{
+  "title": "yes vote cast by a registered drep key credential on an expired governance action",
+  "description": "A registered DRep key credential voting yes on an action whose validUntil sits one epoch behind the current one.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820553dbc004c10f03d774ba0ca5f35e4d50605703f14fdffde60ef4bf8ab84ffb100",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [
+      {
+        "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "deposit": 500000000,
+        "registeredAt": {
+          "transaction": {
+            "slot": 0,
+            "transactionIndex": 0
+          },
+          "certificateIndex": 0
+        },
+        "validUntil": 1000
+      }
+    ],
+    "committee": [],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820553dbc004c10f03d774ba0ca5f35e4d50605703f14fdffde60ef4bf8ab84ffb1000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18202581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018201f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584006d1214f47605cb561a7ea677e9ca26df676058983fc645b8b68674554464fd64127080059fbb2fdc5bbdf3d74dd413a2da01331f9702fd6f5c12460158f5000f5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00226-fail-no-vote-cast-by-a-registered-drep-key-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00226-fail-no-vote-cast-by-a-registered-drep-key-credential-on-an-expired-governance-action.json
@@ -15,8 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
     "dreps": [
       {
         "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
@@ -31,13 +29,9 @@
         "validUntil": 1000
       }
     ],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00226-fail-no-vote-cast-by-a-registered-drep-key-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00226-fail-no-vote-cast-by-a-registered-drep-key-credential-on-an-expired-governance-action.json
@@ -1,0 +1,50 @@
+{
+  "title": "no vote cast by a registered drep key credential on an expired governance action",
+  "description": "A registered DRep key credential voting no on an action whose validUntil sits one epoch behind the current one.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "8258200a6f02fbcde14fd377f0557488843cffe8b3c50c7de68d7aa48057230733d5c700",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [
+      {
+        "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "deposit": 500000000,
+        "registeredAt": {
+          "transaction": {
+            "slot": 0,
+            "transactionIndex": 0
+          },
+          "certificateIndex": 0
+        },
+        "validUntil": 1000
+      }
+    ],
+    "committee": [],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d90102818258200a6f02fbcde14fd377f0557488843cffe8b3c50c7de68d7aa48057230733d5c7000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18202581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018200f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584043f8eea30989a9a47a3fc2131c7d90c43b002f2b5ffb8c07c7bcfb11dbd7f61c1da762e5e6d7cdff94b33ea1fce5cd3b896a1374dfdb9420d431fd5705f1860df5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00227-fail-abstention-cast-by-a-registered-drep-key-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00227-fail-abstention-cast-by-a-registered-drep-key-credential-on-an-expired-governance-action.json
@@ -15,8 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
     "dreps": [
       {
         "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
@@ -31,13 +29,9 @@
         "validUntil": 1000
       }
     ],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00227-fail-abstention-cast-by-a-registered-drep-key-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00227-fail-abstention-cast-by-a-registered-drep-key-credential-on-an-expired-governance-action.json
@@ -1,0 +1,50 @@
+{
+  "title": "abstention cast by a registered drep key credential on an expired governance action",
+  "description": "A registered DRep key credential abstaining on an action whose validUntil sits one epoch behind the current one.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cfad0f2149e5799f1a18e052b3f81dab833dab1f3a6e61b87997da49c156f05500",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [
+      {
+        "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "deposit": 500000000,
+        "registeredAt": {
+          "transaction": {
+            "slot": 0,
+            "transactionIndex": 0
+          },
+          "certificateIndex": 0
+        },
+        "validUntil": 1000
+      }
+    ],
+    "committee": [],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cfad0f2149e5799f1a18e052b3f81dab833dab1f3a6e61b87997da49c156f055000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18202581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018202f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258406ed3d5f7b818b9a07af0618b41ce2de80aa78c8c21faebf656f8c2087ebab1b803d383b35e997231e78de4a296a37015a62378545a97234cc874a418b75cc90df5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00228-fail-yes-vote-cast-by-a-registered-drep-script-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00228-fail-yes-vote-cast-by-a-registered-drep-script-credential-on-an-expired-governance-action.json
@@ -15,8 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
     "dreps": [
       {
         "credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
@@ -31,13 +29,9 @@
         "validUntil": 1000
       }
     ],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00228-fail-yes-vote-cast-by-a-registered-drep-script-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00228-fail-yes-vote-cast-by-a-registered-drep-script-credential-on-an-expired-governance-action.json
@@ -1,0 +1,50 @@
+{
+  "title": "yes vote cast by a registered drep script credential on an expired governance action",
+  "description": "A registered DRep script credential voting yes on an action whose validUntil sits one epoch behind the current one.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820aae445710a43bdff1f526c5bef2ad29c660107cea26f5d9a014fb473b5a2d61e00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [
+      {
+        "credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "deposit": 500000000,
+        "registeredAt": {
+          "transaction": {
+            "slot": 0,
+            "transactionIndex": 0
+          },
+          "certificateIndex": 0
+        },
+        "validUntil": 1000
+      }
+    ],
+    "committee": [],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820aae445710a43bdff1f526c5bef2ad29c660107cea26f5d9a014fb473b5a2d61e000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18203581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcfa18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018201f6a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840ec335789f7d39ac9598cb6eec5714c7cb011598faafd98cacaf6c671b80fcaa6438d8250675680ad8606c5e963420e5e2626d1e8f8e230e03c98036f3f5da8080181820180f5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00229-fail-no-vote-cast-by-a-registered-drep-script-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00229-fail-no-vote-cast-by-a-registered-drep-script-credential-on-an-expired-governance-action.json
@@ -15,8 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
     "dreps": [
       {
         "credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
@@ -31,13 +29,9 @@
         "validUntil": 1000
       }
     ],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00229-fail-no-vote-cast-by-a-registered-drep-script-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00229-fail-no-vote-cast-by-a-registered-drep-script-credential-on-an-expired-governance-action.json
@@ -1,0 +1,50 @@
+{
+  "title": "no vote cast by a registered drep script credential on an expired governance action",
+  "description": "A registered DRep script credential voting no on an action whose validUntil sits one epoch behind the current one.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "8258208983d39ade448cfda0b7cfd42aa086ce6f2f97683c4af7fcc800f9d94e55218200",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [
+      {
+        "credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "deposit": 500000000,
+        "registeredAt": {
+          "transaction": {
+            "slot": 0,
+            "transactionIndex": 0
+          },
+          "certificateIndex": 0
+        },
+        "validUntil": 1000
+      }
+    ],
+    "committee": [],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d90102818258208983d39ade448cfda0b7cfd42aa086ce6f2f97683c4af7fcc800f9d94e552182000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18203581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcfa18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018200f6a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584058781f92ec63c5d24a0b71f420371c01e00f5d0339b1f8f02a28aa64c58e0501b48524c410854886abd66506c519b0987d5bd1125f18eacdaca4a239a8f33f0a0181820180f5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00230-fail-abstention-cast-by-a-registered-drep-script-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00230-fail-abstention-cast-by-a-registered-drep-script-credential-on-an-expired-governance-action.json
@@ -1,0 +1,50 @@
+{
+  "title": "abstention cast by a registered drep script credential on an expired governance action",
+  "description": "A registered DRep script credential abstaining on an action whose validUntil sits one epoch behind the current one.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820189076c1480935538c29ecb111903b05e9671529f0177dcd9b55d2cde8a83d8500",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [
+      {
+        "credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "deposit": 500000000,
+        "registeredAt": {
+          "transaction": {
+            "slot": 0,
+            "transactionIndex": 0
+          },
+          "certificateIndex": 0
+        },
+        "validUntil": 1000
+      }
+    ],
+    "committee": [],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820189076c1480935538c29ecb111903b05e9671529f0177dcd9b55d2cde8a83d85000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18203581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcfa18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018202f6a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258400027abfbebd386e131f13e468870dcd1d2ed2308ea9105a58275c853b36c644e92bfd7a2948381e109a589d66c58a977df5029a99a24a717539585cd38ed96060181820180f5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00230-fail-abstention-cast-by-a-registered-drep-script-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00230-fail-abstention-cast-by-a-registered-drep-script-credential-on-an-expired-governance-action.json
@@ -15,8 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
     "dreps": [
       {
         "credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
@@ -31,13 +29,9 @@
         "validUntil": 1000
       }
     ],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00231-fail-yes-vote-cast-by-an-authorized-committee-hot-key-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00231-fail-yes-vote-cast-by-an-authorized-committee-hot-key-on-an-expired-governance-action.json
@@ -15,9 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
-    "dreps": [],
     "committee": [
       {
         "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
@@ -27,10 +24,7 @@
     ],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00231-fail-yes-vote-cast-by-an-authorized-committee-hot-key-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00231-fail-yes-vote-cast-by-an-authorized-committee-hot-key-on-an-expired-governance-action.json
@@ -1,0 +1,43 @@
+{
+  "title": "yes vote cast by an authorized committee hot key on an expired governance action",
+  "description": "An authorized committee hot key voting yes on an action whose validUntil sits one epoch behind the current one.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "8258202e27f65d9908b511f536959ef26edef3947973ecf992e59be1928d2eb8b06c8400",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "committee": [
+      {
+        "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
+        "status": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "validUntil": 200
+      }
+    ],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d90102818258202e27f65d9908b511f536959ef26edef3947973ecf992e59be1928d2eb8b06c84000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018201f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840f4e38795b7f3d364c50a2cd13bce4d05f60bee4b0077fb2b4ee881f35f2bb35ec2dae27211b288baed74411fe61b98ea6aa195d475141af8ae4b43b142d08203f5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00232-fail-no-vote-cast-by-an-authorized-committee-hot-key-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00232-fail-no-vote-cast-by-an-authorized-committee-hot-key-on-an-expired-governance-action.json
@@ -15,9 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
-    "dreps": [],
     "committee": [
       {
         "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
@@ -27,10 +24,7 @@
     ],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00232-fail-no-vote-cast-by-an-authorized-committee-hot-key-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00232-fail-no-vote-cast-by-an-authorized-committee-hot-key-on-an-expired-governance-action.json
@@ -1,0 +1,43 @@
+{
+  "title": "no vote cast by an authorized committee hot key on an expired governance action",
+  "description": "An authorized committee hot key voting no on an action whose validUntil sits one epoch behind the current one.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "82582089e969e80b0c131dbe1adf0b1689876132020234f7cc0a758b1a647e7ee25da800",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "committee": [
+      {
+        "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
+        "status": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "validUntil": 200
+      }
+    ],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d901028182582089e969e80b0c131dbe1adf0b1689876132020234f7cc0a758b1a647e7ee25da8000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018200f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258403f5a7018f5ab3195de21d18d653b719a4b36ab4230c2d312b20b67ac5aa1f964dd47214977b8101955be599dfed6d5c9044048e202a385b845b214633d2a5208f5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00233-fail-abstention-cast-by-an-authorized-committee-hot-key-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00233-fail-abstention-cast-by-an-authorized-committee-hot-key-on-an-expired-governance-action.json
@@ -15,9 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
-    "dreps": [],
     "committee": [
       {
         "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
@@ -27,10 +24,7 @@
     ],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00233-fail-abstention-cast-by-an-authorized-committee-hot-key-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00233-fail-abstention-cast-by-an-authorized-committee-hot-key-on-an-expired-governance-action.json
@@ -1,0 +1,43 @@
+{
+  "title": "abstention cast by an authorized committee hot key on an expired governance action",
+  "description": "An authorized committee hot key abstaining on an action whose validUntil sits one epoch behind the current one.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "82582065af8c1225df19e715b9d945af19544f01824031f3ac65372a133ecc860b47ee00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "committee": [
+      {
+        "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
+        "status": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "validUntil": 200
+      }
+    ],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d901028182582065af8c1225df19e715b9d945af19544f01824031f3ac65372a133ecc860b47ee000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018202f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584056b80269e7bd260332ec300247f2234091ba436fa89541a44f6925381228be4d1fc5ae89f928db1903a6c00316ea7b52342dc5403dc89c5eaa300ff6fef20b03f5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00234-fail-yes-vote-cast-by-an-authorized-committee-hot-script-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00234-fail-yes-vote-cast-by-an-authorized-committee-hot-script-credential-on-an-expired-governance-action.json
@@ -15,9 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
-    "dreps": [],
     "committee": [
       {
         "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
@@ -27,10 +24,7 @@
     ],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00234-fail-yes-vote-cast-by-an-authorized-committee-hot-script-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00234-fail-yes-vote-cast-by-an-authorized-committee-hot-script-credential-on-an-expired-governance-action.json
@@ -1,0 +1,43 @@
+{
+  "title": "yes vote cast by an authorized committee hot script credential on an expired governance action",
+  "description": "An authorized committee hot script credential voting yes on an action whose validUntil sits one epoch behind the current one.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "8258204b0e1006d0e4dc2b8787656e6aab2724160d533d051c63ed9e12157a4e9b7c9200",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "committee": [
+      {
+        "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
+        "status": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "validUntil": 200
+      }
+    ],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d90102818258204b0e1006d0e4dc2b8787656e6aab2724160d533d051c63ed9e12157a4e9b7c92000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcfa18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018201f6a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840322673266b0df3330ce9db91bb95441ef5a50cfd190f402122e669f32a29a0cdd6cd15975f467417d84dc0a7c0a3d04794185d29e34a6f7894907b54cb08a60b0181820180f5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00235-fail-no-vote-cast-by-an-authorized-committee-hot-script-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00235-fail-no-vote-cast-by-an-authorized-committee-hot-script-credential-on-an-expired-governance-action.json
@@ -15,9 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
-    "dreps": [],
     "committee": [
       {
         "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
@@ -27,10 +24,7 @@
     ],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00235-fail-no-vote-cast-by-an-authorized-committee-hot-script-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00235-fail-no-vote-cast-by-an-authorized-committee-hot-script-credential-on-an-expired-governance-action.json
@@ -1,0 +1,43 @@
+{
+  "title": "no vote cast by an authorized committee hot script credential on an expired governance action",
+  "description": "An authorized committee hot script credential voting no on an action whose validUntil sits one epoch behind the current one.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820f1399c60f51ae38a505dbcf4fc7ea01b57d8ff0c4169827eafc697a166da6b8d00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "committee": [
+      {
+        "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
+        "status": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "validUntil": 200
+      }
+    ],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820f1399c60f51ae38a505dbcf4fc7ea01b57d8ff0c4169827eafc697a166da6b8d000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcfa18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018200f6a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840b8222b3fbcb579dcb16a5d8ab4b8e719c2c56c1b20ca9314e03de55bef4f44947d82ff9249af475a4f8b0ee039ef02789d85f67531d89a946778488ebb84940b0181820180f5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00236-fail-abstention-cast-by-an-authorized-committee-hot-script-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00236-fail-abstention-cast-by-an-authorized-committee-hot-script-credential-on-an-expired-governance-action.json
@@ -15,9 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
-    "dreps": [],
     "committee": [
       {
         "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
@@ -27,10 +24,7 @@
     ],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00236-fail-abstention-cast-by-an-authorized-committee-hot-script-credential-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00236-fail-abstention-cast-by-an-authorized-committee-hot-script-credential-on-an-expired-governance-action.json
@@ -1,0 +1,43 @@
+{
+  "title": "abstention cast by an authorized committee hot script credential on an expired governance action",
+  "description": "An authorized committee hot script credential abstaining on an action whose validUntil sits one epoch behind the current one.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "82582001c1c24be4e51041e29b6181afce3cfbd9d2687d0efe54c7ae682b580c012ae200",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "committee": [
+      {
+        "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
+        "status": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "validUntil": 200
+      }
+    ],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d901028182582001c1c24be4e51041e29b6181afce3cfbd9d2687d0efe54c7ae682b580c012ae2000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcfa18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018202f6a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840fa2ee226f777c50ccc429304434ed571e657f0e6b67384328b3c3c49d9f9fea3c1ba206a08ac48388b11e091de5ac10045cbb8f029dc33f66a5d4f1c379366040181820180f5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00237-fail-yes-vote-cast-by-a-registered-stake-pool-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00237-fail-yes-vote-cast-by-a-registered-stake-pool-on-an-expired-governance-action.json
@@ -18,15 +18,9 @@
     "pools": [
       "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
     ],
-    "accounts": [],
-    "dreps": [],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00237-fail-yes-vote-cast-by-a-registered-stake-pool-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00237-fail-yes-vote-cast-by-a-registered-stake-pool-on-an-expired-governance-action.json
@@ -1,0 +1,39 @@
+{
+  "title": "yes vote cast by a registered stake pool on an expired governance action",
+  "description": "A registered stake pool voting yes on an action whose validUntil sits one epoch behind the current one.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820849c196a0b2fccd03a04bf2f28a3ffdb956368d646d51a250aed5469a8bdeb5900",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [
+      "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
+    ],
+    "accounts": [],
+    "dreps": [],
+    "committee": [],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820849c196a0b2fccd03a04bf2f28a3ffdb956368d646d51a250aed5469a8bdeb59000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18204581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018201f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258409225e8d513a9d63a1b11e8e6799938e88ff39fe23bcf434c86a401f912b4e59e149491522b45fc1ad0cf8d77a3309ea77ee335ddd810e6bdec85a05809c5fe09f5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00238-fail-no-vote-cast-by-a-registered-stake-pool-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00238-fail-no-vote-cast-by-a-registered-stake-pool-on-an-expired-governance-action.json
@@ -18,15 +18,9 @@
     "pools": [
       "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
     ],
-    "accounts": [],
-    "dreps": [],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00238-fail-no-vote-cast-by-a-registered-stake-pool-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00238-fail-no-vote-cast-by-a-registered-stake-pool-on-an-expired-governance-action.json
@@ -1,0 +1,39 @@
+{
+  "title": "no vote cast by a registered stake pool on an expired governance action",
+  "description": "A registered stake pool voting no on an action whose validUntil sits one epoch behind the current one.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "82582046a6726d8ecd6b2a2bd20528689e159d854928c9fc4557cb52b3250b8eca0ddc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [
+      "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
+    ],
+    "accounts": [],
+    "dreps": [],
+    "committee": [],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d901028182582046a6726d8ecd6b2a2bd20528689e159d854928c9fc4557cb52b3250b8eca0ddc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18204581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018200f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840b671f1981f99d9bc8b272fe191b454c0672bf8246d90ef974dcff9278c1d9f9baeacc2766327dbef51cb72eb25d8c409e0f99178e14187cbfdbec46485d02300f5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00239-fail-abstention-cast-by-a-registered-stake-pool-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00239-fail-abstention-cast-by-a-registered-stake-pool-on-an-expired-governance-action.json
@@ -18,15 +18,9 @@
     "pools": [
       "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
     ],
-    "accounts": [],
-    "dreps": [],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00239-fail-abstention-cast-by-a-registered-stake-pool-on-an-expired-governance-action.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00239-fail-abstention-cast-by-a-registered-stake-pool-on-an-expired-governance-action.json
@@ -1,0 +1,39 @@
+{
+  "title": "abstention cast by a registered stake pool on an expired governance action",
+  "description": "A registered stake pool abstaining on an action whose validUntil sits one epoch behind the current one.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820062a253b0e141b6f4f3dd2a42c36e968d20ecbe1de91df6b4829b3a3d8b227c100",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [
+      "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
+    ],
+    "accounts": [],
+    "dreps": [],
+    "committee": [],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820062a253b0e141b6f4f3dd2a42c36e968d20ecbe1de91df6b4829b3a3d8b227c1000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18204581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018202f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840144602fb7b9d3dd33e4061c108760ec6efece9ddc217c50a7cc444b0e5a2b8ac4d95ba90ffcfefc33145959fb243486f95174e72048cb19c855a3e67f219a301f5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00240-fail-one-voter-balloting-on-a-live-governance-action-and-an-expired-one.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00240-fail-one-voter-balloting-on-a-live-governance-action-and-an-expired-one.json
@@ -15,8 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
     "dreps": [
       {
         "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
@@ -31,14 +29,10 @@
         "validUntil": 1000
       }
     ],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 1],
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00240-fail-one-voter-balloting-on-a-live-governance-action-and-an-expired-one.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00240-fail-one-voter-balloting-on-a-live-governance-action-and-an-expired-one.json
@@ -1,0 +1,51 @@
+{
+  "title": "one voter balloting on a live governance action and an expired one",
+  "description": "A single voter casting two ballots of which only the second names an expired action.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820c515b6b14a79098b0407902da5e4adabf05e6992fec48ed296e6e76f8a2fc14500",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [
+      {
+        "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "deposit": 500000000,
+        "registeredAt": {
+          "transaction": {
+            "slot": 0,
+            "transactionIndex": 0
+          },
+          "certificateIndex": 0
+        },
+        "validUntil": 1000
+      }
+    ],
+    "committee": [],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 1],
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820c515b6b14a79098b0407902da5e4adabf05e6992fec48ed296e6e76f8a2fc145000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18202581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a28258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b008201f68258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018200f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840b975313f4b64d95ad73d79cf4fc68a77e039c42b03f026767ac2d6d51c5d67b6c05bc3dfd72aa1a47093833d9d434bcf7b3516d971e4a32b62d1a66edeb8c10af5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00241-fail-expired-governance-action-balloted-on-by-the-second-of-two-voters.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00241-fail-expired-governance-action-balloted-on-by-the-second-of-two-voters.json
@@ -1,0 +1,53 @@
+{
+  "title": "expired governance action balloted on by the second of two voters",
+  "description": "Two voters of which only the second names an expired action.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "82582020e7680c4e4e1ae481d7848d7cf770d6e2ac21775ba14d768fc1c9daaf0be49100",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [
+      "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
+    ],
+    "accounts": [],
+    "dreps": [
+      {
+        "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "deposit": 500000000,
+        "registeredAt": {
+          "transaction": {
+            "slot": 0,
+            "transactionIndex": 0
+          },
+          "certificateIndex": 0
+        },
+        "validUntil": 1000
+      }
+    ],
+    "committee": [],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 1],
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d901028182582020e7680c4e4e1ae481d7848d7cf770d6e2ac21775ba14d768fc1c9daaf0be491000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a28202581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b008201f68204581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b018201f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840c9ef375d88a966dbf9410cea48e7df92469b74997ce2d85450c65072872218ab6176b79477d2c5eb042e930d3cd3740f094de571f52e01c92c97e259c63eef0bf5f6",
+  "expected": {
+    "predicate": "VotingOnExpiredGovAction"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00241-fail-expired-governance-action-balloted-on-by-the-second-of-two-voters.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00241-fail-expired-governance-action-balloted-on-by-the-second-of-two-voters.json
@@ -18,7 +18,6 @@
     "pools": [
       "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
     ],
-    "accounts": [],
     "dreps": [
       {
         "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
@@ -33,14 +32,10 @@
         "validUntil": 1000
       }
     ],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 1],
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 1 }, "Information", 0]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00242-pass-vote-action-expiring-this-epoch-committee-hot-key.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00242-pass-vote-action-expiring-this-epoch-committee-hot-key.json
@@ -1,0 +1,41 @@
+{
+  "title": "abstention cast by an authorized committee hot key on an action expiring in the current epoch",
+  "description": "An authorized committee hot key abstaining on an action whose validUntil is the current epoch.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "82582063ca26efa2dc6d90625cbc8e59c21791e517e91ded191cc9bd7eda4b71dc202200",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "committee": [
+      {
+        "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
+        "status": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "validUntil": 200
+      }
+    ],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 1]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d901028182582063ca26efa2dc6d90625cbc8e59c21791e517e91ded191cc9bd7eda4b71dc2022000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b008202f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258405caf4bc2c3eefbd95f11f6dc5eca57fc1e2189fb13f0ecd6ea115009b4946b0a33f56270d8f07392b50f87f4a3d189d849b90727809eacf801aa31a0d7699c00f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00242-pass-vote-action-expiring-this-epoch-committee-hot-key.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00242-pass-vote-action-expiring-this-epoch-committee-hot-key.json
@@ -15,9 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
-    "dreps": [],
     "committee": [
       {
         "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
@@ -27,10 +24,7 @@
     ],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 1]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00243-pass-vote-action-expiring-this-epoch-committee-hot-script.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00243-pass-vote-action-expiring-this-epoch-committee-hot-script.json
@@ -1,0 +1,41 @@
+{
+  "title": "yes vote cast by an authorized committee hot script credential on an action expiring in the current epoch",
+  "description": "An authorized committee hot script credential voting yes on an action whose validUntil is the current epoch.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "8258208fbfa29ca8f170d06365d49725836d14e890048ef370936621334f350805eca400",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "committee": [
+      {
+        "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
+        "status": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "validUntil": 200
+      }
+    ],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 1]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d90102818258208fbfa29ca8f170d06365d49725836d14e890048ef370936621334f350805eca4000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcfa18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b008201f6a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584052bca539f1b8bc187810e71b573709e3a014f918d424d1729e772376c01455d602b7416aae3da96d63a8546d926c2dee3ebb46fb4b9ce4d78980718c28e9fe020181820180f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00243-pass-vote-action-expiring-this-epoch-committee-hot-script.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00243-pass-vote-action-expiring-this-epoch-committee-hot-script.json
@@ -15,9 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
-    "dreps": [],
     "committee": [
       {
         "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
@@ -27,10 +24,7 @@
     ],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 1]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00244-pass-vote-action-expiring-this-epoch-drep-key.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00244-pass-vote-action-expiring-this-epoch-drep-key.json
@@ -15,8 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
     "dreps": [
       {
         "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
@@ -31,13 +29,9 @@
         "validUntil": 1000
       }
     ],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 1]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00244-pass-vote-action-expiring-this-epoch-drep-key.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00244-pass-vote-action-expiring-this-epoch-drep-key.json
@@ -1,0 +1,48 @@
+{
+  "title": "yes vote cast by a registered drep key credential on an action expiring in the current epoch",
+  "description": "A registered DRep key credential voting yes on an action whose validUntil is the current epoch.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820d476d311f3a9701a4d4f7dcf59b9ca318736ac082be886b0870b3d846cd5b31b00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [
+      {
+        "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "deposit": 500000000,
+        "registeredAt": {
+          "transaction": {
+            "slot": 0,
+            "transactionIndex": 0
+          },
+          "certificateIndex": 0
+        },
+        "validUntil": 1000
+      }
+    ],
+    "committee": [],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 1]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820d476d311f3a9701a4d4f7dcf59b9ca318736ac082be886b0870b3d846cd5b31b000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18202581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b008201f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258405b41bb5a1e4580f9928b4b6acaf1eb9f5f5464493b73c0a84961eb7d3ff5236c0f9f42d089faaf9eb224286bdafc31a3d4166e336a578ab6e7247e8d2ae03104f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00245-pass-vote-action-expiring-this-epoch-drep-script.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00245-pass-vote-action-expiring-this-epoch-drep-script.json
@@ -1,0 +1,48 @@
+{
+  "title": "no vote cast by a registered drep script credential on an action expiring in the current epoch",
+  "description": "A registered DRep script credential voting no on an action whose validUntil is the current epoch.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820705db7d66b415daa4602eda637bf6a603d87f657f9d176db543580e8871f361b00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [
+      {
+        "credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "deposit": 500000000,
+        "registeredAt": {
+          "transaction": {
+            "slot": 0,
+            "transactionIndex": 0
+          },
+          "certificateIndex": 0
+        },
+        "validUntil": 1000
+      }
+    ],
+    "committee": [],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 1]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820705db7d66b415daa4602eda637bf6a603d87f657f9d176db543580e8871f361b000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18203581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcfa18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b008200f6a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258406c110559b38d4dbdd8e90889f9f115b66a14196c56a360ae25111977780f4ff88715e5ffbad800a6050f36285148192906d8c531d5df22ab39d30c3ab5cd4e080181820180f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00245-pass-vote-action-expiring-this-epoch-drep-script.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00245-pass-vote-action-expiring-this-epoch-drep-script.json
@@ -15,8 +15,6 @@
         "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
       }
     ],
-    "pools": [],
-    "accounts": [],
     "dreps": [
       {
         "credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
@@ -31,13 +29,9 @@
         "validUntil": 1000
       }
     ],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 1]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00246-pass-vote-action-expiring-this-epoch-stake-pool.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00246-pass-vote-action-expiring-this-epoch-stake-pool.json
@@ -18,15 +18,9 @@
     "pools": [
       "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
     ],
-    "accounts": [],
-    "dreps": [],
-    "committee": [],
     "proposals": [
       [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 1]
-    ],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
-    }
+    ]
   },
   "point": {
     "slot": 432000,

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00246-pass-vote-action-expiring-this-epoch-stake-pool.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00246-pass-vote-action-expiring-this-epoch-stake-pool.json
@@ -1,0 +1,37 @@
+{
+  "title": "no vote cast by a registered stake pool on an action expiring in the current epoch",
+  "description": "A registered stake pool voting no on an action whose validUntil is the current epoch.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820e739e85e21f50c6d6f618293706eb45e99763ac5517fe42e4fdf73cb0a31114f00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [
+      "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
+    ],
+    "accounts": [],
+    "dreps": [],
+    "committee": [],
+    "proposals": [
+      [{ "transactionId": "7e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b", "proposalIndex": 0 }, "Information", 1]
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820e739e85e21f50c6d6f618293706eb45e99763ac5517fe42e4fdf73cb0a31114f000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18204581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b008200f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840b17a427ee7fcc255bf23ab559011ddc8d03330dfb44ba40e2e5ec2d4a2099d74b9b56af33cb6d7245174b3bc62c5e40af8bdcf0b475de62db912b0d6a86e8806f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/schema.json
+++ b/crates/amaru-ledger/tests/data/transaction/schema.json
@@ -340,14 +340,22 @@
     },
     "ProposalEntry": {
       "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
       "items": [
         { "$ref": "#/$defs/ProposalId" },
-        { "$ref": "#/$defs/ProposalKind" }
+        { "$ref": "#/$defs/ProposalKind" },
+        {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Last epoch a vote on this proposal still counts, i.e. the epoch it was proposed in plus governanceActionLifetime. Required: every proposal on chain has one."
+        }
       ]
     },
     "ProposalKind": {
       "type": "string",
-      "enum": ["ProtocolParameters", "HardFork", "ConstitutionalCommittee", "Constitution", "Orphan"]
+      "description": "The lineage a proposal chains onto. 'ProtocolParameters(security-group)' marks an update touching the security group, and a hard fork names the version it would enact.",
+      "pattern": "^(ProtocolParameters(\\(security-group\\))?|HardFork\\([0-9]+\\.[0-9]+\\)|ConstitutionalCommittee|Constitution|Orphan|Information|TreasuryWithdrawals)$"
     },
     "ProposalsRoots": {
       "type": "object",

--- a/crates/amaru-ledger/tests/evaluate_ledger_states.rs
+++ b/crates/amaru-ledger/tests/evaluate_ledger_states.rs
@@ -31,7 +31,7 @@ pub mod tests {
     };
     use amaru_ledger::{
         self,
-        context::{AccountState, DefaultValidationContext},
+        context::{AccountState, DefaultValidationContext, ProposalStateSlim},
         epoch_transition::GovernanceActivity,
         rules::transaction,
         snapshot,
@@ -302,7 +302,10 @@ pub mod tests {
         let proposals = decoded
             .proposals
             .into_iter()
-            .map(|st| (st.id, ProposalSlim::from(&st.procedure.gov_action)))
+            .map(|st| {
+                let action = ProposalSlim::from(&st.procedure.gov_action);
+                (st.id, ProposalStateSlim { action, valid_until: st.expires_after })
+            })
             .collect::<BTreeMap<_, _>>();
 
         let [root_params, root_hard_fork, root_cc, root_constitution] = decoded.roots;

--- a/crates/amaru/tests/conformance/validation-rules/src/Data/Fixture/InitialState.hs
+++ b/crates/amaru/tests/conformance/validation-rules/src/Data/Fixture/InitialState.hs
@@ -121,6 +121,7 @@ import Data.Aeson
     ( FromJSON (parseJSON)
     , Object
     , Value (Array)
+    , withArray
     , withObject
     , withText
     , (.:)
@@ -368,14 +369,25 @@ instance FromJSON ProposalEntry where
     parseJSON value =
         case value of
             Array _ ->
-                parseSlimPair value
+                parseSlimEntry value
             _ ->
                 parseFullEntry value
       where
-        parseSlimPair =
-            parseJSON >=> \(idValue, lineage) -> do
-                entryId <- parseProposalId idValue
-                pure ProposalEntry{proposalId = entryId, proposalAction = ProposalSlim lineage, proposalValidUntil = Nothing}
+        parseSlimEntry =
+            withArray "ProposalEntry" $ \values ->
+                case toList values of
+                    [idValue, lineageValue, validUntilValue] -> do
+                        entryId <- parseProposalId idValue
+                        lineage <- parseJSON lineageValue
+                        validUntil <- parseJSON validUntilValue
+                        pure
+                            ProposalEntry
+                                { proposalId = entryId
+                                , proposalAction = ProposalSlim lineage
+                                , proposalValidUntil = Just validUntil
+                                }
+                    _ ->
+                        fail "expected a [id, kind, validUntil] triple"
         parseFullEntry =
             withObject "ProposalEntry" $ \objectValue ->
                 ProposalEntry


### PR DESCRIPTION
Closes #926

This PR introduces logic to validate votes are not cast on an expired governance action. This change required changes to the state maintained in the volatile DB. Notably, we materialized a `ProposalState` that is maintained throughout the volatile stack. This allows us to calculate the `valid_until` field once, at acknowledge time, instead of at each read. This will help prevent a class of bugs (though we have not encountered any of them yet) where the calculation at read time produces a different result than we would expect.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Governance actions now record and preserve their expiry epoch.
  * Votes on expired governance actions are rejected with a clear validation result.
  * Votes on actions expiring during the current epoch remain valid.

* **Documentation**
  * Updated governance fixture documentation to include proposal expiry and supported action types.

* **Tests**
  * Added coverage for expired-action votes across DReps, committee members, and stake pools.
  * Added scenarios confirming valid voting near an action’s expiry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->