### PR TITLE
Fix Haskell Conformance Test Runner

### DIFF
--- a/crates/amaru/tests/conformance/validation-rules/.flox/env/manifest.toml
+++ b/crates/amaru/tests/conformance/validation-rules/.flox/env/manifest.toml
@@ -1,8 +1,8 @@
 schema-version = "1.12.0"
 
 [install]
-# Haskell toolchain. cardano-node 10.5.x (which the cabal.project pins)
-# tested against GHC 9.6.x
+# Haskell toolchain. cardano-node 11.0.1 (which the cabal.project pins)
+# is tested against GHC 9.8.x
 cabal-install.pkg-path = "cabal-install"
 
 # Build tools the Makefile relies on.

--- a/crates/amaru/tests/conformance/validation-rules/Makefile
+++ b/crates/amaru/tests/conformance/validation-rules/Makefile
@@ -49,6 +49,16 @@ prerequisites: ## &cmd check required tools, libraries, and local build configur
 			failed=1; \
 		fi; \
 	}; \
+	check_optional_cmd() { \
+		label="$$1"; \
+		cmd="$$2"; \
+		note="$$3"; \
+		if command -v "$$cmd" >/dev/null 2>&1; then \
+			printf '\033[1;32m%s\033[00m %s\n' '  ✓' "$$label"; \
+		else \
+			printf '\033[1;33m%s %s\033[00m \033[2m(%s)\033[00m\n' '  ~' "$$label" "$$note"; \
+		fi; \
+	}; \
 	check_pkg() { \
 		label="$$1"; \
 		hint="$$2"; \
@@ -65,6 +75,18 @@ prerequisites: ## &cmd check required tools, libraries, and local build configur
 			printf '\033[1;32m%s\033[00m %s\n' '  ✓' "$$label"; \
 		else \
 			printf '\033[1;31m%s %s\033[00m → \033[1;37m%s %s\033[00m\n' '  ✗' "$$label" "$$install_cmd" "$$hint"; \
+			failed=1; \
+		fi; \
+	}; \
+	check_vendored_pkg() { \
+		label="$$1"; \
+		target="$$2"; \
+		pkg_name="$$3"; \
+		if pkg-config --exists "$$pkg_name"; then \
+			printf '\033[1;32m%s\033[00m %s\n' '  ✓' "$$label"; \
+		else \
+			printf '\033[1;31m%s %s\033[00m → \033[1;37m%s\033[00m\n' '  ✗' "$$label" "sudo make $$target PREFIX=$(PREFIX)"; \
+			printf '\033[2m%s\033[00m\n' "      installed: $$(pkg-config --modversion "$${pkg_name%% *}" 2>/dev/null || echo 'none')"; \
 			failed=1; \
 		fi; \
 	}; \
@@ -95,14 +117,15 @@ prerequisites: ## &cmd check required tools, libraries, and local build configur
 		check_pkg 'libsodium' libsodium libsodium; \
 		check_pkg 'zlib' zlib zlib; \
 		check_pkg 'openssl' openssl openssl; \
-		check_pkg 'secp256k1' libsecp256k1 libsecp256k1; \
-		check_pkg 'blst' libblst libblst; \
+		check_vendored_pkg 'secp256k1' secp256k1 libsecp256k1; \
+		check_vendored_pkg 'blst >= $(BLST_VERSION:v%=%)' blst 'libblst >= $(BLST_VERSION:v%=%)'; \
 	fi; \
-	check_cmd 'llvm-config' llvm-config llvm; \
+	check_optional_cmd 'llvm-config' llvm-config 'only needed to build with -fllvm'; \
 	if [ "$$os_name" = 'Linux' ]; then \
 		check_path 'libnuma headers' '/usr/include/numa.h' 'sudo apt-get install libnuma-dev'; \
 		check_path 'libsystemd headers' '/usr/include/systemd/sd-daemon.h' 'sudo apt-get install libsystemd-dev'; \
 	fi; \
+	exit "$$failed"
 
 build: ## &cmd compile the main binary
 	$(CABAL) update

--- a/crates/amaru/tests/conformance/validation-rules/README.md
+++ b/crates/amaru/tests/conformance/validation-rules/README.md
@@ -2,7 +2,7 @@
 
 This tool validates phase-one conformance fixtures against the Haskell ledger implementation, so that Amaru's ledger rules can be compared against the reference node.
 
-The fixtures live in [amaru-ledger/tests/data/phase-one](../../../../amaru-ledger/tests/data/phase-one), split into `pass` and `fail` cases.
+The fixtures live in [amaru-ledger/tests/data/phase-one](../../../../amaru-ledger/tests/data/phase-one). Each one under `scenarios` declares its own outcome through its `expected` field.
 
 ## Prerequisites
 
@@ -44,7 +44,7 @@ To validate a single phase-one fixture:
 
 ```console
 cabal run -v0 exe:conformance -- validate-phase-one \
-  --test-case ../../../../amaru-ledger/tests/data/phase-one/fail/00050-unknown-spent-input.json
+  --test-case ../../../../amaru-ledger/tests/data/phase-one/scenarios/00050-fail-unknown-spent-input.json
 ```
 
 The command prints the test case label and either the expected outcome (`PASS` or the expected predicate failure), or a validation mismatch error.

--- a/crates/amaru/tests/conformance/validation-rules/all-conformance-tests.sh
+++ b/crates/amaru/tests/conformance/validation-rules/all-conformance-tests.sh
@@ -18,6 +18,11 @@ run_suite() {
   local dir="$1" title="$2" summary_file rc
   banner "$title"
 
+  if [ ! -d "$PHASE_ONE_ROOT/$dir" ]; then
+    printf '\033[31mNo such fixture directory: %s\033[0m\n' "$PHASE_ONE_ROOT/$dir" >&2
+    return 1
+  fi
+
   summary_file="$(mktemp)"
 
   cabal run -v0 exe:conformance -- validate-phase-one --test-directory "$PHASE_ONE_ROOT/$dir" 2>"$summary_file" |
@@ -55,6 +60,5 @@ fi
 rm -f "$build_log"
 
 overall=0
-run_suite pass "Tests that should PASS (valid transactions)" || overall=1
-run_suite fail "Tests that should FAIL (invalid transactions)" || overall=1
+run_suite scenarios "Phase-one validation rules" || overall=1
 exit "$overall"

--- a/crates/amaru/tests/conformance/validation-rules/src/Command/ValidatePhaseOne/Error.hs
+++ b/crates/amaru/tests/conformance/validation-rules/src/Command/ValidatePhaseOne/Error.hs
@@ -13,7 +13,7 @@ data Error
   | FixtureDecodeError !FilePath !Text
   | FixtureReferenceError !Text
   | UnsupportedFixture !Text
-  | ValidationMismatch !Text !Text
+  | ValidationMismatch !Text !Text -- The outcome the fixture declares, then the outcome the Haskell ledger produced.
   deriving (Eq, Show)
 
 renderError :: Error -> Text

--- a/crates/amaru/tests/conformance/validation-rules/src/Command/ValidatePhaseOne/Run.hs
+++ b/crates/amaru/tests/conformance/validation-rules/src/Command/ValidatePhaseOne/Run.hs
@@ -30,6 +30,7 @@ import Cardano.Ledger.Conway.Rules
     , ConwayCertsPredFailure (..)
     , ConwayDelegPredFailure (..)
     , ConwayGovCertPredFailure (..)
+    , ConwayGovPredFailure (..)
     , ConwayLedgerPredFailure (..)
     , ConwayUtxoPredFailure (..)
     , ConwayUtxowPredFailure (..)
@@ -51,6 +52,9 @@ import Cardano.Ledger.Shelley.LedgerState
     , LedgerState (..)
     , NewEpochState (..)
     , UTxOState (utxosUtxo)
+    )
+import Cardano.Ledger.Shelley.Rules
+    ( ShelleyPoolPredFailure (..)
     )
 import Cardano.Ledger.Shelley.StabilityWindow
     ( computeRandomnessStabilisationWindow
@@ -217,7 +221,7 @@ validateTestCase TestCase{network, eraHistory, protocolParameters, initialState,
         (ExpectedDecodingFailure, Left _) ->
             Right "DecodingFailure"
         (ExpectedDecodingFailure, Right _) ->
-            Left (ValidationMismatch "decoded successfully" "DecodingFailure")
+            Left (ValidationMismatch "DecodingFailure" "decoded successfully")
         (_, Left decodeError) ->
             Left decodeError
         (_, Right decodedTransaction) ->
@@ -260,16 +264,16 @@ validateDecodedTransaction network eraHistory protocolParameters initialState po
         (ExpectedPass, []) ->
             Right "PASS"
         (ExpectedPass, predicates) ->
-            Left (ValidationMismatch (renderActualPredicates predicates) "PASS")
+            Left (ValidationMismatch "PASS" (renderActualPredicates predicates))
         (ExpectedFailure predicateName, predicates)
             | predicateName `elem` predicates ->
                 Right predicateName
             | null predicates ->
-                Left (ValidationMismatch "Pass" predicateName)
+                Left (ValidationMismatch predicateName "PASS")
             | otherwise ->
-                Left (ValidationMismatch (renderActualPredicates predicates) predicateName)
+                Left (ValidationMismatch predicateName (renderActualPredicates predicates))
         (ExpectedDecodingFailure, _) ->
-            Left (ValidationMismatch "decoded successfully" "DecodingFailure")
+            Left (ValidationMismatch "DecodingFailure" "decoded successfully")
 
 manualRefScriptSizeFailure
     :: ProtocolParameters
@@ -330,16 +334,33 @@ renderActualPredicates :: [Text] -> Text
 renderActualPredicates predicates =
     "[" <> Text.intercalate ", " predicates <> "]"
 
+normalizeApplyTxError :: Bool -> Maybe Text -> ApplyTxError ConwayEra -> [Text]
+normalizeApplyTxError emptyInputs expectedHint (ConwayApplyTxError failures) =
+    map (normalizeLedgerFailure emptyInputs expectedHint) (filter isBlockValidationFailure (NonEmpty.toList failures))
+
+-- Amaru's phase-one rules validate a transaction as part of a block, so failures 'applyTx' raises
+-- that block application would not are dropped.
+isBlockValidationFailure :: ConwayLedgerPredFailure ConwayEra -> Bool
+isBlockValidationFailure failure =
+    not (isScriptExecutionFailure failure) && not (isMempoolOnlyFailure failure)
+
 -- Phase-one conformance validates structure only, not Plutus script *execution*. 'applyTx' runs
 -- both phases, so we drop the phase-two script-result failure ('ValidationTagMismatch'). Context
 -- collection failures such as 'OutsideForecast' happen before execution and are kept.
-normalizeApplyTxError :: Bool -> Maybe Text -> ApplyTxError ConwayEra -> [Text]
-normalizeApplyTxError emptyInputs expectedHint (ConwayApplyTxError failures) =
-    map (normalizeLedgerFailure emptyInputs expectedHint) (filter (not . isScriptExecutionFailure) (NonEmpty.toList failures))
-
 isScriptExecutionFailure :: ConwayLedgerPredFailure ConwayEra -> Bool
 isScriptExecutionFailure failure =
     "ValidationTagMismatch" `Text.isInfixOf` showText failure
+
+-- 'applyTx' additionally runs the MEMPOOL rule, which only gates mempool admission. Below
+-- protocol version 11 it stands in for the GOV rule's 'UnelectedCommitteeVoters' predicate, so a
+-- vote by an unelected committee member is refused from the mempool while a block carrying it is
+-- still accepted. From protocol version 11 the GOV predicate takes over and is reported normally.
+isMempoolOnlyFailure :: ConwayLedgerPredFailure ConwayEra -> Bool
+isMempoolOnlyFailure = \case
+    ConwayMempoolFailure message ->
+        "Unelected committee members are not allowed to cast votes" `Text.isPrefixOf` message
+    _ ->
+        False
 
 normalizeLedgerFailure :: Bool -> Maybe Text -> ConwayLedgerPredFailure ConwayEra -> Text
 normalizeLedgerFailure emptyInputs expectedHint = \case
@@ -347,8 +368,14 @@ normalizeLedgerFailure emptyInputs expectedHint = \case
         normalizeUtxowFailure expectedHint failure
     ConwayCertsFailure failure ->
         normalizeCertsFailure expectedHint failure
+    ConwayGovFailure failure ->
+        normalizeGovFailure failure
     ConwayTxRefScriptsSizeTooBig{} ->
         "ConwayTxRefScriptsSizeTooBig"
+    ConwayWdrlNotDelegatedToDRep{} ->
+        "ConwayWdrlNotDelegatedToDRep"
+    ConwayTreasuryValueMismatch{} ->
+        "ConwayTreasuryValueMismatch"
     ConwayMempoolFailure message
         | "All inputs are spent." `Text.isPrefixOf` message ->
             if emptyInputs then "InputSetEmptyUTxO" else "BadInputsUTxO"
@@ -369,6 +396,8 @@ normalizeUtxowFailure expectedHint = \case
         "MissingTxMetadata"
     ConflictingMetadataHash{} ->
         "ConflictingMetadataHash"
+    MalformedReferenceScripts{} ->
+        "MalformedReferenceScripts"
     otherFailure ->
         "unsupported:" <> showText expectedHint <> ":" <> showText otherFailure
 
@@ -394,6 +423,12 @@ normalizeUtxoFailure = \case
         "OutputTooBigUTxO"
     InsufficientCollateral{} ->
         "InsufficientCollateral"
+    IncorrectTotalCollateralField{} ->
+        "IncorrectTotalCollateralField"
+    TooManyCollateralInputs{} ->
+        "TooManyCollateralInputs"
+    ScriptsNotPaidUTxO{} ->
+        "ScriptsNotPaidUTxO"
     WrongNetworkInTxBody{} ->
         "WrongNetworkInTxBody"
     OutsideForecast{} ->
@@ -414,8 +449,8 @@ normalizeCertsFailure :: Maybe Text -> ConwayCertsPredFailure ConwayEra -> Text
 normalizeCertsFailure expectedHint = \case
     CertFailure failure ->
         normalizeCertFailure expectedHint failure
-    otherFailure ->
-        "unsupported:" <> showText otherFailure
+    WithdrawalsNotInRewardsCERTS{} ->
+        "WithdrawalsNotInRewardsCERTS"
 
 normalizeCertFailure :: Maybe Text -> ConwayCertPredFailure ConwayEra -> Text
 normalizeCertFailure expectedHint = \case
@@ -423,8 +458,8 @@ normalizeCertFailure expectedHint = \case
         normalizeDelegFailure expectedHint failure
     GovCertFailure failure ->
         normalizeGovCertFailure failure
-    otherFailure ->
-        "unsupported:" <> showText otherFailure
+    PoolFailure failure ->
+        normalizePoolFailure failure
 
 normalizeDelegFailure :: Maybe Text -> ConwayDelegPredFailure ConwayEra -> Text
 normalizeDelegFailure expectedHint = \case
@@ -447,5 +482,31 @@ normalizeGovCertFailure :: ConwayGovCertPredFailure ConwayEra -> Text
 normalizeGovCertFailure = \case
     ConwayDRepAlreadyRegistered{} ->
         "DRepAlreadyRegistered"
+    otherFailure ->
+        "unsupported:" <> showText otherFailure
+
+normalizePoolFailure :: ShelleyPoolPredFailure ConwayEra -> Text
+normalizePoolFailure = \case
+    StakePoolNotRegisteredOnKeyPOOL{} ->
+        "StakePoolNotRegisteredOnKeyPOOL"
+    StakePoolRetirementWrongEpochPOOL{} ->
+        "StakePoolRetirementWrongEpochPOOL"
+    StakePoolCostTooLowPOOL{} ->
+        "StakePoolCostTooLowPOOL"
+    otherFailure ->
+        "unsupported:" <> showText otherFailure
+
+normalizeGovFailure :: ConwayGovPredFailure ConwayEra -> Text
+normalizeGovFailure = \case
+    ProposalReturnAccountDoesNotExist{} ->
+        "ProposalReturnAccountDoesNotExist"
+    TreasuryWithdrawalReturnAccountsDoNotExist{} ->
+        "TreasuryWithdrawalReturnAccountsDoNotExist"
+    InvalidPrevGovActionId{} ->
+        "InvalidPrevGovActionId"
+    ZeroTreasuryWithdrawals{} ->
+        "TreasuryWithdrawalsAllZeros"
+    VotersDoNotExist{} ->
+        "VotersDoNotExist"
     otherFailure ->
         "unsupported:" <> showText otherFailure

--- a/crates/amaru/tests/conformance/validation-rules/src/Data/Fixture/InitialState.hs
+++ b/crates/amaru/tests/conformance/validation-rules/src/Data/Fixture/InitialState.hs
@@ -8,6 +8,8 @@ module Data.Fixture.InitialState
     , GovernanceActivity (..)
     , InitialState (..)
     , PoolDelegation (..)
+    , Pots (..)
+    , ProposalEntry (..)
     , RegisteredDRep (..)
     , VoteDelegation (..)
     , buildNewEpochState
@@ -16,13 +18,17 @@ module Data.Fixture.InitialState
 import Relude
 
 import Cardano.Ledger.Api.Governance
-    ( curPParamsGovStateL
+    ( cgsProposalsL
+    , curPParamsGovStateL
     , emptyGovState
     , prevPParamsGovStateL
     )
 import Cardano.Ledger.Api.PParams
     ( PParams
     , ppPoolDepositL
+    )
+import Cardano.Ledger.BaseTypes
+    ( addEpochInterval
     )
 import Cardano.Ledger.Coin
     ( Coin (..)
@@ -33,6 +39,24 @@ import Cardano.Ledger.Compactible
     )
 import Cardano.Ledger.Conway
     ( ConwayEra
+    )
+import Cardano.Ledger.Conway.Governance
+    ( GovAction
+    , GovActionId (GovActionId)
+    , GovActionIx (GovActionIx)
+    , GovActionState (..)
+    , GovPurposeId (GovPurposeId)
+    , GovRelation (..)
+    , ProposalProcedure (..)
+    , Proposals
+    , fromPrevGovActionIds
+    , gasDeposit
+    , pRootsL
+    , proposalsAddAction
+    )
+import Cardano.Ledger.Conway.PParams
+    ( ppGovActionDepositL
+    , ppGovActionLifetimeL
     )
 import Cardano.Ledger.Conway.State
     ( ConwayAccountState (..)
@@ -73,17 +97,26 @@ import Cardano.Ledger.State
     , spsDepositL
     )
 import Cardano.Ledger.TxIn
-    ( TxIn
+    ( TxId
+    , TxIn
     )
 import Command.ValidatePhaseOne.Error
     ( Error (..)
     )
 import Data.Aeson
     ( FromJSON (parseJSON)
+    , Object
+    , Value
     , withObject
     , (.:)
     , (.:?)
     , (.!=)
+    )
+import Data.Aeson.Key
+    ( Key
+    )
+import Data.Aeson.Types
+    ( Parser
     )
 import Data.Default.Class
     ( Default (def)
@@ -93,6 +126,7 @@ import Data.Fixture.Common
     , compactCoinOrError
     , parseCborHex
     , parsePoolId
+    , showText
     )
 import Data.Fixture.EraHistory
     ( EraHistory
@@ -102,7 +136,7 @@ import Data.Fixture.Point
     ( Point
     )
 import Data.Maybe.Strict
-    ( StrictMaybe (SNothing)
+    ( StrictMaybe (SJust, SNothing)
     )
 import Lens.Micro
     ( (.~)
@@ -117,6 +151,9 @@ data InitialState = InitialState
     , pools :: ![KeyHash StakePool]
     , accounts :: ![Account]
     , dreps :: ![RegisteredDRep]
+    , proposals :: ![ProposalEntry]
+    , proposalsRoots :: !(GovRelation StrictMaybe)
+    , pots :: !Pots
     , governanceActivity :: !GovernanceActivity
     }
     deriving (Generic)
@@ -129,7 +166,10 @@ instance FromJSON InitialState where
                 <*> (objectValue .:? "pools" .!= [] >>= traverse parsePoolId)
                 <*> objectValue .:? "accounts" .!= []
                 <*> objectValue .:? "dreps" .!= []
-                <*> objectValue .: "governanceActivity"
+                <*> objectValue .:? "proposals" .!= []
+                <*> (objectValue .:? "proposalsRoots" >>= maybe (pure def) parseProposalsRoots)
+                <*> objectValue .:? "pots" .!= def
+                <*> objectValue .:? "governanceActivity" .!= def
 
 data UtxoEntry = UtxoEntry
     { input :: !TxIn
@@ -217,16 +257,72 @@ data GovernanceActivity = GovernanceActivity
 
 instance FromJSON GovernanceActivity
 
+instance Default GovernanceActivity where
+    def = GovernanceActivity 0
+
+data ProposalEntry = ProposalEntry
+    { proposalId :: !GovActionId
+    , govAction :: !(GovAction ConwayEra)
+    }
+
+instance FromJSON ProposalEntry where
+    parseJSON =
+        withObject "ProposalEntry" $ \objectValue ->
+            ProposalEntry
+                <$> (objectValue .: "id" >>= parseProposalId)
+                <*> (objectValue .: "govAction" >>= parseCborHex "GovAction")
+
+data Pots = Pots
+    { treasury :: !Integer
+    , reserves :: !Integer
+    }
+
+instance FromJSON Pots where
+    parseJSON =
+        withObject "Pots" $ \objectValue ->
+            Pots
+                <$> objectValue .:? "treasury" .!= 0
+                <*> objectValue .:? "reserves" .!= 0
+
+instance Default Pots where
+    def = Pots 0 0
+
+parseProposalId :: Value -> Parser GovActionId
+parseProposalId =
+    withObject "ProposalId" $ \objectValue -> do
+        transactionId <- objectValue .: "transactionId" :: Parser TxId
+        proposalIndex <- objectValue .: "proposalIndex"
+        pure (GovActionId transactionId (GovActionIx proposalIndex))
+
+-- | The latest enacted governance action id per purpose. An absent purpose has no root,
+-- so a proposal claiming it as parent must supply an empty parent to be accepted.
+parseProposalsRoots :: Value -> Parser (GovRelation StrictMaybe)
+parseProposalsRoots =
+    withObject "ProposalsRoots" $ \objectValue -> do
+        grPParamUpdate <- parseRoot objectValue "protocolParameters"
+        grHardFork <- parseRoot objectValue "hardFork"
+        grCommittee <- parseRoot objectValue "constitutionalCommittee"
+        grConstitution <- parseRoot objectValue "constitution"
+        pure GovRelation{grPParamUpdate, grHardFork, grCommittee, grConstitution}
+  where
+    parseRoot :: Object -> Key -> Parser (StrictMaybe (GovPurposeId purpose))
+    parseRoot objectValue key =
+        objectValue .:? key
+            >>= maybe (pure SNothing) (fmap (SJust . GovPurposeId) . parseProposalId)
+
 buildNewEpochState
     :: PParams ConwayEra
     -> EraHistory
     -> InitialState
     -> Point
     -> Either Error (NewEpochState ConwayEra)
-buildNewEpochState pparams eraHistory InitialState{utxo, pools, accounts, dreps, governanceActivity} point = do
+buildNewEpochState pparams eraHistory initialState point = do
+    let InitialState{utxo, pools, accounts, dreps, proposals, proposalsRoots, pots, governanceActivity} = initialState
     accountEntries <- traverse toLedgerAccountEntry accounts
     dRepEntries <- traverse toLedgerDRepEntry dreps
     currentEpoch <- pointEpochNo eraHistory point
+    let proposalStates = map (toGovActionState pparams currentEpoch) proposals
+    seededProposals <- buildProposals proposalsRoots proposalStates
 
     let accountsMap = Map.fromList accountEntries
     let dRepDelegators =
@@ -270,12 +366,19 @@ buildNewEpochState pparams eraHistory InitialState{utxo, pools, accounts, dreps,
                         , let Coin dRepDepositValue = fromCompact registeredDRepDeposit
                         ]
                     + (fromIntegral (length pools) * poolDepositAmount pparams)
+                    + sum
+                        [ proposalDepositValue
+                        | proposalState <- proposalStates
+                        , let Coin proposalDepositValue = gasDeposit proposalState
+                        ]
                 )
     let govState =
             emptyGovState
                 & curPParamsGovStateL .~ pparams
                 & prevPParamsGovStateL .~ pparams
-    let chainAccountState = ChainAccountState {casTreasury = Coin 0, casReserves = Coin 0}
+                & cgsProposalsL .~ seededProposals
+    let chainAccountState =
+            ChainAccountState {casTreasury = Coin (treasury pots), casReserves = Coin (reserves pots)}
     let utxoState =
             UTxOState
                 { utxosUtxo = UTxO (Map.fromList [(input entry, output entry) | entry <- utxo])
@@ -371,6 +474,44 @@ toLedgerDRepEntry RegisteredDRep{credential, deposit, validUntil} = do
             , registeredDRepDeposit = compactDeposit
             , registeredDRepValidUntil = validUntil
             }
+
+-- | A fixture describes a seeded proposal by its id and its governance action, which is
+-- all the GOV rule consults when it resolves a new proposal's parent. The deposit, return
+-- address and anchor are filler, and the expiry is derived from @govActionLifetime@ so that
+-- every seeded proposal counts as still in flight.
+toGovActionState :: PParams ConwayEra -> LedgerSlot.EpochNo -> ProposalEntry -> GovActionState ConwayEra
+toGovActionState pparams currentEpoch ProposalEntry{proposalId, govAction} =
+    GovActionState
+        { gasId = proposalId
+        , gasCommitteeVotes = mempty
+        , gasDRepVotes = mempty
+        , gasStakePoolVotes = mempty
+        , gasProposalProcedure =
+            ProposalProcedure
+                { pProcDeposit = pparams ^. ppGovActionDepositL
+                , pProcReturnAddr = def
+                , pProcGovAction = govAction
+                , pProcAnchor = def
+                }
+        , gasProposedIn = currentEpoch
+        , gasExpiresAfter = addEpochInterval currentEpoch (pparams ^. ppGovActionLifetimeL)
+        }
+
+buildProposals
+    :: GovRelation StrictMaybe
+    -> [GovActionState ConwayEra]
+    -> Either Error (Proposals ConwayEra)
+buildProposals roots =
+    foldlM addAction (def & pRootsL .~ fromPrevGovActionIds roots)
+  where
+    addAction acc proposalState =
+        maybe (Left (unplaceable proposalState)) Right (proposalsAddAction proposalState acc)
+    unplaceable proposalState =
+        UnsupportedFixture
+            ( "initial proposal "
+                <> showText (gasId proposalState)
+                <> " does not follow an enacted root or an earlier initial proposal"
+            )
 
 defaultStakePoolState :: Coin -> StakePoolState
 defaultStakePoolState depositCoin =


### PR DESCRIPTION
During work on #1138, I discovered that the Haskell test runner doesn't actually work anymore, after recent changes to the fixture structure.

I also discovered some other bugs with the test runner, since it's drifted from the Amaru implementation. Finally, there are some changes to the `make` Command to fix issues I ran into while going through the flow.

NOTE: The Haskell code was Claude-ed, as I am not a Haskell developer. It has been tested locally to confirm it gives the expected results.

Skip-Changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for conformance scenarios containing expected validation outcomes.
  - Added fixture support for seeded governance proposals, proposal roots, treasury, and reserve balances.
  - Expanded validation coverage for governance, UTxO, certificates, reference scripts, and additional transaction failures.

- **Bug Fixes**
  - Validation mismatch messages now clearly distinguish expected and actual results.
  - Missing test fixtures now produce actionable errors.

- **Documentation**
  - Updated setup guidance, examples, and toolchain information.

- **Tests**
  - Improved prerequisite checks with warnings for optional or locally vendored tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->