### PR TITLE
Implement InvalidGuardrailsScriptHash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Other guiding principles:
 - **amaru-observability**: structured logging for complex values: schema transport preserves JSON primitives and encodes other values as CBOR (`record_bytes`); JSON traces get nested objects/arrays, OTEL logs get nested `AnyValue` maps/lists, OTEL spans upgrade homogeneous CBOR arrays to `Value::Array` (with CBOR diagnostic fallback otherwise), and console logs use CBOR diagnostic notation. ([#1182](https://github.com/pragma-org/amaru/pull/1182))
 - **amaru**: stake-distribution conformance tests no longer partition `#[ignore]` vs active cases from `ledger.<network>.db` at build time (watching that live DB rebuilt `amaru` on every node write). Fixture directories are still watched so tests regenerate when snapshots change; each test soft-skips with a warning when the matching local ledger snapshot is missing.
 - **amaru-ledger**: validate the governance actions a transaction votes on actually exist, counting proposals submitted earlier in the same block. ([#1139][], [#924][])
+- **amaru-ledger**: reject a governance proposal whose policy is not the enacted constitution's guardrails script. ([#931][])
 
 ### Fixed
 
@@ -301,6 +302,7 @@ Other guiding principles:
 [#924]: https://github.com/pragma-org/amaru/issues/924
 [#928]: https://github.com/pragma-org/amaru/issues/928
 [#929]: https://github.com/pragma-org/amaru/issues/929
+[#931]: https://github.com/pragma-org/amaru/issues/931
 [#932]: https://github.com/pragma-org/amaru/issues/932
 [#942]: https://github.com/pragma-org/amaru/pull/942
 [#951]: https://github.com/pragma-org/amaru/pull/951

--- a/crates/amaru-ledger/benches/state/volatile_db/common/scenario.rs
+++ b/crates/amaru-ledger/benches/state/volatile_db/common/scenario.rs
@@ -275,8 +275,12 @@ impl Scenario {
 
     // Create a volatile database, pre-filled with data along the given dimension
     pub fn new_volatile_db(self, rng: &mut impl Rng, scale: &BenchScale) -> VolatileDB {
-        let mut db =
-            VolatileDB::new(Epoch::from(0), MAINNET_DEFAULT_PROTOCOL_PARAMETERS.clone(), GovernanceActivity::default());
+        let mut db = VolatileDB::new(
+            Epoch::from(0),
+            MAINNET_DEFAULT_PROTOCOL_PARAMETERS.clone(),
+            GovernanceActivity::default(),
+            None,
+        );
 
         (0..scale.volatile_size).for_each(|ix| {
             let mut fragment = VolatileFragment::default();

--- a/crates/amaru-ledger/src/rules.rs
+++ b/crates/amaru-ledger/src/rules.rs
@@ -221,6 +221,7 @@ pub(crate) mod tests {
             &PREPROD_ERA_HISTORY,
             &PREPROD_GLOBAL_PARAMETERS,
             GovernanceActivity { consecutive_dormant_epochs: 0 },
+            None,
             &block,
         );
 

--- a/crates/amaru-ledger/src/rules/block.rs
+++ b/crates/amaru-ledger/src/rules/block.rs
@@ -20,7 +20,9 @@ use std::{
 
 use amaru_kernel::{
     Block, EraHistory, ExUnits, GlobalParameters, Hash, HeaderHash, NetworkName, ProtocolParameters, Slot,
-    TransactionId, TransactionIndex, TransactionPointer, cardano::transaction_ref::TransactionRef, size::BLOCK_BODY,
+    TransactionId, TransactionIndex, TransactionPointer,
+    cardano::transaction_ref::TransactionRef,
+    size::{BLOCK_BODY, SCRIPT},
 };
 use amaru_observability::debug_span;
 use amaru_plutus::arena_pool::ArenaPool;
@@ -211,6 +213,7 @@ pub fn execute<C, S: From<C>>(
     era_history: &EraHistory,
     global_parameters: &GlobalParameters,
     governance_activity: GovernanceActivity,
+    guardrail_script: Option<Hash<SCRIPT>>,
     block: &Block,
 ) -> BlockValidation<(), anyhow::Error>
 where
@@ -268,6 +271,7 @@ where
                     era_history,
                     global_parameters,
                     governance_activity,
+                    guardrail_script,
                     TransactionPointer { slot, transaction_index: i as usize },
                     transaction,
                     tx_size,
@@ -303,6 +307,7 @@ pub fn validate_transaction<C>(
     era_history: &EraHistory,
     global_parameters: &GlobalParameters,
     governance_activity: GovernanceActivity,
+    guardrail_script: Option<Hash<SCRIPT>>,
     pointer: TransactionPointer,
     transaction: TransactionRef<'_>,
     tx_size: u64,
@@ -317,6 +322,7 @@ where
         protocol_params,
         era_history,
         governance_activity,
+        guardrail_script,
         pointer,
         transaction.is_expected_valid,
         transaction.body.clone(),

--- a/crates/amaru-ledger/src/rules/transaction/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/fixture.rs
@@ -18,6 +18,7 @@ use amaru_kernel::{
     CertificatePointer, DRep, DRepRegistration, Epoch, EraHistoryProxy, GovernanceAction, Hash, Lovelace,
     MemoizedTransactionOutput, NetworkName, PoolId, Pots, ProposalId, ProposalKind, ProposalsRoots, ProtocolParameters,
     StakeCredential, TransactionInput, TransactionPointer, cbor, json,
+    size::SCRIPT,
     utils::serde::{RefOrInline, deserialize_utxo, hex_to_bytes},
 };
 use serde::Deserialize;
@@ -73,6 +74,10 @@ pub(super) struct InitialState {
     pub(super) governance_activity: GovernanceActivity,
     #[serde(default)]
     pub(super) pots: Pots,
+    /// Guardrails script of the enacted constitution, if it has one. A proposal carrying a policy
+    /// must name exactly this script; absent or `null` requires proposals to carry no policy at all.
+    #[serde(default)]
+    pub(super) guardrail_script: Option<Hash<SCRIPT>>,
 }
 
 fn deserialize_cbor_hex<'de, T, D>(deserializer: D) -> Result<T, D::Error>
@@ -268,6 +273,7 @@ pub(super) enum Predicate {
     ConwayTreasuryValueMismatch,
     InputSetEmptyUTxO,
     InsufficientCollateral,
+    InvalidGuardrailsScriptHash,
     InvalidPrevGovActionId,
     InvalidWitnessesUTXOW,
     MalformedReferenceScripts,
@@ -394,6 +400,9 @@ impl From<PhaseOneError> for Predicate {
             }
             PhaseOneError::Proposals(InvalidProposals::InvalidPrevGovActionId { .. }) => {
                 Predicate::InvalidPrevGovActionId
+            }
+            PhaseOneError::Proposals(InvalidProposals::InvalidGuardrailsScriptHash { .. }) => {
+                Predicate::InvalidGuardrailsScriptHash
             }
             PhaseOneError::VotingProcedures(InvalidVotingProcedures::GovActionsDoNotExist(_)) => {
                 Predicate::GovActionsDoNotExist

--- a/crates/amaru-ledger/src/rules/transaction/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/mod.rs
@@ -82,6 +82,7 @@ mod tests {
             &era_history,
             fixture.network.as_global_parameters().expect("missing global parameters for network"),
             fixture.initial_state.governance_activity,
+            fixture.initial_state.guardrail_script,
             fixture.point,
             tx.tx_ref(),
             tx_size,

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
@@ -15,8 +15,8 @@
 use std::{fmt, mem, ops::Deref};
 
 use amaru_kernel::{
-    AuxiliaryData, EraHistory, HasTransactionId, Lovelace, Network, NetworkName, ProtocolParameters, TransactionBody,
-    TransactionInput, TransactionPointer, WitnessSet, cardano::value::Balance,
+    AuxiliaryData, EraHistory, HasTransactionId, Hash, Lovelace, Network, NetworkName, ProtocolParameters,
+    TransactionBody, TransactionInput, TransactionPointer, WitnessSet, cardano::value::Balance, size::SCRIPT,
 };
 use amaru_observability::debug_span;
 use amaru_plutus::arena_pool::ArenaPool;
@@ -125,6 +125,7 @@ pub fn execute<C>(
     protocol_parameters: &ProtocolParameters,
     era_history: &EraHistory,
     governance_activity: GovernanceActivity,
+    guardrail_script: Option<Hash<SCRIPT>>,
     pointer: TransactionPointer,
     is_valid: bool,
     mut transaction_body: TransactionBody,
@@ -278,6 +279,7 @@ where
                 network,
                 protocol_parameters,
                 era_history,
+                guardrail_script,
                 (transaction_id, pointer),
                 mem::take(&mut transaction_body.proposals).map(|xs| xs.to_vec()),
             )

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/proposals.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/proposals.rs
@@ -61,6 +61,9 @@ pub enum InvalidProposals {
     #[error("invalid previous governance action id: {parent:?}")]
     InvalidPrevGovActionId { parent: Option<ProposalId> },
 
+    #[error("invalid guardrails script hash: provided {provided:?}, expected {expected:?}")]
+    InvalidGuardrailsScriptHash { provided: Option<Hash<SCRIPT>>, expected: Option<Hash<SCRIPT>> },
+
     #[error("era history error: {0}")]
     EraHistory(#[from] amaru_kernel::EraHistoryError),
 }
@@ -70,6 +73,7 @@ pub(crate) fn execute<C>(
     network: Network,
     protocol_parameters: &ProtocolParameters,
     era_history: &EraHistory,
+    guardrail_script: Option<Hash<SCRIPT>>,
     transaction: (TransactionId, TransactionPointer),
     proposals: Option<Vec<Proposal>>,
 ) -> Result<(), InvalidProposals>
@@ -77,7 +81,15 @@ where
     C: ProposalsSlice + AccountsSlice + WitnessSlice + BalanceSlice,
 {
     for (proposal_index, proposal) in proposals.unwrap_or_default().into_iter().enumerate() {
-        validate_proposal(context, &proposal, network, protocol_parameters, era_history, transaction.1)?;
+        validate_proposal(
+            context,
+            &proposal,
+            network,
+            protocol_parameters,
+            era_history,
+            guardrail_script,
+            transaction.1,
+        )?;
 
         if let Some(script_hash) = get_proposal_script_hash(&proposal) {
             context.require_script_witness(RequiredScript {
@@ -119,6 +131,7 @@ fn validate_proposal<C>(
     network: Network,
     protocol_parameters: &ProtocolParameters,
     era_history: &EraHistory,
+    guardrail_script: Option<Hash<SCRIPT>>,
     pointer: TransactionPointer,
 ) -> Result<(), InvalidProposals>
 where
@@ -159,7 +172,7 @@ where
     }
 
     match &proposal.gov_action {
-        GovernanceAction::TreasuryWithdrawals(wdrls, _) => {
+        GovernanceAction::TreasuryWithdrawals(wdrls, policy) => {
             let mut any_positive = false;
             let mut missing = BTreeSet::new();
 
@@ -182,6 +195,8 @@ where
                     _ => return Err(InvalidProposals::MalformedReturnAddress),
                 }
             }
+
+            check_guardrails_script_hash(guardrail_script, *policy)?;
 
             if !any_positive {
                 return Err(InvalidProposals::TreasuryWithdrawalsAllZeros);
@@ -220,11 +235,25 @@ where
             }
         }
 
-        GovernanceAction::ParameterChange(_, ppu, _) => {
+        GovernanceAction::ParameterChange(_, ppu, policy) => {
             ppu_well_formed(ppu)?;
+            check_guardrails_script_hash(guardrail_script, *policy)?;
         }
 
         GovernanceAction::Information => {}
+    }
+
+    Ok(())
+}
+
+/// Only `TreasuryWithdrawals` and `ParameterChange` proposals require the guardrails script hash.
+/// They must match exactly, including in the case that the protocol hasn't enacted a constitution.
+fn check_guardrails_script_hash(
+    expected: Option<Hash<SCRIPT>>,
+    provided: Option<Hash<SCRIPT>>,
+) -> Result<(), InvalidProposals> {
+    if provided != expected {
+        return Err(InvalidProposals::InvalidGuardrailsScriptHash { provided, expected });
     }
 
     Ok(())

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -26,8 +26,8 @@ use std::{
 
 use amaru_kernel::{
     Block, Epoch, EraHistory, EraHistoryError, GlobalParameters, HasTransactionId, Hash, Hasher, NetworkName, Point,
-    PoolId, ProtocolParameters, Slot, Tip, Transaction, TransactionId, TransactionPointer, protocol_version, to_cbor,
-    utils::string::display_collection,
+    PoolId, ProtocolParameters, Slot, Tip, Transaction, TransactionId, TransactionPointer, protocol_version,
+    size::SCRIPT, to_cbor, utils::string::display_collection,
 };
 use amaru_metrics::ledger::LedgerMetrics;
 use amaru_observability::{debug_span, info, info_span, trace, warn};
@@ -162,6 +162,12 @@ impl<S: Store, HS: HistoricalStores> State<S, HS> {
     pub fn governance_activity_for(&self, epoch: Epoch) -> Option<GovernanceActivity> {
         self.volatile.governance_activity_for(epoch)
     }
+
+    /// The guardrails script of the enacted constitution, folding in a constitution enacted by the
+    /// volatile overlay.
+    pub fn guardrail_script(&self) -> Option<Hash<SCRIPT>> {
+        self.volatile.guardrail_script()
+    }
 }
 
 impl<S: Store, HS: HistoricalStores + Send + Sync + 'static> State<S, HS> {
@@ -180,6 +186,8 @@ impl<S: Store, HS: HistoricalStores + Send + Sync + 'static> State<S, HS> {
             .map_err(|e| StoreError::Internal(Box::new(e)))?;
 
         let governance_activity = stable.governance_activity()?;
+
+        let guardrail_script = stable.constitution()?.guardrail_script;
 
         let stake_distributions = initial_stake_distributions(
             network,
@@ -203,6 +211,7 @@ impl<S: Store, HS: HistoricalStores + Send + Sync + 'static> State<S, HS> {
             global_parameters,
             protocol_parameters,
             governance_activity,
+            guardrail_script,
             stake_distributions,
         ))
     }
@@ -217,6 +226,7 @@ impl<S: Store, HS: HistoricalStores + Send + Sync + 'static> State<S, HS> {
         global_parameters: GlobalParameters,
         protocol_parameters: ProtocolParameters,
         governance_activity: GovernanceActivity,
+        guardrail_script: Option<Hash<SCRIPT>>,
         stake_distributions: VecDeque<StakeDistribution>,
     ) -> Self {
         Self {
@@ -234,7 +244,7 @@ impl<S: Store, HS: HistoricalStores + Send + Sync + 'static> State<S, HS> {
             // (2) Re-applying GlobalParameters::consensus_security_param (already synchronized) blocks is _fast-enough_ that it can be
             //     done on restart easily. To be measured; if this turns out to be too slow, we
             //     views of the volatile DB on-disk to be able to restore them quickly.
-            volatile: VolatileDB::new(epoch, protocol_parameters, governance_activity),
+            volatile: VolatileDB::new(epoch, protocol_parameters, governance_activity, guardrail_script),
 
             global_parameters: Arc::new(global_parameters),
 
@@ -710,6 +720,7 @@ impl<S: Store, HS: HistoricalStores + Send + Sync + 'static> State<S, HS> {
             self.era_history(),
             self.global_parameters(),
             self.governance_activity(),
+            self.guardrail_script(),
             TransactionPointer { slot, transaction_index: 0 },
             transaction.tx_ref(),
             tx_size,
@@ -786,6 +797,7 @@ impl<S: Store, HS: HistoricalStores + Send + Sync + 'static> State<S, HS> {
                 self.era_history(),
                 self.global_parameters(),
                 self.governance_activity(),
+                self.guardrail_script(),
                 block,
             )?;
 

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -15,9 +15,9 @@
 use std::{iter, mem};
 
 use amaru_kernel::{
-    Epoch, EraHistory, GlobalParameters, Lovelace, MemoizedTransactionOutput, PREPROD_DEFAULT_PROTOCOL_PARAMETERS,
-    Point, PoolId, Pots, ProposalId, ProposalKind, ProposalsRoots, ProtocolParameters, StakeCredential,
-    TransactionInput,
+    Epoch, EraHistory, GlobalParameters, Hash, Lovelace, MemoizedTransactionOutput,
+    PREPROD_DEFAULT_PROTOCOL_PARAMETERS, Point, PoolId, Pots, ProposalId, ProposalKind, ProposalsRoots,
+    ProtocolParameters, StakeCredential, TransactionInput, size::SCRIPT,
 };
 
 use crate::{
@@ -65,11 +65,17 @@ pub struct VolatileDB {
     /// at flush, never rolled back, and read through [`Self::governance_activity`] to fold in any
     /// pending dormant-epoch bump from the volatile overlay.
     governance_activity: GovernanceActivity,
+
+    /// Cached guardrails script of the enacted constitution; `None` when the constitution names
+    /// none. Same lifecycle as `protocol_parameters`, and read through [`Self::guardrail_script`]
+    /// so that a constitution enacted at a boundary is seen by the blocks validated before the
+    /// overlay is flushed.
+    guardrail_script: Option<Hash<SCRIPT>>,
 }
 
 impl Default for VolatileDB {
     fn default() -> Self {
-        Self::new(Epoch::default(), PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone(), GovernanceActivity::default())
+        Self::new(Epoch::default(), PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone(), GovernanceActivity::default(), None)
     }
 }
 
@@ -227,13 +233,19 @@ impl VolatileSequence for VolatileDB {
 
 impl VolatileDB {
     /// Construct an empty volatile DB whose overlay is anchored to the given epoch.
-    pub fn new(epoch: Epoch, protocol_parameters: ProtocolParameters, governance_activity: GovernanceActivity) -> Self {
+    pub fn new(
+        epoch: Epoch,
+        protocol_parameters: ProtocolParameters,
+        governance_activity: GovernanceActivity,
+        guardrail_script: Option<Hash<SCRIPT>>,
+    ) -> Self {
         Self {
             current: VolatileSeries::default(),
             draining: VolatileSeries::default(),
             overlay: StateOverlay::new(epoch),
             protocol_parameters,
             governance_activity,
+            guardrail_script,
         }
     }
 
@@ -296,6 +308,12 @@ impl VolatileDB {
         } else {
             None
         }
+    }
+
+    /// The guardrails script every proposal's policy must name, preferring the constitution
+    /// enacted by an in-flight epoch transition over the cached base.
+    pub fn guardrail_script(&self) -> Option<Hash<SCRIPT>> {
+        self.overlay.pending_constitution().map_or(self.guardrail_script, |constitution| constitution.guardrail_script)
     }
 
     /// The governance roots, overlaying the pending boundary roots over the stable `base`.
@@ -368,12 +386,13 @@ impl VolatileDB {
             })
     }
 
-    /// Flush the pending epoch transition to the stable store. Returns the freshly-enacted
-    /// `(protocol_parameters, governance_activity)` when a governance transition was applied.
+    /// Flush the pending epoch transition to the stable store, refreshing the cached globals from
+    /// whatever that transition enacted.
     pub fn apply_transition(&mut self, db: &impl Store) -> Result<(), StateError> {
-        if let Some((protocol_parameters, governance_activity)) = self.overlay.apply(db)? {
+        if let Some((protocol_parameters, governance_activity, guardrail_script)) = self.overlay.apply(db)? {
             self.protocol_parameters = protocol_parameters;
             self.governance_activity = governance_activity;
+            self.guardrail_script = guardrail_script;
         }
 
         Ok(())
@@ -398,6 +417,7 @@ impl VolatileDB {
             overlay,
             protocol_parameters: self.protocol_parameters.clone(),
             governance_activity: self.governance_activity,
+            guardrail_script: self.guardrail_script,
         }
     }
 
@@ -894,7 +914,8 @@ mod tests {
     #[test]
     fn clear_empties_the_window_but_keeps_the_epoch_anchor() {
         let epoch = Epoch::from(42);
-        let mut db = VolatileDB::new(epoch, PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone(), GovernanceActivity::default());
+        let mut db =
+            VolatileDB::new(epoch, PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone(), GovernanceActivity::default(), None);
         let block1 = AnchoredVolatileFragment::fixture(10, 1);
         let block2 = AnchoredVolatileFragment::fixture(20, 2);
         db.push_back(block1);
@@ -915,7 +936,8 @@ mod tests {
     #[test]
     fn clear_rewinds_the_retained_window_across_an_epoch_boundary() {
         let epoch = Epoch::from(42);
-        let mut db = VolatileDB::new(epoch, PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone(), GovernanceActivity::default());
+        let mut db =
+            VolatileDB::new(epoch, PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone(), GovernanceActivity::default(), None);
         let block1 = AnchoredVolatileFragment::fixture(10, 1);
         let block2 = AnchoredVolatileFragment::fixture(20, 2);
         db.push_back(block1);

--- a/crates/amaru-ledger/src/state/volatile/overlay.rs
+++ b/crates/amaru-ledger/src/state/volatile/overlay.rs
@@ -15,8 +15,8 @@
 use std::{cell::RefCell, collections::BTreeMap, mem, sync::Arc};
 
 use amaru_kernel::{
-    ConstitutionalCommitteeUpdate, Epoch, Lovelace, PoolId, ProposalId, ProposalsRoots, ProtocolParameters,
-    RatificationStatus, StakeCredential, TreasuryDelta,
+    Constitution, ConstitutionalCommitteeUpdate, Epoch, Hash, Lovelace, PoolId, ProposalId, ProposalsRoots,
+    ProtocolParameters, RatificationStatus, StakeCredential, TreasuryDelta, size::SCRIPT,
 };
 use amaru_observability::{debug, info_span};
 use tracing::Span;
@@ -194,10 +194,14 @@ impl StateOverlay {
 
     /// Flush an overlay to disk.
     ///
-    /// Returns the freshly-enacted `(protocol_parameters, governance_activity)` when a governance
-    /// transition was applied, so the caller can refresh its cached copy. Returns `None` when there
-    /// was no governance update to apply, in which case the cached values are left untouched.
-    pub fn apply(&mut self, db: &impl Store) -> Result<Option<(ProtocolParameters, GovernanceActivity)>, StateError> {
+    /// Returns the freshly-enacted `(protocol_parameters, governance_activity, guardrail_script)`
+    /// when a governance transition was applied, so the caller can refresh its cached copies.
+    /// Returns `None` when there was no governance update to apply, in which case the cached values
+    /// are left untouched.
+    pub fn apply(
+        &mut self,
+        db: &impl Store,
+    ) -> Result<Option<(ProtocolParameters, GovernanceActivity, Option<Hash<SCRIPT>>)>, StateError> {
         let updated = info_span!(ledger::epoch_transition::APPLY, epoch = self.epoch).in_scope(|| {
             use EpochTransitionProgress::*;
 
@@ -342,6 +346,11 @@ impl StateOverlay {
     /// The pending protocol parameters carried by an in-flight governance transition, if any.
     pub fn pending_protocol_parameters(&self) -> Option<&ProtocolParameters> {
         self.governance_updates.as_ref().map(|update| &update.protocol_parameters)
+    }
+
+    /// The constitution enacted by an in-flight epoch transition, if that transition enacts one.
+    pub fn pending_constitution(&self) -> Option<&Constitution> {
+        self.governance_updates.as_ref().and_then(|update| update.new_constitution.as_ref())
     }
 
     /// Whether the in-flight governance transition (if any) corresponds to a dormant epoch; used to

--- a/crates/amaru-ledger/src/store/epoch_transition.rs
+++ b/crates/amaru-ledger/src/store/epoch_transition.rs
@@ -18,8 +18,8 @@ use std::{
 };
 
 use amaru_kernel::{
-    AsHash, ConstitutionalCommitteeStatus, ConstitutionalCommitteeUpdate, Lovelace, PoolId, ProposalId,
-    ProtocolParameters, RatificationStatus, RationalNumber, StakeCredential, StakeCredentialKind,
+    AsHash, ConstitutionalCommitteeStatus, ConstitutionalCommitteeUpdate, Hash, Lovelace, PoolId, ProposalId,
+    ProtocolParameters, RatificationStatus, RationalNumber, StakeCredential, StakeCredentialKind, size::SCRIPT,
 };
 use amaru_observability::{debug, debug_span};
 use num::BigUint;
@@ -221,13 +221,17 @@ pub fn update_or_retire_pools<'store>(
 pub fn apply_governance_updates<'store>(
     db: &impl TransactionalContext<'store>,
     updates: &GovernanceUpdates,
-) -> Result<(ProtocolParameters, GovernanceActivity), StoreError> {
+) -> Result<(ProtocolParameters, GovernanceActivity, Option<Hash<SCRIPT>>), StoreError> {
     debug_span!(stores::ledger::overlay::APPLY_GOVERNANCE_UPDATES,).in_scope(|| {
         db.set_proposals_roots(&updates.roots)?;
 
-        if let Some(new_constitution) = updates.new_constitution.as_ref() {
-            db.set_constitution(new_constitution)?;
-        }
+        let guardrail_script = match updates.new_constitution.as_ref() {
+            Some(new_constitution) => {
+                db.set_constitution(new_constitution)?;
+                new_constitution.guardrail_script
+            }
+            None => db.constitution()?.guardrail_script,
+        };
 
         if let Some(committee_update) = updates.constitutional_committee.as_ref() {
             update_constitutional_committee(db, committee_update)?;
@@ -259,7 +263,7 @@ pub fn apply_governance_updates<'store>(
 
         db.remove_proposals(updates.pruned_proposals.keys())?;
 
-        Ok((updates.protocol_parameters.clone(), governance_activity))
+        Ok((updates.protocol_parameters.clone(), governance_activity, guardrail_script))
     })
 }
 

--- a/crates/amaru-ledger/tests/data/rules-conformance.failures.toml
+++ b/crates/amaru-ledger/tests/data/rules-conformance.failures.toml
@@ -10,13 +10,22 @@
 # PassEpoch event that this harness skips, so the empty prev-gov-action-id can't be rejected here.
 "conway/fail-gov-empty-prevgovid-after-the-first-constitution-was-enacted/0" = "Expected failure, got success"
 "conway/fail-gov-expired-gov-actions/0" = "Expected failure, got success"
-"conway/fail-gov-policy-is-respected-by-proposals/0" = "Expected failure, got success"
+"conway/fail-gov-policy-is-respected-by-proposals/0" = 'Expected success, got failure: invalid proposals: invalid guardrails script hash: provided Some(Hash<28>("232fdf92265c01c8869aec72869c35d83eedd0ff1d139f2c680a0f37")), expected Some(Hash<28>("fa24fb305126805cf2164c161d852a0e7330cf988f1fe558cf7d4a64"))'
 "conway/fail-gov-votersdonotexist/0" = "Expected failure, got success"
 "conway/fail-govcert-resigning-a-non-cc-key/0" = "Expected failure, got success"
-# The gov-policy vectors enact their guardrails script through a proposal ratified by a PassEpoch
-# event that this harness skips, so no proposal ends up requiring that script and the witness
-# carrying it reads as extraneous.
+# Every vector in the gov-policy family enacts a new constitution mid-sequence, through a proposal,
+# votes and two epoch transitions. The harness skips PassTick/PassEpoch and does not ratify, so the
+# enacted guardrails script stays the one in the initial state and no policy in these transactions
+# can match it.
+#
+# This transaction is marked invalid, so proposal validation is skipped entirely along with the
+# script witness it would have required, and the policy carried by the witness set reads as
+# extraneous before the guardrails check is ever reached.
 "conway/fail-utxos-alwaysfails-plutus-govpolicy-does-not-validate/0" = "Expected success, got failure: invalid transaction scripts: extraneous script witnesses: extra [e4ed1d2a73cfad8751a777ff93ad6763603d633c47f2a0480acc6db9]"
+# This one no longer even reaches its own defect: the transaction it expects to fail now fails at
+# the guardrails check, leaving less of the shared context mutated than the value preservation of a
+# later transaction was recorded against.
+"conway/fail-utxos-failing-native-script-govpolicy/0" = "Expected success, got failure: value not preserved: balance = (123, [])"
 "conway/fail-utxos-fails-when-using-inline-datums-for-plutusv1/0" = "Expected failure, got success"
 "conway/fail-utxos-proposalprocedures-v1/0" = "Expected failure, got success"
 "conway/fail-utxos-proposalprocedures-v2/0" = "Expected failure, got success"
@@ -32,5 +41,6 @@
 "conway/pass-govcert-registering-a-resigned-cc-member-hotkey/0" = "Expected success, got failure: invalid transaction verification key witness: missing required signatures for keys or roots: [204c5f1bafe8ee289c881cb48d5f1b2abf97e8720d18526561d93be7]"
 "conway/pass-ratify-rewards-contribute-to-active-voting-stake-even-in-the-absence-of-stakedistr/0" = "Expected success, got failure: invalid certificates: pool retirement epoch out of range: epoch 918, must satisfy 45 < epoch <= 50"
 "conway/pass-ratify-stakepool-rewards-contribute-to-active-voting-stake-even-in-the-absence-of-e489f777/0" = "Expected success, got failure: invalid certificates: pool retirement epoch out of range: epoch 918, must satisfy 45 < epoch <= 50"
-"conway/pass-utxos-updating-costmodels-and-setting-the-govpolicy-afterwards-succeeds/0" = "Expected success, got failure: invalid transaction scripts: no cost model in protocol parameters for language used by transaction: V3"
-"conway/pass-utxos-updating-costmodels-with-alwaysfails-govpolicy-does-not-validate/0" = "Expected success, got failure: invalid transaction scripts: extraneous script witnesses: extra [e4ed1d2a73cfad8751a777ff93ad6763603d633c47f2a0480acc6db9]"
+"conway/pass-utxos-alwayssucceeds-plutus-govpolicy-validates/0" = 'Expected success, got failure: invalid proposals: invalid guardrails script hash: provided Some(Hash<28>("71d5fb4f7ac68b9df1d234fc0f6ae0aad3c9dff1b0cb9451a51679fb")), expected Some(Hash<28>("fa24fb305126805cf2164c161d852a0e7330cf988f1fe558cf7d4a64"))'
+"conway/pass-utxos-updating-costmodels-and-setting-the-govpolicy-afterwards-succeeds/0" = 'Expected success, got failure: invalid proposals: invalid guardrails script hash: provided None, expected Some(Hash<28>("fa24fb305126805cf2164c161d852a0e7330cf988f1fe558cf7d4a64"))'
+"conway/pass-utxos-updating-costmodels-with-alwaysfails-govpolicy-does-not-validate/0" = 'Expected success, got failure: invalid proposals: invalid guardrails script hash: provided None, expected Some(Hash<28>("fa24fb305126805cf2164c161d852a0e7330cf988f1fe558cf7d4a64"))'

--- a/crates/amaru-ledger/tests/data/transaction/README.md
+++ b/crates/amaru-ledger/tests/data/transaction/README.md
@@ -92,6 +92,9 @@ it is made up of the following fields:
   (see below). Use `{}` when none are enacted; absent purposes default to none.
 - `governanceActivity`: `{ consecutiveDormantEpochs }`.
 - `pots`: `{ treasury, reserves }`, the protocol pots as of the initial state.
+- `guardrailScript`: hex-encoded script hash of the enacted constitution's
+  guardrails script. A proposal carrying a policy must name exactly this script;
+  absent or `null` requires proposals to carry no policy at all.
 
 A governance action id is `{ transactionId, proposalIndex }`, mirroring
 `CertificatePointer`: `transactionId` is the hex-encoded 32-byte hash of the

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00191-fail-parameter-change-proposal-with-a-policy-the-constitution-has-no-script-for.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00191-fail-parameter-change-proposal-with-a-policy-the-constitution-has-no-script-for.json
@@ -1,0 +1,38 @@
+{
+  "title": "parameter change proposal with a policy the constitution has no script for",
+  "description": "A ParameterChange proposal carrying a policy, against a constitution that names no guardrails script. The named script is witnessed.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "accounts": [
+      {
+        "credential": "8200581cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    },
+    "guardrailScript": null
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8400f6a1001864581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584014d6bd21cf93405f515869bbc7f86d386f757a9c6c492d6e92ef1e64fdf3026fac1d2df218e1e9b2373f68730eb1e8a9165e58bc5452d8383c2d680ca974930b0181820180f5f6",
+  "expected": {
+    "predicate": "InvalidGuardrailsScriptHash"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00192-fail-parameter-change-proposal-omitting-the-constitutions-guardrails-script.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00192-fail-parameter-change-proposal-omitting-the-constitutions-guardrails-script.json
@@ -1,0 +1,38 @@
+{
+  "title": "parameter change proposal omitting the constitution's guardrails script",
+  "description": "A ParameterChange proposal carrying no policy, against a constitution that names a guardrails script.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "accounts": [
+      {
+        "credential": "8200581cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    },
+    "guardrailScript": "d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf"
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8400f6a1001864f6827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840ee54a69d13a9a37532cc28d8d76c30bb3796223d8c58cb81da876f84651ffe5c1398e83f6bb680860c748330c6557a5a7edc6a42d8304442970dea242be77a05f5f6",
+  "expected": {
+    "predicate": "InvalidGuardrailsScriptHash"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00193-fail-parameter-change-proposal-naming-a-script-other-than-the-constitutions.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00193-fail-parameter-change-proposal-naming-a-script-other-than-the-constitutions.json
@@ -1,0 +1,38 @@
+{
+  "title": "parameter change proposal naming a script other than the constitution's",
+  "description": "A ParameterChange proposal whose policy is a different script from the constitution's guardrails script. The named script is witnessed.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "accounts": [
+      {
+        "credential": "8200581cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    },
+    "guardrailScript": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8400f6a1001864581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584014d6bd21cf93405f515869bbc7f86d386f757a9c6c492d6e92ef1e64fdf3026fac1d2df218e1e9b2373f68730eb1e8a9165e58bc5452d8383c2d680ca974930b0181820180f5f6",
+  "expected": {
+    "predicate": "InvalidGuardrailsScriptHash"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00194-fail-treasury-withdrawals-proposal-with-a-policy-the-constitution-has-no-script-for.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00194-fail-treasury-withdrawals-proposal-with-a-policy-the-constitution-has-no-script-for.json
@@ -1,0 +1,43 @@
+{
+  "title": "treasury withdrawals proposal with a policy the constitution has no script for",
+  "description": "A TreasuryWithdrawals proposal carrying a policy, against a constitution that names no guardrails script. The named script is witnessed, and both the return and withdrawal accounts are registered.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "accounts": [
+      {
+        "credential": "8200581cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "deposit": 2000000,
+        "rewards": 0
+      },
+      {
+        "credential": "8200581caaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    },
+    "guardrailScript": null
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8302a1581de0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1a000f4240581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840ff3239747eff53d9595a30757a4f037003b6e8e6df584f4f18ed4d36e92296414ae20fe46e29488d1a69fc7722cfd9640e4253b41617157672a43b0dd0ccec060181820180f5f6",
+  "expected": {
+    "predicate": "InvalidGuardrailsScriptHash"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00195-fail-treasury-withdrawals-proposal-omitting-the-constitutions-guardrails-script.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00195-fail-treasury-withdrawals-proposal-omitting-the-constitutions-guardrails-script.json
@@ -1,0 +1,43 @@
+{
+  "title": "treasury withdrawals proposal omitting the constitution's guardrails script",
+  "description": "A TreasuryWithdrawals proposal carrying no policy, against a constitution that names a guardrails script.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "accounts": [
+      {
+        "credential": "8200581cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "deposit": 2000000,
+        "rewards": 0
+      },
+      {
+        "credential": "8200581caaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    },
+    "guardrailScript": "d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf"
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8302a1581de0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1a000f4240f6827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840c6df443bdb9443e114af6ffeb60f7aca8afbcdfe1a5f3b1b6244cc045a1f20a6a137e119b922a5993e3cdf31191105ac141dd4a12956d7b01cc6e40d8a1d0800f5f6",
+  "expected": {
+    "predicate": "InvalidGuardrailsScriptHash"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00196-pass-parameter-change-proposal-naming-the-constitutions-guardrails-script.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00196-pass-parameter-change-proposal-naming-the-constitutions-guardrails-script.json
@@ -1,0 +1,36 @@
+{
+  "title": "parameter change proposal naming the constitution's guardrails script",
+  "description": "A ParameterChange proposal whose policy is the enacted constitution's guardrails script, witnessed by the matching native script.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "accounts": [
+      {
+        "credential": "8200581cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    },
+    "guardrailScript": "d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf"
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8400f6a1001864581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584014d6bd21cf93405f515869bbc7f86d386f757a9c6c492d6e92ef1e64fdf3026fac1d2df218e1e9b2373f68730eb1e8a9165e58bc5452d8383c2d680ca974930b0181820180f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00197-pass-treasury-withdrawals-proposal-naming-the-constitutions-guardrails-script.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00197-pass-treasury-withdrawals-proposal-naming-the-constitutions-guardrails-script.json
@@ -1,0 +1,41 @@
+{
+  "title": "treasury withdrawals proposal naming the constitution's guardrails script",
+  "description": "A TreasuryWithdrawals proposal whose policy is the enacted constitution's guardrails script, witnessed by the matching native script.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b00000017489879c0"
+      }
+    ],
+    "accounts": [
+      {
+        "credential": "8200581cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "deposit": 2000000,
+        "rewards": 0
+      },
+      {
+        "credential": "8200581caaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    },
+    "guardrailScript": "d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf"
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480021a00030d400f0014d9010281841b000000174876e800581de0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb8302a1581de0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1a000f4240581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840ff3239747eff53d9595a30757a4f037003b6e8e6df584f4f18ed4d36e92296414ae20fe46e29488d1a69fc7722cfd9640e4253b41617157672a43b0dd0ccec060181820180f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/schema.json
+++ b/crates/amaru-ledger/tests/data/transaction/schema.json
@@ -184,6 +184,11 @@
       "pattern": "^[0-9a-fA-F]{56}$",
       "description": "Hex-encoded stake pool key hash (28 bytes)."
     },
+    "ScriptHash": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{56}$",
+      "description": "Hex-encoded script hash (28 bytes)."
+    },
     "CertificatePointer": {
       "type": "object",
       "required": ["transaction", "certificateIndex"],
@@ -286,7 +291,11 @@
           "description": "The latest enacted governance action id per purpose. Absent purposes default to none."
         },
         "governanceActivity": { "$ref": "#/$defs/VotingState" },
-        "pots": { "$ref": "#/$defs/Pots" }
+        "pots": { "$ref": "#/$defs/Pots" },
+        "guardrailScript": {
+          "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/ScriptHash" }],
+          "description": "Guardrails script of the enacted constitution. A proposal carrying a policy must name exactly this script; absent or null requires proposals to carry no policy at all."
+        }
       }
     },
     "Pots": {

--- a/crates/amaru-ledger/tests/evaluate_ledger_states.rs
+++ b/crates/amaru-ledger/tests/evaluate_ledger_states.rs
@@ -23,7 +23,7 @@ pub mod tests {
     };
 
     use amaru_kernel::{
-        Account, Bytes, CertificatePointer, ConstitutionalCommittee, ConstitutionalCommitteeMemberStatus,
+        Account, Bytes, CertificatePointer, Constitution, ConstitutionalCommittee, ConstitutionalCommitteeMemberStatus,
         DRepRegistration, DRepState, Epoch, EraHistory, Lovelace, MemoizedTransactionOutput, NetworkName,
         PROTOCOL_VERSION_10, Point, PoolId, PoolParams, ProposalId, ProposalKind,
         ProposalState as NewEpochProposalState, ProtocolParameters, Slot, StakeCredential, Transaction,
@@ -116,6 +116,7 @@ pub mod tests {
         pparams_hash: &'b cbor::bytes::ByteSlice,
         dormant_epochs: Epoch,
         treasury: Lovelace,
+        constitution: Constitution,
     }
 
     fn decode_ledger_state<'b>(d: &mut cbor::Decoder<'b>) -> Result<DecodedLedgerState<'b>, cbor::decode::Error> {
@@ -202,7 +203,7 @@ pub mod tests {
         ];
         let proposals = d.decode()?;
         let cc_state = d.decode::<SerialisedAsArray<_>>()?.0;
-        d.skip()?; // constitution
+        let constitution: Constitution = d.decode()?;
         let pparams_hash = d.decode()?;
         d.skip()?; // previous_pparams_hash
         d.skip()?; // future_pparams
@@ -228,6 +229,7 @@ pub mod tests {
             pparams_hash,
             dormant_epochs,
             treasury,
+            constitution,
         })
     }
 
@@ -349,6 +351,7 @@ pub mod tests {
                 &protocol_parameters,
                 era_history,
                 governance_activity,
+                decoded.constitution.guardrail_script,
                 pointer,
                 tx.is_expected_valid,
                 tx.body.clone(),

--- a/crates/amaru-node/src/tests/configuration.rs
+++ b/crates/amaru-node/src/tests/configuration.rs
@@ -14,13 +14,14 @@
 
 use std::{
     fmt::{Debug, Formatter},
+    str::FromStr,
     sync::Arc,
 };
 
 use amaru_consensus::headers_tree::data_generation::Action;
 use amaru_kernel::{
-    BlockHeader, Epoch, EraHistory, IsHeader, NetworkName, Peer, Point, ProtocolParameters, Transaction, TransactionId,
-    cardano::network_block::make_encoded_block,
+    Anchor, BlockHeader, Constitution, Epoch, EraHistory, IsHeader, MaxString128, NetworkName, Peer, Point,
+    ProtocolParameters, Transaction, TransactionId, cardano::network_block::make_encoded_block,
 };
 use amaru_ledger::{
     epoch_transition::GovernanceActivity,
@@ -298,6 +299,15 @@ impl NodeTestConfig {
             )?;
             tx.set_protocol_parameters(pp)?;
             tx.set_governance_activity(governance_activity)?;
+            // A bootstrapped ledger always has a constitution; these tests never propose one, so
+            // any anchor will do and there is no guardrails script to enforce.
+            tx.set_constitution(&Constitution {
+                anchor: Anchor {
+                    url: MaxString128::from_str("https://example.com").map_err(anyhow::Error::msg)?,
+                    content_hash: [0; 32].into(),
+                },
+                guardrail_script: None,
+            })?;
             tx.commit()?;
             // initial_stake_distributions needs snapshots at most_recent, most_recent - 1, and
             // most_recent - 2; take three so that for_epoch(0) and for_epoch(1) both succeed.

--- a/crates/amaru-stores/src/lib.rs
+++ b/crates/amaru-stores/src/lib.rs
@@ -22,9 +22,10 @@ pub mod tests {
     #[cfg(not(target_os = "windows"))]
     use amaru_kernel::any_proposal_id;
     use amaru_kernel::{
-        Anchor, DRepRegistration, Epoch, EraHistory, Hash, Lovelace, MaxString128, MemoizedTransactionOutput,
-        PREPROD_DEFAULT_PROTOCOL_PARAMETERS, PREPROD_ERA_HISTORY, Point, PoolId, PoolParams, Slot, StakeCredential,
-        TransactionInput, any_certificate_pointer, any_hash28, any_lovelace, any_pool_params, any_stake_credential,
+        Anchor, Constitution, DRepRegistration, Epoch, EraHistory, Hash, Lovelace, MaxString128,
+        MemoizedTransactionOutput, PREPROD_DEFAULT_PROTOCOL_PARAMETERS, PREPROD_ERA_HISTORY, Point, PoolId, PoolParams,
+        Slot, StakeCredential, TransactionInput, any_certificate_pointer, any_hash28, any_lovelace, any_pool_params,
+        any_stake_credential,
     };
     #[cfg(not(target_os = "windows"))]
     use amaru_ledger::store::columns::proposals;
@@ -198,6 +199,16 @@ pub mod tests {
                 Columns::empty(),
                 std::iter::empty(),
             )?;
+
+            // A bootstrapped ledger always has a constitution, and an enacted governance update
+            // reads it back to report the guardrails script in force.
+            context.set_constitution(&Constitution {
+                anchor: Anchor {
+                    url: MaxString128::from_str("https://example.com").unwrap(),
+                    content_hash: Hash::from([0u8; 32]),
+                },
+                guardrail_script: None,
+            })?;
 
             context.commit()?;
         }

--- a/crates/amaru-stores/tests/state_rollback.rs
+++ b/crates/amaru-stores/tests/state_rollback.rs
@@ -214,6 +214,7 @@ fn make_state() -> State<MockStore, RocksDBHistoricalStores> {
         global_parameters,
         protocol_parameters,
         GovernanceActivity::default(),
+        None,
         VecDeque::new(),
     )
 }


### PR DESCRIPTION
Closes #931

This PR introduce logic to validate that the guardrails script hash referenced in the `TreasuryWithdrawal` and `ParameterChange` gov actions matches the expected one defined in the on-chain constitution. It also requires some updates to the state logic to expose to the guardrails script hash, as well as changes to the fixture schema to allow test coverage for this logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Governance proposals now require a policy matching the enacted constitution’s guardrails script.
  * Proposals are rejected when the script is missing, unexpected, or mismatched.
  * Added support for tracking guardrails scripts across constitution updates.

* **Bug Fixes**
  * Treasury withdrawal proposals now preserve and validate their policy correctly.

* **Documentation**
  * Documented the guardrails script in transaction schemas, test guidance, and the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->