### PR TITLE
feat(amaru-tui): display both RSS and footprint using top for sampling

### DIFF
--- a/crates/amaru-tui/README.md
+++ b/crates/amaru-tui/README.md
@@ -29,7 +29,7 @@ The architectural rationale lives in
 
 Most changes should fall into one of two buckets:
 
-- UI work: layout, formatting, focus, copy mode, new widgets
+- UI work: layout, formatting, focus, copy mode, shutdown mode, new widgets
 - observability work: telemetry or metrics changed and the reducer must follow
 
 The crate should not become a backdoor into Amaru internals. Prefer deriving

--- a/crates/amaru-tui/src/events/host_sample.rs
+++ b/crates/amaru-tui/src/events/host_sample.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, Instant};
 pub struct HostSample {
     pub at: Instant,
     pub interval: Duration,
+    pub process_memory_bytes: Option<u64>,
     pub memory_used_bytes: u64,
     pub memory_total_bytes: u64,
     pub other_processes_live_read_bytes: u64,

--- a/crates/amaru-tui/src/host_metrics.rs
+++ b/crates/amaru-tui/src/host_metrics.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use std::process::Command;
 use std::{
     io,
     sync::mpsc::{self, Receiver, RecvTimeoutError, Sender, SyncSender},
@@ -86,6 +88,7 @@ fn run(tx: SyncSender<Message>, shutdown_rx: Receiver<()>) -> io::Result<()> {
 fn emit_sample(sys: &mut System, tx: &SyncSender<Message>, own_pid: sysinfo::Pid, interval: Duration, at: Instant) {
     sys.refresh_memory_specifics(MemoryRefreshKind::nothing().with_ram());
     sys.refresh_processes_specifics(ProcessesToUpdate::All, true, ProcessRefreshKind::nothing().with_disk_usage());
+    let process_memory = sample_process_memory(own_pid);
 
     let (other_processes_live_read_bytes, other_processes_live_write_bytes) = sys
         .processes()
@@ -99,9 +102,144 @@ fn emit_sample(sys: &mut System, tx: &SyncSender<Message>, own_pid: sysinfo::Pid
     let _ = tx.try_send(Message::HostSample(HostSample {
         at,
         interval,
+        process_memory_bytes: process_memory,
         memory_used_bytes: sys.used_memory(),
         memory_total_bytes: sys.total_memory(),
         other_processes_live_read_bytes,
         other_processes_live_write_bytes,
     }));
+}
+
+#[cfg(target_os = "macos")]
+fn sample_process_memory(pid: sysinfo::Pid) -> Option<u64> {
+    let output =
+        Command::new("top").args(["-l", "1", "-pid", &pid.as_u32().to_string(), "-stats", "pid,mem"]).output().ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    parse_top_process_memory(&String::from_utf8_lossy(&output.stdout), pid.as_u32())
+}
+
+#[cfg(target_os = "linux")]
+fn sample_process_memory(pid: sysinfo::Pid) -> Option<u64> {
+    let output = Command::new("top").args(["-b", "-n", "1", "-p", &pid.as_u32().to_string()]).output().ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    parse_linux_top_process_memory(&String::from_utf8_lossy(&output.stdout), pid.as_u32())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn sample_process_memory(_pid: sysinfo::Pid) -> Option<u64> {
+    None
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn parse_top_process_memory(output: &str, pid: u32) -> Option<u64> {
+    output.lines().rev().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        let line_pid = fields.next()?.parse::<u32>().ok()?;
+        if line_pid != pid {
+            return None;
+        }
+
+        parse_top_bytes(fields.next()?, PlainUnit::Bytes)
+    })
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_linux_top_process_memory(output: &str, pid: u32) -> Option<u64> {
+    output.lines().rev().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        let line_pid = fields.next()?.parse::<u32>().ok()?;
+        if line_pid != pid {
+            return None;
+        }
+
+        for _ in 0..4 {
+            fields.next()?;
+        }
+
+        parse_top_bytes(fields.next()?, PlainUnit::KiB)
+    })
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", test))]
+#[allow(dead_code)]
+enum PlainUnit {
+    Bytes,
+    KiB,
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos", test))]
+fn parse_top_bytes(value: &str, plain_unit: PlainUnit) -> Option<u64> {
+    let value = value.trim_end_matches('+');
+    let suffix = value.chars().last()?;
+
+    let multiplier = match suffix {
+        'K' => 1_024f64,
+        'M' => 1_024f64 * 1_024f64,
+        'G' => 1_024f64 * 1_024f64 * 1_024f64,
+        'T' => 1_024f64 * 1_024f64 * 1_024f64 * 1_024f64,
+        'P' => 1_024f64 * 1_024f64 * 1_024f64 * 1_024f64 * 1_024f64,
+        'k' => 1_024f64,
+        'm' => 1_024f64 * 1_024f64,
+        'g' => 1_024f64 * 1_024f64 * 1_024f64,
+        't' => 1_024f64 * 1_024f64 * 1_024f64 * 1_024f64,
+        'p' => 1_024f64 * 1_024f64 * 1_024f64 * 1_024f64 * 1_024f64,
+        '0'..='9' => {
+            let amount = value.parse::<u64>().ok()?;
+            return Some(match plain_unit {
+                PlainUnit::Bytes => amount,
+                PlainUnit::KiB => amount.saturating_mul(1_024),
+            });
+        }
+        _ => return None,
+    };
+
+    let amount = value[..value.len() - 1].parse::<f64>().ok()?;
+    Some((amount * multiplier).round() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_top_memory_suffixes() {
+        assert_eq!(parse_top_bytes("1201K", PlainUnit::Bytes), Some(1_229_824));
+        assert_eq!(parse_top_bytes("1.5M", PlainUnit::Bytes), Some(1_572_864));
+        assert_eq!(parse_top_bytes("2.0G", PlainUnit::Bytes), Some(2_147_483_648));
+        assert_eq!(parse_top_bytes("42", PlainUnit::Bytes), Some(42));
+        assert_eq!(parse_top_bytes("42", PlainUnit::KiB), Some(43_008));
+        assert_eq!(parse_top_bytes("1.5g", PlainUnit::KiB), Some(1_610_612_736));
+    }
+
+    #[test]
+    fn parses_top_process_sample_for_expected_pid() {
+        let output = "\
+Processes: 1 total\n\
+PID    MEM\n\
+73194  1.5G\n";
+
+        assert_eq!(parse_top_process_memory(output, 73_194), Some(1_610_612_736));
+    }
+
+    #[test]
+    fn parses_linux_top_process_sample_for_expected_pid() {
+        let output = "\
+top - 12:00:00 up 1 day,  1 user,  load average: 0.00, 0.00, 0.00\n\
+Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie\n\
+%Cpu(s):  0.0 us,  0.0 sy,  0.0 ni,100.0 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st \n\
+MiB Mem :   1024.0 total,    256.0 free,    512.0 used,    256.0 buff/cache\n\
+\n\
+    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND\n\
+  73194 user      20   0 1234567 654321  12345 S   0.0   0.1   0:00.01 amaru\n";
+
+        assert_eq!(parse_linux_top_process_memory(output, 73_194), Some(670_024_704));
+    }
 }

--- a/crates/amaru-tui/src/model.rs
+++ b/crates/amaru-tui/src/model.rs
@@ -215,6 +215,19 @@ mod tests {
         Message::HostSample(HostSample {
             at,
             interval,
+            process_memory_bytes: None,
+            memory_used_bytes: 100_000,
+            memory_total_bytes: 200_000,
+            other_processes_live_read_bytes: 1_500,
+            other_processes_live_write_bytes: 2_500,
+        })
+    }
+
+    fn host_sample_with_process_memory(at: Instant, interval: Duration, process_memory_bytes: u64) -> Message {
+        Message::HostSample(HostSample {
+            at,
+            interval,
+            process_memory_bytes: Some(process_memory_bytes),
             memory_used_bytes: 100_000,
             memory_total_bytes: 200_000,
             other_processes_live_read_bytes: 1_500,
@@ -284,6 +297,51 @@ mod tests {
         assert_eq!(tip.slot, 1);
         assert_eq!(tip.epoch, 3);
         assert_eq!(tip.block_height, 2);
+    }
+
+    #[test]
+    fn keeps_host_process_memory_override_across_metrics_updates() {
+        let mut model = Model::new(Config::default(), startup_context());
+        let at = Instant::now();
+
+        model.handle_message(metric(
+            at,
+            MetricsEvent::SystemMetrics(SystemMetrics {
+                runtime_seconds: 1,
+                cpu_percent: 12.5,
+                process_memory_bytes: 10_000,
+                rss_bytes: 9_000,
+                virtual_bytes: 12_000,
+                disk_read_bytes: 300,
+                disk_write_bytes: 400,
+                disk_live_read_bytes: 30,
+                disk_live_write_bytes: 40,
+                open_files: 5,
+            }),
+        ));
+        model.handle_message(host_sample_with_process_memory(
+            at + Duration::from_secs(5),
+            Duration::from_secs(5),
+            15_000,
+        ));
+        model.handle_message(metric(
+            at + Duration::from_secs(6),
+            MetricsEvent::SystemMetrics(SystemMetrics {
+                runtime_seconds: 2,
+                cpu_percent: 14.5,
+                process_memory_bytes: 10_500,
+                rss_bytes: 9_500,
+                virtual_bytes: 12_500,
+                disk_read_bytes: 350,
+                disk_write_bytes: 450,
+                disk_live_read_bytes: 35,
+                disk_live_write_bytes: 45,
+                open_files: 6,
+            }),
+        ));
+
+        assert_eq!(model.system_samples.back().map(|sample| sample.process_memory_bytes), Some(15_000));
+        assert_eq!(model.system_samples.back().map(|sample| sample.rss_bytes), Some(9_500));
     }
 
     #[test]

--- a/crates/amaru-tui/src/model.rs
+++ b/crates/amaru-tui/src/model.rs
@@ -971,4 +971,23 @@ mod tests {
         assert_eq!(model.page, Page::Cardano);
         assert_eq!(model.scroll_focus, ScrollFocus::Logs);
     }
+
+    #[test]
+    fn shutdown_mode_ignores_follow_up_terminal_input() {
+        let mut model = Model::new(Config::default(), startup_context());
+        model.enter_shutdown_mode();
+
+        assert_eq!(
+            model.handle_key_event(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE)),
+            TerminalEventOutcome::Continue
+        );
+        assert_eq!(
+            model.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+            TerminalEventOutcome::Continue
+        );
+        assert!(model.is_shutdown_mode());
+        assert_eq!(model.interaction_mode, InteractionMode::Shutdown);
+        assert_eq!(model.page, Page::Amaru);
+        assert_eq!(model.scroll_focus, ScrollFocus::Logs);
+    }
 }

--- a/crates/amaru-tui/src/model/interaction.rs
+++ b/crates/amaru-tui/src/model/interaction.rs
@@ -52,12 +52,20 @@ impl Model {
         self.interaction_mode = InteractionMode::Copy;
     }
 
+    pub fn enter_shutdown_mode(&mut self) {
+        self.interaction_mode = InteractionMode::Shutdown;
+    }
+
     pub fn exit_copy_mode(&mut self) {
         self.interaction_mode = InteractionMode::Normal;
     }
 
     pub fn is_copy_mode(&self) -> bool {
         self.interaction_mode == InteractionMode::Copy
+    }
+
+    pub fn is_shutdown_mode(&self) -> bool {
+        self.interaction_mode == InteractionMode::Shutdown
     }
 
     pub fn cycle_log_pane(&mut self) {
@@ -217,6 +225,10 @@ impl Model {
     }
 
     pub(super) fn handle_key_event(&mut self, key: event::KeyEvent) -> TerminalEventOutcome {
+        if self.is_shutdown_mode() {
+            return TerminalEventOutcome::Continue;
+        }
+
         if self.is_copy_mode() {
             return if key.code == KeyCode::Esc {
                 self.exit_copy_mode();
@@ -296,6 +308,10 @@ impl Model {
     }
 
     fn handle_mouse_event(&mut self, mouse: event::MouseEvent, views: &Views) -> TerminalEventOutcome {
+        if self.is_shutdown_mode() {
+            return TerminalEventOutcome::Continue;
+        }
+
         let point = Rect { x: mouse.column, y: mouse.row, width: 1, height: 1 };
 
         match mouse.kind {

--- a/crates/amaru-tui/src/model/interaction_mode.rs
+++ b/crates/amaru-tui/src/model/interaction_mode.rs
@@ -16,4 +16,5 @@
 pub enum InteractionMode {
     Normal,
     Copy,
+    Shutdown,
 }

--- a/crates/amaru-tui/src/model/metrics_update.rs
+++ b/crates/amaru-tui/src/model/metrics_update.rs
@@ -58,13 +58,18 @@ impl Model {
     }
 
     fn record_system_metrics(&mut self, at: Instant, metrics: SystemMetrics) {
-        let (memory_used_bytes, memory_total_bytes, other_processes_live_read_bytes, other_processes_live_write_bytes) =
-            self.latest_host_metrics();
+        let (
+            memory_used_bytes,
+            memory_total_bytes,
+            process_memory_bytes_override,
+            other_processes_live_read_bytes,
+            other_processes_live_write_bytes,
+        ) = self.latest_host_metrics();
 
         self.push_system_sample(SystemSample {
             at,
             cpu_percent: metrics.cpu_percent,
-            process_memory_bytes: metrics.process_memory_bytes,
+            process_memory_bytes: process_memory_bytes_override.unwrap_or(metrics.process_memory_bytes),
             rss_bytes: metrics.rss_bytes,
             virtual_bytes: metrics.virtual_bytes,
             memory_used_bytes,
@@ -93,7 +98,7 @@ impl Model {
         self.push_system_sample(SystemSample {
             at: sample.at,
             cpu_percent,
-            process_memory_bytes,
+            process_memory_bytes: sample.process_memory_bytes.unwrap_or(process_memory_bytes),
             rss_bytes,
             virtual_bytes,
             memory_used_bytes: sample.memory_used_bytes,
@@ -130,18 +135,19 @@ pub(crate) fn prune_recent(entries: &mut VecDeque<Instant>, now: Instant, max_wi
 }
 
 impl Model {
-    fn latest_host_metrics(&self) -> (u64, u64, u64, u64) {
+    fn latest_host_metrics(&self) -> (u64, u64, Option<u64>, u64, u64) {
         self.system_samples
             .back()
             .map(|sample| {
                 (
                     sample.memory_used_bytes,
                     sample.memory_total_bytes,
+                    Some(sample.process_memory_bytes),
                     sample.other_processes_live_read_bytes,
                     sample.other_processes_live_write_bytes,
                 )
             })
-            .unwrap_or((0, 0, 0, 0))
+            .unwrap_or((0, 0, None, 0, 0))
     }
 
     fn latest_process_metrics(&self) -> (f64, u64, u64, u64, u64, u64, u64, u64) {

--- a/crates/amaru-tui/src/session.rs
+++ b/crates/amaru-tui/src/session.rs
@@ -16,6 +16,7 @@ use std::{
     io::{self, IsTerminal},
     sync::{
         Arc,
+        atomic::{AtomicU8, Ordering},
         mpsc::{self, Receiver, Sender},
     },
     thread::{self, JoinHandle},
@@ -41,7 +42,7 @@ pub struct Session {
 }
 
 impl Session {
-    pub fn spawn(config: Config, startup: StartupContext) -> io::Result<Self> {
+    pub fn spawn(config: Config, startup: StartupContext, signal_count: Arc<AtomicU8>) -> io::Result<Self> {
         let (telemetry_tx, telemetry_rx) = mpsc::sync_channel(config.channel_capacity);
         let (control_tx, control_rx) = mpsc::channel();
         let layer = TracingLayer::new(telemetry_tx);
@@ -49,7 +50,7 @@ impl Session {
 
         let join = thread::Builder::new()
             .name("amaru-tui".into())
-            .spawn(move || run_terminal(config, startup, telemetry_rx, control_rx))
+            .spawn(move || run_terminal(config, startup, telemetry_rx, control_rx, signal_count))
             .map_err(|err| io::Error::other(format!("failed to spawn tui thread: {err}")))?;
 
         let host_metrics = match host_metrics::Sampler::spawn(layer.sender()) {
@@ -116,6 +117,7 @@ fn run_terminal(
     startup: StartupContext,
     telemetry_rx: Receiver<crate::events::Message>,
     control_rx: Receiver<Control>,
+    signal_count: Arc<AtomicU8>,
 ) -> io::Result<()> {
     let mut terminal = TerminalGuard::enter()?;
     let mut model = Model::new(config.clone(), startup);
@@ -128,6 +130,11 @@ fn run_terminal(
 
         while let Ok(message) = telemetry_rx.try_recv() {
             model.handle_message(message);
+        }
+
+        if signal_count.load(Ordering::SeqCst) > 0 && !model.is_shutdown_mode() {
+            model.enter_shutdown_mode();
+            terminal.set_mouse_capture(true)?;
         }
 
         let now = Instant::now();

--- a/crates/amaru-tui/src/ui/common.rs
+++ b/crates/amaru-tui/src/ui/common.rs
@@ -211,6 +211,7 @@ pub(super) fn accent_primary(mode: InteractionMode) -> Color {
     match mode {
         InteractionMode::Normal => Color::Rgb(110, 228, 150),
         InteractionMode::Copy => Color::Rgb(96, 171, 255),
+        InteractionMode::Shutdown => Color::Rgb(180, 184, 192),
     }
 }
 

--- a/crates/amaru-tui/src/ui/components/memory_card.rs
+++ b/crates/amaru-tui/src/ui/components/memory_card.rs
@@ -1,0 +1,151 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ratatui::{
+    Frame,
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{Color, Style},
+    text::Span,
+    widgets::{Block, Borders, Gauge, Paragraph},
+};
+
+use super::super::theme::{accent_primary, block_title, border_primary, border_secondary, muted};
+use crate::{events::SystemSample, model::InteractionMode};
+
+pub(in crate::ui) fn render_memory_card(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    sample: Option<&SystemSample>,
+    mode: InteractionMode,
+) {
+    let title = memory_title(sample);
+    let card =
+        Block::default().title(block_title(mode, &title)).borders(Borders::ALL).border_style(border_secondary(mode));
+    let inner = card.inner(area);
+    frame.render_widget(card, area);
+
+    if inner.height == 0 {
+        return;
+    }
+
+    let rows = Layout::vertical([Constraint::Length(1), Constraint::Length(1), Constraint::Length(1)]).split(inner);
+    render_memory_row(
+        frame,
+        rows[0],
+        "Footprint",
+        sample.map(|sample| sample.process_memory_bytes),
+        sample,
+        mode,
+        false,
+    );
+    render_memory_row(frame, rows[2], "RSS", sample.map(|sample| sample.rss_bytes), sample, mode, true);
+}
+
+fn render_memory_row(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    label: &str,
+    current_bytes: Option<u64>,
+    sample: Option<&SystemSample>,
+    mode: InteractionMode,
+    dimmed: bool,
+) {
+    if area.height == 0 {
+        return;
+    }
+
+    let current_bytes = current_bytes.unwrap_or(0);
+    let total_bytes = sample.map_or(0, |sample| sample.memory_total_bytes);
+    let ratio = memory_ratio(current_bytes, total_bytes);
+    let value = match sample {
+        Some(_) => format!("{} / {} MiB", bytes_to_mib(current_bytes), bytes_to_mib(total_bytes)),
+        None => "—".into(),
+    };
+    let [label_area, gauge_area] = Layout::horizontal([Constraint::Length(11), Constraint::Fill(1)]).areas(area);
+
+    frame.render_widget(
+        Paragraph::new(label).style(if dimmed { muted() } else { Style::default() }).alignment(Alignment::Left),
+        label_area,
+    );
+
+    let gauge_style = if dimmed {
+        border_primary(mode).bg(Color::Rgb(10, 22, 17))
+    } else {
+        Style::default().fg(accent_primary(mode)).bg(Color::Rgb(10, 22, 17))
+    };
+
+    let gauge = Gauge::default()
+        .gauge_style(gauge_style)
+        .label(Span::styled(value, if dimmed { muted() } else { Style::default() }))
+        .ratio(ratio)
+        .use_unicode(true);
+    frame.render_widget(gauge, gauge_area);
+}
+
+fn memory_ratio(current_bytes: u64, total_bytes: u64) -> f64 {
+    if total_bytes == 0 { 0.0 } else { (current_bytes as f64 / total_bytes as f64).clamp(0.0, 1.0) }
+}
+
+fn bytes_to_mib(bytes: u64) -> String {
+    crate::ui::format::format_count(bytes.div_ceil(1_048_576))
+}
+
+fn memory_title(sample: Option<&SystemSample>) -> String {
+    let Some(sample) = sample else {
+        return "Memory".into();
+    };
+
+    format!(
+        "Memory ({:.1}%, {:.1}%)",
+        memory_ratio(sample.process_memory_bytes, sample.memory_total_bytes) * 100.0,
+        memory_ratio(sample.rss_bytes, sample.memory_total_bytes) * 100.0,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use super::*;
+
+    #[test]
+    fn memory_ratio_keeps_bounds() {
+        assert_eq!(memory_ratio(0, 1_000), 0.0);
+        assert_eq!(memory_ratio(1_000, 1_000), 1.0);
+        assert_eq!(memory_ratio(42, 300), 0.14);
+    }
+
+    #[test]
+    fn bytes_to_mib_formats_counts() {
+        let sample = SystemSample {
+            at: Instant::now(),
+            cpu_percent: 0.0,
+            process_memory_bytes: 512 * 1_048_576,
+            rss_bytes: 384 * 1_048_576,
+            virtual_bytes: 0,
+            memory_used_bytes: 0,
+            memory_total_bytes: 2 * 1_024 * 1_048_576,
+            disk_read_bytes: 0,
+            disk_write_bytes: 0,
+            disk_live_read_bytes: 0,
+            disk_live_write_bytes: 0,
+            other_processes_live_read_bytes: 0,
+            other_processes_live_write_bytes: 0,
+        };
+
+        assert_eq!(bytes_to_mib(sample.process_memory_bytes), "512");
+        assert_eq!(bytes_to_mib(sample.rss_bytes), "384");
+        assert_eq!(bytes_to_mib(sample.memory_total_bytes), "2,048");
+    }
+}

--- a/crates/amaru-tui/src/ui/components/mod.rs
+++ b/crates/amaru-tui/src/ui/components/mod.rs
@@ -17,10 +17,12 @@ mod config_sections;
 mod epoch_progress;
 mod gauge_card;
 mod logs;
+mod memory_card;
 mod peers;
 mod proposals;
 
 pub(super) use self::{
     card::render_card, config_sections::render_section_groups, epoch_progress::render_epoch_progress,
-    gauge_card::render_gauge_card, logs::render_logs, peers::render_peers_table, proposals::render_proposals_table,
+    gauge_card::render_gauge_card, logs::render_logs, memory_card::render_memory_card, peers::render_peers_table,
+    proposals::render_proposals_table,
 };

--- a/crates/amaru-tui/src/ui/mod.rs
+++ b/crates/amaru-tui/src/ui/mod.rs
@@ -54,6 +54,9 @@ pub fn render(frame: &mut Frame<'_>, model: &Model, views: &mut Views, now: Inst
     frame.render_widget(shell, shell_area);
     if !is_ready {
         render_splash(frame, inner, model, views);
+        if model.is_shutdown_mode() {
+            apply_shutdown_overlay(frame, inner);
+        }
         return;
     }
 
@@ -61,16 +64,25 @@ pub fn render(frame: &mut Frame<'_>, model: &Model, views: &mut Views, now: Inst
 
     if model.page == Page::Amaru && model.peer_pane_mode.is_maximized() {
         render_peers_table(frame, inner, model, views, now);
+        if model.is_shutdown_mode() {
+            apply_shutdown_overlay(frame, inner);
+        }
         return;
     }
 
     if model.page == Page::Cardano && model.proposal_pane_mode.is_maximized() {
         render_proposals_table(frame, inner, model, views);
+        if model.is_shutdown_mode() {
+            apply_shutdown_overlay(frame, inner);
+        }
         return;
     }
 
     if model.log_pane_mode.is_maximized() && model.page != Page::Config {
         render_logs(frame, inner, model, views);
+        if model.is_shutdown_mode() {
+            apply_shutdown_overlay(frame, inner);
+        }
         return;
     }
 
@@ -113,6 +125,10 @@ pub fn render(frame: &mut Frame<'_>, model: &Model, views: &mut Views, now: Inst
         } else {
             render_splash(frame, layout[0], model, views);
         }
+    }
+
+    if model.is_shutdown_mode() {
+        apply_shutdown_overlay(frame, inner);
     }
 }
 
@@ -174,6 +190,20 @@ fn page_tabs_line(model: &Model) -> Line<'static> {
 }
 
 fn shell_title(model: &Model) -> Line<'static> {
+    if model.is_shutdown_mode() {
+        return border_title_line(
+            vec![Span::styled(
+                " SHUTTING DOWN ",
+                Style::default()
+                    .fg(emphasis_white_color())
+                    .bg(accent_primary(model.interaction_mode))
+                    .add_modifier(Modifier::BOLD),
+            )],
+            model.interaction_mode,
+            false,
+        );
+    }
+
     if model.is_copy_mode() {
         return border_title_line(
             vec![Span::styled(
@@ -200,6 +230,14 @@ fn shell_title(model: &Model) -> Line<'static> {
 }
 
 fn shell_hint(model: &Model) -> Line<'static> {
+    if model.is_shutdown_mode() {
+        return border_title_line(
+            vec![Span::styled("please wait", theme::muted().add_modifier(Modifier::BOLD))],
+            model.interaction_mode,
+            false,
+        );
+    }
+
     if model.is_copy_mode() {
         return border_title_line(
             vec![
@@ -259,4 +297,49 @@ fn page_content_height(model: &Model) -> u16 {
         Page::Cardano => screens::cardano_page_content_height(model),
         Page::Config => screens::config_page_content_height(model),
     }
+}
+
+fn apply_shutdown_overlay(frame: &mut Frame<'_>, area: Rect) {
+    let buffer = frame.buffer_mut();
+
+    for y in area.y..area.y.saturating_add(area.height) {
+        for x in area.x..area.x.saturating_add(area.width) {
+            let Some(cell) = buffer.cell_mut((x, y)) else {
+                continue;
+            };
+            cell.fg = grayscale_color(cell.fg);
+            cell.bg = grayscale_color(cell.bg);
+            cell.modifier.remove(Modifier::BOLD);
+            cell.modifier.insert(Modifier::DIM);
+        }
+    }
+}
+
+fn grayscale_color(color: Color) -> Color {
+    match color {
+        Color::Reset => Color::Reset,
+        Color::Black => Color::Black,
+        Color::Red => grayscale_rgb(205, 49, 49),
+        Color::Green => grayscale_rgb(13, 188, 121),
+        Color::Yellow => grayscale_rgb(229, 229, 16),
+        Color::Blue => grayscale_rgb(36, 114, 200),
+        Color::Magenta => grayscale_rgb(188, 63, 188),
+        Color::Cyan => grayscale_rgb(17, 168, 205),
+        Color::Gray => grayscale_rgb(192, 192, 192),
+        Color::DarkGray => grayscale_rgb(128, 128, 128),
+        Color::LightRed => grayscale_rgb(241, 76, 76),
+        Color::LightGreen => grayscale_rgb(35, 209, 139),
+        Color::LightYellow => grayscale_rgb(245, 245, 67),
+        Color::LightBlue => grayscale_rgb(59, 142, 234),
+        Color::LightMagenta => grayscale_rgb(214, 112, 214),
+        Color::LightCyan => grayscale_rgb(41, 184, 219),
+        Color::White => grayscale_rgb(255, 255, 255),
+        Color::Rgb(r, g, b) => grayscale_rgb(r, g, b),
+        Color::Indexed(_) => Color::DarkGray,
+    }
+}
+
+fn grayscale_rgb(r: u8, g: u8, b: u8) -> Color {
+    let gray = ((299_u32 * r as u32 + 587_u32 * g as u32 + 114_u32 * b as u32) / 1000) as u8;
+    Color::Rgb(gray, gray, gray)
 }

--- a/crates/amaru-tui/src/ui/screens/amaru.rs
+++ b/crates/amaru-tui/src/ui/screens/amaru.rs
@@ -20,7 +20,7 @@ use ratatui::{
 };
 
 use super::super::{
-    components::{render_card, render_gauge_card, render_peers_table},
+    components::{render_card, render_gauge_card, render_memory_card, render_peers_table},
     format::{
         aligned_pair_lines, format_count, format_density, format_duration, format_secs_frequency, format_slot_ratio,
     },
@@ -47,16 +47,7 @@ pub(in crate::ui) fn render_amaru(frame: &mut Frame<'_>, area: Rect, model: &Mod
         ])
         .split(layout[0]);
     let sample = latest_system_sample(model);
-    let memory = memory_gauge(sample);
-    render_gauge_card(
-        frame,
-        charts[0],
-        "Memory (RSS)",
-        memory.label,
-        memory.ratio,
-        memory.detail,
-        model.interaction_mode,
-    );
+    render_memory_card(frame, charts[0], sample, model.interaction_mode);
     let cpu = cpu_gauge(sample);
     render_gauge_card(frame, charts[1], "CPU", cpu.label, cpu.ratio, cpu.detail, model.interaction_mode);
     let disk_read = disk_read_gauge(sample);
@@ -199,21 +190,6 @@ struct GaugeMetric {
     detail: Option<String>,
 }
 
-fn memory_gauge(sample: Option<&SystemSample>) -> GaugeMetric {
-    let Some(sample) = sample else {
-        return GaugeMetric { label: "—".into(), ratio: 0.0, detail: None };
-    };
-
-    let current_mib = bytes_to_mib(sample.process_memory_bytes);
-    let total_mib = bytes_to_mib(sample.memory_total_bytes);
-    let ratio = linear_ratio(sample.process_memory_bytes, sample.memory_total_bytes);
-    GaugeMetric {
-        label: format!("{} / {} MiB", format_count(current_mib), format_count(total_mib)),
-        ratio,
-        detail: Some(format!("{:.1}%", ratio * 100.0)),
-    }
-}
-
 fn cpu_gauge(sample: Option<&SystemSample>) -> GaugeMetric {
     let Some(sample) = sample else {
         return GaugeMetric { label: "—".into(), ratio: 0.0, detail: None };
@@ -251,10 +227,6 @@ fn disk_gauge(
         ratio: raw_ratio,
         detail: Some(format!("{:.1}%", raw_ratio * 100.0)),
     }
-}
-
-fn bytes_to_mib(bytes: u64) -> u64 {
-    bytes.div_ceil(1_048_576)
 }
 
 fn bytes_to_kib(bytes: u64) -> u64 {
@@ -300,31 +272,6 @@ mod tests {
         assert_eq!(linear_ratio(0, 1_000), 0.0);
         assert_eq!(linear_ratio(1_000, 1_000), 1.0);
         assert_eq!(linear_ratio(42, 300), 0.14);
-    }
-
-    #[test]
-    fn memory_gauge_uses_process_footprint_against_total_memory() {
-        let sample = SystemSample {
-            at: Instant::now(),
-            cpu_percent: 0.0,
-            process_memory_bytes: 512 * 1_048_576,
-            rss_bytes: 0,
-            virtual_bytes: 0,
-            memory_used_bytes: 0,
-            memory_total_bytes: 2 * 1_048_576 * 1_024,
-            disk_read_bytes: 0,
-            disk_write_bytes: 0,
-            disk_live_read_bytes: 0,
-            disk_live_write_bytes: 0,
-            other_processes_live_read_bytes: 0,
-            other_processes_live_write_bytes: 0,
-        };
-
-        let gauge = memory_gauge(Some(&sample));
-
-        assert_eq!(gauge.label, "512 / 2,048 MiB");
-        assert_eq!(gauge.detail.as_deref(), Some("25.0%"));
-        assert_eq!(gauge.ratio, 0.25);
     }
 
     #[test]

--- a/crates/amaru-tui/src/ui/theme.rs
+++ b/crates/amaru-tui/src/ui/theme.rs
@@ -24,6 +24,7 @@ pub(super) fn accent_primary(mode: InteractionMode) -> Color {
     match mode {
         InteractionMode::Normal => Color::Rgb(110, 228, 150),
         InteractionMode::Copy => Color::Rgb(96, 171, 255),
+        InteractionMode::Shutdown => Color::Rgb(180, 184, 192),
     }
 }
 
@@ -39,6 +40,7 @@ pub(super) fn border_primary(mode: InteractionMode) -> Style {
     match mode {
         InteractionMode::Normal => Style::default().fg(Color::Rgb(80, 156, 105)),
         InteractionMode::Copy => Style::default().fg(Color::Rgb(71, 126, 186)),
+        InteractionMode::Shutdown => Style::default().fg(Color::Rgb(120, 126, 136)),
     }
 }
 
@@ -46,6 +48,7 @@ pub(super) fn border_secondary(mode: InteractionMode) -> Style {
     match mode {
         InteractionMode::Normal => Style::default().fg(Color::Rgb(57, 108, 75)),
         InteractionMode::Copy => Style::default().fg(Color::Rgb(50, 92, 141)),
+        InteractionMode::Shutdown => Style::default().fg(Color::Rgb(88, 94, 104)),
     }
 }
 
@@ -105,6 +108,7 @@ pub(super) fn table_header_style(mode: InteractionMode) -> Style {
     let background = match mode {
         InteractionMode::Normal => Color::Rgb(22, 48, 33),
         InteractionMode::Copy => Color::Rgb(19, 39, 68),
+        InteractionMode::Shutdown => Color::Rgb(40, 44, 52),
     };
 
     Style::default().fg(Color::Rgb(246, 250, 247)).bg(background).add_modifier(Modifier::BOLD)

--- a/crates/amaru/src/bin/amaru/main.rs
+++ b/crates/amaru/src/bin/amaru/main.rs
@@ -16,7 +16,7 @@ use std::{error::Error, process::ExitCode, time::Duration};
 
 use amaru::{
     exit::install_termination_signals,
-    lifecycle::RUNTIME_SHUTDOWN_TIMEOUT,
+    lifecycle::{RUNTIME_SHUTDOWN_TIMEOUT, set_signal_stderr_enabled},
     observability::{Color, ObservabilityHints, setup_observability},
     panic::panic_handler,
     version,
@@ -78,10 +78,11 @@ fn try_main() -> Result<(), Box<dyn Error>> {
             .filter(|settings| tui::should_enable(settings.no_tui, with_json_traces))
             .map(|settings| {
                 let (_, config, startup) = settings.into_parts();
-                tui::Session::spawn(config, startup)
+                tui::Session::spawn(config, startup, signals.shared_count())
             })
             .transpose()?
     };
+    set_signal_stderr_enabled(tui.is_none());
     let _metrics_subscription = tui.as_ref().map(tui::Session::subscribe_to_metrics);
 
     let (metrics, teardown) = if skip_logging {

--- a/crates/amaru/src/lifecycle.rs
+++ b/crates/amaru/src/lifecycle.rs
@@ -18,7 +18,11 @@ use std::{
     error::Error,
     future::Future,
     io, process,
-    sync::{Arc, mpsc},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
     thread,
     time::Duration,
 };
@@ -40,6 +44,8 @@ pub const FORCE_EXIT_CODE: i32 = 130;
 /// Grace period for draining the Tokio runtime after command and observability teardown.
 pub const RUNTIME_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
+static SIGNAL_STDERR_ENABLED: AtomicBool = AtomicBool::new(true);
+
 /// Which Tokio runtime configuration a subcommand should use.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuntimeKind {
@@ -59,6 +65,10 @@ impl RuntimeKind {
             Self::Node => runtime_node(),
         }
     }
+}
+
+pub fn set_signal_stderr_enabled(enabled: bool) {
+    SIGNAL_STDERR_ENABLED.store(enabled, Ordering::SeqCst);
 }
 
 /// How the first termination signal is handled for a subcommand.
@@ -180,7 +190,7 @@ impl ShutdownHandle {
 
     fn request_graceful(&self) {
         if !self.cancel.is_cancelled() {
-            eprintln!("amaru: termination signal received — shutting down");
+            emit_signal_stderr("amaru: termination signal received — shutting down");
             warn!("termination signal received — shutting down");
             self.cancel.cancel();
         }
@@ -252,11 +262,11 @@ pub fn run_until_exit(
         if n >= 1 {
             match first_signal {
                 FirstSignal::ImmediateExit => {
-                    eprintln!("amaru: termination signal received — exiting");
+                    emit_signal_stderr("amaru: termination signal received — exiting");
                     process::exit(FORCE_EXIT_CODE);
                 }
                 FirstSignal::SoftShutdown if n >= 2 => {
-                    eprintln!("amaru: second termination signal — forcing exit");
+                    emit_signal_stderr("amaru: second termination signal — forcing exit");
                     process::exit(FORCE_EXIT_CODE);
                 }
                 FirstSignal::SoftShutdown if !graceful => {
@@ -281,6 +291,12 @@ pub fn run_until_exit(
     }
 
     result.map_err(|msg| msg.into())
+}
+
+fn emit_signal_stderr(message: &str) {
+    if SIGNAL_STDERR_ENABLED.load(Ordering::SeqCst) {
+        eprintln!("{message}");
+    }
 }
 
 #[cfg(test)]

--- a/engineering-decision-records/030-embedded-terminal-observability-ui.md
+++ b/engineering-decision-records/030-embedded-terminal-observability-ui.md
@@ -177,6 +177,15 @@ While copy mode is active:
 - the header indicates the mode clearly
 - command hints reflect the reduced interaction surface
 
+The same shell chrome also supports a non-interactive shutdown mode. When the
+first termination signal is observed:
+
+- the TUI suppresses the extra stderr status line that would otherwise corrupt
+  the alternate screen
+- the interaction mode switches to a dimmed shutdown presentation
+- further local keyboard and mouse interaction is ignored while the node drains
+  normally
+
 ### Degrade gracefully under filtered telemetry
 
 The TUI must not assume it sees every event. If the log or metric stream is


### PR DESCRIPTION
No-changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a terminal memory card showing process footprint and RSS with MiB values, gauges, and percentages.
  * Added process-memory monitoring on supported macOS and Linux systems.
  * Added a graceful shutdown mode that dims the interface, updates status messaging, and ignores further input.

* **Bug Fixes**
  * Preserved explicitly sampled process-memory values during system metric updates.
  * Improved handling of unavailable, invalid, or unsupported memory data.
  * Suppressed duplicate shutdown status output while the terminal interface is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->