### PR TITLE
tiny fix for “please migrate DB” message

### DIFF
--- a/crates/amaru-ouroboros-traits/src/stores/chain_store/types.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/chain_store/types.rs
@@ -62,8 +62,7 @@ impl Display for StoreError {
                 write!(
                     f,
                     "Incompatible chain DB versions: found {stored}, expected {current}. \
-Run `amaru dev chain migrate --network <NETWORK>` to migrate, or pass `--migrate-chain-db` \
-(or set `AMARU_MIGRATE_CHAIN_DB=true`) when starting the node with `amaru node run`"
+Pass `--migrate-chain-db` (or set `AMARU_MIGRATE_CHAIN_DB=true`) when starting the node with `amaru node run`."
                 )
             }
         }

--- a/crates/amaru-stores/src/rocksdb/consensus/tests.rs
+++ b/crates/amaru-stores/src/rocksdb/consensus/tests.rs
@@ -1380,11 +1380,7 @@ fn open_with_older_version_recommends_migration() {
         "expected IncompatibleChainStoreVersions, got: {err:?}"
     );
     assert!(
-        message.contains("amaru dev chain migrate"),
-        "error should recommend `amaru dev chain migrate`, got: {message}"
-    );
-    assert!(
-        message.contains("--migrate-chain-db") || message.contains("AMARU_MIGRATE_CHAIN_DB"),
+        message.contains("--migrate-chain-db") && message.contains("AMARU_MIGRATE_CHAIN_DB"),
         "error should recommend enabling migration on node run, got: {message}"
     );
 }


### PR DESCRIPTION
Alternative solution to making `amaru dev migrate` part of the public CLI surface.

fixes #1150

Skip-changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the incompatible chain-store version message to provide the correct migration options when running an Amaru node.
  * Removed the outdated migration command from the guidance.
  * Clarified that users can migrate using the `--migrate-chain-db` option or the `AMARU_MIGRATE_CHAIN_DB=true` environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->