### PR TITLE
bump chain DB version to 5 due to opcerts missing

### DIFF
--- a/.github/actions/bootstrap-db/action.yml
+++ b/.github/actions/bootstrap-db/action.yml
@@ -16,7 +16,7 @@ inputs:
   cache-version:
     description: Cache key version
     required: false
-    default: "v17"
+    default: "v18"
 
 runs:
   using: composite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Other guiding principles:
 
 ### Changed
 
+- **amaru-stores**: bump chain DB schema to version 5. Migration from earlier versions is intentionally refused: opcert sequence numbers must come from a snapshot bootstrap (`amaru node rm --wipe-all-dbs` then `amaru node bootstrap`). Version-mismatch errors on `amaru node run` now suggest `amaru dev chain migrate` / `--migrate-chain-db`. ([#1152](https://github.com/pragma-org/amaru/issues/1152))
 - **amaru-consensus**: skip the validation of headers whose evolved nonces are already stored, to avoid unnecessary rechecks when getting the same header from different peers. ([#1087][])
 - **amaru-ledger**: keep only slim stake summaries in runtime memory, and rebuild the full account-heavy stake distribution from snapshots when computing rewards.
 - **amaru-ledger**: compute rewards and stake distributions asynchronously to prevent blocking the main roll forward loop from times to times.

--- a/crates/amaru-node/src/stages/build_node.rs
+++ b/crates/amaru-node/src/stages/build_node.rs
@@ -116,6 +116,9 @@ pub fn build_node(
     meter: Option<Meter>,
     stage_builder: &mut impl StageGraph,
 ) -> anyhow::Result<NodeStages> {
+    // NOTE: Open the chain store first so incompatible DB versions fail before the slower ledger open.
+    let chain_store = make_chain_store(config)?;
+
     // Make the ledger state and get its tip
     let state = make_state(&config.ledger_config, Some(with_startup_hook::<RocksDB>))?;
     let ledger_tip = state.tip().into_owned();
@@ -125,7 +128,6 @@ pub fn build_node(
         "build_ledger"
     );
 
-    let chain_store = make_chain_store(config)?;
     let pool_summaries = state.pool_summaries();
     let block_validator = Arc::new(make_block_validator(&config.ledger_config, state, chain_store.clone())?);
     let max_epoch = pool_summaries.max_epoch();

--- a/crates/amaru-ouroboros-traits/src/stores/chain_store/types.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/chain_store/types.rs
@@ -59,7 +59,12 @@ impl Display for StoreError {
             StoreError::ReadError { error } => write!(f, "ReadError: {}", error),
             StoreError::OpenError { error } => write!(f, "OpenError: {}", error),
             StoreError::IncompatibleChainStoreVersions { stored, current } => {
-                write!(f, "Incompatible DB Versions: found {}, expected {}", stored, current)
+                write!(
+                    f,
+                    "Incompatible chain DB versions: found {stored}, expected {current}. \
+Run `amaru dev chain migrate --network <NETWORK>` to migrate, or pass `--migrate-chain-db` \
+(or set `AMARU_MIGRATE_CHAIN_DB=true`) when starting the node with `amaru node run`"
+                )
             }
         }
     }

--- a/crates/amaru-stores/src/rocksdb/consensus/migration.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/migration.rs
@@ -38,7 +38,7 @@ pub const VERSION_KEY: [u8; 11] = *b"__VERSION__";
 /// DB schema, create migration function and add it to this array
 /// bumping its length.
 static MIGRATIONS: [fn(&RocksDBStore<DB>) -> Result<(), StoreError>; CHAIN_DB_VERSION as usize] =
-    [migrate_to_v1, migrate_to_v2, migrate_to_v3, migrate_to_v4];
+    [migrate_to_v1, migrate_to_v2, migrate_to_v3, migrate_to_v4, migrate_to_v5];
 
 /// Migrate the Chain Database at the given `path` to the current `CHAIN_DB_VERSION`.
 /// Returns the pair of numbers consisting in the initial version of the database and
@@ -73,7 +73,7 @@ pub(crate) fn migrate_to_v1(store: &RocksDBStore<DB>) -> Result<(), StoreError> 
 
 /// "Migrate" DB to version 2
 /// Walks the best chain backwards and re-inserts all points.
-fn migrate_to_v2(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
+pub(crate) fn migrate_to_v2(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
     let mut hash = store.get_best_chain_hash();
     if hash == ORIGIN_HASH {
         return Ok(());
@@ -91,7 +91,7 @@ fn migrate_to_v2(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
 }
 
 #[expect(clippy::panic)]
-fn migrate_to_v3(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
+pub(crate) fn migrate_to_v3(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
     // the reason is that v3 stores the block validation result, which cannot be derived from the v2 DB without
     // running the consensus algorithm and ledger validation. previously, blocks were stored before validation,
     tracing::warn!(
@@ -118,7 +118,7 @@ fn migrate_to_v3(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
     set_version(store, 3)
 }
 
-fn migrate_to_v4(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
+pub(crate) fn migrate_to_v4(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
     tracing::warn!(
         "migrating chain DB to version 4: opcert sequence numbers are reconstructed from stored \
            headers only; counters from before this database was bootstrapped are unknown, which can \
@@ -133,6 +133,28 @@ fn migrate_to_v4(store: &RocksDBStore<DB>) -> Result<(), StoreError> {
             .map_err(|e| StoreError::WriteError { error: e.to_string() })?;
     }
     set_version(store, 4)
+}
+
+/// Migration to version 5 is intentionally impossible.
+///
+/// Opcert sequence numbers must be seeded from a recent cardano-node snapshot at bootstrap.
+/// Reconstructing them only from headers already in the chain store leaves most pools at an
+/// implicit zero, so live opcert numbers (typically much higher) fail the Praos check.
+fn migrate_to_v5(_store: &RocksDBStore<DB>) -> Result<(), StoreError> {
+    Err(StoreError::OpenError {
+        error: "\
+chain database cannot be migrated to version 5 automatically: opcert sequence numbers for pools
+are incomplete unless the chain DB was bootstrapped from a recent snapshot (values reconstructed
+only from stored headers, or defaulting to zero, cause valid headers to be rejected).
+
+Remove the existing node databases and re-bootstrap from a recent snapshot, for example:
+
+  amaru node rm --wipe-all-dbs --network=<NETWORK>
+  amaru node bootstrap --network=<NETWORK>
+
+Then start the node with `amaru node run --network=<NETWORK>`."
+            .to_string(),
+    })
 }
 
 /// Check the version stored in the `store` matches `CHAIN_DB_VERSION`.

--- a/crates/amaru-stores/src/rocksdb/consensus/tests.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/tests.rs
@@ -1359,6 +1359,36 @@ fn fails_to_open_rw_db_if_it_exists_with_wrong_version() {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn open_with_older_version_recommends_migration() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let target = tempdir.path();
+    let config = RocksDbConfig::new(target.to_path_buf());
+    let source = PathBuf::from("sample-chain-db/v0");
+
+    copy_recursively(source, target).unwrap();
+
+    let err = match RocksDBStore::open(&config) {
+        Err(err) => err,
+        Ok(_) => panic!("opening an older chain DB version must fail"),
+    };
+    let message = err.to_string();
+
+    assert!(
+        matches!(err, StoreError::IncompatibleChainStoreVersions { stored: 0, current } if current == CHAIN_DB_VERSION),
+        "expected IncompatibleChainStoreVersions, got: {err:?}"
+    );
+    assert!(
+        message.contains("amaru dev chain migrate"),
+        "error should recommend `amaru dev chain migrate`, got: {message}"
+    );
+    assert!(
+        message.contains("--migrate-chain-db") || message.contains("AMARU_MIGRATE_CHAIN_DB"),
+        "error should recommend enabling migration on node run, got: {message}"
+    );
+}
+
 #[test]
 fn raises_an_error_when_creating_a_database_given_directory_is_non_empty() {
     let tempdir = tempfile::tempdir().unwrap();
@@ -1438,7 +1468,7 @@ fn can_convert_v0_sample_db_to_v1() {
 
 #[cfg(not(target_os = "windows"))]
 #[test]
-fn can_convert_v1_sample_db_to_v2() {
+fn can_convert_v1_sample_db_to_v4() {
     use std::str::FromStr;
 
     let tempdir = tempfile::tempdir().unwrap();
@@ -1448,12 +1478,19 @@ fn can_convert_v1_sample_db_to_v2() {
 
     copy_recursively(source, target).unwrap();
 
-    let result = migrate_db_path(target).expect("Migration should succeed");
+    let (basedir, db) = open_db(&config).expect("cannot open sample v1 DB");
+    let store = RocksDBStore { db, basedir };
 
-    let db = RocksDBStore::open(&config).expect("DB should successfully be opened as it's been migrated");
-    assert_eq!((1, CHAIN_DB_VERSION), result);
+    assert_eq!(get_version(&store).unwrap(), 1, "sample DB should be v1");
+    migrate_to_v2(&store).expect("Migration to v2 should succeed");
+    assert_eq!(get_version(&store).unwrap(), 2, "sample DB should be v2");
+    migrate_to_v3(&store).expect("Migration to v3 should succeed");
+    assert_eq!(get_version(&store).unwrap(), 3, "sample DB should be v3");
+    migrate_to_v4(&store).expect("Migration to v4 should succeed");
+    assert_eq!(get_version(&store).unwrap(), 4, "sample DB should be v4");
+
     let header: Option<HeaderHash> = <RocksDBStore as BaseReadChainStore>::load_from_best_chain(
-        &db,
+        &store,
         &Point::Specific(5.into(), Hash::from_str(SAMPLE_HASH).unwrap()),
     );
     assert!(header.is_some(), "Sample data should be preserved");
@@ -1476,13 +1513,29 @@ fn migrate_to_v4_backfills_opcert_entries_from_stored_headers() {
     set_version(&store, 3).unwrap();
     assert_eq!(store.load_opcert_sequence_numbers().count(), 0);
 
-    migrate_db(&store).unwrap();
+    migrate_to_v4(&store).unwrap();
 
-    assert_eq!(get_version(&store).unwrap(), CHAIN_DB_VERSION);
+    assert_eq!(get_version(&store).unwrap(), 4);
     let entries: Vec<_> = store.load_opcert_sequence_numbers().collect();
     assert_eq!(entries.len(), 2);
     assert!(entries.contains(&(header1.pool_id(), Slot::from(10), header1.hash(), 1)));
     assert!(entries.contains(&(header2.pool_id(), Slot::from(20), header2.hash(), 2)));
+}
+
+#[test]
+fn migrate_to_v5_requires_rebootstrap_from_snapshot() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let store = initialise_test_rw_store(tempdir.path());
+    set_version(&store, 4).unwrap();
+
+    let err = migrate_db(&store).expect_err("migration to v5 must fail");
+    let StoreError::OpenError { error } = err else {
+        panic!("expected OpenError, got: {err:?}");
+    };
+    assert!(error.contains("cannot be migrated to version 5"), "unexpected message: {error}");
+    assert!(error.contains("amaru node rm --wipe-all-dbs"), "missing rm command: {error}");
+    assert!(error.contains("amaru node bootstrap"), "missing bootstrap command: {error}");
+    assert_eq!(get_version(&store).unwrap(), 4, "failed migration must not bump the version");
 }
 
 #[test]
@@ -1503,7 +1556,7 @@ fn migrate_db_fails_given_directory_does_not_exist() {
 
 #[cfg(not(target_os = "windows"))]
 #[test]
-fn open_or_create_succeeds_given_directory_exists() {
+fn open_and_migrate_fails_on_existing_db_that_cannot_reach_v5() {
     let tempdir = tempfile::tempdir().unwrap();
     let target = tempdir.path();
     let config = RocksDbConfig::new(target.to_path_buf());
@@ -1511,10 +1564,13 @@ fn open_or_create_succeeds_given_directory_exists() {
 
     copy_recursively(source, target).unwrap();
 
-    let store = RocksDBStore::open_and_migrate(&config).expect("should create DB successfully");
-    let version = get_version(&store).expect("should read version successfully");
-
-    assert_eq!(version, CHAIN_DB_VERSION);
+    let Err(err) = RocksDBStore::open_and_migrate(&config) else {
+        panic!("migration to v5 must fail");
+    };
+    let StoreError::OpenError { error } = err else {
+        panic!("expected OpenError, got: {err:?}");
+    };
+    assert!(error.contains("cannot be migrated to version 5"), "unexpected message: {error}");
 }
 
 #[test]

--- a/crates/amaru-stores/src/rocksdb/consensus/util.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/util.rs
@@ -25,7 +25,7 @@ pub(crate) const CONSENSUS_PREFIX_LEN: usize = 5;
 /// Increment this number by 1 every time the "schema" is updated, eg. a new
 /// type of keys is added, prefixes are changed, etc. then provide a migration
 /// function from the previous version.
-pub const CHAIN_DB_VERSION: u16 = 4;
+pub const CHAIN_DB_VERSION: u16 = 5;
 
 pub(crate) const ANCHOR_PREFIX: [u8; CONSENSUS_PREFIX_LEN] = *b"ancho";
 pub(crate) const BEST_CHAIN_PREFIX: [u8; CONSENSUS_PREFIX_LEN] = *b"best_";


### PR DESCRIPTION
This was raised on Discord: the header validation failures induced by the v4 migration are a bigger
issue than anticipated, so this migration should be rejected with a helpful message.

fixes #1152


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added chain database schema version 5 support.
  - Improved version-mismatch errors with clear migration and command-line guidance.

- **Bug Fixes**
  - Prevented unsafe automatic migration when operational certificate data cannot be reconstructed reliably.

- **Documentation**
  - Added release notes explaining that affected databases must be wiped and re-bootstrapped from a recent snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->