### PR TITLE
feat: trace the tx-submission exchange with schema-validated events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Other guiding principles:
 - **amaru-observability**: shared `TelemetryCaptureLayer` / `subscribe_telemetry` for schema-oriented in-process event subscription (used by the TUI and embedders).
 - **amaru-ledger**: `LedgerObservers` with `on_block` / `LedgerBlockEvent` (adopt + tip-first undo on successful fork switch) and opt-in `on_ledger_snapshot` (full `StakeSummary` by reference before slim in-memory retention).
 - **amaru-observability**: schema field transport now preserves JSON primitives (`bool`/`number`/`string`) and encodes other values as CBOR (`record_bytes`); console/JSON layers decode CBOR for structured output (including real JSON arrays/objects). OTEL logs use a project-owned bridge that maps CBOR fields to nested `AnyValue` maps/lists rather than opaque bytes.
+- **amaru-consensus**: add more debug events for the txsubmission stage ([#1173](https://github.com/pragma-org/amaru/issues/1173))
 
 ### Changed
 

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -1644,20 +1644,81 @@ define_schemas! {
                     /// Handle tx-submission initiator stage messages
                     TX_SUBMISSION_INITIATOR_STAGE {
                         required message_type: String
+                        required peer: amaru_kernel::Peer
                     }
                     /// Handle tx-submission initiator protocol messages
                     TX_SUBMISSION_INITIATOR_PROTOCOL {
                         required message_type: String
+                    }
+                    /// Advertise transaction ids (and their sizes) to the peer in a ReplyTxIds.
+                    REPLY_TX_IDS {
+                        required peer: amaru_kernel::Peer
+                        required count: usize
+                        required tx_ids: &[amaru_kernel::TransactionId]
+                    }
+                    /// Send transaction bodies to the peer in a ReplyTxs. Advertised ids whose
+                    /// tx was evicted before the fetch are listed in `omitted`.
+                    REPLY_TXS {
+                        required peer: amaru_kernel::Peer
+                        required count: usize
+                        optional omitted: String
+                    }
+                    /// The peer acknowledged the advertised ids.
+                    ACKNOWLEDGED {
+                        required peer: amaru_kernel::Peer
+                        required ack: u16
+                        required window: usize
+                    }
+                    /// A blocking RequestTxIds needs to wait until the mempool reaches `seq_no`.
+                    WAIT_FOR_AT_LEAST {
+                        required peer: amaru_kernel::Peer
+                        required seq_no: u64
+                        optional req: u16
                     }
                 }
                 responder {
                     /// Handle tx-submission responder stage messages
                     TX_SUBMISSION_RESPONDER_STAGE {
                         required message_type: String
+                        required peer: amaru_kernel::Peer
                     }
                     /// Handle tx-submission responder protocol messages
                     TX_SUBMISSION_RESPONDER_PROTOCOL {
                         required message_type: String
+                    }
+                    /// The peer advertised transaction ids in a ReplyTxIds.
+                    REPLY_TX_IDS_RECEIVED {
+                        required peer: amaru_kernel::Peer
+                        required count: usize
+                    }
+                    /// The peer delivered transaction bodies in a ReplyTxs.
+                    REPLY_TXS_RECEIVED {
+                        required peer: amaru_kernel::Peer
+                        required count: usize
+                    }
+                    /// An advertised tx is already in our mempool: it will be acknowledged
+                    /// without ever fetching its body.
+                    SKIP_FETCH {
+                        required peer: amaru_kernel::Peer
+                        required tx_id: amaru_kernel::TransactionId
+                    }
+                    /// Request tx ids from the peer, acknowledging processed ones.
+                    REQUEST_TX_IDS {
+                        required peer: amaru_kernel::Peer
+                        required ack: u16
+                        required req: u16
+                        required blocking: bool
+                    }
+                    /// Request tx bodies from the peer.
+                    REQUEST_TXS {
+                        required peer: amaru_kernel::Peer
+                        required count: usize
+                        required tx_ids: &[amaru_kernel::TransactionId]
+                    }
+                    /// Mempool near capacity: fetching is deferred until capacity frees up.
+                    AWAITING_CAPACITY {
+                        required peer: amaru_kernel::Peer
+                        required pending: usize
                     }
                 }
             }

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -369,6 +369,7 @@ async fn do_handshake(
     .await;
     let tx_submission = register_tx_submission(
         *role,
+        peer.clone(),
         muxer.clone(),
         &eff,
         TxOrigin::Remote(peer.clone()),

--- a/crates/amaru-protocols/src/tx_submission/initiator.rs
+++ b/crates/amaru-protocols/src/tx_submission/initiator.rs
@@ -47,15 +47,15 @@
 /// - Acknowledgment counts don't exceed advertised transactions
 /// - Only advertised transaction IDs are requested
 /// - Appropriate blocking/non-blocking requests based on acknowledgment state
-use std::collections::VecDeque;
+use std::collections::{BTreeSet, VecDeque};
 use std::{
     fmt::{Debug, Display},
     sync::Arc,
 };
 
 use ProtocolError::*;
-use amaru_kernel::{EraHistory, Transaction, TransactionId, utils::string::display_collection};
-use amaru_observability::debug_span;
+use amaru_kernel::{EraHistory, Peer, Transaction, TransactionId, utils::string::display_collection};
+use amaru_observability::{debug, debug_span};
 use amaru_ouroboros::{MempoolMsg, MempoolSeqNo};
 use amaru_pure_stage::{DeserializerGuards, Effects, StageRef, Void};
 use tracing::Instrument;
@@ -101,6 +101,7 @@ impl StageState<State, Initiator> for TxSubmissionInitiator {
                     // Mempool reached the expected seq_no but the tx was removed before we could read it
                     // Send a new wait message with the last_seq_no next value
                     let seq_no = mempool.last_seq_no().await.next();
+                    debug!(protocols::tx_submission::initiator::WAIT_FOR_AT_LEAST, peer = self.peer, seq_no = seq_no.0);
                     eff.send(
                         &self.mempool_stage,
                         MempoolMsg::WaitForAtLeast { seq_no, caller: self.wait_for_at_least_callback.clone() },
@@ -120,6 +121,7 @@ impl StageState<State, Initiator> for TxSubmissionInitiator {
         eff: &Effects<Inputs<Self::LocalIn>>,
     ) -> anyhow::Result<(Option<InitiatorAction>, Self)> {
         let message_type = input.message_type().to_string();
+        let peer = self.peer.clone();
 
         async move {
             let mempool = MemoryPool::new(eff.clone());
@@ -137,7 +139,8 @@ impl StageState<State, Initiator> for TxSubmissionInitiator {
         }
         .instrument(debug_span!(
             protocols::tx_submission::initiator::TX_SUBMISSION_INITIATOR_STAGE,
-            message_type = message_type
+            message_type = message_type,
+            peer = peer
         ))
         .await
     }
@@ -261,6 +264,8 @@ impl Display for InitiatorResult {
 
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct TxSubmissionInitiator {
+    /// The connected peer, expecting transactions to be received.
+    peer: Peer,
     /// What we’ve already advertised but has not yet been fully acked.
     window: VecDeque<(TransactionId, MempoolSeqNo)>,
     /// Last seq_no we have ever pulled from the mempool for this peer.
@@ -277,6 +282,7 @@ pub struct TxSubmissionInitiator {
 
 impl TxSubmissionInitiator {
     pub fn new(
+        peer: Peer,
         muxer: StageRef<MuxMessage>,
         mempool_stage: StageRef<MempoolMsg>,
         era_history: Arc<EraHistory>,
@@ -284,6 +290,7 @@ impl TxSubmissionInitiator {
         (
             State::Init,
             Self {
+                peer,
                 window: VecDeque::new(),
                 last_seq: None,
                 pending_blocking_request: None,
@@ -331,6 +338,12 @@ impl TxSubmissionInitiator {
                 })
                 .await;
         }
+        debug!(
+            protocols::tx_submission::initiator::WAIT_FOR_AT_LEAST,
+            peer = self.peer,
+            seq_no = expected_seq_no.0,
+            req = req
+        );
         eff.send(
             &self.mempool_stage,
             MempoolMsg::WaitForAtLeast { seq_no: expected_seq_no, caller: self.wait_for_at_least_callback.clone() },
@@ -380,6 +393,7 @@ impl TxSubmissionInitiator {
             return Ok(None);
         }
         self.pending_blocking_request = None;
+        self.emit_reply_tx_ids(&tx_ids);
         Ok(Some(InitiatorAction::SendReplyTxIds(self.tag_ids(tx_ids))))
     }
 
@@ -406,6 +420,7 @@ impl TxSubmissionInitiator {
         // update the window by discarding acknowledged tx ids and update the last_seq
         self.discard(ack);
         let tx_ids = self.get_next_tx_ids(mempool, req).await?;
+        self.emit_reply_tx_ids(&tx_ids);
         Ok(Some(InitiatorAction::SendReplyTxIds(self.tag_ids(tx_ids))))
     }
 
@@ -422,7 +437,20 @@ impl TxSubmissionInitiator {
             tracing::warn!(?unavailable, "peer requested transactions that are not in our window");
             return terminate(RequestedUnavailableTx);
         }
-        Ok(Some(InitiatorAction::SendReplyTxs(self.tag_txs(mempool.get_txs_for_ids(&tx_ids).await))))
+        let txs = mempool.get_txs_for_ids(&tx_ids).await;
+        let delivered: BTreeSet<TransactionId> = txs.iter().map(|tx| tx.tx_id()).collect();
+        let omitted: Vec<&TransactionId> = tx_ids.iter().filter(|id| !delivered.contains(id)).collect();
+        if omitted.is_empty() {
+            debug!(protocols::tx_submission::initiator::REPLY_TXS, peer = self.peer, count = txs.len());
+        } else {
+            debug!(
+                protocols::tx_submission::initiator::REPLY_TXS,
+                peer = self.peer,
+                count = txs.len(),
+                omitted = display_collection(omitted.iter().map(|id| id.short()))
+            );
+        }
+        Ok(Some(InitiatorAction::SendReplyTxs(self.tag_txs(txs))))
     }
 
     /// Check that `ack` does not exceed the outstanding window.
@@ -460,7 +488,26 @@ impl TxSubmissionInitiator {
     fn discard(&mut self, acknowledged: u16) {
         if self.window.len() >= acknowledged as usize {
             self.window = self.window.drain(acknowledged as usize..).collect();
+            if acknowledged > 0 {
+                debug!(
+                    protocols::tx_submission::initiator::ACKNOWLEDGED,
+                    peer = self.peer,
+                    ack = acknowledged,
+                    window = self.window.len()
+                );
+            }
         }
+    }
+
+    /// Trace the tx ids about to be advertised in a `ReplyTxIds` (possibly none).
+    fn emit_reply_tx_ids(&self, tx_ids: &[(TransactionId, u32)]) {
+        let ids = tx_ids.iter().map(|(id, _)| *id).collect::<Vec<_>>();
+        debug!(
+            protocols::tx_submission::initiator::REPLY_TX_IDS,
+            peer = self.peer,
+            count = ids.len(),
+            tx_ids = ids.as_slice()
+        );
     }
 
     /// We update our window with tx ids retrieved from the mempool and just sent to the server.
@@ -608,8 +655,12 @@ mod tests {
     async fn blocking_request_waits_for_one_new_tx_id() -> anyhow::Result<()> {
         let mempool = new_mempool();
         let txs = create_transactions(1);
-        let (_, mut initiator) =
-            TxSubmissionInitiator::new(StageRef::blackhole(), StageRef::blackhole(), Arc::new(EraHistory::default()));
+        let (_, mut initiator) = TxSubmissionInitiator::new(
+            Peer::new("peer"),
+            StageRef::blackhole(),
+            StageRef::blackhole(),
+            Arc::new(EraHistory::default()),
+        );
 
         let seq_no = initiator.begin_request_tx_ids_blocking(0, 10).map_err(|error| anyhow::anyhow!(error))?;
 
@@ -625,8 +676,12 @@ mod tests {
     async fn blocking_request_keeps_pending_when_tx_was_removed() -> anyhow::Result<()> {
         let mempool = new_mempool();
         let txs = create_transactions(1);
-        let (_, mut initiator) =
-            TxSubmissionInitiator::new(StageRef::blackhole(), StageRef::blackhole(), Arc::new(EraHistory::default()));
+        let (_, mut initiator) = TxSubmissionInitiator::new(
+            Peer::new("peer"),
+            StageRef::blackhole(),
+            StageRef::blackhole(),
+            Arc::new(EraHistory::default()),
+        );
 
         let seq_no = initiator.begin_request_tx_ids_blocking(0, 10).map_err(|error| anyhow::anyhow!(error))?;
 
@@ -877,6 +932,7 @@ mod tests {
     ) -> anyhow::Result<(Vec<InitiatorAction>, TxSubmissionInitiator)> {
         run_stage_and_return_state_with(
             TxSubmissionInitiator::new(
+                Peer::new("peer"),
                 StageRef::named_for_tests("muxer"),
                 StageRef::blackhole(),
                 Arc::new(EraHistory::default()),

--- a/crates/amaru-protocols/src/tx_submission/mod.rs
+++ b/crates/amaru-protocols/src/tx_submission/mod.rs
@@ -29,7 +29,7 @@ mod tests;
 
 use std::sync::Arc;
 
-use amaru_kernel::EraHistory;
+use amaru_kernel::{EraHistory, Peer};
 use amaru_ouroboros::{MempoolMsg, TxOrigin};
 use amaru_pure_stage::{Effects, StageRef};
 pub use initiator::initiator;
@@ -74,6 +74,7 @@ where
 #[expect(clippy::too_many_arguments)]
 pub async fn register_tx_submission(
     role: Role,
+    peer: Peer,
     muxer: StageRef<mux::MuxMessage>,
     eff: &Effects<ConnectionMessage>,
     origin: TxOrigin,
@@ -83,14 +84,15 @@ pub async fn register_tx_submission(
     tombstone: ConnectionMessage,
 ) -> StageRef<mux::HandlerMessage> {
     let tx_submission = if role == Role::Initiator {
-        let (state, stage) = initiator::TxSubmissionInitiator::new(muxer.clone(), mempool_stage.clone(), era_history);
+        let (state, stage) =
+            initiator::TxSubmissionInitiator::new(peer, muxer.clone(), mempool_stage.clone(), era_history);
         let tx_submission = eff.stage("tx_submission", initiator::initiator()).await;
         let tx_submission = eff.supervise(tx_submission, tombstone);
         let tx_submission = eff.wire_up(tx_submission, (state, stage)).await;
         eff.contramap(&tx_submission, "tx_submission_handler", Inputs::<initiator::InitiatorLocalIn>::Network).await
     } else {
         let (state, stage) =
-            responder::TxSubmissionResponder::new(muxer.clone(), params, origin, mempool_stage, era_history);
+            responder::TxSubmissionResponder::new(peer, muxer.clone(), params, origin, mempool_stage, era_history);
         let tx_submission = eff.stage("tx_submission", responder::responder()).await;
         let tx_submission = eff.supervise(tx_submission, tombstone);
         let tx_submission = eff.wire_up(tx_submission, (state, stage)).await;

--- a/crates/amaru-protocols/src/tx_submission/responder.rs
+++ b/crates/amaru-protocols/src/tx_submission/responder.rs
@@ -21,8 +21,8 @@ use std::{
 
 use ProtocolError::*;
 use TerminationCause::*;
-use amaru_kernel::{EraHistory, Transaction, TransactionId, to_cbor};
-use amaru_observability::debug_span;
+use amaru_kernel::{EraHistory, Peer, Transaction, TransactionId, to_cbor};
+use amaru_observability::{debug, debug_span};
 use amaru_ouroboros::{MempoolInsertResult, MempoolMsg, MempoolSeqNo, TxInsertResult, TxOrigin, TxRejectReason};
 use amaru_pure_stage::{DeserializerGuards, Effects, StageRef, Void};
 use tracing::Instrument;
@@ -86,6 +86,7 @@ impl StageState<State, Responder> for TxSubmissionResponder {
         eff: &Effects<Inputs<Self::LocalIn>>,
     ) -> anyhow::Result<(Option<ResponderAction>, Self)> {
         let message_type = input.message_type().to_string();
+        let peer = self.peer.clone();
 
         async move {
             let mempool = MemoryPool::new(eff.clone());
@@ -112,7 +113,8 @@ impl StageState<State, Responder> for TxSubmissionResponder {
         }
         .instrument(debug_span!(
             protocols::tx_submission::responder::TX_SUBMISSION_RESPONDER_STAGE,
-            message_type = message_type
+            message_type = message_type,
+            peer = peer
         ))
         .await
     }
@@ -235,6 +237,8 @@ impl Display for ResponderResult {
 
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct TxSubmissionResponder {
+    /// The connected peer, sending transactions.
+    peer: Peer,
     /// Responder parameters: batch sizes, window sizes, etc.
     params: ResponderParams,
     /// Sequence of tx_ids advertised by the peer in arrival order. May contain duplicates: a
@@ -275,6 +279,7 @@ pub struct TxStateEntry {
 
 impl TxSubmissionResponder {
     pub fn new(
+        peer: Peer,
         muxer: StageRef<MuxMessage>,
         params: ResponderParams,
         origin: TxOrigin,
@@ -284,6 +289,7 @@ impl TxSubmissionResponder {
         (
             State::Init,
             Self {
+                peer,
                 params,
                 unacked: VecDeque::new(),
                 tx_states: BTreeMap::new(),
@@ -314,6 +320,7 @@ impl TxSubmissionResponder {
         mempool: &dyn AsyncMempool,
         tx_ids: Vec<(TransactionId, u32)>,
     ) -> anyhow::Result<FetchOutcome> {
+        debug!(protocols::tx_submission::responder::REPLY_TX_IDS_RECEIVED, peer = self.peer, count = tx_ids.len());
         let max_window: usize = self.params.max_window.get().into();
         if self.unacked.len() + tx_ids.len() > max_window {
             // The peer was told it could send at most `max_window - unacked.len()` ids.
@@ -352,7 +359,12 @@ impl TxSubmissionResponder {
                         entry.refcount.checked_add(1).expect("refcount overflow: protocol invariant violated");
                 }
                 Entry::Vacant(v) => {
-                    let status = if mempool.contains(&tx_id).await { TxStatus::Done } else { TxStatus::Pending(size) };
+                    let status = if mempool.contains(&tx_id).await {
+                        debug!(protocols::tx_submission::responder::SKIP_FETCH, peer = self.peer, tx_id = tx_id);
+                        TxStatus::Done
+                    } else {
+                        TxStatus::Pending(size)
+                    };
                     v.insert(TxStateEntry { status, refcount: one() });
                 }
             }
@@ -412,6 +424,13 @@ impl TxSubmissionResponder {
             .expect("req underflow: protocol invariant violated");
 
         let blocking = if self.unacked.is_empty() { Blocking::Yes } else { Blocking::No };
+        debug!(
+            protocols::tx_submission::responder::REQUEST_TX_IDS,
+            peer = self.peer,
+            ack = ack,
+            req = req,
+            blocking = blocking == Blocking::Yes
+        );
         (ack, req, blocking)
     }
 
@@ -452,6 +471,14 @@ impl TxSubmissionResponder {
             reserved = next_total;
         }
 
+        if !tx_ids.is_empty() {
+            debug!(
+                protocols::tx_submission::responder::REQUEST_TXS,
+                peer = self.peer,
+                count = tx_ids.len(),
+                tx_ids = tx_ids.as_slice()
+            );
+        }
         tx_ids
     }
 
@@ -464,6 +491,7 @@ impl TxSubmissionResponder {
         txs: Vec<Transaction>,
         eff: &Effects<Inputs<ResponderLocalIn>>,
     ) -> anyhow::Result<Option<ResponderAction>> {
+        debug!(protocols::tx_submission::responder::REPLY_TXS_RECEIVED, peer = self.peer, count = txs.len());
         // De-duplicate transactions by tx_id.
         let txs: Vec<Transaction> =
             txs.into_iter().map(|tx| (tx.tx_id(), tx)).collect::<BTreeMap<_, _>>().into_values().collect();
@@ -561,6 +589,8 @@ impl TxSubmissionResponder {
         if self.capacity_subscribed {
             return;
         }
+        let pending = self.tx_states.values().filter(|e| e.status.is_pending()).count();
+        debug!(protocols::tx_submission::responder::AWAITING_CAPACITY, peer = self.peer, pending = pending);
         if self.capacity_callback.is_blackhole() {
             self.capacity_callback = eff
                 .contramap(eff.me_ref(), "tx_submission_capacity_callback", |_: ()| {
@@ -992,8 +1022,14 @@ mod tests {
         let muxer = StageRef::<MuxMessage>::blackhole();
         let mempool_stage = StageRef::<MempoolMsg>::blackhole();
         let era_history = Arc::new(EraHistory::default());
-        let (_state, mut responder) =
-            TxSubmissionResponder::new(muxer, test_params(), TxOrigin::Local, mempool_stage, era_history);
+        let (_state, mut responder) = TxSubmissionResponder::new(
+            Peer::new("peer"),
+            muxer,
+            test_params(),
+            TxOrigin::Local,
+            mempool_stage,
+            era_history,
+        );
 
         responder.fetch_id = 5;
         add_tx_id(&mut responder, txs[0].tx_id(), TxStatus::Inflight(to_cbor(&txs[0]).len() as u32));
@@ -1009,8 +1045,14 @@ mod tests {
         let muxer = StageRef::<MuxMessage>::blackhole();
         let mempool_stage = StageRef::<MempoolMsg>::blackhole();
         let era_history = Arc::new(EraHistory::default());
-        let (_state, mut responder) =
-            TxSubmissionResponder::new(muxer, test_params(), TxOrigin::Local, mempool_stage, era_history);
+        let (_state, mut responder) = TxSubmissionResponder::new(
+            Peer::new("peer"),
+            muxer,
+            test_params(),
+            TxOrigin::Local,
+            mempool_stage,
+            era_history,
+        );
 
         responder.fetch_id = 7;
         add_tx_id(&mut responder, txs[0].tx_id(), TxStatus::Inflight(to_cbor(&txs[0]).len() as u32));
@@ -1024,8 +1066,14 @@ mod tests {
         let muxer = StageRef::<MuxMessage>::blackhole();
         let mempool_stage = StageRef::<MempoolMsg>::blackhole();
         let era_history = Arc::new(EraHistory::default());
-        let (_state, mut responder) =
-            TxSubmissionResponder::new(muxer, test_params(), TxOrigin::Local, mempool_stage, era_history);
+        let (_state, mut responder) = TxSubmissionResponder::new(
+            Peer::new("peer"),
+            muxer,
+            test_params(),
+            TxOrigin::Local,
+            mempool_stage,
+            era_history,
+        );
 
         responder.fetch_id = 5;
         assert!(responder.handle_inflight_timeout(5).is_none());
@@ -1040,8 +1088,14 @@ mod tests {
         let muxer = StageRef::<MuxMessage>::blackhole();
         let mempool_stage = StageRef::<MempoolMsg>::blackhole();
         let era_history = Arc::new(EraHistory::default());
-        let (_state, mut responder) =
-            TxSubmissionResponder::new(muxer, test_params(), TxOrigin::Local, mempool_stage, era_history);
+        let (_state, mut responder) = TxSubmissionResponder::new(
+            Peer::new("peer"),
+            muxer,
+            test_params(),
+            TxOrigin::Local,
+            mempool_stage,
+            era_history,
+        );
 
         responder.fetch_id = 5;
         add_tx_id(&mut responder, txs[0].tx_id(), TxStatus::Inflight(to_cbor(&txs[0]).len() as u32));
@@ -1056,8 +1110,14 @@ mod tests {
         let muxer = StageRef::<MuxMessage>::blackhole();
         let mempool_stage = StageRef::<MempoolMsg>::blackhole();
         let era_history = Arc::new(EraHistory::default());
-        let (_state, mut responder) =
-            TxSubmissionResponder::new(muxer, test_params(), TxOrigin::Local, mempool_stage, era_history);
+        let (_state, mut responder) = TxSubmissionResponder::new(
+            Peer::new("peer"),
+            muxer,
+            test_params(),
+            TxOrigin::Local,
+            mempool_stage,
+            era_history,
+        );
 
         // Mempool reports zero capacity left, so any pending fetch should yield AwaitingCapacity.
         let mempool = full_mempool();
@@ -1077,8 +1137,14 @@ mod tests {
         let muxer = StageRef::<MuxMessage>::blackhole();
         let mempool_stage = StageRef::<MempoolMsg>::blackhole();
         let era_history = Arc::new(EraHistory::default());
-        let (_state, mut responder) =
-            TxSubmissionResponder::new(muxer, test_params(), TxOrigin::Local, mempool_stage, era_history);
+        let (_state, mut responder) = TxSubmissionResponder::new(
+            Peer::new("peer"),
+            muxer,
+            test_params(),
+            TxOrigin::Local,
+            mempool_stage,
+            era_history,
+        );
 
         // First the mempool is full.
         let full = full_mempool();
@@ -1141,6 +1207,7 @@ mod tests {
     ) -> anyhow::Result<(Vec<ResponderAction>, TxSubmissionResponder)> {
         run_stage_and_return_state_with(
             TxSubmissionResponder::new(
+                Peer::new("peer"),
                 StageRef::named_for_tests("muxer"),
                 test_params(),
                 TxOrigin::Local,


### PR DESCRIPTION
This PR adds a few events to help us debug the behavior of the txsubmission protocol.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed debug events for transaction submission, covering advertisements, requests, deliveries, acknowledgements, skipped fetches, and capacity waits.
  * Transaction submission events now include peer information for improved connection-level visibility.
  * Added visibility into transaction IDs and bodies delivered, omitted, received, or requested during submission.
* **Documentation**
  * Added an unreleased changelog entry documenting the expanded transaction-submission diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->