### PR TITLE
add collection of information needed for peer sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Other guiding principles:
 
 ## v10.11.20260813 _[unreleased; planned for 2026-08-13]_
 
+### Added
+
+- **amaru-consensus**: track peer-sharing reputation (handshake advertisability, connection failures, sticky adversarial flag, and whether a successful connection was ever established) so peer selection can filter share candidates. ([#1167](https://github.com/pragma-org/amaru/issues/1167))
+
 ### Fixed
 
 - **amaru-ledger**: reject governance proposals whose previous action does not match the enacted root nor an in-flight proposal of the same purpose. ([#1090][], [#932][])

--- a/crates/amaru-consensus/src/performance/effects.rs
+++ b/crates/amaru-consensus/src/performance/effects.rs
@@ -32,8 +32,8 @@ use amaru_pure_stage::{BoxFuture, ExternalEffect, ExternalEffectAPI, Instant, Re
 use tokio::sync::oneshot;
 
 use super::{
-    ClaimKind, FetchPeerSet, HeaderLifecycleOutcome, HeaderPerformance, HeaderTelemetry, PeerScores, PeerSnapshot,
-    Performance, PerformanceOp, ResourcePerformance, SelectPeersParams,
+    ClaimKind, FetchPeerSet, HeaderLifecycleOutcome, HeaderPerformance, HeaderTelemetry, PeerScores, PeerShareFlags,
+    PeerSnapshot, Performance, PerformanceOp, ResourcePerformance, SelectPeersParams,
 };
 
 fn require_perf(resources: &Resources) -> ResourcePerformance {
@@ -121,12 +121,23 @@ impl Performance {
         RecordKeepaliveRttEffect { peer, rtt, at }
     }
 
+    /// Record latest handshake peer-sharing willingness (`peer_sharing == 1` ⇒ advertisable).
+    pub fn record_advertisability(peer: Peer, advertisable: bool, at: Instant) -> RecordAdvertisabilityEffect {
+        RecordAdvertisabilityEffect { peer, advertisable, at }
+    }
+
+    /// Record a connection/protocol failure (increments `failure_count`).
+    pub fn record_connection_failure(peer: Peer, at: Instant) -> RecordConnectionFailureEffect {
+        RecordConnectionFailureEffect { peer, at }
+    }
+
     pub fn clear_peer_availability(peer: Peer) -> ClearPeerAvailabilityEffect {
         ClearPeerAvailabilityEffect { peer }
     }
 
-    pub fn forget_peer(peer: Peer) -> ForgetPeerEffect {
-        ForgetPeerEffect { peer }
+    /// Mark a peer as adversarial: clear claims/scores, keep a reputation stub with `adversarial = true`.
+    pub fn peer_adversarial(peer: Peer) -> PeerAdversarialEffect {
+        PeerAdversarialEffect { peer }
     }
 
     pub fn prune_below(min_height: BlockHeight, now: Instant) -> PruneBelowEffect {
@@ -157,8 +168,16 @@ impl Performance {
         ScoresEffect { peer }
     }
 
+    pub fn share_flags(peer: Peer) -> ShareFlagsEffect {
+        ShareFlagsEffect { peer }
+    }
+
     pub fn snapshot(peer: Peer) -> SnapshotEffect {
         SnapshotEffect { peer }
+    }
+
+    pub fn ok_for_sharing(peer: Peer) -> OkForSharingEffect {
+        OkForSharingEffect { peer }
     }
 
     pub fn record_rollback(peer: Peer, point: Tip, parent: Option<HeaderHash>, at: Instant) -> RecordRollbackEffect {
@@ -322,6 +341,45 @@ impl ExternalEffectAPI for RecordKeepaliveRttEffect {
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RecordAdvertisabilityEffect {
+    pub(crate) peer: Peer,
+    pub(crate) advertisable: bool,
+    pub(crate) at: Instant,
+}
+
+impl ExternalEffect for RecordAdvertisabilityEffect {
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        Self::wrap_sync({
+            let perf = require_perf(&resources);
+            enqueue(&perf, PerformanceOp::RecordAdvertisability { effect: *self });
+        })
+    }
+}
+
+impl ExternalEffectAPI for RecordAdvertisabilityEffect {
+    type Response = ();
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RecordConnectionFailureEffect {
+    pub(crate) peer: Peer,
+    pub(crate) at: Instant,
+}
+
+impl ExternalEffect for RecordConnectionFailureEffect {
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        Self::wrap_sync({
+            let perf = require_perf(&resources);
+            enqueue(&perf, PerformanceOp::RecordConnectionFailure { effect: *self });
+        })
+    }
+}
+
+impl ExternalEffectAPI for RecordConnectionFailureEffect {
+    type Response = ();
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ClearPeerAvailabilityEffect {
     pub(crate) peer: Peer,
 }
@@ -340,20 +398,20 @@ impl ExternalEffectAPI for ClearPeerAvailabilityEffect {
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct ForgetPeerEffect {
+pub struct PeerAdversarialEffect {
     pub(crate) peer: Peer,
 }
 
-impl ExternalEffect for ForgetPeerEffect {
+impl ExternalEffect for PeerAdversarialEffect {
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
         Self::wrap_sync({
             let perf = require_perf(&resources);
-            enqueue(&perf, PerformanceOp::ForgetPeer { effect: *self });
+            enqueue(&perf, PerformanceOp::PeerAdversarial { effect: *self });
         })
     }
 }
 
-impl ExternalEffectAPI for ForgetPeerEffect {
+impl ExternalEffectAPI for PeerAdversarialEffect {
     type Response = ();
 }
 
@@ -486,6 +544,24 @@ impl ExternalEffectAPI for ScoresEffect {
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ShareFlagsEffect {
+    pub(crate) peer: Peer,
+}
+
+impl ExternalEffect for ShareFlagsEffect {
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        Self::wrap(
+            async move { enqueue_query(&perf, |reply| PerformanceOp::ShareFlags { effect: *self, reply }).await },
+        )
+    }
+}
+
+impl ExternalEffectAPI for ShareFlagsEffect {
+    type Response = Option<PeerShareFlags>;
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SnapshotEffect {
     pub(crate) peer: Peer,
 }
@@ -499,6 +575,24 @@ impl ExternalEffect for SnapshotEffect {
 
 impl ExternalEffectAPI for SnapshotEffect {
     type Response = Option<PeerSnapshot>;
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct OkForSharingEffect {
+    pub(crate) peer: Peer,
+}
+
+impl ExternalEffect for OkForSharingEffect {
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        Self::wrap(
+            async move { enqueue_query(&perf, |reply| PerformanceOp::OkForSharing { effect: *self, reply }).await },
+        )
+    }
+}
+
+impl ExternalEffectAPI for OkForSharingEffect {
+    type Response = bool;
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/crates/amaru-consensus/src/performance/mod.rs
+++ b/crates/amaru-consensus/src/performance/mod.rs
@@ -49,7 +49,9 @@ use amaru_pure_stage::Instant;
 pub use effects::*;
 pub use header::{ForkSwitchOutcome, HeaderLifecycleOutcome, HeaderPerformance, HeaderTelemetry};
 use parking_lot::Mutex;
-pub use peer::{BlockClaim, ClaimKind, FetchPeerSet, PeerPerformance, PeerScores, PeerSnapshot, SelectPeersParams};
+pub use peer::{
+    BlockClaim, ClaimKind, FetchPeerSet, PeerPerformance, PeerScores, PeerShareFlags, PeerSnapshot, SelectPeersParams,
+};
 use tokio::{
     sync::{
         mpsc::{UnboundedSender, unbounded_channel},
@@ -137,8 +139,10 @@ pub(crate) enum PerformanceOp {
     RecordBlockDelivery { effect: RecordBlockDeliveryEffect },
     RecordFetchFailure { effect: RecordFetchFailureEffect },
     RecordKeepaliveRtt { effect: RecordKeepaliveRttEffect },
+    RecordAdvertisability { effect: RecordAdvertisabilityEffect },
+    RecordConnectionFailure { effect: RecordConnectionFailureEffect },
     ClearPeerAvailability { effect: ClearPeerAvailabilityEffect },
-    ForgetPeer { effect: ForgetPeerEffect },
+    PeerAdversarial { effect: PeerAdversarialEffect },
     PruneBelow { effect: PruneBelowEffect, reply: oneshot::Sender<Vec<HeaderTelemetry>> },
     SelectPeersForFetch { effect: SelectPeersForFetchEffect, reply: oneshot::Sender<FetchPeerSet> },
     PeerCoversFragment { effect: PeerCoversFragmentEffect, reply: oneshot::Sender<bool> },
@@ -146,7 +150,9 @@ pub(crate) enum PerformanceOp {
     FirstAnnouncedAt { effect: FirstAnnouncedAtEffect, reply: oneshot::Sender<Option<(Peer, Instant)>> },
     RankPeersForChurn { effect: RankPeersForChurnEffect, reply: oneshot::Sender<Vec<(Peer, PeerScores)>> },
     Scores { effect: ScoresEffect, reply: oneshot::Sender<PeerScores> },
+    ShareFlags { effect: ShareFlagsEffect, reply: oneshot::Sender<Option<PeerShareFlags>> },
     Snapshot { effect: SnapshotEffect, reply: oneshot::Sender<Option<PeerSnapshot>> },
+    OkForSharing { effect: OkForSharingEffect, reply: oneshot::Sender<bool> },
     RecordRollback { effect: RecordRollbackEffect },
     RecordHeaderAbandoned { effect: RecordHeaderAbandonedEffect, reply: oneshot::Sender<Vec<HeaderTelemetry>> },
     RecordForkStarted { effect: RecordForkStartedEffect, reply: oneshot::Sender<Vec<HeaderTelemetry>> },
@@ -277,11 +283,17 @@ fn dispatch(peers: &mut PeerPerformance, headers: &mut HeaderPerformance, op: Pe
         PerformanceOp::RecordKeepaliveRtt { effect } => {
             peers.apply_keepalive_rtt(effect.peer, effect.rtt, effect.at);
         }
+        PerformanceOp::RecordAdvertisability { effect } => {
+            peers.apply_advertisability(effect.peer, effect.advertisable, effect.at);
+        }
+        PerformanceOp::RecordConnectionFailure { effect } => {
+            peers.apply_connection_failure(effect.peer, effect.at);
+        }
         PerformanceOp::ClearPeerAvailability { effect } => {
             peers.apply_clear_peer_availability(&effect.peer);
         }
-        PerformanceOp::ForgetPeer { effect } => {
-            peers.apply_forget_peer(&effect.peer);
+        PerformanceOp::PeerAdversarial { effect } => {
+            peers.apply_peer_adversarial(&effect.peer);
         }
         PerformanceOp::PruneBelow { effect, reply } => {
             peers.apply_prune_below(effect.min_height);
@@ -312,8 +324,16 @@ fn dispatch(peers: &mut PeerPerformance, headers: &mut HeaderPerformance, op: Pe
             let result = peers.apply_scores(&effect.peer);
             let _ = reply.send(result);
         }
+        PerformanceOp::ShareFlags { effect, reply } => {
+            let result = peers.apply_share_flags(&effect.peer);
+            let _ = reply.send(result);
+        }
         PerformanceOp::Snapshot { effect, reply } => {
             let result = peers.apply_snapshot(&effect.peer);
+            let _ = reply.send(result);
+        }
+        PerformanceOp::OkForSharing { effect, reply } => {
+            let result = peers.apply_ok_for_sharing(&effect.peer);
             let _ = reply.send(result);
         }
         PerformanceOp::RecordRollback { effect } => {

--- a/crates/amaru-consensus/src/performance/peer.rs
+++ b/crates/amaru-consensus/src/performance/peer.rs
@@ -66,11 +66,41 @@ pub struct PeerScores {
     pub last_change: Option<Instant>,
 }
 
+/// Share-relevant reputation flags stored on the performance map.
+///
+/// Origin (ledger / snapshot / static) and listen-address policy live in peer selection;
+/// this type only exposes what Performance observes across stages.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct PeerShareFlags {
+    /// Whether a successful connection (handshake) was ever established with this peer.
+    ///
+    /// Distinct from map presence: connection failures upsert a reputation stub without
+    /// setting this flag.
+    pub ever_connected: bool,
+    /// Latest handshake peer-sharing willingness (`peer_sharing == 1`).
+    pub advertisable: bool,
+    /// Connection / protocol failure count; sharing requires zero.
+    pub failure_count: u32,
+    /// Sticky adversarial marker retained across [`PeerPerformance::apply_peer_adversarial`].
+    pub adversarial: bool,
+}
+
+impl PeerShareFlags {
+    /// Whether Performance would allow this peer into a share reply filter.
+    ///
+    /// Peer selection still applies origin and listen-address rules on top of this check.
+    /// Map presence is required separately (no record ⇒ not shareable).
+    pub fn ok_for_sharing(self) -> bool {
+        self.ever_connected && self.advertisable && self.failure_count == 0 && !self.adversarial
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PeerSnapshot {
     pub peer: Peer,
     pub scores: PeerScores,
     pub tips: Vec<BlockClaim>,
+    pub share: PeerShareFlags,
 }
 
 /// Result of peer selection for a fetch batch.
@@ -108,6 +138,25 @@ struct ClaimMeta {
 struct PeerState {
     tips: BTreeMap<HeaderHash, ClaimMeta>,
     scores: PeerScores,
+    /// Sticky once a successful handshake is observed; not set by connection-failure upserts.
+    ever_connected: bool,
+    /// Latest handshake peer-sharing willingness; latest successful handshake wins.
+    advertisable: bool,
+    /// Connection / protocol failures (distinct from blockfetch `fetch_timeouts`).
+    failure_count: u32,
+    /// Sticky once set by [`PeerPerformance::apply_peer_adversarial`]; not cleared by clear/availability.
+    adversarial: bool,
+}
+
+impl PeerState {
+    fn share_flags(&self) -> PeerShareFlags {
+        PeerShareFlags {
+            ever_connected: self.ever_connected,
+            advertisable: self.advertisable,
+            failure_count: self.failure_count,
+            adversarial: self.adversarial,
+        }
+    }
 }
 
 /// Peer performance map (availability + scores). Owned by the performance worker thread.
@@ -179,12 +228,43 @@ impl PeerPerformance {
         self.direct.retain(|_, claimants| !claimants.is_empty());
     }
 
-    pub fn apply_forget_peer(&mut self, peer: &Peer) {
-        self.peers.remove(peer);
+    /// Mark peer adversarial: clear claims and scores, keep a durable reputation stub.
+    ///
+    /// Retains `ever_connected`, `failure_count`, and last `advertisable`; sets `adversarial = true`.
+    /// The peer entry remains so share filters and cool-down policy can still see the ban history.
+    ///
+    /// This is not a generic “forget”: a future erase-without-adversarial path would be a
+    /// separate operation.
+    pub fn apply_peer_adversarial(&mut self, peer: &Peer) {
         for claimants in self.direct.values_mut() {
             claimants.remove(peer);
         }
         self.direct.retain(|_, claimants| !claimants.is_empty());
+
+        let state = self.peers.entry(peer.clone()).or_default();
+        state.tips.clear();
+        state.scores = PeerScores::default();
+        state.adversarial = true;
+    }
+
+    /// Record latest handshake peer-sharing willingness (overwrites prior value).
+    ///
+    /// Marks the peer as ever-connected (successful handshake). Connection-failure
+    /// upserts do not set that flag.
+    pub fn apply_advertisability(&mut self, peer: Peer, advertisable: bool, at: Instant) {
+        let state = self.peers.entry(peer).or_default();
+        state.ever_connected = true;
+        state.advertisable = advertisable;
+        state.scores.last_change = Some(at);
+    }
+
+    /// Increment connection/protocol failure count (e.g. outbound connect exhausted).
+    ///
+    /// Upserts a reputation stub when needed, but does **not** set `ever_connected`.
+    pub fn apply_connection_failure(&mut self, peer: Peer, at: Instant) {
+        let state = self.peers.entry(peer).or_default();
+        state.failure_count = state.failure_count.saturating_add(1);
+        state.scores.last_change = Some(at);
     }
 
     pub fn apply_prune_below(&mut self, min_height: BlockHeight) {
@@ -216,8 +296,19 @@ impl PeerPerformance {
         self.peers.get(peer).map(|s| s.scores.clone()).unwrap_or_default()
     }
 
+    pub fn apply_share_flags(&self, peer: &Peer) -> Option<PeerShareFlags> {
+        self.peers.get(peer).map(|s| s.share_flags())
+    }
+
     pub fn apply_snapshot(&self, peer: &Peer) -> Option<PeerSnapshot> {
         self.snapshot(peer)
+    }
+
+    /// Whether this peer has a Performance record and passes share reputation checks.
+    ///
+    /// Peer selection still excludes ledger/snapshot origins and pure inbound addresses.
+    pub fn apply_ok_for_sharing(&self, peer: &Peer) -> bool {
+        self.peers.get(peer).is_some_and(|s| s.share_flags().ok_for_sharing())
     }
 
     /// Re-tip a peer after chainsync rollback to `point`.
@@ -362,7 +453,7 @@ impl PeerPerformance {
                 at: meta.at,
             })
             .collect();
-        Some(PeerSnapshot { peer: peer.clone(), scores: state.scores.clone(), tips })
+        Some(PeerSnapshot { peer: peer.clone(), scores: state.scores.clone(), tips, share: state.share_flags() })
     }
 
     fn record_rollback(&mut self, peer: Peer, point: Tip, parent: Option<HeaderHash>, at: Instant) {

--- a/crates/amaru-consensus/src/performance/tests.rs
+++ b/crates/amaru-consensus/src/performance/tests.rs
@@ -21,8 +21,8 @@ use amaru_kernel::{BlockHeight, HeaderHash, Peer, Point, Slot, Tip};
 use amaru_pure_stage::{ExternalEffect, Instant, Resources};
 
 use super::{
-    ClaimKind, HeaderLifecycleOutcome, HeaderPerformance, PeerPerformance, Performance, ResourcePerformance,
-    SelectPeersParams,
+    ClaimKind, HeaderLifecycleOutcome, HeaderPerformance, PeerPerformance, PeerShareFlags, Performance,
+    ResourcePerformance, SelectPeersParams,
 };
 
 fn t(secs: u64) -> Instant {
@@ -205,10 +205,11 @@ fn prune_removes_old_tips_but_retains_scores() {
 }
 
 #[test]
-fn clear_availability_keeps_scores_forget_removes_all() {
+fn clear_availability_keeps_scores_and_share_flags() {
     let mut peers = PeerPerformance::new();
     let alice = peer("alice");
 
+    peers.apply_advertisability(alice.clone(), true, t(0));
     peers.apply_header_announcement(alice.clone(), tip(1, 1), None, t(1));
     peers.apply_block_delivery(
         alice.clone(),
@@ -224,10 +225,94 @@ fn clear_availability_keeps_scores_forget_removes_all() {
     assert!(!peers.apply_peer_covers_fragment(&alice, &[hash(1)]));
     assert_eq!(peers.apply_scores(&alice).fetch_successes, 1);
     assert!(peers.apply_direct_claimants(&hash(1)).is_empty());
+    assert_eq!(
+        peers.apply_share_flags(&alice),
+        Some(PeerShareFlags { ever_connected: true, advertisable: true, failure_count: 0, adversarial: false })
+    );
+    assert!(peers.apply_ok_for_sharing(&alice));
+}
 
-    peers.apply_forget_peer(&alice);
-    assert!(peers.apply_snapshot(&alice).is_none());
-    assert_eq!(peers.apply_scores(&alice).fetch_successes, 0);
+#[test]
+fn peer_adversarial_keeps_reputation_stub_clears_claims_and_scores() {
+    let mut peers = PeerPerformance::new();
+    let alice = peer("alice");
+
+    peers.apply_advertisability(alice.clone(), true, t(0));
+    peers.apply_connection_failure(alice.clone(), t(1));
+    peers.apply_header_announcement(alice.clone(), tip(1, 1), None, t(2));
+    peers.apply_block_delivery(
+        alice.clone(),
+        hash(1),
+        BlockHeight::from(1),
+        None,
+        t(3),
+        Duration::from_millis(20),
+        1000,
+    );
+
+    peers.apply_peer_adversarial(&alice);
+
+    let snap = peers.apply_snapshot(&alice).expect("stub retained after adversarial mark");
+    assert!(snap.tips.is_empty());
+    assert_eq!(snap.scores.fetch_successes, 0);
+    assert!(snap.scores.block_response_ewma.is_none());
+    assert_eq!(
+        snap.share,
+        PeerShareFlags { ever_connected: true, advertisable: true, failure_count: 1, adversarial: true }
+    );
+    assert!(!peers.apply_ok_for_sharing(&alice));
+    assert!(peers.apply_direct_claimants(&hash(1)).is_empty());
+}
+
+#[test]
+fn advertisability_latest_handshake_wins() {
+    let mut peers = PeerPerformance::new();
+    let alice = peer("alice");
+
+    peers.apply_advertisability(alice.clone(), true, t(1));
+    assert!(peers.apply_ok_for_sharing(&alice));
+
+    peers.apply_advertisability(alice.clone(), false, t(2));
+    assert_eq!(
+        peers.apply_share_flags(&alice),
+        Some(PeerShareFlags { ever_connected: true, advertisable: false, failure_count: 0, adversarial: false })
+    );
+    assert!(!peers.apply_ok_for_sharing(&alice));
+
+    peers.apply_advertisability(alice.clone(), true, t(3));
+    assert!(peers.apply_ok_for_sharing(&alice));
+}
+
+#[test]
+fn connection_failure_blocks_sharing_until_count_is_nonzero() {
+    let mut peers = PeerPerformance::new();
+    let alice = peer("alice");
+
+    assert!(!peers.apply_ok_for_sharing(&alice));
+
+    peers.apply_advertisability(alice.clone(), true, t(1));
+    assert!(peers.apply_ok_for_sharing(&alice));
+
+    peers.apply_connection_failure(alice.clone(), t(2));
+    assert_eq!(peers.apply_share_flags(&alice).map(|f| f.failure_count), Some(1));
+    assert!(!peers.apply_ok_for_sharing(&alice));
+
+    peers.apply_connection_failure(alice.clone(), t(3));
+    assert_eq!(peers.apply_share_flags(&alice).map(|f| f.failure_count), Some(2));
+}
+
+#[test]
+fn connection_failure_only_does_not_mark_ever_connected() {
+    let mut peers = PeerPerformance::new();
+    let alice = peer("alice");
+
+    peers.apply_connection_failure(alice.clone(), t(1));
+
+    assert_eq!(
+        peers.apply_share_flags(&alice),
+        Some(PeerShareFlags { ever_connected: false, advertisable: false, failure_count: 1, adversarial: false })
+    );
+    assert!(!peers.apply_ok_for_sharing(&alice));
 }
 
 #[test]

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -109,7 +109,8 @@ const STATIC_PEER_BAN_PERIOD: Duration = Duration::from_secs(10);
 ///   (if any). A past `Instant` is delivered on the priority path as soon as the runtime
 ///   can run this stage again.
 ///
-/// - **Connected**:
+/// - **Connected** `(peer, conn, direction, advertisable)`:
+///   Records latest handshake advertisability on the Performance resource, then:
 ///   - `Inbound`: If `inbound_peers.len() >= target_downstream_peers`, logs
 ///     `"rejecting inbound connection: too many peers"`, sends `ManagerMessage::Disconnect`,
 ///     and returns early (no insert). Otherwise inserts (or replaces a prior
@@ -128,7 +129,7 @@ const STATIC_PEER_BAN_PERIOD: Duration = Duration::from_secs(10);
 ///     (Connecting-state peers with `!will_retry` reach the arm but the inner
 ///     `let PeerState::Connected` guard fails silently.)
 ///
-/// - **ConnectFailed**: Removes the peer from
+/// - **ConnectFailed**: Records a connection failure on Performance, removes the peer from
 ///   `outbound_peers` (any `PeerState`), then calls `regulate_peers`.
 ///
 /// - **LedgerCheckCandidates**:
@@ -253,7 +254,8 @@ pub enum PeerSelectionMsg {
     /// A peer has connected and the peer_selection stage can start tracking it.
     ///
     /// This may be a downstream peer or the successful result of a connection attempt.
-    Connected(Peer, Connection, ConnectionDirection),
+    /// `advertisable` is the remote handshake peer-sharing willingness (latest wins in Performance).
+    Connected(Peer, Connection, ConnectionDirection, bool),
     /// A peer has disconnected and the peer_selection stage can stop tracking it.
     Disconnected(Peer, ConnectionId, ConnectionDirection, bool),
     /// A (re)connection attempt has failed, the Manager has removed this peer.
@@ -303,7 +305,7 @@ impl PeerSelection {
     async fn ban_peer(&mut self, peer: Peer, eff: &Effects<PeerSelectionMsg>) {
         let is_static = self.static_peers.contains(&peer);
 
-        eff.external(Performance::forget_peer(peer.clone())).await;
+        eff.external(Performance::peer_adversarial(peer.clone())).await;
 
         let mut send_remove = false;
         if let Some(peer_state) = self.inbound_peers.remove(&peer) {
@@ -547,7 +549,9 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
                 tracing::info!(%peer, "not adding peer because already added");
             }
         }
-        PeerSelectionMsg::Connected(peer, connection, ConnectionDirection::Inbound) => {
+        PeerSelectionMsg::Connected(peer, connection, ConnectionDirection::Inbound, advertisable) => {
+            let now = eff.clock().await;
+            eff.external(Performance::record_advertisability(peer.clone(), advertisable, now)).await;
             if state.inbound_peers.len() >= state.target_downstream_peers {
                 tracing::info!(%peer, "rejecting inbound connection: too many peers");
                 eff.send(&state.manager, ManagerMessage::Disconnect(peer, connection.id)).await;
@@ -569,7 +573,9 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
                 eff.send(&state.manager, ManagerMessage::Disconnect(peer, conn.id)).await;
             }
         }
-        PeerSelectionMsg::Connected(peer, connection, ConnectionDirection::Outbound) => {
+        PeerSelectionMsg::Connected(peer, connection, ConnectionDirection::Outbound, advertisable) => {
+            let now = eff.clock().await;
+            eff.external(Performance::record_advertisability(peer.clone(), advertisable, now)).await;
             let span = debug_span!(
                 amaru::protocols::peer_selection::peer::CONNECTED,
                 peer = &peer,
@@ -625,6 +631,8 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
             }
         }
         PeerSelectionMsg::ConnectFailed(peer) => {
+            let now = eff.clock().await;
+            eff.external(Performance::record_connection_failure(peer.clone(), now)).await;
             state.outbound_peers.remove(&peer);
             state.clear_availability_if_gone(&peer, &eff).await;
             state.regulate_peers(&eff).await;

--- a/crates/amaru-consensus/src/stages/peer_selection/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/test_setup.rs
@@ -129,18 +129,39 @@ pub fn register_guards() -> DeserializerGuards {
         amaru_pure_stage::register_data_deserializer::<ScheduleId>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<GenerateRandomSeed>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::ClearPeerAvailabilityEffect>().boxed(),
-        amaru_pure_stage::register_effect_deserializer::<crate::performance::ForgetPeerEffect>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<crate::performance::PeerAdversarialEffect>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordAdvertisabilityEffect>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordConnectionFailureEffect>().boxed(),
     ]
 }
 
-pub fn te_forget_peer(at_stage: &str, peer: Peer) -> TraceEntry {
-    TraceEntry::suspend(Effect::external(at_stage, Box::new(crate::performance::Performance::forget_peer(peer))))
+/// Simulation clock at t0 (matches `run_simulation` initial clock of +10s).
+pub fn sim_t0() -> Instant {
+    Instant::at_offset(Duration::from_secs(SIM_INITIAL_CLOCK_SECS), start_in_era().relative_time)
+}
+
+pub fn te_peer_adversarial(at_stage: &str, peer: Peer) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(at_stage, Box::new(crate::performance::Performance::peer_adversarial(peer))))
 }
 
 pub fn te_clear_peer_availability(at_stage: &str, peer: Peer) -> TraceEntry {
     TraceEntry::suspend(Effect::external(
         at_stage,
         Box::new(crate::performance::Performance::clear_peer_availability(peer)),
+    ))
+}
+
+pub fn te_record_advertisability(at_stage: &str, peer: Peer, advertisable: bool, at: Instant) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(
+        at_stage,
+        Box::new(crate::performance::Performance::record_advertisability(peer, advertisable, at)),
+    ))
+}
+
+pub fn te_record_connection_failure(at_stage: &str, peer: Peer, at: Instant) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(
+        at_stage,
+        Box::new(crate::performance::Performance::record_connection_failure(peer, at)),
     ))
 }
 

--- a/crates/amaru-consensus/src/stages/peer_selection/tests.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/tests.rs
@@ -27,9 +27,9 @@ use crate::stages::{
     peer_selection::test_setup::{
         TestPrep, cooldown_duration, cooldown_instant, first_schedule_id, first_static_schedule_id,
         peer_selection_stage, second_schedule_id_at, setup, setup_preload, setup_preload_until_sleeping, sim_at,
-        static_cooldown_instant, te_cancel_schedule, te_clear_peer_availability, te_clock, te_clock_suspend,
-        te_forget_peer, te_random_seed, te_schedule, te_send, test_prep, test_prep_with_snapshot,
-        tm_add_stage_starts_with, with_single_cooldown,
+        sim_t0, static_cooldown_instant, te_cancel_schedule, te_clear_peer_availability, te_clock, te_clock_suspend,
+        te_peer_adversarial, te_random_seed, te_record_advertisability, te_record_connection_failure, te_schedule,
+        te_send, test_prep, test_prep_with_snapshot, tm_add_stage_starts_with, with_single_cooldown,
     },
     test_utils::{assert_trace, te_input, te_state, tm_state},
 };
@@ -250,7 +250,7 @@ fn test_add_peer_during_cooldown_cancels_timer() {
         &[
             te_state("ps-1", &state),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())),
-            te_forget_peer("ps-1", p.clone()),
+            te_peer_adversarial("ps-1", p.clone()),
             te_clock_suspend("ps-1"),
             te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid),
             te_state("ps-1", &after_ban),
@@ -286,7 +286,7 @@ fn test_adversarial_outbound_connected() {
         &[
             te_state("ps-1", &state),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())),
-            te_forget_peer("ps-1", p.clone()),
+            te_peer_adversarial("ps-1", p.clone()),
             te_clock_suspend("ps-1"),
             te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid),
             te_state("ps-1", &after),
@@ -350,7 +350,7 @@ fn test_check_cooldowns_before_due_does_not_lift_ban() {
         &[
             te_state("ps-1", &state),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())),
-            te_forget_peer("ps-1", p.clone()),
+            te_peer_adversarial("ps-1", p.clone()),
             te_clock_suspend("ps-1"),
             te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid0),
             te_state("ps-1", &after_ban),
@@ -381,35 +381,50 @@ fn test_connected_inbound_success() {
     let prep = test_prep(&[]);
     let p = TestPrep::peer("4.4.4.4:4");
     let state = prep.state.clone();
-    let msg = PeerSelectionMsg::Connected(p.clone(), conn(), ConnectionDirection::Inbound);
+    let msg = PeerSelectionMsg::Connected(p.clone(), conn(), ConnectionDirection::Inbound, true);
     let after = {
         let mut s = state.clone();
         s.inbound_peers.insert(p.clone(), conn());
         s
     };
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
-    assert_trace(&running, &[te_state("ps-1", &state), te_input("ps-1", &msg), te_state("ps-1", &after)]);
+    assert_trace(
+        &running,
+        &[
+            te_state("ps-1", &state),
+            te_input("ps-1", &msg),
+            te_clock_suspend("ps-1"),
+            te_record_advertisability("ps-1", p.clone(), true, sim_t0()),
+            te_state("ps-1", &after),
+        ],
+    );
     logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 
 #[test]
 fn test_connected_inbound_too_many() {
-    let prep = test_prep(&[]);
+    let mut prep = test_prep(&[]);
     let p = TestPrep::peer("3.3.3.3:3");
-    let state = prep.state.clone();
-    let mut state_full = state.clone();
     for i in 0..10u8 {
-        state_full.inbound_peers.insert(TestPrep::peer(&format!("1.1.1.{i}:1")), conn());
+        prep.state.inbound_peers.insert(TestPrep::peer(&format!("1.1.1.{i}:1")), conn());
     }
-    let msg = PeerSelectionMsg::Connected(p.clone(), conn(), ConnectionDirection::Inbound);
-    let (running, _guards, mut logs) = setup_preload(&prep, [msg.clone()]);
-    let after = {
-        let mut s = state.clone();
-        s.inbound_peers.insert(p.clone(), conn());
-        s
-    };
-    assert_trace(&running, &[te_state("ps-1", &state), te_input("ps-1", &msg), te_state("ps-1", &after)]);
-    logs.assert_no_remaining_at([Level::WARN, Level::ERROR]);
+    let state = prep.state.clone();
+    let msg = PeerSelectionMsg::Connected(p.clone(), conn(), ConnectionDirection::Inbound, false);
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    // At capacity: still records advertisability, then disconnects without inserting.
+    assert_trace(
+        &running,
+        &[
+            te_state("ps-1", &state),
+            te_input("ps-1", &msg),
+            te_clock_suspend("ps-1"),
+            te_record_advertisability("ps-1", p.clone(), false, sim_t0()),
+            te_send("ps-1", "manager", ManagerMessage::Disconnect(p.clone(), ConnectionId::initial())),
+            te_state("ps-1", &state),
+        ],
+    );
+    logs.assert_and_remove(Level::INFO, &["rejecting inbound connection: too many peers"])
+        .assert_no_remaining_at([Level::WARN, Level::ERROR]);
 }
 
 #[test]
@@ -417,14 +432,52 @@ fn test_connected_outbound() {
     let prep = test_prep(&[]);
     let p = TestPrep::peer("2.2.2.2:2");
     let state = prep.state.clone();
-    let msg = PeerSelectionMsg::Connected(p.clone(), conn(), ConnectionDirection::Outbound);
+    let msg = PeerSelectionMsg::Connected(p.clone(), conn(), ConnectionDirection::Outbound, true);
     let after = {
         let mut s = state.clone();
         s.outbound_peers.insert(p.clone(), PeerState::Connected(conn()));
         s
     };
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
-    assert_trace(&running, &[te_state("ps-1", &state), te_input("ps-1", &msg), te_state("ps-1", &after)]);
+    assert_trace(
+        &running,
+        &[
+            te_state("ps-1", &state),
+            te_input("ps-1", &msg),
+            te_clock_suspend("ps-1"),
+            te_record_advertisability("ps-1", p.clone(), true, sim_t0()),
+            te_state("ps-1", &after),
+        ],
+    );
+    logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_connect_failed_records_failure() {
+    let mut prep = test_prep(&[]);
+    let p = TestPrep::peer("5.5.5.5:5");
+    prep.state.outbound_peers.insert(p.clone(), PeerState::Connecting);
+    let state = prep.state.clone();
+    // Empty static/snapshot: regulate finds no replacements after remove.
+    let after = {
+        let mut s = state.clone();
+        s.outbound_peers.remove(&p);
+        s
+    };
+    let msg = PeerSelectionMsg::ConnectFailed(p.clone());
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    assert_trace(
+        &running,
+        &[
+            te_state("ps-1", &state),
+            te_input("ps-1", &msg),
+            te_clock_suspend("ps-1"),
+            te_record_connection_failure("ps-1", p.clone(), sim_t0()),
+            te_clear_peer_availability("ps-1", p.clone()),
+            te_random_seed("ps-1"),
+            te_state("ps-1", &after),
+        ],
+    );
     logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 
@@ -504,12 +557,12 @@ fn test_adversarial_twice_extends_cooldown_single_timer() {
         &[
             te_state("ps-1", &state),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())),
-            te_forget_peer("ps-1", p.clone()),
+            te_peer_adversarial("ps-1", p.clone()),
             te_clock_suspend("ps-1"),
             te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid0),
             te_state("ps-1", &after_first),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())),
-            te_forget_peer("ps-1", p.clone()),
+            te_peer_adversarial("ps-1", p.clone()),
             te_clock_suspend("ps-1"),
             te_state("ps-1", &after_second),
             te_clock(cooldown_instant()),
@@ -860,12 +913,12 @@ fn test_second_cooldown_does_not_schedule_again() {
         &[
             te_state("ps-1", &prep.state),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p1.clone())),
-            te_forget_peer("ps-1", p1.clone()),
+            te_peer_adversarial("ps-1", p1.clone()),
             te_clock_suspend("ps-1"),
             te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid),
             te_state("ps-1", &after_first),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p2.clone())),
-            te_forget_peer("ps-1", p2.clone()),
+            te_peer_adversarial("ps-1", p2.clone()),
             te_clock_suspend("ps-1"),
             te_state("ps-1", &after_second),
             te_clock(cooldown_instant()),

--- a/crates/amaru-node/src/stages/build_stage_graph.rs
+++ b/crates/amaru-node/src/stages/build_stage_graph.rs
@@ -76,13 +76,19 @@ pub fn build_stage_graph(
 
     let peer_selection_notify =
         stage_graph.contramap(&peer_selection_ref, "peer_selection_notify", |n: PeerSelectionNotify| match n {
-            PeerSelectionNotify::Connected { peer, conn_id, direction, full_duplex_capable, full_duplex } => {
-                PeerSelectionMsg::Connected(
-                    peer,
-                    peer_selection::Connection::new(conn_id, full_duplex_capable, full_duplex),
-                    direction,
-                )
-            }
+            PeerSelectionNotify::Connected {
+                peer,
+                conn_id,
+                direction,
+                full_duplex_capable,
+                full_duplex,
+                advertisable,
+            } => PeerSelectionMsg::Connected(
+                peer,
+                peer_selection::Connection::new(conn_id, full_duplex_capable, full_duplex),
+                direction,
+                advertisable,
+            ),
             PeerSelectionNotify::Disconnected { peer, conn_id, direction, will_retry } => {
                 PeerSelectionMsg::Disconnected(peer, conn_id, direction, will_retry)
             }

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -315,6 +315,7 @@ async fn do_handshake(
     let full_duplex_capable = version_data.is_full_duplex_capable();
     // TODO: this needs to change once we actually start supporting full duplex mode
     let full_duplex = false;
+    let advertisable = version_data.is_advertisable();
 
     eff.send(
         manager,
@@ -325,6 +326,7 @@ async fn do_handshake(
             role: *role,
             full_duplex_capable,
             full_duplex,
+            advertisable,
         },
     )
     .await;

--- a/crates/amaru-protocols/src/manager/mod.rs
+++ b/crates/amaru-protocols/src/manager/mod.rs
@@ -46,6 +46,7 @@ pub enum PeerSelectionNotify {
         direction: ConnectionDirection,
         full_duplex_capable: bool,
         full_duplex: bool,
+        advertisable: bool,
     },
 
     /// A connection has been terminated (graceful disconnect, error, handshake refusal,
@@ -98,6 +99,7 @@ pub enum ManagerMessage {
         role: Role,
         full_duplex_capable: bool,
         full_duplex: bool,
+        advertisable: bool,
     },
 }
 
@@ -422,13 +424,14 @@ impl Manager {
         role: Role,
         full_duplex_capable: bool,
         full_duplex: bool,
+        advertisable: bool,
         eff: &Effects<ManagerMessage>,
     ) {
         let direction = match role {
             Role::Initiator => ConnectionDirection::Outbound,
             Role::Responder => ConnectionDirection::Inbound,
         };
-        tracing::info!(%peer, %conn_id, full_duplex_capable, full_duplex, "handshake completed");
+        tracing::info!(%peer, %conn_id, full_duplex_capable, full_duplex, advertisable, "handshake completed");
         let peer_state = self.peers.entry(peer.clone()).or_default();
         let accept_this = match direction {
             ConnectionDirection::Outbound => {
@@ -457,6 +460,7 @@ impl Manager {
                     direction,
                     full_duplex_capable,
                     full_duplex,
+                    advertisable,
                 },
             )
             .await;
@@ -656,8 +660,27 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
                 );
                 manager.connection_died(peer, conn_id, role, &eff).instrument(span).await;
             }
-            ManagerMessage::HandshakeComplete { peer, stage, conn_id, role, full_duplex_capable, full_duplex } => {
-                manager.handshake_complete(peer, stage, conn_id, role, full_duplex_capable, full_duplex, &eff).await;
+            ManagerMessage::HandshakeComplete {
+                peer,
+                stage,
+                conn_id,
+                role,
+                full_duplex_capable,
+                full_duplex,
+                advertisable,
+            } => {
+                manager
+                    .handshake_complete(
+                        peer,
+                        stage,
+                        conn_id,
+                        role,
+                        full_duplex_capable,
+                        full_duplex,
+                        advertisable,
+                        &eff,
+                    )
+                    .await;
             }
             ManagerMessage::Listen(listen_addr) => {
                 manager.listen(listen_addr, &eff).await;

--- a/crates/amaru-protocols/src/protocol_messages/version_data.rs
+++ b/crates/amaru-protocols/src/protocol_messages/version_data.rs
@@ -45,6 +45,11 @@ impl VersionData {
     pub fn is_full_duplex_capable(&self) -> bool {
         !self.initiator_only_diffusion_mode
     }
+
+    /// Whether the remote peer is willing to be advertised via peer sharing (`peer_sharing == 1`).
+    pub fn is_advertisable(&self) -> bool {
+        self.peer_sharing == PEER_SHARING_ENABLED
+    }
 }
 
 impl Display for VersionData {

--- a/engineering-decision-records/030-consensus-performance-resource.md
+++ b/engineering-decision-records/030-consensus-performance-resource.md
@@ -47,11 +47,15 @@ Splitting queues or stages would force dual instrumentation for the same domain 
 
 | Component | Role |
 | --- | --- |
-| `PeerPerformance` | Per-peer **claims** (intersection / header / block delivery on the parent chain) and **scores** (EWMAs of header lag, block response time, bandwidth; counters for fetch success/timeout; keepalive RTT). |
+| `PeerPerformance` | Per-peer **claims** (intersection / header / block delivery on the parent chain), **scores** (EWMAs of header lag, block response time, bandwidth; counters for fetch success/timeout; keepalive RTT), and **share-relevant reputation** (`ever_connected`, latest handshake advertisability, connection failure count, sticky adversarial flag). |
 | `HeaderPerformance` | Open **header lifecycles** (received / requested / downloaded) until a terminal outcome; optional in-progress **fork switch**. |
 
 Unit tests exercise these types directly without spawning the worker.
 Integration and stage tests install `ResourcePerformance` and assert effect traces.
+
+Performance is **cross-stage memory** for observations that many stages produce and few consumers need (fetch ranking, churn, peer-sharing filters).
+It does **not** own peer origin (static / snapshot / ledger), cool-downs, or listen-address policy — those remain in peer selection.
+Successful connection is tracked by an explicit sticky `ever_connected` flag set on handshake; map presence alone is not sufficient (connection failures also upsert a reputation stub).
 
 ### Event-oriented API
 
@@ -59,9 +63,9 @@ Stages emit domain events, not low-level map mutations, currently:
 
 - **Peer / chain tips:** `record_intersection`, `record_header_announcement`, `record_rollback`, `record_block_delivery`, `record_fetch_failure`
 - **Header lifecycle / forks:** `record_blocks_requested`, `record_block_valid`, `record_block_pruned`, `record_header_abandoned`, `record_header_rejected`, `record_fork_started`
-- **Peer lifecycle:** `clear_peer_availability` (disconnect / no remaining live connection; scores kept), `forget_peer` (ban; scores and claims removed)
+- **Peer lifecycle:** `record_advertisability` (successful handshake: sets `ever_connected`, records peer-sharing willingness; overwrites advertisability), `record_connection_failure` (increments failure count; does not set `ever_connected`), `clear_peer_availability` (disconnect / no remaining live connection; scores and reputation kept, claims cleared), `peer_adversarial` (adversarial ban: claims and scores cleared, entry retained with `adversarial = true` and prior `ever_connected` / `failure_count` / last `advertisable`; not a generic erase)
 - **Horizon:** `prune_below(min_height, now)`
-- **Queries:** `select_peers_for_fetch`, `peer_covers_fragment`, `direct_claimants`, `rank_peers_for_churn`, `scores`, `snapshot`
+- **Queries:** `select_peers_for_fetch`, `peer_covers_fragment`, `direct_claimants`, `rank_peers_for_churn`, `scores`, `share_flags`, `snapshot` (includes share flags), `ok_for_sharing`
 
 Timestamps use pure-stage `Instant` so simulation remains deterministic ([EDR-014][edr-time] for wall-clock vs monotonic concerns at the node boundary).
 
@@ -81,14 +85,31 @@ Header lifecycles must always reach a terminal outcome so the map won't grow wit
 | `Pruned` | Header height falls below the immutable horizon |
 
 The immutable horizon is `tip.height − k` after anchor drag in `adopt_chain` (`drag_anchor_forward`).
-Peer maps are also cleaned on connection end (`clear_peer_availability` when no live connection remains) and on adversarial ban (`forget_peer`).
+Peer **claims** are cleared on connection end (`clear_peer_availability` when no live connection remains).
+Adversarial ban uses `peer_adversarial`, which clears claims and scores but **retains a reputation stub** (`adversarial`, `failure_count`, last `advertisable`) so peer-sharing and reconnection policy can still see the ban. A future plain-forget (drop memory without implying adversarial behaviour) would be a separate operation.
+
+### Peer-sharing reputation (Performance half)
+
+Peer-sharing reply filters need observations that span handshake, connection attempts, and bans.
+Performance stores only the reputation half; peer selection applies origin and address rules.
+
+| Flag / rule | Owner | Notes |
+| --- | --- | --- |
+| `ever_connected` | Performance | Sticky; set on successful handshake only (not by connection-failure upserts); sharing requires true |
+| `advertisable` | Performance | Latest handshake wins (`VersionData.peer_sharing == 1`) |
+| `failure_count` | Performance | Incremented on outbound connect exhaustion (`ConnectFailed`); sharing requires zero |
+| `adversarial` | Performance | Set sticky by `peer_adversarial`; sharing requires false |
+| Not ledger / not snapshot (big-ledger) | Peer selection | Origin pools live there; snapshot peers are excluded from sharing |
+| Known listen address (not pure inbound) | Peer selection | Inbound remote port is not a listen advertisement; optional outbound probe (~3000) may promote a peer later |
+
+`ok_for_sharing` / `share_flags` expose the Performance half so peer selection can compose the full filter without duplicating counters.
 
 ### Relation to tracing and metrics
 
 [EDR-026][edr-tracing] spans (`perf.header.forward`, `perf.blocks.fetch`, `perf.fork.switch`, …) remain the span-based story for distributed traces and operator debugging.
 The performance resource complements that with:
 
-- **decision state** (who can serve what; ranked peer sets);
+- **decision state** (who can serve what; ranked peer sets; share-relevant reputation);
 - **closed lifecycle telemetry** (`perf.header.lifecycle` intervals, fork-switch outcomes): the worker produces pure payloads when a lifecycle terminates; the external-effect handler emits tracing events and optional metrics ([EDR-015][edr-metrics]) on the stage effect executor.
 
 OpenTelemetry export may drop or lag under resource or connectivity pressure. That must not stall the performance worker or couple export failure modes to peer/header state. Therefore **no OTel/metric emission runs on the performance thread**.
@@ -104,6 +125,7 @@ Probe points should stay aligned: the same stage moments that open/close [EDR-02
 - Dropping the last `Performance` handle joins the worker after the channel closes; teardown should avoid doing that join on a multi-thread Tokio worker under a deep queue.
 - Ranking and churn algorithms can evolve inside `PeerPerformance` without reshaping the stage graph, as long as the event/query API remains stable.
 - Until keepalive RTT and churn ranking are wired (below), peer quality is incomplete relative to the network-spec intent described in [EDR-024][edr-peer-handling] (latency + bandwidth-based selection).
+- Peer-sharing reply construction composes Performance reputation (`ok_for_sharing`) with peer-selection origin and listen-address policy; Performance alone is not a complete share filter.
 
 ## Future work
 
@@ -111,6 +133,8 @@ Probe points should stay aligned: the same stage moments that open/close [EDR-02
 2. **Churn** — peer selection should demote/promote using `rank_peers_for_churn` (or successor) on a schedule, not only react to adversarial bans.
 3. **Scoring policy** — replace provisional EWMA heuristics with an explicit, testable policy (document knobs; avoid silent retunes).
 4. **Horizon / dual-connection edge cases** — keep pruning and clear/forget rules aligned with multi-connection peers (inbound+outbound) so availability is cleared only when no usable connection remains.
+5. **Failure-count decay** — optionally reset `failure_count` after a connection remains healthy for a policy window (network-spec style), if sharing should rehabilitate peers without a full forget cycle.
+6. **Peer-sharing consumer** — peer selection / peer-sharing responder composes Performance `ok_for_sharing` with origin (exclude ledger and big-ledger snapshot) and listen-address rules; sticky sampling lives there, not in this resource.
 
 ## Discussion points
 


### PR DESCRIPTION
fixes #1167

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added peer-sharing status tracking, including advertisability, connection failures, successful connections, and adversarial status.
  - Added checks to determine whether a peer is eligible for sharing.
  - Peer handshake notifications now include whether the negotiated protocol supports advertisability.
- **Bug Fixes**
  - Peer reputation is retained when availability is cleared or a peer is disconnected.
  - Connection failures are recorded before peer cleanup.
- **Documentation**
  - Updated the consensus performance decision record with peer-sharing lifecycle behavior and policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->