### PR TITLE
Introduce UnelectedCommitteeVoters logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Other guiding principles:
 - **amaru-ledger**: validate voters in a transaction actually exist in ledger state. ([#1138][], [#923][])
 - **amaru-ledger**: validate the governance actions a transaction votes on actually exist, counting proposals submitted earlier in the same block. ([#1139][], [#924][])
 - **amaru-ledger**: reject votes cast on governance actions that have expired. A proposal's expiry is now stamped once, when it is submitted, and carried through the volatile state, which will resolve some potential bugs. ([#1143][], [#926][])
+- **amaru-ledger**: from protocol version 11 on, reject votes cast by constitutional committee members the *elected* committee does not name, even when they hold an authorized hot credential. ([#1157][], [#922][])
 
 ## [v10.11.20260806](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260807)
 
@@ -64,10 +65,6 @@ Other guiding principles:
 - **amaru-ledger**: compute rewards and stake distributions asynchronously to prevent blocking the main roll forward loop from times to times.
 - **amaru**: bootstrap snapshots now are retrieved directly from R2 (no embedded manifests) and compressed with zstandard. ([#1012][])
 - **amaru**: metrics are now (also) exported through gRPC on `:4317` by default instead of `:4318` over HTTP.
-- **amaru-ledger**: validate voters in a transaction actually exist in ledger state. ([#1138][], [#923][])
-- **amaru-ledger**: validate the governance actions a transaction votes on actually exist, counting proposals submitted earlier in the same block. ([#1139][], [#924][])
-- **amaru-ledger**: reject votes cast on governance actions that have expired. A proposal's expiry is now stamped once, when it is submitted, and carried through the volatile state, which will resolve some potential bugs. ([#1143][], [#926][])
-- **amaru-ledger**: from protocol version 11 on, reject votes cast by constitutional committee members the *elected* committee does not name, even when they hold an authorized hot credential. ([#922][])
 
 ### Removed
 
@@ -276,7 +273,6 @@ Other guiding principles:
 [#909]: https://github.com/pragma-org/amaru/issues/909
 [#912]: https://github.com/pragma-org/amaru/issues/912
 [#915]: https://github.com/pragma-org/amaru/issues/915
-[#928]: https://github.com/pragma-org/amaru/issues/928
 [#922]: https://github.com/pragma-org/amaru/issues/922
 [#923]: https://github.com/pragma-org/amaru/issues/923
 [#924]: https://github.com/pragma-org/amaru/issues/924
@@ -336,3 +332,4 @@ Other guiding principles:
 [#1138]: https://github.com/pragma-org/amaru/pull/1138
 [#1139]: https://github.com/pragma-org/amaru/pull/1139
 [#1143]: https://github.com/pragma-org/amaru/pull/1143
+[#1157]: https://github.com/pragma-org/amaru/pull/1157

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ Other guiding principles:
 - **amaru-ledger**: compute rewards and stake distributions asynchronously to prevent blocking the main roll forward loop from times to times.
 - **amaru**: bootstrap snapshots now are retrieved directly from R2 (no embedded manifests) and compressed with zstandard. ([#1012][])
 - **amaru**: metrics are now (also) exported through gRPC on `:4317` by default instead of `:4318` over HTTP.
+- **amaru-ledger**: validate voters in a transaction actually exist in ledger state. ([#1138][], [#923][])
+- **amaru-ledger**: validate the governance actions a transaction votes on actually exist, counting proposals submitted earlier in the same block. ([#1139][], [#924][])
+- **amaru-ledger**: reject votes cast on governance actions that have expired. A proposal's expiry is now stamped once, when it is submitted, and carried through the volatile state, which will resolve some potential bugs. ([#1143][], [#926][])
+- **amaru-ledger**: from protocol version 11 on, reject votes cast by constitutional committee members the *elected* committee does not name, even when they hold an authorized hot credential. ([#922][])
 
 ### Removed
 
@@ -272,6 +276,8 @@ Other guiding principles:
 [#909]: https://github.com/pragma-org/amaru/issues/909
 [#912]: https://github.com/pragma-org/amaru/issues/912
 [#915]: https://github.com/pragma-org/amaru/issues/915
+[#928]: https://github.com/pragma-org/amaru/issues/928
+[#922]: https://github.com/pragma-org/amaru/issues/922
 [#923]: https://github.com/pragma-org/amaru/issues/923
 [#924]: https://github.com/pragma-org/amaru/issues/924
 [#926]: https://github.com/pragma-org/amaru/issues/926

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/fixture.rs
@@ -297,6 +297,7 @@ pub(super) enum Predicate {
     StakePoolRetirementWrongEpochPOOL,
     StakePoolNotRegisteredOnKeyPOOL,
     StakePoolCostTooLowPOOL,
+    UnelectedCommitteeVoters,
     ValueNotConservedUTxO,
     VotersDoNotExist,
     VotingOnExpiredGovAction,
@@ -364,6 +365,9 @@ impl From<PhaseOneError> for Predicate {
             }
             PhaseOneError::Proposals(InvalidProposals::ProposalReturnAccountDoesNotExist(_)) => {
                 Predicate::ProposalReturnAccountDoesNotExist
+            }
+            PhaseOneError::VotingProcedures(InvalidVotingProcedures::UnelectedCommitteeVoter(_)) => {
+                Predicate::UnelectedCommitteeVoters
             }
             PhaseOneError::VotingProcedures(InvalidVotingProcedures::VotersDoNotExist(_)) => {
                 Predicate::VotersDoNotExist

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
@@ -287,7 +287,13 @@ where
         })?;
 
         debug_span!(ledger::rules::phase_one::VOTES).in_scope(|| {
-            voting_procedures::execute(context, era_history, pointer, mem::take(&mut transaction_body.votes))
+            voting_procedures::execute(
+                context,
+                protocol_parameters.protocol_version,
+                era_history,
+                pointer,
+                mem::take(&mut transaction_body.votes),
+            )
         })?;
     } else {
         debug_span!(ledger::rules::phase_one::CERTIFICATES).in_scope(|| {

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/voting_procedures.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/voting_procedures.rs
@@ -15,8 +15,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use amaru_kernel::{
-    EraHistory, HasOwnership, MemoizedDatum, NonEmptyKeyValuePairs, ProposalId, RedeemerTag, RequiredScript,
-    StakeCredential, TransactionPointer, Voter, VotingProcedure,
+    EraHistory, HasOwnership, MemoizedDatum, NonEmptyKeyValuePairs, ProposalId, ProtocolVersion, RedeemerTag,
+    RequiredScript, StakeCredential, TransactionPointer, Voter, VotingProcedure,
 };
 use thiserror::Error;
 
@@ -24,6 +24,9 @@ use crate::context::{CommitteeSlice, DRepsSlice, PoolsSlice, ProposalsSlice, Wit
 
 #[derive(Debug, Error)]
 pub enum InvalidVotingProcedures {
+    #[error("vote cast by committee member who is not yet elected: {0:?}")]
+    UnelectedCommitteeVoter(Voter),
+
     #[error("voters do not exist: {0:?}")]
     VotersDoNotExist(BTreeSet<Voter>),
 
@@ -39,6 +42,7 @@ pub enum InvalidVotingProcedures {
 
 pub(crate) fn execute<C>(
     context: &mut C,
+    protocol_version: ProtocolVersion,
     era_history: &EraHistory,
     pointer: TransactionPointer,
     voting_procedures: Option<NonEmptyKeyValuePairs<Voter, NonEmptyKeyValuePairs<ProposalId, VotingProcedure>>>,
@@ -57,6 +61,10 @@ where
         let mut unknown_proposals = BTreeSet::new();
 
         for (voter, votes) in voting_procedures.iter() {
+            if protocol_version.0 > 10 && is_unelected_committee_voter(context, voter) {
+                return Err(InvalidVotingProcedures::UnelectedCommitteeVoter(voter.clone()));
+            }
+
             if !exists(context, voter) {
                 unknown_voters.insert(voter.clone());
             }
@@ -104,6 +112,24 @@ where
     }
 
     Ok(())
+}
+
+/// Election statushere is membership, not an unexpired term: a member whose term has run out is still
+/// named by the committee, and their vote is discounted when the action is ratified instead.
+///
+/// Voters that are not committee members are never rejected by this check.
+fn is_unelected_committee_voter<C>(context: &C, voter: &Voter) -> bool
+where
+    C: CommitteeSlice,
+{
+    match voter {
+        Voter::ConstitutionalCommitteeKey(_) | Voter::ConstitutionalCommitteeScript(_) => {
+            !CommitteeSlice::lookup_by_hot_credential(context, &voter.owner())
+                .iter()
+                .any(|member| member.valid_until.is_some())
+        }
+        Voter::DRepKey(_) | Voter::DRepScript(_) | Voter::StakePoolKey(_) => false,
+    }
 }
 
 /// Whether the entity a vote is cast by is known at this point in the block.

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/voting_procedures.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/voting_procedures.rs
@@ -15,8 +15,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use amaru_kernel::{
-    EraHistory, HasOwnership, MemoizedDatum, NonEmptyKeyValuePairs, ProposalId, ProtocolVersion, RedeemerTag,
-    RequiredScript, StakeCredential, TransactionPointer, Voter, VotingProcedure,
+    EraHistory, HasMajorVersion, HasOwnership, MemoizedDatum, NonEmptyKeyValuePairs, PROTOCOL_VERSION_10, ProposalId,
+    ProtocolVersion, RedeemerTag, RequiredScript, StakeCredential, TransactionPointer, Voter, VotingProcedure,
 };
 use thiserror::Error;
 
@@ -61,7 +61,7 @@ where
         let mut unknown_proposals = BTreeSet::new();
 
         for (voter, votes) in voting_procedures.iter() {
-            if protocol_version.0 > 10 && is_unelected_committee_voter(context, voter) {
+            if protocol_version.major() > PROTOCOL_VERSION_10.major() && is_unelected_committee_voter(context, voter) {
                 return Err(InvalidVotingProcedures::UnelectedCommitteeVoter(voter.clone()));
             }
 

--- a/crates/amaru-ledger/tests/data/phase-one/fail/UnelectedCommitteeVoters/0.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/UnelectedCommitteeVoters/0.json
@@ -1,0 +1,56 @@
+{
+  "title": "vote cast by an unelected committee member with an authorized hot key at protocol version 11",
+  "description": "A member holding no term but an authorized hot key.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json",
+    "$override": {
+      "version": {
+        "major": 11,
+        "minor": 0
+      }
+    }
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820e4ab7bd9de7060f2f81fc907132ce2942081ac10b2b9454d53642eb304a64a3800",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "committee": [
+      {
+        "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
+        "hotCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "validUntil": null
+      }
+    ],
+    "proposals": [
+      {
+        "id": "8258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b00",
+        "validUntil": 100
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    },
+    "pots": {
+      "treasury": 0,
+      "reserves": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820e4ab7bd9de7060f2f81fc907132ce2942081ac10b2b9454d53642eb304a64a38000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b008201f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840f46d6100d906cb1424b6f9234fd187090bddf85d0453f8f09700cbcdf7491556c325dac760dc35efd1dc234e532e357d413aa35a99c1ba2310ed73caa9306008f5f6",
+  "expected": {
+    "predicate": "UnelectedCommitteeVoters"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/fail/UnelectedCommitteeVoters/1.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/UnelectedCommitteeVoters/1.json
@@ -1,0 +1,56 @@
+{
+  "title": "vote cast by an unelected committee member with an authorized hot script credential",
+  "description": "The hot script credential case of an authorization held by a member with no term.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json",
+    "$override": {
+      "version": {
+        "major": 11,
+        "minor": 0
+      }
+    }
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820b9488a2acb2a4de446769c8e4b2aebf0045e79ee0f7ca36473f94113c34918bf00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "committee": [
+      {
+        "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
+        "hotCredential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "validUntil": null
+      }
+    ],
+    "proposals": [
+      {
+        "id": "8258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b00",
+        "validUntil": 100
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    },
+    "pots": {
+      "treasury": 0,
+      "reserves": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820b9488a2acb2a4de446769c8e4b2aebf0045e79ee0f7ca36473f94113c34918bf000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcfa18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b008201f6a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840920b2ee06e8fdbebd15ddfa5c34d00b8197bc3b0ecd2f99d0dff19d9b8093e4de816b5f007239fe7ef4593a9414771bf0b26160cb255fd8e0025917f4b49bc060181820180f5f6",
+  "expected": {
+    "predicate": "UnelectedCommitteeVoters"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/fail/UnelectedCommitteeVoters/2.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/UnelectedCommitteeVoters/2.json
@@ -1,0 +1,61 @@
+{
+  "title": "vote cast by an unelected member's hot key while an elected member holds another",
+  "description": "Two authorizations, one by an elected member and one by a member with no term, with the vote naming the unelected member's hot key.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json",
+    "$override": {
+      "version": {
+        "major": 11,
+        "minor": 0
+      }
+    }
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "8258205a69bb3f301c252d55c3cde9eb24c01988937c00e2dec75ea0f64625fb408a5700",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "committee": [
+      {
+        "coldCredential": "8200581c2e06285720a42375de8c91a3f9f27d89516f93a2f60ad638ef30eea6",
+        "hotCredential": "8200581cba40f56c8091f0646c5c55e15d5b19d555d4a59aaf1b6d09b5ce19c8",
+        "validUntil": 200
+      },
+      {
+        "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
+        "hotCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "validUntil": null
+      }
+    ],
+    "proposals": [
+      {
+        "id": "8258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b00",
+        "validUntil": 100
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    },
+    "pots": {
+      "treasury": 0,
+      "reserves": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d90102818258205a69bb3f301c252d55c3cde9eb24c01988937c00e2dec75ea0f64625fb408a57000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b008201f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840973b06957b62b5d3149ef6a6137ffc4f4e1305eedbb706cb80c1bcaee815eafb6aa52d14384905d4799726eb4fa4d139c39a292adda60818f17da9d1c75e220df5f6",
+  "expected": {
+    "predicate": "UnelectedCommitteeVoters"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/fail/UnelectedCommitteeVoters/3.json
+++ b/crates/amaru-ledger/tests/data/phase-one/fail/UnelectedCommitteeVoters/3.json
@@ -1,0 +1,50 @@
+{
+  "title": "vote cast by a committee hot key at protocol version 11 with an empty committee",
+  "description": "A hot credential no member authorized, reported as an unelected voter rather than an unknown one.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json",
+    "$override": {
+      "version": {
+        "major": 11,
+        "minor": 0
+      }
+    }
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820c14fc165f73be892fa7f9be6ea80949c2ac86fe38ff70dbb8f41de266b8c21ce00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "committee": [],
+    "proposals": [
+      {
+        "id": "8258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b00",
+        "validUntil": 100
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    },
+    "pots": {
+      "treasury": 0,
+      "reserves": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820c14fc165f73be892fa7f9be6ea80949c2ac86fe38ff70dbb8f41de266b8c21ce000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b008201f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840f15048fe89e5c3ad5c1a5af9d5149d4d5b5ec03952c956dfe637db88bfe443af0cc6382ac9cccfd465e8bea685c714735703b81f3e34576b9813bde88dce8d0df5f6",
+  "expected": {
+    "predicate": "UnelectedCommitteeVoters"
+  }
+}

--- a/crates/amaru-ledger/tests/data/phase-one/pass/vote-committee-elected-member-protocol-version-11.json
+++ b/crates/amaru-ledger/tests/data/phase-one/pass/vote-committee-elected-member-protocol-version-11.json
@@ -1,0 +1,54 @@
+{
+  "title": "vote cast by an elected committee member at protocol version 11",
+  "description": "The hot key of a member the elected committee names.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json",
+    "$override": {
+      "version": {
+        "major": 11,
+        "minor": 0
+      }
+    }
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820c805346fe5bc524a57d0434e0c0596d8e703655bd1802b528e2d43032f991ec800",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "committee": [
+      {
+        "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
+        "hotCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "validUntil": 200
+      }
+    ],
+    "proposals": [
+      {
+        "id": "8258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b00",
+        "validUntil": 100
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    },
+    "pots": {
+      "treasury": 0,
+      "reserves": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820c805346fe5bc524a57d0434e0c0596d8e703655bd1802b528e2d43032f991ec8000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b008201f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584099d68d82522be6276bdf13e8c709e12518dffacb5090c45d3f29caa9a3739aef9e0f5e8b521d577798bacc06098c6802bd6bb40a45b01594a5b87416b2182705f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/phase-one/pass/vote-committee-hot-key-shared-with-unelected-member.json
+++ b/crates/amaru-ledger/tests/data/phase-one/pass/vote-committee-hot-key-shared-with-unelected-member.json
@@ -1,0 +1,59 @@
+{
+  "title": "vote cast on a hot key authorized by both an elected and an unelected member",
+  "description": "Two seats authorizing the same hot credential, only one of which holds a term.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json",
+    "$override": {
+      "version": {
+        "major": 11,
+        "minor": 0
+      }
+    }
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820722ef456f8bcb80eab3620934c77b0bf50fc4cd4e1dbd55e443baa3d18161dc100",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "committee": [
+      {
+        "coldCredential": "8200581c2e06285720a42375de8c91a3f9f27d89516f93a2f60ad638ef30eea6",
+        "hotCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "validUntil": null
+      },
+      {
+        "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
+        "hotCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "validUntil": 200
+      }
+    ],
+    "proposals": [
+      {
+        "id": "8258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b00",
+        "validUntil": 100
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    },
+    "pots": {
+      "treasury": 0,
+      "reserves": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820722ef456f8bcb80eab3620934c77b0bf50fc4cd4e1dbd55e443baa3d18161dc1000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b008201f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840eb50ad888110eed1b5c885e4f4f9d3780be395bbf58f37811877e95521b479ee7b9a1b893f71ca06a0f3ecd559dc98d0cb2b033302e75c4bda7a4974907a7400f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/phase-one/pass/vote-committee-member-with-expired-term.json
+++ b/crates/amaru-ledger/tests/data/phase-one/pass/vote-committee-member-with-expired-term.json
@@ -1,0 +1,54 @@
+{
+  "title": "vote cast by an elected committee member whose term has already ended",
+  "description": "A member the elected committee still names, voting in epoch 1 with a term that ran out at the end of epoch 0.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json",
+    "$override": {
+      "version": {
+        "major": 11,
+        "minor": 0
+      }
+    }
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "8258209f80dc0e852f8e5fc6960f88a5fe36c4a8c28062b6fe1e12413dce0aa0be8cb000",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "committee": [
+      {
+        "coldCredential": "8200581cecc3093b061a9ed426cd9956161fc48d4ed1ac58dc4aaed7e1ce1830",
+        "hotCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "validUntil": 0
+      }
+    ],
+    "proposals": [
+      {
+        "id": "8258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b00",
+        "validUntil": 1
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    },
+    "pots": {
+      "treasury": 0,
+      "reserves": 0
+    }
+  },
+  "point": {
+    "slot": 432000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d90102818258209f80dc0e852f8e5fc6960f88a5fe36c4a8c28062b6fe1e12413dce0aa0be8cb0000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b008201f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840e6c05014e54850899138772c451de55960a347237854c87aa8434457d51235a85ba84bd57d6c5a04259c4a842684851560e7227447b4336ee6e9bb155c55940af5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/phase-one/pass/vote-drep-protocol-version-11.json
+++ b/crates/amaru-ledger/tests/data/phase-one/pass/vote-drep-protocol-version-11.json
@@ -1,0 +1,61 @@
+{
+  "title": "vote cast by a registered drep key credential at protocol version 11",
+  "description": "A drep vote under an empty committee.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json",
+    "$override": {
+      "version": {
+        "major": 11,
+        "minor": 0
+      }
+    }
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "82582034dddf8594f3f31b278e95c154bf1ce39452cae2308654c224c55661ecfaaaad00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [
+      {
+        "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "deposit": 500000000,
+        "registeredAt": {
+          "transaction": {
+            "slot": 0,
+            "transactionIndex": 0
+          },
+          "certificateIndex": 0
+        },
+        "validUntil": 1000
+      }
+    ],
+    "committee": [],
+    "proposals": [
+      {
+        "id": "8258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b00",
+        "validUntil": 100
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    },
+    "pots": {
+      "treasury": 0,
+      "reserves": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d901028182582034dddf8594f3f31b278e95c154bf1ce39452cae2308654c224c55661ecfaaaad000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d400f0013a18202581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a18258207e2b9d5f1a3c7e5b9d1f3a5c7e9b1d3f5a7c9e1b3d5f7a9c1e3b5d7f9a1c3e5b008201f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584045133ca066b7bd4cf08b707e4367485b024b149a4a4d823f85059d9f4cc849a7a72f14ab2892f135c7e4a9eebc36e09b5e03fbab8c47a7a318f5b7f9ce62670ef5f6",
+  "expected": "Pass"
+}


### PR DESCRIPTION
Closes #922

This PR doesn't allow votes from committee members who have not yet been elected (pending election). It is possible to authorize a hot key from a pending cold key. Importantly, this logic does NOT validate the valid_until of the committee member. That is validated separately, and will be implemented as part of that work.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>