### PR TITLE
fix: use local amaru with gliveview

### DIFF
--- a/.github/scripts/test-gliveview
+++ b/.github/scripts/test-gliveview
@@ -4,6 +4,7 @@ set -euo pipefail
 
 test_timeout=${TOOL_TEST_TIMEOUT:-300}
 gliveview_home=${GLIVEVIEW_HOME:-/opt/cardano/amaru}
+amaru_binary=${AMARU_BIN:-$PWD/target/release/amaru}
 screen_output=$(mktemp)
 gliveview_pid=
 trap '
@@ -20,7 +21,7 @@ render_screen_output() {
 }
 
 cp amaru.pid "$gliveview_home/runtime/amaru.pid"
-timeout "$test_timeout" script --quiet --flush \
+AMARU_BIN="$amaru_binary" timeout "$test_timeout" script --quiet --flush \
   --command "stty rows 60 cols 120 && TERM=xterm $gliveview_home/scripts/gLiveView.sh -u" \
   "$screen_output" >/dev/null 2>&1 &
 gliveview_pid=$!
@@ -34,6 +35,11 @@ while (( SECONDS < deadline )); do
   if [[ "$slot" =~ ^[0-9]+$ ]] && (( slot > 0 )); then
     echo "GLiveView displayed a non-zero slot: $slot"
     exit 0
+  fi
+  if render_screen_output | grep -Fq "Node version mismatch"; then
+    echo "GLiveView found a different binary than the running Amaru process."
+    render_screen_output | tail -50
+    exit 1
   fi
   if ! kill -0 "$gliveview_pid" 2>/dev/null; then
     wait "$gliveview_pid" || true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test tooling reliability by supporting an alternate executable selection.
  * Added clearer reporting when the detected runtime version does not match the expected version.
  * Tests can now continue polling after reporting version differences, making compatibility issues easier to identify without interrupting diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->