### PR TITLE
rebuild only when needed, demote noisy log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ crates/amaru/tests/**/stake-distributions/**/*.json.zst
 !crates/amaru/tests/**/haskell-node-extractor/**/schemas/*.json
 
 # Files downloaded for the demo
-/snapshots/
+/snapshots
 
 # Files downloaded by mithril
 /mithril-snapshots/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Other guiding principles:
 - **scripts/run-until**: drives the `amaru-node` `run_until` example (observer-based stop). The example installs OTLP via `amaru_node::Telemetry` when `AMARU_WITH_OPEN_TELEMETRY` is set, so e2e metrics still flow to the collector.
 - **amaru-node**: `Telemetry::install` embedder helper for fmt / JSON / OTLP (metrics + traces + logs) using the same env knobs as the product binary.
 - **amaru-observability**: structured logging for complex values: schema transport preserves JSON primitives and encodes other values as CBOR (`record_bytes`); JSON traces get nested objects/arrays, OTEL logs get nested `AnyValue` maps/lists, OTEL spans upgrade homogeneous CBOR arrays to `Value::Array` (with CBOR diagnostic fallback otherwise), and console logs use CBOR diagnostic notation. ([#1182](https://github.com/pragma-org/amaru/pull/1182))
+- **amaru**: stake-distribution conformance tests no longer partition `#[ignore]` vs active cases from `ledger.<network>.db` at build time (watching that live DB rebuilt `amaru` on every node write). Fixture directories are still watched so tests regenerate when snapshots change; each test soft-skips with a warning when the matching local ledger snapshot is missing.
 
 ### Fixed
 

--- a/crates/amaru-ledger/src/governance/ratification.rs
+++ b/crates/amaru-ledger/src/governance/ratification.rs
@@ -20,7 +20,7 @@ use amaru_kernel::{
     RatificationStatus, StakeCredential, Vote, Voter,
     rational_number::{SafeRatio, into_safe_ratio},
 };
-use amaru_observability::info_span;
+use amaru_observability::{debug_span, info_span};
 use num::Zero;
 use tracing::{Span, field};
 
@@ -282,7 +282,11 @@ impl<'distr> RatificationContext<'distr> {
     }
 
     fn new_ratify_span(id: &ProposalId, proposal: &ProposalEnum) -> Span {
-        info_span!(ledger::governance::RATIFYING, proposal_id = id.to_string(), proposal_kind = proposal.display_kind())
+        debug_span!(
+            ledger::governance::RATIFYING,
+            proposal_id = id.to_string(),
+            proposal_kind = proposal.display_kind()
+        )
     }
 
     fn is_accepted_by_everyone(

--- a/crates/amaru-node/build/build.rs
+++ b/crates/amaru-node/build/build.rs
@@ -46,3 +46,15 @@ fn write_if_changed(path: &Path, contents: &str) -> Result<()> {
     fs::write(path, contents)?;
     Ok(())
 }
+
+/// Byte-oriented variant of [`write_if_changed`].
+fn write_if_changed_bytes(path: &Path, contents: &[u8]) -> Result<()> {
+    if fs::read(path).ok().as_deref() == Some(contents) {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, contents)?;
+    Ok(())
+}

--- a/crates/amaru-node/build/peer_snapshot.rs
+++ b/crates/amaru-node/build/peer_snapshot.rs
@@ -15,26 +15,34 @@
 //! Best-effort download of Cardano peer snapshots for networks listed in
 //! [`amaru_kernel::PEER_SNAPSHOT_NETWORKS`] (for example mainnet, preprod, preview).
 //!
-//! Snapshots are staged under `config/peer-snapshots/{network}/peer-snapshot.json`
-//! (not committed). When GitHub is reachable, files are refreshed from
-//! `cardano-foundation/cardano-configurations` at the youngest commit at or
-//! before the Amaru HEAD committer timestamp.
+//! ## Cargo rebuild hygiene
 //!
-//! Commit metadata is cached in `CONFIGS_COMMIT_CACHE`, including the Amaru HEAD
-//! committer time (`until`, unix seconds) used to resolve the configs-repo SHA.
-//! A successful resolve rewrites that file so its mtime is current; the commits
-//! API is not contacted again while the file is younger than
-//! [`COMMIT_CACHE_TTL`] (12 hours) **and** the currently required HEAD time is
-//! within [`UNTIL_CACHE_TOLERANCE`] (1 hour) of the cached value. When a request
-//! is made, it is conditional on any stored `ETag` / `Last-Modified` only if the
-//! cached `until` is still compatible. A `304 Not Modified` reuses the cached
-//! SHA. Snapshot files are only re-downloaded when missing or not strictly
-//! newer than the cache file.
+//! The only package-tree inputs this script tells Cargo to watch are the optional
+//! staged offline files:
 //!
-//! Every network in [`PEER_SNAPSHOT_NETWORKS`] must have a staged file after the
-//! fetch attempt (empty placeholders are allowed offline; see
-//! `config/peer-snapshots/README.md`). Optional `GITHUB_TOKEN` / `GH_TOKEN`
-//! raises GitHub API rate limits.
+//! ```text
+//! config/peer-snapshots/<network>/peer-snapshot.json
+//! ```
+//!
+//! Fetch metadata (`CONFIGS_COMMIT_CACHE`) and downloaded snapshot bytes live under
+//! `OUT_DIR` only. Writing them must never dirty a `rerun-if-changed` path, or every
+//! successful fetch / token env flip would recompile `amaru-node`.
+//!
+//! Credentials and `AMARU_SKIP_PEER_SNAPSHOT_FETCH` are read when the script runs but
+//! are **not** listed as `rerun-if-env-changed`: they only affect best-effort network
+//! access, not the embedded bytes once `OUT_DIR` / staged inputs are stable.
+//!
+//! ## Fetch behaviour
+//!
+//! When GitHub is reachable, snapshots are downloaded from
+//! `cardano-foundation/cardano-configurations` at the youngest commit at or before the
+//! Amaru HEAD committer timestamp into `OUT_DIR`. Commit metadata is cached in
+//! `OUT_DIR/CONFIGS_COMMIT_CACHE` for [`COMMIT_CACHE_TTL`] so frequent local rebuilds
+//! do not spam the commits API.
+//!
+//! Every network in [`PEER_SNAPSHOT_NETWORKS`] must end up with bytes in `OUT_DIR`
+//! (from download and/or staged offline files). See
+//! `config/peer-snapshots/README.md`.
 
 use std::{
     env, fs,
@@ -48,7 +56,7 @@ use amaru_kernel::PEER_SNAPSHOT_NETWORKS;
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 
-use crate::{emit_rerun_if_exists, write_if_changed};
+use crate::{emit_rerun_if_exists, write_if_changed, write_if_changed_bytes};
 
 const CONFIGS_REPO: &str = "cardano-foundation/cardano-configurations";
 const USER_AGENT: &str = "amaru-build (https://github.com/pragma-org/amaru)";
@@ -63,27 +71,24 @@ fn peer_snapshot_network_names() -> impl Iterator<Item = &'static str> {
 
 /// Stage peer snapshots and embed them into `OUT_DIR`.
 ///
-/// Fails if any network in [`PEER_SNAPSHOT_NETWORKS`] still lacks a staged file
-/// after the fetch attempt.
+/// Fails if any network in [`PEER_SNAPSHOT_NETWORKS`] still lacks embeddable bytes
+/// after the fetch attempt and staged-file fallback.
 pub fn prepare_peer_snapshots() -> Result<()> {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").context("CARGO_MANIFEST_DIR")?);
     let out_dir = PathBuf::from(env::var("OUT_DIR").context("OUT_DIR")?);
     let staging_root = manifest_dir.join("config").join("peer-snapshots");
 
-    println!("cargo:rerun-if-env-changed=AMARU_SKIP_PEER_SNAPSHOT_FETCH");
-    println!("cargo:rerun-if-env-changed=GITHUB_TOKEN");
-    println!("cargo:rerun-if-env-changed=GH_TOKEN");
-
+    // Content inputs only: optional offline/CI staged snapshots. Never watch fetch
+    // caches or anything this script writes under OUT_DIR.
     for network in peer_snapshot_network_names() {
         emit_rerun_if_exists(&staging_path(&staging_root, network));
     }
-    emit_rerun_if_exists(&configs_commit_cache_path(&staging_root));
 
     let skip_fetch = env_flag("AMARU_SKIP_PEER_SNAPSHOT_FETCH");
 
-    let mut configs_sha: Option<String> = read_configs_commit_cache(&staging_root).map(|c| c.sha);
+    let mut configs_sha: Option<String> = read_configs_commit_cache(&out_dir).map(|c| c.sha);
     if !skip_fetch {
-        match fetch_all(&staging_root) {
+        match fetch_all(&out_dir) {
             Ok(sha) => {
                 configs_sha = Some(sha);
             }
@@ -98,10 +103,18 @@ pub fn prepare_peer_snapshots() -> Result<()> {
     let mut present = Vec::new();
     let mut missing = Vec::new();
     for network in peer_snapshot_network_names() {
-        let path = staging_path(&staging_root, network);
-        if path.is_file() {
-            let dest = out_dir.join(format!("peer_snapshot_{network}.json"));
-            fs::copy(&path, &dest).with_context(|| format!("copy {} -> {}", path.display(), dest.display()))?;
+        let dest = out_dir_snapshot_path(&out_dir, network);
+        if dest.is_file() {
+            present.push(network);
+            continue;
+        }
+
+        // Offline / CI fallback: copy staged package inputs into OUT_DIR.
+        let staged = staging_path(&staging_root, network);
+        if staged.is_file() {
+            let bytes = fs::read(&staged).with_context(|| format!("read staged {}", staged.display()))?;
+            write_if_changed_bytes(&dest, &bytes)
+                .with_context(|| format!("copy staged {} -> {}", staged.display(), dest.display()))?;
             present.push(network);
         } else {
             missing.push(network);
@@ -112,7 +125,7 @@ pub fn prepare_peer_snapshots() -> Result<()> {
         bail!(
             "no embeddable peer snapshot(s) for network(s): {}. \
              Stage files under config/peer-snapshots/<network>/peer-snapshot.json \
-             (empty placeholders work offline). \
+             (empty placeholders work offline), or allow the build script to fetch. \
              See crates/amaru-node/config/peer-snapshots/README.md",
             missing.join(", ")
         );
@@ -122,15 +135,15 @@ pub fn prepare_peer_snapshots() -> Result<()> {
     Ok(())
 }
 
-fn fetch_all(staging_root: &Path) -> Result<String> {
+/// Download snapshots into `out_dir`, using an OUT_DIR-local API cache.
+fn fetch_all(out_dir: &Path) -> Result<String> {
     let amaru_time = amaru_head_committer_time().context("determine Amaru HEAD committer date")?;
-    let existing = read_configs_commit_cache(staging_root);
+    let existing = read_configs_commit_cache(out_dir);
 
-    // Skip the commits API while the cache file is younger than COMMIT_CACHE_TTL
+    // Skip the commits API while the OUT_DIR cache is younger than COMMIT_CACHE_TTL
     // and was resolved for a sufficiently close Amaru HEAD committer time.
-    // A successful resolve always rewrites the cache so its mtime starts a new window.
-    let sha = match existing.as_ref() {
-        Some(cache) if commit_cache_is_reusable(staging_root, cache, &amaru_time) => cache.sha.clone(),
+    let (sha, cache_for_write) = match existing.as_ref() {
+        Some(cache) if commit_cache_is_reusable(out_dir, cache, &amaru_time) => (cache.sha.clone(), None),
         _ => {
             let agent = http_agent()?;
             // Conditional headers are only valid for the same logical `until` query.
@@ -149,29 +162,24 @@ fn fetch_all(staging_root: &Path) -> Result<String> {
                     cache
                 }
             };
-            // Write (or rewrite) before downloads so the TTL and snapshot mtime
-            // comparisons use a fresh cache timestamp.
-            write_configs_commit_cache(staging_root, &cache)?;
-            cache.sha
+            let sha = cache.sha.clone();
+            (sha, Some(cache))
         }
     };
 
-    let agent = http_agent()?;
-    let cache_mtime = fs::metadata(configs_commit_cache_path(staging_root)).and_then(|m| m.modified()).ok();
+    let previous_sha = existing.as_ref().map(|c| c.sha.as_str());
+    let sha_changed = previous_sha != Some(sha.as_str());
 
+    let agent = http_agent()?;
     for network in peer_snapshot_network_names() {
-        if !snapshot_needs_download(staging_root, network, cache_mtime) {
+        let dest = out_dir_snapshot_path(out_dir, network);
+        if !sha_changed && dest.is_file() {
             continue;
         }
         match download_snapshot(&agent, &sha, network) {
             Ok(bytes) => {
-                let path = staging_path(staging_root, network);
-                if let Some(parent) = path.parent() {
-                    fs::create_dir_all(parent)?;
-                }
-                let tmp = path.with_extension("json.tmp");
-                fs::write(&tmp, &bytes)?;
-                fs::rename(&tmp, &path)?;
+                write_if_changed_bytes(&dest, &bytes)
+                    .with_context(|| format!("write downloaded snapshot for {network}"))?;
             }
             Err(err) => {
                 println!(
@@ -181,17 +189,21 @@ fn fetch_all(staging_root: &Path) -> Result<String> {
         }
     }
 
+    if let Some(cache) = cache_for_write {
+        write_configs_commit_cache(out_dir, &cache)?;
+    }
+
     Ok(sha)
 }
 
 /// True when the cache may be reused without contacting the commits API.
-fn commit_cache_is_reusable(staging_root: &Path, cache: &ConfigsCommitCache, amaru_time: &AmaruHeadTime) -> bool {
-    commit_cache_mtime_is_fresh(staging_root) && until_is_compatible(cache, amaru_time)
+fn commit_cache_is_reusable(out_dir: &Path, cache: &ConfigsCommitCache, amaru_time: &AmaruHeadTime) -> bool {
+    commit_cache_mtime_is_fresh(out_dir) && until_is_compatible(cache, amaru_time)
 }
 
-/// True when `CONFIGS_COMMIT_CACHE` exists and was modified within [`COMMIT_CACHE_TTL`].
-fn commit_cache_mtime_is_fresh(staging_root: &Path) -> bool {
-    let path = configs_commit_cache_path(staging_root);
+/// True when the OUT_DIR `CONFIGS_COMMIT_CACHE` exists and was modified within [`COMMIT_CACHE_TTL`].
+fn commit_cache_mtime_is_fresh(out_dir: &Path) -> bool {
+    let path = configs_commit_cache_path(out_dir);
     let Ok(meta) = fs::metadata(path) else {
         return false;
     };
@@ -213,26 +225,6 @@ fn until_is_compatible(cache: &ConfigsCommitCache, amaru_time: &AmaruHeadTime) -
         return false;
     };
     amaru_time.unix.abs_diff(cached_unix) <= UNTIL_CACHE_TOLERANCE.as_secs()
-}
-
-/// True when the staged snapshot is missing or not strictly newer than the cache file.
-fn snapshot_needs_download(staging_root: &Path, network: &str, cache_mtime: Option<SystemTime>) -> bool {
-    let path = staging_path(staging_root, network);
-    let Ok(meta) = fs::metadata(&path) else {
-        return true;
-    };
-    #[expect(clippy::panic)]
-    if !meta.is_file() {
-        panic!("peer snapshot file path `{}` exists but is not a file", path.display());
-    }
-    let Some(cache_mtime) = cache_mtime else {
-        // No cache mtime to compare against; treat existing files as usable.
-        return false;
-    };
-    match meta.modified() {
-        Ok(mtime) => mtime <= cache_mtime,
-        Err(_) => true,
-    }
 }
 
 /// Amaru HEAD committer time: ISO-8601 for the GitHub `until` query, unix for comparisons.
@@ -385,12 +377,16 @@ fn staging_path(staging_root: &Path, network: &str) -> PathBuf {
     staging_root.join(network).join("peer-snapshot.json")
 }
 
-fn configs_commit_cache_path(staging_root: &Path) -> PathBuf {
-    staging_root.join(CACHE_FILE_NAME)
+fn out_dir_snapshot_path(out_dir: &Path, network: &str) -> PathBuf {
+    out_dir.join(format!("peer_snapshot_{network}.json"))
 }
 
-fn read_configs_commit_cache(staging_root: &Path) -> Option<ConfigsCommitCache> {
-    let content = fs::read_to_string(configs_commit_cache_path(staging_root)).ok()?;
+fn configs_commit_cache_path(out_dir: &Path) -> PathBuf {
+    out_dir.join(CACHE_FILE_NAME)
+}
+
+fn read_configs_commit_cache(out_dir: &Path) -> Option<ConfigsCommitCache> {
+    let content = fs::read_to_string(configs_commit_cache_path(out_dir)).ok()?;
     parse_configs_commit_cache(&content)
 }
 
@@ -428,8 +424,8 @@ fn parse_configs_commit_cache(content: &str) -> Option<ConfigsCommitCache> {
     Some(ConfigsCommitCache { sha: sha?, until, etag, last_modified })
 }
 
-fn write_configs_commit_cache(staging_root: &Path, cache: &ConfigsCommitCache) -> Result<()> {
-    fs::create_dir_all(staging_root)?;
+fn write_configs_commit_cache(out_dir: &Path, cache: &ConfigsCommitCache) -> Result<()> {
+    fs::create_dir_all(out_dir)?;
     let mut body = format!("sha: {}\n", cache.sha);
     if let Some(until) = cache.until {
         body.push_str(&format!("until: {until}\n"));
@@ -440,7 +436,8 @@ fn write_configs_commit_cache(staging_root: &Path, cache: &ConfigsCommitCache) -
     if let Some(last_modified) = &cache.last_modified {
         body.push_str(&format!("last-modified: {last_modified}\n"));
     }
-    fs::write(configs_commit_cache_path(staging_root), body)?;
+    // OUT_DIR is not cargo-watched; unconditional write is fine and refreshes the API TTL.
+    fs::write(configs_commit_cache_path(out_dir), body)?;
     Ok(())
 }
 

--- a/crates/amaru-node/config/peer-snapshots/README.md
+++ b/crates/amaru-node/config/peer-snapshots/README.md
@@ -1,18 +1,25 @@
 # Peer snapshots (build-time staging)
 
-JSON peer snapshots for networks listed in `amaru_kernel::PEER_SNAPSHOT_NETWORKS`
-(for example `mainnet`, `preprod`, `preview`) are staged here during `cargo build`:
+Optional **offline / CI inputs** for networks listed in `amaru_kernel::PEER_SNAPSHOT_NETWORKS`
+(for example `mainnet`, `preprod`, `preview`):
 
 ```text
 config/peer-snapshots/<network>/peer-snapshot.json
 ```
 
-These files are **not** committed. The build script downloads them from
+These files are **not** committed. The build script embeds peer snapshots into `OUT_DIR`
+(and may download them there from
 [cardano-foundation/cardano-configurations](https://github.com/cardano-foundation/cardano-configurations)
-at the youngest commit at or before the Amaru `HEAD` committer timestamp.
+when GitHub is reachable). Staged files under this directory are only a fallback when
+fetch is skipped or fails.
 
-The build **requires** a staged file for every known network. If GitHub is unreachable
-and no files are present yet, the build fails with a message pointing here.
+Cargo is told to re-run the build script when these staged files change. Fetch metadata
+and downloaded bytes live only under `OUT_DIR`, so a successful fetch does **not** dirty
+the package tree or force an `amaru-node` rebuild on the next `cargo build`.
+
+The build **requires** embeddable bytes for every known network (from download and/or
+staged files). If GitHub is unreachable and no staged files are present yet, the build
+fails with a message pointing here.
 
 File format: [peer-snapshot.schema.json](./peer-snapshot.schema.json)
 (compatible with cardano-node `peerSnapshotFile` / big-ledger peer snapshots).
@@ -57,30 +64,27 @@ config/peer-snapshots/preprod/peer-snapshot.json
 config/peer-snapshots/preview/peer-snapshot.json
 ```
 
-## Conditional fetch cache
+## Conditional fetch cache (OUT_DIR only)
 
-After a successful commits-API response, `CONFIGS_COMMIT_CACHE` records the configs-repo
-SHA, the Amaru HEAD committer time used as GitHub `until` (unix seconds), plus any
-`ETag` / `Last-Modified` headers (also not committed), and gets a fresh modification
-time. Builds reuse that cached SHA without contacting the commits API only when
-**both** hold:
+After a successful commits-API response, `OUT_DIR/CONFIGS_COMMIT_CACHE` records the
+configs-repo SHA, the Amaru HEAD committer time used as GitHub `until` (unix seconds),
+plus any `ETag` / `Last-Modified` headers. That file is **not** a Cargo rebuild input.
 
-- the cache file is younger than **12 hours** (avoids rate-limit noise on frequent
-  local/LSP rebuilds), and
-- the currently required Amaru HEAD committer time is within **1 hour** of the
-  cached `until` (so checking out a much older/newer commit re-resolves the
-  configs SHA instead of reusing a mismatched snapshot).
-
-When a refresh runs, later builds send conditional requests if `until` is still
-compatible; a `304 Not Modified` rewrites the cache (refreshing the 12h window) and
-only re-downloads missing or stale snapshot files.
+While the cache is younger than **12 hours** and the required Amaru HEAD committer time
+is within **1 hour** of the cached `until`, later build-script runs reuse the cached SHA
+without contacting the commits API. Snapshot files already present in `OUT_DIR` for that
+SHA are not re-downloaded.
 
 ## Optional env vars
 
 | Variable | Effect |
 |----------|--------|
-| `AMARU_SKIP_PEER_SNAPSHOT_FETCH=1` | Do not contact GitHub; use staged files only |
+| `AMARU_SKIP_PEER_SNAPSHOT_FETCH=1` | Do not contact GitHub; use staged files / existing `OUT_DIR` bytes only |
 | `GITHUB_TOKEN` / `GH_TOKEN` | Authenticate GitHub API (higher rate limits; 304s do not count against the primary limit) |
+
+These are **not** listed as `cargo:rerun-if-env-changed`. Flipping a token or skip flag
+alone will not recompile `amaru-node`; they are consulted only when the build script runs
+for another reason (clean build, staged-file change, build-script source change, etc.).
 
 ## CI staging
 

--- a/crates/amaru/build/build.rs
+++ b/crates/amaru/build/build.rs
@@ -21,8 +21,8 @@ use anyhow::{Context, Result};
 
 /// Generate:
 ///  1. build-time information (via `built`)
-///  2. The stake distribution test cases for each supported network.
-///  3. Peer snapshots for known networks (best-effort fetch; embed if present).
+///  2. git commit identity for logging
+///  3. stake distribution conformance test cases for each supported network
 fn main() -> Result<()> {
     write_built_file().context("Failed to acquire build-time information")?;
     write_git_info_file().context("Failed to acquire git build information")?;

--- a/crates/amaru/build/stake_distribution.rs
+++ b/crates/amaru/build/stake_distribution.rs
@@ -24,31 +24,25 @@ use crate::{emit_rerun_if_changed, write_if_changed};
 
 /// Generate `stake_distribution_<network>_test_cases.rs` in `OUT_DIR`, containing one test
 /// case per stake distribution fixture.
+///
+/// Availability of the local `ledger.<network>.db` snapshot is **not** checked here: that path is
+/// a live RocksDB for node runs, so watching it would rebuild `amaru` on every SST/LOG write.
+/// The generated tests check snapshot presence at runtime and soft-skip when missing.
 pub(crate) fn write_stake_distribution_test_cases_file(network: &str) -> Result<()> {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
-    let workspace_dir = manifest_dir.join("../..");
     let fixtures_root = manifest_dir.join("tests").join("conformance").join("stake-distributions");
     let network_dir = fixtures_root.join(network);
-    let ledger_dir = default_ledger_dir(&workspace_dir, network);
 
-    // Fixture JSON/ZST files are pure inputs. Do **not** cargo-watch `ledger.{network}.db`:
-    // that path is a live RocksDB used by a running node, and any SST/LOG write would re-run
-    // this build script and recompile `amaru` on every `cargo build`.
+    // Fixture JSON/ZST files are pure inputs; regenerate when they change.
     emit_rerun_if_changed(&network_dir);
 
     let epochs = stake_distribution_epochs(&network_dir)?;
-    let available_epochs = available_ledger_snapshot_epochs(&ledger_dir)?;
-    let contents = stake_distribution_test_cases_source(network, &epochs, &available_epochs)?;
+    let contents = stake_distribution_test_cases_source(network, &epochs)?;
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
 
     write_if_changed(&out_dir.join(format!("stake_distribution_{network}_test_cases.rs")), &contents)?;
 
     Ok(())
-}
-
-/// Return the local ledger database directory for `network`, at the workspace root.
-fn default_ledger_dir(workspace_dir: &Path, network: &str) -> PathBuf {
-    workspace_dir.join(format!("ledger.{network}.db"))
 }
 
 /// List the epochs having a fixture file in `network_dir`, most recent first.
@@ -86,53 +80,11 @@ fn stake_distribution_epoch(path: &Path) -> Option<u64> {
     epoch.parse().ok()
 }
 
-/// List the epochs for which a ledger snapshot is available locally in `ledger_dir`.
+/// Render one active test function comparing stake distributions for every fixture epoch.
 ///
-/// Scanned when the build script runs for other reasons (fixture change, git change, clean
-/// build). Intentionally **not** registered with `cargo:rerun-if-changed`: the directory is a
-/// live RocksDB for node runs, and watching it makes every DB write rebuild `amaru`.
-///
-/// After importing new ledger snapshots, touch a stake-distribution fixture path (or
-/// `cargo clean -p amaru`) so the generated `#[test_case]` list is refreshed.
-fn available_ledger_snapshot_epochs(ledger_dir: &Path) -> Result<BTreeSet<u64>> {
-    if !ledger_dir.is_dir() {
-        return Ok(BTreeSet::new());
-    }
-
-    let mut epochs = BTreeSet::new();
-    for entry in fs::read_dir(ledger_dir)? {
-        let entry = entry?;
-        let path = entry.path();
-
-        if !path.is_dir() {
-            continue;
-        }
-
-        if let Some(epoch) = ledger_snapshot_epoch(&path) {
-            epochs.insert(epoch);
-        }
-    }
-
-    Ok(epochs)
-}
-
-/// Extract the epoch number from a ledger snapshot directory name.
-fn ledger_snapshot_epoch(path: &Path) -> Option<u64> {
-    path.file_name()?.to_str()?.parse().ok()
-}
-
-/// Split the fixture epochs into those with a local ledger snapshot and those without.
-fn partition_fixture_epochs(epochs: &[u64], available_epochs: &BTreeSet<u64>) -> (Vec<u64>, Vec<u64>) {
-    epochs.iter().copied().partition(|epoch| available_epochs.contains(epoch))
-}
-
-/// Render the test functions comparing stake distributions for `network`: an active test for the
-/// epochs with a local ledger snapshot, and an `#[ignore]`d one for the epochs without.
-fn stake_distribution_test_cases_source(
-    network: &str,
-    epochs: &[u64],
-    available_epochs: &BTreeSet<u64>,
-) -> Result<String> {
+/// Missing local ledger snapshots are handled at test runtime (warn + soft success), not via
+/// build-time `#[ignore]`.
+fn stake_distribution_test_cases_source(network: &str, epochs: &[u64]) -> Result<String> {
     if epochs.is_empty() {
         return Ok(format!(
             r#"// No stake distribution fixtures found for network={network}.
@@ -145,59 +97,24 @@ const _: fn(
     }
 
     let network_variant = network_name_to_rust_variant(network)?;
-    let (active_epochs, ignored_epochs) = partition_fixture_epochs(epochs, available_epochs);
     let mut contents = String::new();
 
-    contents.push_str(&format!(
-        "// Generated from {} fixture epoch(s): {} active, {} ignored.\n",
-        epochs.len(),
-        active_epochs.len(),
-        ignored_epochs.len(),
-    ));
-
-    if !active_epochs.is_empty() {
-        contents.push_str(&render_stake_distribution_test_function(
-            network,
-            network_variant,
-            "compare",
-            &active_epochs,
-            false,
-        ));
-    }
-
-    if !ignored_epochs.is_empty() {
-        contents.push_str(&render_stake_distribution_test_function(
-            network,
-            network_variant,
-            "compare_missing_local_snapshot",
-            &ignored_epochs,
-            true,
-        ));
-    }
+    contents.push_str(&format!("// Generated from {} fixture epoch(s).\n", epochs.len()));
+    contents.push_str(&render_stake_distribution_test_function(network, network_variant, epochs));
 
     Ok(contents)
 }
 
 /// Render one test function with a `#[test_case]` attribute per epoch.
-fn render_stake_distribution_test_function(
-    network: &str,
-    network_variant: &str,
-    prefix: &str,
-    epochs: &[u64],
-    ignored: bool,
-) -> String {
+fn render_stake_distribution_test_function(network: &str, network_variant: &str, epochs: &[u64]) -> String {
     let mut contents = String::new();
 
     for epoch in epochs {
         contents.push_str(&format!("#[test_case::test_case({epoch})]\n"));
     }
 
-    if ignored {
-        contents.push_str("#[ignore]\n");
-    }
-
     contents.push_str(&format!(
-        r#"pub fn {prefix}_{network}_stake_distribution_with_haskell_node(epoch: u64) -> Result<(), Box<dyn std::error::Error>> {{
+        r#"pub fn compare_{network}_stake_distribution_with_haskell_node(epoch: u64) -> Result<(), Box<dyn std::error::Error>> {{
     compare_stake_distribution_with_haskell_node(
         amaru_kernel::NetworkName::{network_variant},
         amaru_kernel::Epoch::from(epoch),

--- a/crates/amaru/build/stake_distribution.rs
+++ b/crates/amaru/build/stake_distribution.rs
@@ -31,8 +31,10 @@ pub(crate) fn write_stake_distribution_test_cases_file(network: &str) -> Result<
     let network_dir = fixtures_root.join(network);
     let ledger_dir = default_ledger_dir(&workspace_dir, network);
 
+    // Fixture JSON/ZST files are pure inputs. Do **not** cargo-watch `ledger.{network}.db`:
+    // that path is a live RocksDB used by a running node, and any SST/LOG write would re-run
+    // this build script and recompile `amaru` on every `cargo build`.
     emit_rerun_if_changed(&network_dir);
-    ensure_ledger_dir(&ledger_dir, &workspace_dir);
 
     let epochs = stake_distribution_epochs(&network_dir)?;
     let available_epochs = available_ledger_snapshot_epochs(&ledger_dir)?;
@@ -47,24 +49,6 @@ pub(crate) fn write_stake_distribution_test_cases_file(network: &str) -> Result<
 /// Return the local ledger database directory for `network`, at the workspace root.
 fn default_ledger_dir(workspace_dir: &Path, network: &str) -> PathBuf {
     workspace_dir.join(format!("ledger.{network}.db"))
-}
-
-/// Create `ledger_dir` when it is missing, so that cargo has an existing path to watch.
-///
-/// Cargo treats a `rerun-if-changed` on a missing path as permanently stale, which would rebuild
-/// this crate on every build; but dropping the watch altogether would leave the generated test
-/// cases partitioned against the snapshots available when the directory did not exist yet, and
-/// silently skip the conformance tests once it appears. An empty placeholder gives cargo something
-/// stable to watch, whose modification time changes as soon as snapshots are imported into it.
-///
-/// Only done inside the amaru workspace: when this crate is built from a registry checkout, the
-/// workspace root is not ours to write to.
-fn ensure_ledger_dir(ledger_dir: &Path, workspace_dir: &Path) {
-    if !workspace_dir.join("Cargo.toml").is_file() {
-        return;
-    }
-
-    let _ = fs::create_dir_all(ledger_dir);
 }
 
 /// List the epochs having a fixture file in `network_dir`, most recent first.
@@ -103,9 +87,14 @@ fn stake_distribution_epoch(path: &Path) -> Option<u64> {
 }
 
 /// List the epochs for which a ledger snapshot is available locally in `ledger_dir`.
+///
+/// Scanned when the build script runs for other reasons (fixture change, git change, clean
+/// build). Intentionally **not** registered with `cargo:rerun-if-changed`: the directory is a
+/// live RocksDB for node runs, and watching it makes every DB write rebuild `amaru`.
+///
+/// After importing new ledger snapshots, touch a stake-distribution fixture path (or
+/// `cargo clean -p amaru`) so the generated `#[test_case]` list is refreshed.
 fn available_ledger_snapshot_epochs(ledger_dir: &Path) -> Result<BTreeSet<u64>> {
-    emit_rerun_if_changed(ledger_dir);
-
     if !ledger_dir.is_dir() {
         return Ok(BTreeSet::new());
     }

--- a/crates/amaru/tests/conformance/stake-distributions/README.md
+++ b/crates/amaru/tests/conformance/stake-distributions/README.md
@@ -30,13 +30,15 @@ The extractor README documents the exact command-line usage and validation flow.
 
 ## Generated Rust tests
 
-[build.rs](../../../build/build.rs) scans `tests/stake-distributions/$AMARU_NETWORK/` for `epoch_*.json` and `epoch_*.json.zst` files and generates the matching `test_case` entries automatically. There is no manually-maintained test list anymore.
+[build.rs](../../../build/build.rs) scans `tests/conformance/stake-distributions/<network>/` for `epoch_*.json` and `epoch_*.json.zst` files and generates the matching `test_case` entries automatically. There is no manually-maintained test list anymore. The fixture directory is watched by cargo so tests regenerate when snapshots are added, removed, or replaced.
+
+Availability of the matching epoch in the local `ledger.<network>.db` is **not** decided at build time (watching that live RocksDB would rebuild `amaru` on every node write). Each generated test checks for the snapshot at runtime: if it is missing, the test succeeds after printing a warning (visible with `--nocapture`).
 
 To list or run the generated comparison tests for a given network:
 
 ```console
-AMARU_NETWORK=preview cargo test -p amaru --test summary -- --list
-AMARU_NETWORK=preview cargo test -p amaru --test summary
+cargo test -p amaru --test summary -- --list
+cargo test -p amaru --test summary --nocapture
 ```
 
 Those tests compare the extracted JSON fixtures against stake distributions computed by Amaru from the local `ledger.<network>.db` store at the repository root, for example `ledger.preview.db`.

--- a/crates/amaru/tests/summary.rs
+++ b/crates/amaru/tests/summary.rs
@@ -19,7 +19,7 @@ use std::{
     fmt::Write,
     fs::File,
     io::Read,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{Arc, LazyLock, Mutex},
 };
 
@@ -43,8 +43,14 @@ static GLOBAL_ALLOCATOR: memory::CountingAllocator<System> = memory::CountingAll
 pub static CONNECTIONS: LazyLock<Mutex<BTreeMap<Epoch, Arc<RocksDBSnapshot>>>> =
     LazyLock::new(|| Mutex::new(BTreeMap::new()));
 
-fn default_ledger_dir(network: NetworkName) -> String {
-    format!("./ledger.{}.db", network.to_string().to_lowercase())
+/// Path to the workspace-root ledger DB for `network`, from the summary test binary cwd.
+fn ledger_dir_from_tests(network: NetworkName) -> PathBuf {
+    PathBuf::from(format!("../../ledger.{}.db", network.to_string().to_lowercase()))
+}
+
+/// Whether `ledger_dir` contains a RocksDB snapshot directory for `epoch`.
+fn has_ledger_snapshot(ledger_dir: &Path, epoch: Epoch) -> bool {
+    ledger_dir.join(epoch.to_string()).is_dir()
 }
 
 #[expect(clippy::panic)]
@@ -62,11 +68,8 @@ fn load_snapshot(network: NetworkName, epoch: Epoch) -> Arc<impl Snapshot + Send
         .entry(epoch)
         .or_insert_with(|| {
             Arc::new(
-                RocksDBHistoricalStores::for_epoch_with(
-                    &RocksDbConfig::new(PathBuf::from(format!("../../{}", default_ledger_dir(network)))),
-                    epoch,
-                )
-                .unwrap_or_else(|err| panic!("Failed to open ledger snapshot for epoch {}: {}", epoch, err)),
+                RocksDBHistoricalStores::for_epoch_with(&RocksDbConfig::new(ledger_dir_from_tests(network)), epoch)
+                    .unwrap_or_else(|err| panic!("Failed to open ledger snapshot for epoch {}: {}", epoch, err)),
             )
         })
         .clone();
@@ -80,6 +83,18 @@ fn compare_stake_distribution_with_haskell_node(
     network: NetworkName,
     epoch: Epoch,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let ledger_dir = ledger_dir_from_tests(network);
+    if !has_ledger_snapshot(&ledger_dir, epoch) {
+        // Soft-skip: missing snapshots used to be `#[ignore]`d at build time. Print a warning so
+        // `--nocapture` (or harness failure logs) still surfaces the gap.
+        eprintln!(
+            "warning: skipping stake distribution comparison for {network} epoch {epoch}; \
+             local ledger snapshot missing at {}",
+            ledger_dir.join(epoch.to_string()).display()
+        );
+        return Ok(());
+    }
+
     let snapshot = load_snapshot(network, epoch);
 
     let era_history = network.as_era_history().ok_or("no era history for network={network:?}?!")?;
@@ -102,7 +117,7 @@ fn measure_new_snapshot_summary_memory() -> Result<(), Box<dyn std::error::Error
 
     let era_history = network.as_era_history().unwrap_or(&PREPROD_ERA_HISTORY);
 
-    let ledger_dir = PathBuf::from(format!("../../{}", default_ledger_dir(network)));
+    let ledger_dir = ledger_dir_from_tests(network);
     if !ledger_dir.is_dir() {
         eprintln!("skipping summary memory measurement; ledger directory {} does not exist", ledger_dir.display());
         return Ok(());

--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# post-checkout: share the primary worktree's snapshots/ with linked worktrees.
+#
+# Fires on `git worktree add`, branch switches, and other checkouts. The script
+# it calls is idempotent and a no-op on the primary worktree.
+#
+# If this branch does not yet contain the setup script (e.g. not merged), exit
+# quietly so checkout is never blocked.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+script="${repo_root}/scripts/setup-worktree-snapshots.sh"
+
+if [[ ! -f "${script}" ]]; then
+  exit 0
+fi
+
+exec "${script}"

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -7,7 +7,9 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOKS_DIR="$SCRIPT_DIR/hooks"
-GIT_HOOKS_DIR="$(git rev-parse --git-dir)/hooks"
+# Use --git-path so hooks install into the shared .git/hooks even when run from a
+# linked worktree (where --git-dir points at .git/worktrees/<name>).
+GIT_HOOKS_DIR="$(git rev-parse --git-path hooks)"
 
 echo "Setting up git hooks..."
 
@@ -22,6 +24,8 @@ if [ ! -d "$HOOKS_DIR" ]; then
     exit 1
 fi
 
+mkdir -p "$GIT_HOOKS_DIR"
+
 for hook in "$HOOKS_DIR"/*; do
     if [ -f "$hook" ]; then
         hook_name=$(basename "$hook")
@@ -33,7 +37,7 @@ for hook in "$HOOKS_DIR"/*; do
 done
 
 echo ""
-echo "Git hooks setup complete!"
+echo "Git hooks setup complete (installed to $GIT_HOOKS_DIR)!"
 echo ""
 echo "The following hooks are now active:"
 for hook in "$GIT_HOOKS_DIR"/*; do

--- a/scripts/setup-worktree-snapshots.sh
+++ b/scripts/setup-worktree-snapshots.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Link this worktree's snapshots/ directory to the primary (main) worktree's
+# snapshots/, so bootstrap/dev data is shared instead of re-downloaded per worktree.
+#
+# Safe to run repeatedly. No-ops on the primary worktree, when the main
+# snapshots/ directory is missing, or when a real (non-symlink) snapshots/
+# path already exists here.
+#
+# Invoked from the post-checkout hook (git worktree add / branch checkout)
+# and can be run manually after creating a worktree:
+#   ./scripts/setup-worktree-snapshots.sh
+
+set -euo pipefail
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "setup-worktree-snapshots: not inside a git repository" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+# First entry of `git worktree list` is always the primary worktree.
+main_root="$(git worktree list --porcelain | awk '/^worktree / { print $2; exit }')"
+
+if [[ -z "${main_root}" ]]; then
+  echo "setup-worktree-snapshots: could not determine primary worktree" >&2
+  exit 1
+fi
+
+if [[ "${repo_root}" == "${main_root}" ]]; then
+  exit 0
+fi
+
+src="${main_root}/snapshots"
+dst="${repo_root}/snapshots"
+
+if [[ ! -d "${src}" ]]; then
+  # Nothing to share yet; leave the worktree alone.
+  exit 0
+fi
+
+if [[ -L "${dst}" ]]; then
+  current="$(readlink "${dst}")"
+  if [[ "${current}" == "${src}" ]]; then
+    exit 0
+  fi
+  echo "setup-worktree-snapshots: replacing snapshots symlink (${current} -> ${src})"
+  rm "${dst}"
+elif [[ -e "${dst}" ]]; then
+  # Real directory or file — do not clobber local data.
+  echo "setup-worktree-snapshots: ${dst} already exists and is not a symlink; leaving it alone" >&2
+  exit 0
+fi
+
+ln -s "${src}" "${dst}"
+echo "setup-worktree-snapshots: linked ${dst} -> ${src}"


### PR DESCRIPTION
- ledger DB directories were triggering rebuilds of `amaru`, which I don’t think is useful -- please correct me if wrong
- peer snapshot download metadata was triggering rebuilds of `amaru-node`, which was incorrect (moved that file to $out_dir)
- printing span close for every single gov prop at INFO level seems inappropriate to me, the aggregate count is still there and I’ve seen INFO log when a gov prop is opened

Skip-changelog

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Developer Experience**
  - Added automatic snapshot sharing across Git worktrees.
  - Improved hook installation for standard repositories and linked worktrees.
  - Reused cached snapshots and avoided rewriting unchanged generated files.

- **Tests**
  - Stake-distribution and ledger tests now warn and continue when snapshots are missing.

- **Documentation**
  - Clarified peer snapshot setup, offline usage, caching, rebuild behavior, and test data refresh guidance.

- **Observability**
  - Reduced proposal-ratification log verbosity while preserving enactment details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->