### PR TITLE
fix handling of already validated blocks in select_chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Other guiding principles:
 
 ### Fixed
 
+- **amaru-consensus**: make `select_chain` handle already-validated tips idempotently so concurrent startup recovery cannot terminate the stage. ([#1124](https://github.com/pragma-org/amaru/pull/1124))
+- **amaru**: store nonces with both packaged bootstrap headers so the "nonces present ⇔ header validated" invariant holds after bootstrap. ([#1124](https://github.com/pragma-org/amaru/pull/1124))
 - **amaru-ledger**: reject governance proposals whose previous action does not match the enacted root nor an in-flight proposal of the same purpose. ([#1090][], [#932][])
 
 ## [v10.11.20260806](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260807)

--- a/crates/amaru-consensus/src/stages/select_chain/mod.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/mod.rs
@@ -55,10 +55,14 @@ use crate::{effects::FindBestCandidate, performance::Performance};
 ///   - Always returns the (mutated) state. Preloaded at startup for non-empty stores.
 ///
 /// - **TipFromUpstream(tip: Tip, parent: Point)**:
-///   - Loads the header+validity via store (terminates with error log if missing or already validated).
-///   - Inserts/extends a `tips` entry: special-cases `parent == Origin`; extends an existing pending chain;
-///     or (for new forks) queries store ancestors (only if the prefix is valid) and inserts the fragment.
-///     Ignores (with info log) tips depending on invalid blocks.
+///   - Loads the header+validity via store (terminates with error log if the header is missing).
+///   - Already-validated or already-invalid tips are dropped (debug/info); this stage must not
+///     terminate on a pre-existing validity flag, because startup recovery may set block validity
+///     after `track_peers` sent `NewTip` and before this message is processed. Already-tracked tips
+///     (same hash already in `tips` or equal to `best_tip`) are a pure no-op.
+///   - Otherwise inserts/extends a `tips` entry: special-cases `parent == Origin`; extends an existing
+///     pending chain; or (for new forks) queries store ancestors (only if the prefix is valid) and
+///     inserts the fragment. Ignores (with info log) tips depending on invalid blocks.
 ///   - If the new tip is now tracked in `tips` *and* is strictly better than `best_tip` per `cmp_tip`:
 ///     logs "new best tip candidate"; **if** `may_fetch_blocks` then sets it `false` and `eff.send(&downstream, (tip, parent))`;
 ///     unconditionally updates `best_tip`.
@@ -185,18 +189,36 @@ impl SelectChain {
     ) {
         let store = Store::new(eff.clone()).with_trace_context(&stage_context);
 
-        let Some((header, valid)) = store.load_header_with_validity(&tip.hash()).await else {
+        let Some((header, validity)) = store.load_header_with_validity(&tip.hash()).await else {
             tracing::error!(tip = %tip.point(), "tip not found");
             return eff.terminate().await;
         };
 
-        if let Some(valid) = valid {
-            // track_peers only sends a tip if the header was just validated,
-            // so its block cannot be already validated.
-            tracing::error!(tip = %tip.point(), %valid, "got tip from upstream that was already validated");
-            return eff.terminate().await;
-        } else {
-            tracing::debug!(tip = %tip.point(), "got new tip from upstream");
+        // Block-body validity is independent of header validation. During startup,
+        // `fetch_blocks` recovery can set a validity flag after `track_peers` checked the
+        // header and before this message is processed. Already-decided blocks are dropped:
+        // recovery/`Initialize` already own that chain; re-adopting here would grow `tips`
+        // and disturb best-tip bookkeeping for no gain.
+        match validity {
+            Some(true) => {
+                tracing::debug!(tip = %tip.point(), "ignoring tip from upstream that was already validated");
+                return;
+            }
+            Some(false) => {
+                tracing::info!(tip = %tip.point(), "ignoring tip from upstream whose block is already invalid");
+                let now = eff.clock().await;
+                eff.external(Performance::record_header_abandoned(tip.hash(), now)).await;
+                return;
+            }
+            None => {
+                tracing::debug!(tip = %tip.point(), "got new tip from upstream");
+            }
+        }
+
+        // Redundant NewTip (e.g. concurrent peers announcing the same header) must be a no-op.
+        if self.tips.contains_key(&tip.hash()) || self.best_tip.as_ref().is_some_and(|h| h.hash() == tip.hash()) {
+            tracing::debug!(tip = %tip.point(), "ignoring tip from upstream that is already tracked");
+            return;
         }
 
         if parent == Point::Origin {
@@ -209,9 +231,8 @@ impl SelectChain {
             chain.push(tip.hash());
             self.tips.insert(tip.hash(), chain);
         } else {
-            // since track_peers will only send newly stored tips, this is the case where
-            // a new fork is detected; while the new fork can only be one header long, it
-            // may still require multiple block validations to reach a valid chain
+            // New fork (or first tip on a path not yet tracked): the new branch can only be one
+            // header long, but it may still require multiple block validations to reach a valid chain.
             let (mut ancestors, valid) = store.unvalidated_ancestor_hashes(parent.hash()).await;
             if valid {
                 tracing::debug!(%parent, tip = %tip.point(), "new chain");

--- a/crates/amaru-consensus/src/stages/select_chain/tests.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/tests.rs
@@ -60,7 +60,9 @@ fn test_tip_not_found() {
 }
 
 #[test]
-fn test_tip_already_validated() {
+fn test_tip_already_validated_is_ignored() {
+    // Concurrent startup recovery can mark a block valid after track_peers sent NewTip and
+    // before select_chain processes it. Drop the tip; do not re-adopt or terminate.
     let prep = test_prep();
     prep.store_headers(&prep.headers.main());
     prep.set_validity(prep.headers.h2.hash(), true);
@@ -75,12 +77,73 @@ fn test_tip_already_validated() {
             te_state("sc-1", &prep.state),
             te_input("sc-1", &msg),
             te_load_header("sc-1", tip.hash(), true),
-            te_terminate("sc-1"),
-            te_terminated("sc-1", TerminationReason::Voluntary),
+            te_state("sc-1", &prep.state),
         ],
     );
-    logs.assert_and_remove(Level::ERROR, &["got tip from upstream that was already validated"])
-        .assert_and_remove(Level::INFO, &["terminated"])
+    logs.assert_and_remove(Level::DEBUG, &["already validated"]).assert_no_remaining_at([
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
+}
+
+#[test]
+fn test_tip_already_invalid_is_abandoned() {
+    let prep = test_prep();
+    prep.store_headers(&prep.headers.main());
+    prep.set_validity(prep.headers.h2.hash(), false);
+    let tip = prep.headers.h2.tip();
+    let parent = prep.headers.h1.point();
+    let msg = SelectChainMsg::tip_from_upstream(tip, parent);
+
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    assert_trace(
+        &running,
+        &[
+            te_state("sc-1", &prep.state),
+            te_input("sc-1", &msg),
+            te_load_header("sc-1", tip.hash(), true),
+            te_clock_read("sc-1"),
+            te_record_header_abandoned(
+                "sc-1",
+                tip.hash(),
+                Instant::at_offset(Duration::from_secs(10), start_in_era().relative_time),
+            ),
+            te_state("sc-1", &prep.state),
+        ],
+    );
+    logs.assert_and_remove(Level::INFO, &["already invalid"]).assert_no_remaining_at([
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
+}
+
+#[test]
+fn test_tip_already_tracked_is_noop() {
+    let mut prep = test_prep();
+    prep.store_headers(&prep.headers.main());
+    let tip = prep.headers.h2.tip();
+    let parent = prep.headers.h1.point();
+    prep.state.best_tip = Some(prep.headers.h2.clone());
+    prep.state.tips = BTreeMap::from_iter([(
+        tip.hash(),
+        vec![prep.headers.h0.hash(), prep.headers.h1.hash(), prep.headers.h2.hash()],
+    )]);
+    let msg = SelectChainMsg::tip_from_upstream(tip, parent);
+
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    assert_trace(
+        &running,
+        &[
+            te_state("sc-1", &prep.state),
+            te_input("sc-1", &msg),
+            te_load_header("sc-1", tip.hash(), true),
+            te_state("sc-1", &prep.state),
+        ],
+    );
+    logs.assert_and_remove(Level::DEBUG, &["got new tip from upstream"])
+        .assert_and_remove(Level::DEBUG, &["already tracked"])
         .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -381,8 +381,9 @@ impl TrackPeers {
     /// and `None` is returned. Otherwise the header is validated and the point of its parent is
     /// returned, together with the nonces to store alongside it.
     ///
-    /// Note: a header can already sit in the chain store without carrying any nonces, as is the
-    /// case for headers imported during bootstrap. Those still need to be validated.
+    /// Note: a header can already sit in the chain store without carrying any nonces (legacy
+    /// imports or incomplete migrations). Those still need to be validated so descendants can
+    /// evolve nonces. Proper bootstrap stores nonces with every packaged header.
     #[expect(clippy::too_many_arguments)]
     async fn validate_header(
         &mut self,

--- a/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
@@ -99,7 +99,7 @@ pub fn build_store(headers: &[BlockHeader]) -> Arc<InMemoryChainStore> {
 }
 
 /// Like [`build_store`] but also persists nonces for each header, mimicking a header that has
-/// already been fully validated (as opposed to one merely imported during bootstrap).
+/// already been fully validated (as opposed to a legacy import without nonces).
 pub fn build_store_with_nonces(headers: &[BlockHeader]) -> Arc<InMemoryChainStore> {
     let store = build_store(headers);
     for header in headers {

--- a/crates/amaru-consensus/src/stages/track_peers/tests.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/tests.rs
@@ -402,11 +402,11 @@ fn test_roll_forward_known_peer_header_already_stored() {
     ]);
 }
 
-/// A header imported during bootstrap is present in the chain store but has no evolved nonces.
-/// When re-received from a peer, its nonces must still be computed (via `validate_header`) so
-/// that descendant headers can be validated. Nonce absence means the header was never fully
-/// validated, so it is treated like a new header: stored with its nonces and propagated
-/// downstream.
+/// A header may already sit in the chain store without nonces (legacy import / incomplete
+/// migration). When re-received from a peer, its nonces must still be computed so descendant
+/// headers can be validated. Nonce absence means the header was never fully validated, so it is
+/// treated like a new header: stored with its nonces and propagated downstream. `select_chain`
+/// accepts the resulting tip even if concurrent recovery already validated the block body.
 #[test]
 fn test_roll_forward_stored_header_missing_nonces_revalidates() {
     let prep = test_prep();

--- a/crates/amaru/src/bootstrap/mod.rs
+++ b/crates/amaru/src/bootstrap/mod.rs
@@ -27,7 +27,7 @@ use amaru_kernel::{
 };
 use amaru_ledger::store::{EpochTransitionProgress, Store, TransactionalContext};
 use amaru_observability::{error, info};
-use amaru_ouroboros::{ChainStore, Nonces, OpcertSequenceNumbers, WriteChainStore};
+use amaru_ouroboros::{BaseReadChainStore, ChainStore, Nonces, OpcertSequenceNumbers, WriteChainStore};
 use amaru_progress_bar::TerminalProgressBar;
 use amaru_stores::rocksdb::{RocksDB, RocksDbConfig, consensus::RocksDBStore};
 use anyhow::anyhow;
@@ -430,11 +430,15 @@ pub async fn bootstrap(
     import_snapshot(network, global_parameters, &first_snapshot_path, &ledger_dir, &mut recently_unregistered_accounts)
         .await?;
 
-    import_snapshot(
+    // Extract nonces for the second snapshot tip as well: packaged bootstrap headers must enter
+    // the chain store already carrying nonces so that "nonces present ⇔ header validated" holds
+    // with no bootstrap exception.
+    let imported_second_snapshot = import_snapshot_with_optional_nonces(
         network,
         global_parameters,
         &second_snapshot_path,
         &ledger_dir,
+        Some(snapshot_hash(first_snapshot)?),
         &mut recently_unregistered_accounts,
     )
     .await?;
@@ -450,10 +454,16 @@ pub async fn bootstrap(
     .await?;
 
     let chain_db = RocksDBStore::create(RocksDbConfig::new(chain_dir.clone()))?;
-    let chain_state = imported_third_snapshot
+    let second_chain_state = imported_second_snapshot
+        .chain_state
+        .ok_or("bootstrap import must produce the chain state for the second snapshot")?;
+    let third_chain_state = imported_third_snapshot
         .chain_state
         .ok_or("bootstrap import must produce the chain state for the latest snapshot")?;
-    store_chain_state(imported_third_snapshot.epoch, &chain_db, chain_state)?;
+    // Nonces for both packaged tips are stored before the headers so
+    // `import_packaged_blocks` can attach each header via `store_validated_header`.
+    store_chain_state(imported_second_snapshot.epoch, &chain_db, second_chain_state)?;
+    store_chain_state(imported_third_snapshot.epoch, &chain_db, third_chain_state)?;
     let blocks = load_packaged_blocks_for_bootstrap(
         &second_snapshot_path,
         second_snapshot,
@@ -474,7 +484,13 @@ pub async fn import_packaged_blocks(db: &RocksDBStore, blocks: Vec<Vec<u8>>) -> 
 
         info!(bootstrap::header::IMPORT, header = %hash);
 
-        db.store_header(&block_header)?;
+        // Packaged bootstrap headers are trusted as fully validated; nonces must already have
+        // been imported for each tip so the durable "nonces present ⇔ header validated" invariant
+        // holds with no special case for bootstrap.
+        let nonces = db.get_nonces(&hash).ok_or_else(|| {
+            format!("bootstrap packaged header {hash} is missing nonces; refuse to store incomplete tip")
+        })?;
+        db.store_validated_header(&block_header, &nonces)?;
         db.store_block(&hash, &RawBlock::from(block.as_slice()))?;
     }
 


### PR DESCRIPTION
This followed from a discussion on #1124, it was easier to create the code as a basis for discussion than to describe it in English in detail.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup recovery when chain tips have already been validated, invalidated, or tracked.
  * Preserved nonce data for packaged bootstrap headers and rejected incomplete bootstrap tips.
  * Improved handling of legacy or partially migrated headers so they can be revalidated and recovered correctly.

* **Tests**
  * Added coverage for concurrent recovery and duplicate or previously processed chain tips.

* **Documentation**
  * Clarified validation and recovery behavior for stored headers and bootstrap data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->