### PR TITLE
add `amaru node rollback` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Other guiding principles:
 
 ### Added
 
+- **amaru**: add `amaru node rollback` to recover after a wrongly invalidated block or to rewind to an epoch start. Supports `--immutable-tip` (chain store only) and `--epoch` (ledger snapshot reset + chain realign). Clears all descendant validation flags, sets the anchor/best tip, and culls the best-chain fragment. ([#1072](https://github.com/pragma-org/amaru/issues/1072))
 - **amaru**: add `amaru mithril sync` to download verified Mithril immutable files and replay their blocks directly into the chain and ledger stores.
 - **amaru**: add `amaru node rm --wipe-all-dbs` to remove the ledger and chain databases resolved from the selected network.
 - **amaru-tui**: `node run` now launches a feature-rich TUI that feeds from the emitted traces and metrics to provide an out-of-the-box dashboard for Amaru. Can be disabled with `--no-tui`.
@@ -47,6 +48,7 @@ Other guiding principles:
 ### Changed
 
 - **amaru-stores**: bump chain DB schema to version 5. Migration from earlier versions is intentionally refused: opcert sequence numbers must come from a snapshot bootstrap (`amaru node rm --wipe-all-dbs` then `amaru node bootstrap`). Version-mismatch errors on `amaru node run` now suggest `amaru dev chain migrate` / `--migrate-chain-db`. ([#1152](https://github.com/pragma-org/amaru/issues/1152))
+- **amaru**: prefer `amaru node rollback --epoch` over `amaru dev ledger reset` / legacy `reset-to-epoch`. The low-level ledger-only reset is hidden; the legacy alias now performs full recovery (ledger + chain realign). ([#1072](https://github.com/pragma-org/amaru/issues/1072))
 - **amaru-consensus**: skip the validation of headers whose evolved nonces are already stored, to avoid unnecessary rechecks when getting the same header from different peers. ([#1087][])
 - **amaru-ledger**: keep only slim stake summaries in runtime memory, and rebuild the full account-heavy stake distribution from snapshots when computing rewards.
 - **amaru-ledger**: compute rewards and stake distributions asynchronously to prevent blocking the main roll forward loop from times to times.

--- a/crates/amaru-node/src/chain_realign.rs
+++ b/crates/amaru-node/src/chain_realign.rs
@@ -1,0 +1,222 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use amaru_kernel::{ORIGIN_HASH, Point};
+use amaru_observability::{debug, info, info_record};
+use amaru_ouroboros::ChainStore;
+use anyhow::bail;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClearValidity {
+    /// Startup path: only clear `valid=true` after the tip (volatile ledger is rebuilt).
+    /// Invalid flags are kept so previously rejected blocks stay skipped.
+    ValidOnly,
+    /// Offline recovery: clear both valid and invalid flags on all descendants so blocks can be
+    /// re-validated after a false invalid or a deeper rewind.
+    All,
+}
+
+/// Realign the chain store so the best chain ends at `tip`, the anchor is `tip`, and validation
+/// flags after `tip` are cleared according to `clear`.
+///
+/// Headers and blocks are retained. When a best chain already exists, `tip` must lie on it;
+/// otherwise the store is left untouched and an error is returned.
+pub fn realign_chain_store_to(chain_store: &dyn ChainStore, tip: Point, clear: ClearValidity) -> anyhow::Result<()> {
+    info!(consensus::chain_db::INITIALIZE, ledger_tip = %tip);
+
+    let best_chain_hash = chain_store.get_best_chain_hash();
+    let has_best_chain = best_chain_hash != ORIGIN_HASH;
+
+    // Every fork branches at or after the immutable tip, which cannot be rolled back, so the
+    // ledger tip is always on the recorded best chain. When it is not, the two databases describe
+    // different chains and truncating the best chain would silently discard headers. This is
+    // checked before any mutation so that a rejected chain database is left untouched.
+    if has_best_chain && chain_store.load_from_best_chain(&tip).is_none() {
+        bail!(
+            "the chain database is inconsistent with the ledger: its best chain, ending at \
+             {best_chain_hash}, does not contain the ledger tip {tip}. This happens when \
+             a ledger snapshot is imported on top of a chain database built for another chain. \
+             Remove the chain database so that it can be rebuilt from the ledger tip."
+        );
+    }
+
+    chain_store.set_anchor_hash(&tip.hash())?;
+    chain_store.set_block_valid(&tip.hash(), true)?;
+    if has_best_chain {
+        chain_store.switch_to_fork(&tip, &[])?;
+    } else {
+        chain_store.roll_forward_chain(&tip)?;
+    }
+
+    info_record!(consensus::chain_db::INITIALIZE, best_chain_hash = best_chain_hash);
+    clear_validation_after_tip(chain_store, tip, clear)?;
+    Ok(())
+}
+
+fn clear_validation_after_tip(chain_store: &dyn ChainStore, tip: Point, clear: ClearValidity) -> anyhow::Result<()> {
+    let mut to_visit = chain_store.get_children(&tip.hash());
+    let mut count = 0;
+
+    while let Some(hash) = to_visit.pop() {
+        let Some((_header, validity)) = chain_store.load_header_with_validity(&hash) else {
+            continue;
+        };
+
+        let should_clear =
+            matches!((clear, validity), (ClearValidity::ValidOnly, Some(true)) | (ClearValidity::All, Some(_)));
+
+        if should_clear {
+            count += 1;
+            chain_store.remove_block_valid(&hash)?;
+        }
+
+        to_visit.extend(chain_store.get_children(&hash));
+    }
+    debug!(consensus::chain_db::CLEAR_VALID_DESCENDANTS, count = count);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use amaru_kernel::{BlockHeader, IsHeader, make_header};
+    use amaru_ouroboros::{BaseReadChainStore, WriteChainStore, in_memory_chain_store::InMemoryChainStore};
+
+    use super::*;
+
+    #[test]
+    fn realign_valid_only_keeps_invalid_flags() {
+        // h0 -- h1 -- h2 -- h3   the chain the consensus had validated
+        //         \
+        //          h2a          a fork that was validated and rejected
+        let h0 = header(1, 1, None);
+        let h1 = header(2, 2, Some(&h0));
+        let h2 = header(3, 3, Some(&h1));
+        let h3 = header(4, 4, Some(&h2));
+        let h2a = header(3, 30, Some(&h1));
+
+        let chain_store = Arc::new(InMemoryChainStore::new());
+        for header in [&h0, &h1, &h2, &h3, &h2a] {
+            chain_store.store_header(header).unwrap();
+            chain_store.set_block_valid(&header.hash(), true).unwrap();
+        }
+        chain_store.set_block_valid(&h2a.hash(), false).unwrap();
+        for header in [&h0, &h1, &h2, &h3] {
+            chain_store.roll_forward_chain(&header.point()).unwrap();
+        }
+        chain_store.set_anchor_hash(&h0.hash()).unwrap();
+
+        realign_chain_store_to(chain_store.as_ref(), h1.point(), ClearValidity::ValidOnly).unwrap();
+
+        assert_eq!(chain_store.get_anchor_hash(), h1.hash(), "the anchor must move to the ledger tip");
+        assert_eq!(chain_store.get_best_chain_hash(), h1.hash(), "the best chain must end at the ledger tip");
+        assert!(chain_store.load_from_best_chain(&h1.point()).is_some(), "the ledger tip stays on the best chain");
+        assert!(chain_store.load_from_best_chain(&h2.point()).is_none(), "h2 must leave the best chain");
+        assert!(chain_store.load_from_best_chain(&h3.point()).is_none(), "h3 must leave the best chain");
+
+        assert_eq!(validity(chain_store.as_ref(), &h0), Some(true), "blocks before the ledger tip stay validated");
+        assert_eq!(validity(chain_store.as_ref(), &h1), Some(true), "the ledger tip stays validated");
+        assert_eq!(validity(chain_store.as_ref(), &h2), None, "h2 must be applied to the ledger again");
+        assert_eq!(validity(chain_store.as_ref(), &h3), None, "h3 must be applied to the ledger again");
+        assert_eq!(validity(chain_store.as_ref(), &h2a), Some(false), "an invalid block was never applied");
+    }
+
+    #[test]
+    fn realign_all_clears_invalid_flags_on_descendants() {
+        let h0 = header(1, 1, None);
+        let h1 = header(2, 2, Some(&h0));
+        let h2 = header(3, 3, Some(&h1));
+        let h3 = header(4, 4, Some(&h2));
+        let h2a = header(3, 30, Some(&h1));
+
+        let chain_store = Arc::new(InMemoryChainStore::new());
+        for header in [&h0, &h1, &h2, &h3, &h2a] {
+            chain_store.store_header(header).unwrap();
+            chain_store.set_block_valid(&header.hash(), true).unwrap();
+        }
+        chain_store.set_block_valid(&h2a.hash(), false).unwrap();
+        for header in [&h0, &h1, &h2, &h3] {
+            chain_store.roll_forward_chain(&header.point()).unwrap();
+        }
+        chain_store.set_anchor_hash(&h0.hash()).unwrap();
+
+        realign_chain_store_to(chain_store.as_ref(), h1.point(), ClearValidity::All).unwrap();
+
+        assert_eq!(chain_store.get_anchor_hash(), h1.hash());
+        assert_eq!(chain_store.get_best_chain_hash(), h1.hash());
+        assert!(chain_store.load_from_best_chain(&h2.point()).is_none());
+        assert_eq!(validity(chain_store.as_ref(), &h0), Some(true));
+        assert_eq!(validity(chain_store.as_ref(), &h1), Some(true));
+        assert_eq!(validity(chain_store.as_ref(), &h2), None);
+        assert_eq!(validity(chain_store.as_ref(), &h3), None);
+        assert_eq!(
+            validity(chain_store.as_ref(), &h2a),
+            None,
+            "invalid flags after the tip must be cleared for recovery"
+        );
+    }
+
+    #[test]
+    fn start_the_best_chain_on_a_store_that_has_none() {
+        let h0 = header(1, 1, None);
+
+        let chain_store = Arc::new(InMemoryChainStore::new());
+        chain_store.store_header(&h0).unwrap();
+
+        realign_chain_store_to(chain_store.as_ref(), h0.point(), ClearValidity::ValidOnly).unwrap();
+
+        assert_eq!(chain_store.get_anchor_hash(), h0.hash());
+        assert_eq!(chain_store.get_best_chain_hash(), h0.hash());
+        assert!(chain_store.load_from_best_chain(&h0.point()).is_some(), "the ledger tip starts the best chain");
+        assert_eq!(validity(chain_store.as_ref(), &h0), Some(true));
+    }
+
+    #[test]
+    fn reject_a_chain_store_that_does_not_contain_the_ledger_tip() {
+        // h0 -- h1     the chain the consensus had built
+        //   \
+        //    h1a       the branch the ledger was bootstrapped on
+        let h0 = header(1, 1, None);
+        let h1 = header(2, 2, Some(&h0));
+        let h1a = header(2, 20, Some(&h0));
+
+        let chain_store = Arc::new(InMemoryChainStore::new());
+        for header in [&h0, &h1, &h1a] {
+            chain_store.store_header(header).unwrap();
+        }
+        for header in [&h0, &h1] {
+            chain_store.roll_forward_chain(&header.point()).unwrap();
+        }
+        chain_store.set_anchor_hash(&h0.hash()).unwrap();
+
+        let error =
+            realign_chain_store_to(chain_store.as_ref(), h1a.point(), ClearValidity::All).unwrap_err().to_string();
+
+        assert!(error.contains("inconsistent with the ledger"), "unexpected error: {error}");
+        assert_eq!(chain_store.get_best_chain_hash(), h1.hash(), "the best chain must be left untouched");
+        assert_eq!(chain_store.get_anchor_hash(), h0.hash(), "the anchor must be left untouched");
+        for header in [&h0, &h1, &h1a] {
+            assert_eq!(validity(chain_store.as_ref(), header), None, "no block validity must be recorded");
+        }
+    }
+
+    fn header(block_height: u64, slot: u64, parent: Option<&BlockHeader>) -> BlockHeader {
+        BlockHeader::from(make_header(block_height, slot, parent.map(BlockHeader::hash)))
+    }
+
+    fn validity(chain_store: &dyn ChainStore, header: &BlockHeader) -> Option<bool> {
+        chain_store.load_header_with_validity(&header.hash()).and_then(|(_, validity)| validity)
+    }
+}

--- a/crates/amaru-node/src/ledger_reset.rs
+++ b/crates/amaru-node/src/ledger_reset.rs
@@ -1,0 +1,152 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Offline reset of the ledger database to the beginning of a stored epoch.
+
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use amaru_ledger::state::MIN_LEDGER_SNAPSHOTS;
+use anyhow::{Context, Result, bail};
+
+/// Reset the ledger database at `ledger_dir` so that live state corresponds to the start of
+/// `epoch` (by deleting later snapshots and copying epoch `epoch - 1` to `live/`).
+///
+/// This only mutates ledger snapshot directories. It does not touch the chain store.
+pub fn reset_ledger_to_epoch(ledger_dir: &Path, epoch: amaru_kernel::Epoch) -> Result<()> {
+    let folders = get_ledger_db_snapshots(ledger_dir)?;
+    check_safe_to_reset(epoch, &folders)?;
+
+    // Note: given the `check_safe_to_reset` above ensures we have epochs
+    // we know penultimate_epoch will get reassigned
+    let mut penultimate_epoch: Option<PathBuf> = None;
+    for folder in folders {
+        match folder.epoch {
+            Epoch::Live => {
+                fs::remove_dir_all(&folder.path)
+                    .with_context(|| format!("failed to remove {}", folder.path.display()))?;
+            }
+            Epoch::Past(folder_epoch) => {
+                if folder_epoch == epoch - 1 {
+                    // set this aside to make a copy of it at the end
+                    // if we were to copy right now, it could collide
+                    // with the existing directory
+                    penultimate_epoch = Some(folder.path);
+                } else if folder_epoch >= epoch {
+                    fs::remove_dir_all(&folder.path)
+                        .with_context(|| format!("failed to remove {}", folder.path.display()))?;
+                }
+            }
+        }
+    }
+
+    let penultimate_epoch = penultimate_epoch.unwrap_or_else(|| {
+        unreachable!(
+            "invariant violated: check_safe_to_reset should have guaranteed that penultimate_epoch gets assigned"
+        );
+    });
+
+    copy_dir_recursive(&penultimate_epoch, &ledger_dir.join("live"))
+        .with_context(|| format!("failed to copy {} to live/", penultimate_epoch.display()))?;
+
+    Ok(())
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Epoch {
+    Live,
+    Past(amaru_kernel::Epoch),
+}
+
+impl Epoch {
+    fn epoch_no(&self) -> Option<amaru_kernel::Epoch> {
+        match self {
+            Epoch::Live => None,
+            Epoch::Past(e) => Some(*e),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Folder {
+    epoch: Epoch,
+    path: PathBuf,
+}
+
+fn get_ledger_db_snapshots(ledger_dir: &Path) -> Result<Vec<Folder>> {
+    // The ledger db snapshots are organized as folders in ledger_dir
+    // There's one folder for the "current" epoch, and one for each past epoch that's been saved
+    Ok(fs::read_dir(ledger_dir)
+        .with_context(|| format!("failed to read ledger_dir {}", ledger_dir.display()))?
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|f| f.is_dir())
+        .filter_map(|path| {
+            let stem = path.file_stem()?.to_str()?;
+            let epoch = if stem == "live" { Epoch::Live } else { Epoch::Past(stem.parse().ok()?) };
+            Some(Folder { epoch, path })
+        })
+        .collect())
+}
+
+fn epoch_boundaries(folders: &[Folder]) -> Option<(amaru_kernel::Epoch, amaru_kernel::Epoch)> {
+    let epoch_numbers = folders.iter().filter_map(|f| f.epoch.epoch_no());
+    Some((epoch_numbers.clone().min()?, epoch_numbers.max()?))
+}
+
+fn check_safe_to_reset(epoch: amaru_kernel::Epoch, folders: &[Folder]) -> Result<()> {
+    let (min_epoch, max_epoch) =
+        epoch_boundaries(folders).ok_or_else(|| anyhow::anyhow!("no epochs to roll back to"))?;
+
+    if epoch < min_epoch {
+        bail!("cannot reset to an epoch that far in the past. We've only kept snapshots as far back as {}", min_epoch);
+    }
+
+    // The +1 here is because if we're resetting to 175, and the max epoch is 174,
+    // we're *in* epoch 175, and we can just delete `live/` and copy `174` to `live`
+    if epoch > max_epoch + 1 {
+        bail!("cannot reset to an epoch in the future. We're currently in epoch {}", max_epoch + 1);
+    }
+
+    // We need MIN_LEDGER_SNAPSHOTS=3 previous epochs *plus* the "live" epoch, to function
+    // so if we try to reset to the start of 165, but our earliest epoch is 163
+    // this will break: we can keep 163 and 164, and copy 164 to live, but
+    // that leaves us with only 2 epochs
+    if epoch < min_epoch + MIN_LEDGER_SNAPSHOTS {
+        bail!(
+            "resetting to epoch {} would leave us with too few historical epochs to proceed. The earliest epoch you can reset to is {}",
+            epoch,
+            min_epoch + MIN_LEDGER_SNAPSHOTS,
+        );
+    }
+
+    Ok(())
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path)?;
+        } else {
+            fs::copy(&src_path, &dst_path)?;
+        }
+    }
+    Ok(())
+}

--- a/crates/amaru-node/src/lib.rs
+++ b/crates/amaru-node/src/lib.rs
@@ -12,9 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod chain_realign;
+pub mod ledger_reset;
 pub mod peer_snapshot;
 pub mod stages;
 pub mod submit_api;
+
+pub use chain_realign::{ClearValidity, realign_chain_store_to};
+pub use ledger_reset::reset_ledger_to_epoch;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod tests;

--- a/crates/amaru-node/src/stages/build_node.rs
+++ b/crates/amaru-node/src/stages/build_node.rs
@@ -22,14 +22,13 @@ use amaru_consensus::{
     },
     stages::track_peers::TrackPeersMsg,
 };
-use amaru_kernel::{ConsensusParameters, EraHistory, GlobalParameters, ORIGIN_HASH, Point, Transaction};
+use amaru_kernel::{ConsensusParameters, EraHistory, GlobalParameters, Point, Transaction};
 use amaru_ledger::{
     startup::{StartupHook, with_startup_hook},
     state::State,
 };
 use amaru_mempool::{InMemoryMempool, MempoolConfig};
 use amaru_network::connection::TokioConnections;
-use amaru_observability::{debug, info, info_record};
 use amaru_ouroboros::{ChainStore, ConnectionsResource, MempoolMsg, PoolSummaries, ResourceMempool};
 use amaru_plutus::arena_pool::ArenaPool;
 use amaru_protocols::{
@@ -42,14 +41,17 @@ use amaru_pure_stage::{
     trace_buffer::TraceBuffer,
 };
 use amaru_stores::rocksdb::{RocksDB, RocksDBHistoricalStores, consensus::RocksDBStore};
-use anyhow::{anyhow, bail};
+use anyhow::anyhow;
 use opentelemetry::metrics::Meter;
 use parking_lot::Mutex;
 use tokio::runtime::Handle;
 
-use crate::stages::{
-    build_stage_graph::{NodeStages, build_stage_graph},
-    config::{Config, LedgerConfig, StoreType},
+use crate::{
+    ClearValidity, realign_chain_store_to,
+    stages::{
+        build_stage_graph::{NodeStages, build_stage_graph},
+        config::{Config, LedgerConfig, StoreType},
+    },
 };
 
 /// Build a node given the provided configuration and run it using Tokio.
@@ -283,154 +285,7 @@ pub fn make_state(
 }
 
 fn initialize_chain_store(chain_store: Arc<dyn ChainStore>, ledger_tip: Point) -> anyhow::Result<()> {
-    info!(consensus::chain_db::INITIALIZE, ledger_tip = %ledger_tip);
-
-    let best_chain_hash = chain_store.get_best_chain_hash();
-    let has_best_chain = best_chain_hash != ORIGIN_HASH;
-
-    // Every fork branches at or after the immutable tip, which cannot be rolled back, so the
-    // ledger tip is always on the recorded best chain. When it is not, the two databases describe
-    // different chains and truncating the best chain would silently discard headers. This is
-    // checked before any mutation so that a rejected chain database is left untouched.
-    if has_best_chain && chain_store.load_from_best_chain(&ledger_tip).is_none() {
-        bail!(
-            "the chain database is inconsistent with the ledger: its best chain, ending at \
-             {best_chain_hash}, does not contain the ledger tip {ledger_tip}. This happens when \
-             a ledger snapshot is imported on top of a chain database built for another chain. \
-             Remove the chain database so that it can be rebuilt from the ledger tip."
-        );
-    }
-
-    chain_store.set_anchor_hash(&ledger_tip.hash())?;
-    chain_store.set_block_valid(&ledger_tip.hash(), true)?;
-    if has_best_chain {
-        chain_store.switch_to_fork(&ledger_tip, &[])?;
-    } else {
-        chain_store.roll_forward_chain(&ledger_tip)?;
-    }
-
-    info_record!(consensus::chain_db::INITIALIZE, best_chain_hash = best_chain_hash);
-    clear_valid_descendants_after_ledger_tip(chain_store.as_ref(), ledger_tip)?;
-    Ok(())
-}
-
-/// Consider that previously validated blocks haven't been validated now, since the volatile ledger
-/// is going to be reconstructed on a restart.
-fn clear_valid_descendants_after_ledger_tip(chain_store: &dyn ChainStore, ledger_tip: Point) -> anyhow::Result<()> {
-    let mut to_visit = chain_store.get_children(&ledger_tip.hash());
-    let mut count = 0;
-
-    while let Some(hash) = to_visit.pop() {
-        let Some((_header, validity)) = chain_store.load_header_with_validity(&hash) else {
-            continue;
-        };
-
-        if validity == Some(true) {
-            count += 1;
-            chain_store.remove_block_valid(&hash)?;
-        }
-
-        to_visit.extend(chain_store.get_children(&hash));
-    }
-    debug!(consensus::chain_db::CLEAR_VALID_DESCENDANTS, count = count);
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use amaru_kernel::{BlockHeader, IsHeader, make_header};
-    use amaru_ouroboros::{BaseReadChainStore, WriteChainStore, in_memory_chain_store::InMemoryChainStore};
-
-    use super::*;
-
-    #[test]
-    fn realign_the_chain_store_on_the_ledger_tip() {
-        // h0 -- h1 -- h2 -- h3   the chain the consensus had validated
-        //         \
-        //          h2a          a fork that was validated and rejected
-        let h0 = header(1, 1, None);
-        let h1 = header(2, 2, Some(&h0));
-        let h2 = header(3, 3, Some(&h1));
-        let h3 = header(4, 4, Some(&h2));
-        let h2a = header(3, 30, Some(&h1));
-
-        let chain_store = Arc::new(InMemoryChainStore::new());
-        for header in [&h0, &h1, &h2, &h3, &h2a] {
-            chain_store.store_header(header).unwrap();
-            chain_store.set_block_valid(&header.hash(), true).unwrap();
-        }
-        chain_store.set_block_valid(&h2a.hash(), false).unwrap();
-        for header in [&h0, &h1, &h2, &h3] {
-            chain_store.roll_forward_chain(&header.point()).unwrap();
-        }
-        chain_store.set_anchor_hash(&h0.hash()).unwrap();
-
-        // the ledger restarts from h1, behind the blocks the consensus had validated
-        initialize_chain_store(chain_store.clone(), h1.point()).unwrap();
-
-        assert_eq!(chain_store.get_anchor_hash(), h1.hash(), "the anchor must move to the ledger tip");
-        assert_eq!(chain_store.get_best_chain_hash(), h1.hash(), "the best chain must end at the ledger tip");
-        assert!(chain_store.load_from_best_chain(&h1.point()).is_some(), "the ledger tip stays on the best chain");
-        assert!(chain_store.load_from_best_chain(&h2.point()).is_none(), "h2 must leave the best chain");
-        assert!(chain_store.load_from_best_chain(&h3.point()).is_none(), "h3 must leave the best chain");
-
-        assert_eq!(validity(chain_store.as_ref(), &h0), Some(true), "blocks before the ledger tip stay validated");
-        assert_eq!(validity(chain_store.as_ref(), &h1), Some(true), "the ledger tip stays validated");
-        assert_eq!(validity(chain_store.as_ref(), &h2), None, "h2 must be applied to the ledger again");
-        assert_eq!(validity(chain_store.as_ref(), &h3), None, "h3 must be applied to the ledger again");
-        assert_eq!(validity(chain_store.as_ref(), &h2a), Some(false), "an invalid block was never applied");
-    }
-
-    #[test]
-    fn start_the_best_chain_on_a_store_that_has_none() {
-        let h0 = header(1, 1, None);
-
-        let chain_store = Arc::new(InMemoryChainStore::new());
-        chain_store.store_header(&h0).unwrap();
-
-        initialize_chain_store(chain_store.clone(), h0.point()).unwrap();
-
-        assert_eq!(chain_store.get_anchor_hash(), h0.hash());
-        assert_eq!(chain_store.get_best_chain_hash(), h0.hash());
-        assert!(chain_store.load_from_best_chain(&h0.point()).is_some(), "the ledger tip starts the best chain");
-        assert_eq!(validity(chain_store.as_ref(), &h0), Some(true));
-    }
-
-    #[test]
-    fn reject_a_chain_store_that_does_not_contain_the_ledger_tip() {
-        // h0 -- h1     the chain the consensus had built
-        //   \
-        //    h1a       the branch the ledger was bootstrapped on
-        let h0 = header(1, 1, None);
-        let h1 = header(2, 2, Some(&h0));
-        let h1a = header(2, 20, Some(&h0));
-
-        let chain_store = Arc::new(InMemoryChainStore::new());
-        for header in [&h0, &h1, &h1a] {
-            chain_store.store_header(header).unwrap();
-        }
-        for header in [&h0, &h1] {
-            chain_store.roll_forward_chain(&header.point()).unwrap();
-        }
-        chain_store.set_anchor_hash(&h0.hash()).unwrap();
-
-        let error = initialize_chain_store(chain_store.clone(), h1a.point()).unwrap_err().to_string();
-
-        assert!(error.contains("inconsistent with the ledger"), "unexpected error: {error}");
-        assert_eq!(chain_store.get_best_chain_hash(), h1.hash(), "the best chain must be left untouched");
-        assert_eq!(chain_store.get_anchor_hash(), h0.hash(), "the anchor must be left untouched");
-        for header in [&h0, &h1, &h1a] {
-            assert_eq!(validity(chain_store.as_ref(), header), None, "no block validity must be recorded");
-        }
-    }
-
-    // HELPERS
-
-    fn header(block_height: u64, slot: u64, parent: Option<&BlockHeader>) -> BlockHeader {
-        BlockHeader::from(make_header(block_height, slot, parent.map(BlockHeader::hash)))
-    }
-
-    fn validity(chain_store: &dyn ChainStore, header: &BlockHeader) -> Option<bool> {
-        chain_store.load_header_with_validity(&header.hash()).and_then(|(_, validity)| validity)
-    }
+    // Consider that previously validated blocks haven't been validated now, since the volatile
+    // ledger is going to be reconstructed on a restart. Invalid flags are kept.
+    realign_chain_store_to(chain_store.as_ref(), ledger_tip, ClearValidity::ValidOnly)
 }

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -1013,6 +1013,17 @@ define_schemas! {
                     required ledger_dir: String
                     required network: amaru_kernel::NetworkName
                 }
+                /// Roll the node databases back after a failure
+                public ROLLBACK {
+                    required chain_dir: String
+                    required ledger_dir: String
+                    required network: amaru_kernel::NetworkName
+                    required mode: String
+                    optional epoch: u64
+                    optional ledger_tip: String
+                    optional best_chain: String
+                    optional anchor: String
+                }
             }
             snapshot {
                 /// Create snapshots for the given network

--- a/crates/amaru/src/bin/amaru/cli.rs
+++ b/crates/amaru/src/bin/amaru/cli.rs
@@ -54,6 +54,7 @@ pub(crate) enum Command {
     #[command(hide = true, name = "bootstrap")]
     LegacyBootstrap(cmd::node::bootstrap::Args),
 
+    /// Legacy alias for `amaru node rollback --epoch` (positional epoch for compatibility).
     #[command(hide = true, name = "reset-to-epoch")]
     LegacyResetToEpoch(cmd::dev::ledger::reset::Args),
 
@@ -95,7 +96,9 @@ impl Command {
             // Legacy top-level aliases: same behaviour as their modern counterparts.
             Command::LegacyRun(args) | Command::LegacyDaemon(args) => cmd::node::run::runnable(args),
             Command::LegacyBootstrap(args) => cmd::node::bootstrap::runnable(args),
-            Command::LegacyResetToEpoch(args) => cmd::dev::ledger::reset::runnable(args),
+            Command::LegacyResetToEpoch(args) => {
+                cmd::node::rollback::runnable_epoch(args.network, args.epoch, args.ledger_dir, None)
+            }
             Command::LegacyCreateSnapshots(args) => cmd::snapshot::create::runnable(args),
             Command::LegacyDumpChainDB(args) => cmd::dev::chain::dump::runnable(args),
             Command::LegacyRemoveValidationStatus(args) => cmd::dev::chain::clear_invalid::runnable(args),

--- a/crates/amaru/src/bin/amaru/cmd/dev/ledger/mod.rs
+++ b/crates/amaru/src/bin/amaru/cmd/dev/ledger/mod.rs
@@ -34,6 +34,9 @@ pub(crate) enum LedgerCommand {
     States(states::StatesCommand),
 
     /// Reset the ledger database to the beginning of a specific epoch.
+    ///
+    /// Prefer `amaru node rollback --epoch`, which also realigns the chain store.
+    #[command(hide = true)]
     Reset(reset::Args),
 }
 

--- a/crates/amaru/src/bin/amaru/cmd/dev/ledger/reset.rs
+++ b/crates/amaru/src/bin/amaru/cmd/dev/ledger/reset.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 PRAGMA
+// Copyright 2026 PRAGMA
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{fs, io, path::PathBuf};
+//! Low-level ledger-only epoch reset.
+//!
+//! Prefer [`amaru node rollback --epoch`](crate::cmd::node::rollback) which also realigns the
+//! chain store and clears descendant validation flags.
+
+use std::path::PathBuf;
 
 use amaru::{
     default_ledger_dir,
     lifecycle::{Runnable, RuntimeKind},
 };
-use amaru_kernel::NetworkName;
-use amaru_ledger::state::MIN_LEDGER_SNAPSHOTS;
+use amaru_kernel::{Epoch, NetworkName};
+use amaru_node::reset_ledger_to_epoch;
 use clap::Parser;
 use tracing::info;
 
@@ -30,7 +35,7 @@ pub struct Args {
         value_name = amaru::value_names::UINT,
         env = amaru::env_vars::EPOCH,
     )]
-    epoch: u64,
+    pub epoch: Epoch,
 
     /// The path to the ledger database to reset
     #[arg(
@@ -38,7 +43,7 @@ pub struct Args {
         value_name = amaru::value_names::DIRECTORY,
         env = amaru::env_vars::LEDGER_DIR,
     )]
-    ledger_dir: Option<PathBuf>,
+    pub ledger_dir: Option<PathBuf>,
 
     /// Network of the underlying chain database.
     #[arg(
@@ -46,7 +51,7 @@ pub struct Args {
         value_name = amaru::value_names::NETWORK,
         env = amaru::env_vars::NETWORK,
     )]
-    network: NetworkName,
+    pub network: NetworkName,
 }
 
 pub(crate) fn runnable(args: Args) -> Runnable {
@@ -61,135 +66,10 @@ async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         epoch = %args.epoch,
         ledger_dir = %ledger_dir.to_string_lossy(),
         network = %args.network,
+        hint = "prefer `amaru node rollback --epoch` which also realigns the chain store",
         "running",
     );
 
-    let folders = get_ledger_db_snapshots(&ledger_dir)?;
-
-    check_safe_to_reset(args.epoch, &folders)?;
-
-    // Note: given the `check_safe_to_reset` above ensures we have epochs
-    // we know pentultimate_epoch will get reassigned
-    let mut pentultimate_epoch: Option<PathBuf> = None;
-    for folder in folders {
-        match folder.epoch {
-            Epoch::Live => {
-                fs::remove_dir_all(&folder.path)
-                    .map_err(|e| format!("failed to remove {}: {}", folder.path.display(), e))?;
-            }
-            Epoch::Past(epoch) => {
-                if epoch == args.epoch - 1 {
-                    // set this aside to make a copy of it at the end
-                    // if we were to copy right now, it could collide
-                    // with the existing directory
-                    pentultimate_epoch = Some(folder.path);
-                } else if epoch >= args.epoch {
-                    fs::remove_dir_all(&folder.path)
-                        .map_err(|e| format!("failed to remove {}: {}", folder.path.display(), e))?;
-                }
-            }
-        }
-    }
-
-    let pentultimate_epoch = pentultimate_epoch.unwrap_or_else(|| {
-        unreachable!(
-            "invariant violated: check_safe_to_reset should have guaranteed that pentultimate_epoch gets assigned"
-        );
-    });
-
-    copy_dir_recursive(&pentultimate_epoch, &ledger_dir.join("live"))?;
-
-    Ok(())
-}
-
-#[derive(Clone, Copy, PartialEq)]
-enum Epoch {
-    Live,
-    Past(u64),
-}
-
-impl Epoch {
-    fn epoch_no(&self) -> Option<u64> {
-        match self {
-            Epoch::Live => None,
-            Epoch::Past(e) => Some(*e),
-        }
-    }
-}
-
-#[derive(Clone)]
-struct Folder {
-    epoch: Epoch,
-    path: PathBuf,
-}
-
-fn get_ledger_db_snapshots(ledger_dir: &PathBuf) -> Result<Vec<Folder>, Box<dyn std::error::Error>> {
-    // The ledger db snapshots are organized as folders in ledger_dir
-    // There's one folder for the "current" epoch, and one for each past epoch that's been saved
-    Ok(fs::read_dir(ledger_dir)
-        .map_err(|e| format!("failed to read ledger_dir {}: {}", ledger_dir.display(), e))?
-        .filter_map(|entry| entry.ok().map(|e| e.path()))
-        .filter(|f| f.is_dir())
-        .filter_map(|path| {
-            let stem = path.file_stem()?.to_str()?;
-            let epoch = if stem == "live" { Epoch::Live } else { Epoch::Past(stem.parse::<u64>().ok()?) };
-            Some(Folder { epoch, path })
-        })
-        .collect())
-}
-
-fn epoch_boundaries(folders: &[Folder]) -> Option<(u64, u64)> {
-    let epoch_numbers = folders.iter().filter_map(|f| f.epoch.epoch_no());
-    Some((epoch_numbers.clone().min()?, epoch_numbers.max()?))
-}
-
-fn check_safe_to_reset(epoch: u64, folders: &[Folder]) -> Result<(), Box<dyn std::error::Error>> {
-    let (min_epoch, max_epoch) = epoch_boundaries(folders).ok_or("no epochs to roll back to")?;
-
-    if epoch < min_epoch {
-        return Err(format!(
-            "cannot reset to an epoch that far in the past. We've only kept snapshots as far back as {}",
-            min_epoch
-        )
-        .into());
-    }
-
-    // The +1 here is because if we're resetting to 175, and the max epoch is 174,
-    // we're *in* epoch 175, and we can just delete `live/` and copy `174` to `live`
-    if epoch > max_epoch + 1 {
-        return Err(
-            format!("cannot reset to an epoch in the future. We're currently in epoch {}", max_epoch + 1).into()
-        );
-    }
-
-    // We need MIN_LEDGER_SNAPSHOTS=3 previous epochs *plus* the "live" epoch, to function
-    // so if we try to reset to the start of 165, but our earliest epoch is 163
-    // this will break: we can keep 163 and 164, and copy 164 to live, but
-    // that leaves us with only 2 epochs
-    if epoch < min_epoch + MIN_LEDGER_SNAPSHOTS {
-        return Err(format!(
-            "resetting to epoch {} would leave us with too few historical epochs to proceed. The earliest epoch you can reset to is {}",
-            epoch,
-            min_epoch + MIN_LEDGER_SNAPSHOTS,
-        )
-        .into());
-    }
-
-    Ok(())
-}
-
-fn copy_dir_recursive(src: &PathBuf, dst: &PathBuf) -> io::Result<()> {
-    fs::create_dir_all(dst)?;
-    for entry in fs::read_dir(src)? {
-        let entry = entry?;
-        let file_type = entry.file_type()?;
-        let src_path = entry.path();
-        let dst_path = dst.join(entry.file_name());
-        if file_type.is_dir() {
-            copy_dir_recursive(&src_path, &dst_path)?;
-        } else {
-            fs::copy(&src_path, &dst_path)?;
-        }
-    }
+    reset_ledger_to_epoch(&ledger_dir, args.epoch)?;
     Ok(())
 }

--- a/crates/amaru/src/bin/amaru/cmd/node/mod.rs
+++ b/crates/amaru/src/bin/amaru/cmd/node/mod.rs
@@ -17,6 +17,7 @@ use clap::Subcommand;
 
 pub(crate) mod bootstrap;
 pub(crate) mod rm;
+pub(crate) mod rollback;
 pub(crate) mod run;
 
 #[derive(Debug, Subcommand)]
@@ -37,6 +38,21 @@ pub(crate) enum NodeCommand {
     #[clap(verbatim_doc_comment)]
     Bootstrap(bootstrap::Args),
 
+    /// Roll the node databases back after a failure (for example a wrongly invalidated block).
+    ///
+    /// The node should be stopped before running this command.
+    ///
+    /// - `--immutable-tip` only realigns the chain store to the ledger's immutable tip. The ledger is
+    ///   left unchanged (the volatile DB is not persisted, so offline it is already gone).
+    ///
+    /// - `--epoch` rewinds the ledger to the start of the given epoch (via historical snapshots) and
+    ///   then realigns the chain store to the new ledger tip.
+    ///
+    /// Chain realignment sets the anchor and best tip to the target point, culls the best-chain
+    /// fragment after it, and clears all block-validation flags on descendant headers so they can be
+    /// re-validated on the next run. Headers and blocks themselves are kept.
+    Rollback(rollback::Args),
+
     /// Remove the node's ledger and chain databases.
     Rm(rm::Args),
 }
@@ -46,6 +62,7 @@ impl NodeCommand {
         match self {
             Self::Run(args) => run::runnable(args),
             Self::Bootstrap(args) => bootstrap::runnable(args),
+            Self::Rollback(args) => rollback::runnable(args),
             Self::Rm(args) => rm::runnable(args),
         }
     }

--- a/crates/amaru/src/bin/amaru/cmd/node/rollback.rs
+++ b/crates/amaru/src/bin/amaru/cmd/node/rollback.rs
@@ -1,0 +1,122 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{error::Error, path::PathBuf};
+
+use amaru::{
+    default_chain_dir, default_ledger_dir,
+    lifecycle::{Runnable, RuntimeKind},
+};
+use amaru_kernel::{Epoch, NetworkName};
+use amaru_ledger::store::ReadStore;
+use amaru_node::{ClearValidity, realign_chain_store_to, reset_ledger_to_epoch};
+use amaru_observability::info;
+use amaru_ouroboros::BaseReadChainStore;
+use amaru_stores::rocksdb::{ReadOnlyRocksDB, RocksDbConfig, consensus::RocksDBStore};
+use clap::{ArgGroup, Parser};
+
+#[derive(Debug, Parser)]
+#[command(group(
+    ArgGroup::new("target")
+        .required(true)
+        .args(["immutable_tip", "epoch"])
+))]
+pub struct Args {
+    /// Roll the chain store back to the ledger's immutable tip.
+    ///
+    /// Does not modify the ledger database.
+    #[arg(long)]
+    immutable_tip: bool,
+
+    /// Roll the ledger back to the beginning of this epoch, then realign the chain store to the
+    /// resulting ledger tip.
+    #[arg(long, value_name = amaru::value_names::UINT, env = amaru::env_vars::EPOCH)]
+    epoch: Option<Epoch>,
+
+    /// Path of the chain on-disk storage.
+    ///
+    /// Defaults to ./chain.<NETWORK>.db when unspecified.
+    #[arg(
+        long,
+        value_name = amaru::value_names::DIRECTORY,
+        env = amaru::env_vars::CHAIN_DIR,
+    )]
+    chain_dir: Option<PathBuf>,
+
+    /// Path of the ledger on-disk storage.
+    ///
+    /// Defaults to ./ledger.<NETWORK>.db when unspecified.
+    #[arg(
+        long,
+        value_name = amaru::value_names::DIRECTORY,
+        env = amaru::env_vars::LEDGER_DIR,
+    )]
+    ledger_dir: Option<PathBuf>,
+
+    /// Network whose node databases should be rolled back.
+    #[arg(
+        long,
+        value_name = amaru::value_names::NETWORK,
+        env = amaru::env_vars::NETWORK,
+    )]
+    network: NetworkName,
+}
+
+pub(crate) fn runnable(args: Args) -> Runnable {
+    Runnable::exit_on_signal(RuntimeKind::Simple, move || run(args))
+}
+
+/// Full recovery to the start of `epoch`: ledger snapshot reset + chain realign.
+///
+/// Used by `amaru node rollback --epoch` and the legacy `reset-to-epoch` alias.
+pub(crate) fn runnable_epoch(
+    network: NetworkName,
+    epoch: Epoch,
+    ledger_dir: Option<PathBuf>,
+    chain_dir: Option<PathBuf>,
+) -> Runnable {
+    runnable(Args { immutable_tip: false, epoch: Some(epoch), chain_dir, ledger_dir, network })
+}
+
+async fn run(args: Args) -> Result<(), Box<dyn Error>> {
+    let network = args.network;
+    let chain_dir = args.chain_dir.unwrap_or_else(|| default_chain_dir(network).into());
+    let ledger_dir = args.ledger_dir.unwrap_or_else(|| default_ledger_dir(network).into());
+
+    let mode = if args.immutable_tip { "immutable_tip" } else { "epoch" };
+
+    if let Some(epoch) = args.epoch {
+        reset_ledger_to_epoch(&ledger_dir, epoch)?;
+    }
+
+    let ledger = ReadOnlyRocksDB::new(&RocksDbConfig::new(ledger_dir.clone()))?;
+    let tip = ledger.tip()?;
+
+    let chain_store = RocksDBStore::open(&RocksDbConfig::new(chain_dir.clone()))?;
+    realign_chain_store_to(&chain_store, tip, ClearValidity::All)?;
+
+    info!(
+        cli::node::ROLLBACK,
+        chain_dir = %chain_dir.display(),
+        ledger_dir = %ledger_dir.display(),
+        network = network,
+        mode = mode,
+        epoch = @args.epoch.map(|e| e.as_u64()),
+        ledger_tip = @Some(tip.to_string()),
+        best_chain = @Some(chain_store.get_best_chain_hash().to_string()),
+        anchor = @Some(chain_store.get_anchor_hash().to_string()),
+    );
+
+    Ok(())
+}

--- a/crates/amaru/tests/cli.rs
+++ b/crates/amaru/tests/cli.rs
@@ -149,6 +149,19 @@ fn node_help_shows_subcommands() -> Result<(), Box<dyn Error>> {
     let help = amaru_help(&["node"])?;
     assert!(help.contains("run"), "node help should show 'run'");
     assert!(help.contains("bootstrap"), "node help should show 'bootstrap'");
+    assert!(help.contains("rollback"), "node help should show 'rollback'");
+    assert!(help.contains("rm"), "node help should show 'rm'");
+    Ok(())
+}
+
+#[test]
+fn node_rollback_help_shows_targets() -> Result<(), Box<dyn Error>> {
+    let help = amaru_help(&["node", "rollback"])?;
+    assert!(help.contains("--immutable-tip"), "rollback should accept --immutable-tip");
+    assert!(help.contains("--epoch"), "rollback should accept --epoch");
+    assert!(help.contains("--network"), "rollback should accept --network");
+    assert!(help.contains("--chain-dir"), "rollback should accept --chain-dir");
+    assert!(help.contains("--ledger-dir"), "rollback should accept --ledger-dir");
     Ok(())
 }
 

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -503,6 +503,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | --- | --- | --- | --- | --- | --- |
 | `bootstrap` | `TRACE` | public | Bootstrap a node from published snapshots | chain_dir, ledger_dir, network | epoch |
 | `rm` | `TRACE` | public | Remove ledger and chain database from disk | chain_dir, ledger_dir, network |  |
+| `rollback` | `TRACE` | public | Roll the node databases back after a failure | chain_dir, ledger_dir, network, mode | epoch, ledger_tip, best_chain, anchor |
 
 <details><summary>span: `bootstrap`</summary>
 
@@ -522,6 +523,21 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | `chain_dir` | `string` | ✓ |
 | `ledger_dir` | `string` | ✓ |
 | `network` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `rollback`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `chain_dir` | `string` | ✓ |
+| `ledger_dir` | `string` | ✓ |
+| `network` | `string` | ✓ |
+| `mode` | `string` | ✓ |
+| `epoch` | `integer` |  |
+| `ledger_tip` | `string` |  |
+| `best_chain` | `string` |  |
+| `anchor` | `string` |  |
 
 </details>
 

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -860,6 +860,54 @@
       "description": "Remove ledger and chain database from disk",
       "public": true
     },
+    "amaru::cli::node::ROLLBACK": {
+      "type": "object",
+      "properties": {
+        "chain_dir": {
+          "type": "string"
+        },
+        "ledger_dir": {
+          "type": "string"
+        },
+        "network": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::NetworkName"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "epoch": {
+          "type": "integer"
+        },
+        "ledger_tip": {
+          "type": "string"
+        },
+        "best_chain": {
+          "type": "string"
+        },
+        "anchor": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "chain_dir",
+        "ledger_dir",
+        "network",
+        "mode"
+      ],
+      "optional": [
+        "epoch",
+        "ledger_tip",
+        "best_chain",
+        "anchor"
+      ],
+      "additionalProperties": false,
+      "name": "rollback",
+      "level": "TRACE",
+      "target": "amaru::cli::node",
+      "description": "Roll the node databases back after a failure",
+      "public": true
+    },
     "amaru::cli::snapshot::CREATE": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
fixes #1072


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `amaru node rollback` for immutable-tip and epoch-based rollback.
  * Added chain-state realignment after ledger rollback.
  * Added configurable network and database locations.
  * Added rollback observability and trace details.

* **Changed**
  * Updated legacy reset commands to recommend the new rollback workflow.
  * Preserved compatibility for epoch-based reset usage.
  * Added command-line help coverage for rollback options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->