### PR TITLE
Reduce stake distribution / rewards churn allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Other guiding principles:
 - **amaru-ledger**: a transaction marked invalid that carries no Plutus script is no longer accepted. ([#894][])
 - **amaru-pure-stage**: avoid constructing short string errors when failing to cast types in pure-stage.
 - **amaru**: fix a switch to fork when fork length was than one block. (#1162, #1190).
+- **amaru-ledger**: reduce churn allocations during stake distribution and rewards calculations.
 
 ## [v10.11.20260807](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260807)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Other guiding principles:
 - **amaru-plutus**: encode `CostModels` as a map from language to cost model (#1219).
 - **amaru-ledger**: compute the size of a value using the same encoding as the Haskell node.
 - **amaru-ledger**: validate voters in a transaction actually exist in ledger state. ([#1138][], [#923][])
+- **amaru-ledger**: reduce churn allocations during stake distribution and rewards calculations.
 
 ## v10.11.20260813 _[unreleased; planned for 2026-08-13]_
 
@@ -79,7 +80,6 @@ Other guiding principles:
 - **amaru-ledger**: a transaction marked invalid that carries no Plutus script is no longer accepted. ([#894][])
 - **amaru-pure-stage**: avoid constructing short string errors when failing to cast types in pure-stage.
 - **amaru**: fix a switch to fork when fork length was than one block. (#1162, #1190).
-- **amaru-ledger**: reduce churn allocations during stake distribution and rewards calculations.
 
 ## [v10.11.20260807](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260807)
 

--- a/crates/amaru-kernel/src/cardano.rs
+++ b/crates/amaru-kernel/src/cardano.rs
@@ -111,6 +111,7 @@ pub mod slot;
 pub mod stake_address;
 pub mod stake_credential;
 pub mod stake_credential_kind;
+pub mod stake_entry;
 pub mod time_range;
 pub mod tip;
 pub mod transaction;

--- a/crates/amaru-kernel/src/cardano/address.rs
+++ b/crates/amaru-kernel/src/cardano/address.rs
@@ -34,6 +34,9 @@ pub use delegation_part::ShelleyDelegationPart;
 mod payment_part;
 pub use payment_part::ShelleyPaymentPart;
 
+mod address_type;
+pub use address_type::AddressType;
+
 #[derive(Debug, Clone, PartialEq, Eq, std::hash::Hash)]
 pub enum Address {
     Byron(ByronAddress),
@@ -98,19 +101,18 @@ impl Address {
 
         let payload = &bytes[1..];
 
-        match (header & 0b1111_0000) >> 4 {
-            0 => parse_type_0(header, payload),
-            1 => parse_type_1(header, payload),
-            2 => parse_type_2(header, payload),
-            3 => parse_type_3(header, payload),
-            4 => parse_type_4(header, payload),
-            5 => parse_type_5(header, payload),
-            6 => parse_type_6(header, payload),
-            7 => parse_type_7(header, payload),
-            8 => parse_type_8(header, payload),
-            14 => parse_type_14(header, payload),
-            15 => parse_type_15(header, payload),
-            _ => None,
+        match AddressType::try_from_header_byte(header)? {
+            AddressType::Type0 => parse_type_0(header, payload),
+            AddressType::Type1 => parse_type_1(header, payload),
+            AddressType::Type2 => parse_type_2(header, payload),
+            AddressType::Type3 => parse_type_3(header, payload),
+            AddressType::Type4 => parse_type_4(header, payload),
+            AddressType::Type5 => parse_type_5(header, payload),
+            AddressType::Type6 => parse_type_6(header, payload),
+            AddressType::Type7 => parse_type_7(header, payload),
+            AddressType::Type8 => parse_type_8(header, payload),
+            AddressType::Type14 => parse_type_14(header, payload),
+            AddressType::Type15 => parse_type_15(header, payload),
         }
     }
 
@@ -126,15 +128,6 @@ impl Address {
             Address::Byron(x) => x.network(),
             Address::Shelley(x) => x.network(),
             Address::Stake(x) => x.network(),
-        }
-    }
-
-    /// Gets a numeric id describing the type of the address
-    pub fn typeid(&self) -> u8 {
-        match self {
-            Address::Byron(x) => x.typeid(),
-            Address::Shelley(x) => x.typeid(),
-            Address::Stake(x) => x.typeid(),
         }
     }
 

--- a/crates/amaru-kernel/src/cardano/address/address_type.rs
+++ b/crates/amaru-kernel/src/cardano/address/address_type.rs
@@ -1,0 +1,59 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum AddressType {
+    /// Base Key/Key Shelley address
+    Type0 = 0,
+    /// Base Script/Key Shelley address
+    Type1 = 1,
+    /// Base Key/Script Shelley address
+    Type2 = 2,
+    /// Base Script/Script Shelley address
+    Type3 = 3,
+    /// Pointer Key Shelley address deprecated since Conway
+    Type4 = 4,
+    /// Pointer Script Shelley address deprecated since Conway
+    Type5 = 5,
+    /// Payment Key Shelley address (a.k.a. Key Enterprise address)
+    Type6 = 6,
+    /// Payment Script Shelley address (a.k.a Script Enterprise address)
+    Type7 = 7,
+    /// Byron / Bootstrap address
+    Type8 = 8,
+    /// Stake Key Shelley address
+    Type14 = 14,
+    /// Stake Script Shelley address
+    Type15 = 15,
+}
+
+impl AddressType {
+    pub fn try_from_header_byte(header_byte: u8) -> Option<Self> {
+        match (header_byte & 0b1111_0000) >> 4 {
+            0 => Some(Self::Type0),
+            1 => Some(Self::Type1),
+            2 => Some(Self::Type2),
+            3 => Some(Self::Type3),
+            4 => Some(Self::Type4),
+            5 => Some(Self::Type5),
+            6 => Some(Self::Type6),
+            7 => Some(Self::Type7),
+            8 => Some(Self::Type8),
+            14 => Some(Self::Type14),
+            15 => Some(Self::Type15),
+            _ => None,
+        }
+    }
+}

--- a/crates/amaru-kernel/src/cardano/address/shelley.rs
+++ b/crates/amaru-kernel/src/cardano/address/shelley.rs
@@ -33,7 +33,7 @@ impl ShelleyAddress {
     }
 
     /// Gets a numeric id describing the type of the address
-    pub fn typeid(&self) -> u8 {
+    fn typeid(&self) -> u8 {
         match (&self.1, &self.2) {
             (ShelleyPaymentPart::Key(_), ShelleyDelegationPart::Key(_)) => 0b0000,
             (ShelleyPaymentPart::Script(_), ShelleyDelegationPart::Key(_)) => 0b0001,
@@ -46,7 +46,7 @@ impl ShelleyAddress {
         }
     }
 
-    pub fn to_header(&self) -> u8 {
+    fn as_header(&self) -> u8 {
         let type_id = self.typeid();
         let type_id = type_id << 4;
         let network = u8::from(self.0);
@@ -62,7 +62,7 @@ impl ShelleyAddress {
     }
 
     pub fn to_vec(&self) -> Vec<u8> {
-        let header = self.to_header();
+        let header = self.as_header();
         let payment = self.1.to_vec();
         let delegation = self.2.to_vec();
 

--- a/crates/amaru-kernel/src/cardano/drep.rs
+++ b/crates/amaru-kernel/src/cardano/drep.rs
@@ -19,7 +19,7 @@ use crate::{
     size::{KEY, SCRIPT},
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 pub enum DRep {
     Key(Hash<{ KEY }>),
     Script(Hash<{ SCRIPT }>),

--- a/crates/amaru-kernel/src/cardano/stake_address.rs
+++ b/crates/amaru-kernel/src/cardano/stake_address.rs
@@ -31,7 +31,7 @@ impl StakeAddress {
     }
 
     /// Gets a numeric id describing the type of the address
-    pub fn typeid(&self) -> u8 {
+    fn typeid(&self) -> u8 {
         match &self.1 {
             StakePayload::Key(_) => 0b1110,
             StakePayload::Script(_) => 0b1111,
@@ -39,7 +39,7 @@ impl StakeAddress {
     }
 
     /// Builds the header for this address
-    pub fn to_header(&self) -> u8 {
+    fn as_header(&self) -> u8 {
         let type_id = self.typeid();
         let type_id = type_id << 4;
         let network = u8::from(self.0);
@@ -53,7 +53,7 @@ impl StakeAddress {
     }
 
     pub fn to_vec(&self) -> Vec<u8> {
-        let header = self.to_header();
+        let header = self.as_header();
         [&[header], self.1.as_ref()].concat()
     }
 

--- a/crates/amaru-kernel/src/cardano/stake_credential.rs
+++ b/crates/amaru-kernel/src/cardano/stake_credential.rs
@@ -15,7 +15,7 @@
 use std::fmt;
 
 use crate::{
-    Address, HasOwnership, Hash, Network, ShelleyDelegationPart, ShelleyPaymentPart, StakePayload, cbor,
+    Address, AddressType, HasOwnership, Hash, Network, ShelleyDelegationPart, ShelleyPaymentPart, StakePayload, cbor,
     size::{CREDENTIAL, KEY, SCRIPT},
 };
 
@@ -38,10 +38,15 @@ pub enum StakeCredential {
 
 impl StakeCredential {
     pub fn from_raw_address(bytes: &[u8]) -> Option<Self> {
-        match (bytes.first()? & 0b1111_0000) >> 4 {
-            0 | 1 if bytes.len() == 2 * CREDENTIAL + 1 => Some(Self::AddrKeyhash(Hash::from(&bytes[KEY + 1..]))),
-            2 | 3 if bytes.len() == 2 * CREDENTIAL + 1 => Some(Self::ScriptHash(Hash::from(&bytes[SCRIPT + 1..]))),
-            _ => None,
+        use AddressType::*;
+        match AddressType::try_from_header_byte(*bytes.first()?)? {
+            Type0 | Type1 => {
+                (bytes.len() == 2 * CREDENTIAL + 1).then(|| Self::AddrKeyhash(Hash::from(&bytes[KEY + 1..])))
+            }
+            Type2 | Type3 => {
+                (bytes.len() == 2 * CREDENTIAL + 1).then(|| Self::ScriptHash(Hash::from(&bytes[SCRIPT + 1..])))
+            }
+            Type4 | Type5 | Type6 | Type7 | Type8 | Type14 | Type15 => None,
         }
     }
 }

--- a/crates/amaru-kernel/src/cardano/stake_credential.rs
+++ b/crates/amaru-kernel/src/cardano/stake_credential.rs
@@ -15,8 +15,8 @@
 use std::fmt;
 
 use crate::{
-    Address, HasOwnership, Hash, Network, StakePayload, cbor,
-    size::{KEY, SCRIPT},
+    Address, HasOwnership, Hash, Network, ShelleyDelegationPart, ShelleyPaymentPart, StakePayload, cbor,
+    size::{CREDENTIAL, KEY, SCRIPT},
 };
 
 // NOTE: Stake Credential variant order
@@ -34,6 +34,16 @@ use crate::{
 pub enum StakeCredential {
     ScriptHash(Hash<{ SCRIPT }>),
     AddrKeyhash(Hash<{ KEY }>),
+}
+
+impl StakeCredential {
+    pub fn from_raw_address(bytes: &[u8]) -> Option<Self> {
+        match (bytes.first()? & 0b1111_0000) >> 4 {
+            0 | 1 if bytes.len() == 2 * CREDENTIAL + 1 => Some(Self::AddrKeyhash(Hash::from(&bytes[KEY + 1..]))),
+            2 | 3 if bytes.len() == 2 * CREDENTIAL + 1 => Some(Self::ScriptHash(Hash::from(&bytes[SCRIPT + 1..]))),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for StakeCredential {
@@ -101,6 +111,26 @@ impl From<StakePayload> for StakeCredential {
         match payload {
             StakePayload::Key(hash) => Self::AddrKeyhash(hash),
             StakePayload::Script(hash) => Self::ScriptHash(hash),
+        }
+    }
+}
+
+impl From<ShelleyPaymentPart> for StakeCredential {
+    fn from(part: ShelleyPaymentPart) -> Self {
+        match part {
+            ShelleyPaymentPart::Key(hash) => Self::AddrKeyhash(hash),
+            ShelleyPaymentPart::Script(hash) => Self::ScriptHash(hash),
+        }
+    }
+}
+
+impl TryFrom<ShelleyDelegationPart> for StakeCredential {
+    type Error = ();
+    fn try_from(part: ShelleyDelegationPart) -> Result<Self, Self::Error> {
+        match part {
+            ShelleyDelegationPart::Key(hash) => Ok(Self::AddrKeyhash(hash)),
+            ShelleyDelegationPart::Script(hash) => Ok(Self::ScriptHash(hash)),
+            ShelleyDelegationPart::Pointer(..) | ShelleyDelegationPart::Null => Err(()),
         }
     }
 }

--- a/crates/amaru-kernel/src/cardano/stake_entry.rs
+++ b/crates/amaru-kernel/src/cardano/stake_entry.rs
@@ -1,0 +1,108 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{Address, Lovelace, StakeCredential, Value, cbor};
+
+/// A stake distribution entry corresponding to a single key/value mapping between a stake
+/// credential and an amount. This is decoded from a UTxO but in a way that circumvent allocations
+/// to avoid unnecessary churn when scanning a large number of UTxOs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StakeEntry {
+    pub credential: Option<StakeCredential>,
+    pub lovelace: Lovelace,
+}
+
+impl<'d, C> cbor::Decode<'d, C> for StakeEntry {
+    fn decode(d: &mut cbor::Decoder<'d>, ctx: &mut C) -> Result<Self, cbor::decode::Error> {
+        let data_type = d.datatype()?;
+
+        Ok(if matches!(data_type, cbor::Type::MapIndef | cbor::Type::Map) {
+            decode_modern(d, ctx)?
+        } else if matches!(data_type, cbor::Type::ArrayIndef | cbor::Type::Array) {
+            decode_legacy(d, ctx)?
+        } else {
+            return Err(cbor::decode::Error::type_mismatch(data_type));
+        })
+    }
+}
+
+fn decode_modern<C>(d: &mut cbor::Decoder<'_>, ctx: &mut C) -> Result<StakeEntry, cbor::decode::Error> {
+    let (credential, lovelace) = cbor::heterogeneous_map(
+        d,
+        (None, None),
+        |d| d.u8(),
+        |d, state, field| {
+            match field {
+                0 => state.0 = Some(StakeCredential::from_raw_address(d.bytes()?)),
+                1 => state.1 = Some(Value::decode_lovelace(d, ctx)?),
+                2 => d.skip()?,
+                3 => d.skip()?,
+                _ => return cbor::unexpected_field::<StakeEntry, _>(field),
+            }
+            Ok(())
+        },
+    )?;
+
+    Ok(StakeEntry {
+        credential: credential.ok_or_else(|| cbor::missing_field::<StakeEntry, Address>(0))?,
+        lovelace: lovelace.ok_or_else(|| cbor::missing_field::<StakeEntry, Lovelace>(1))?,
+    })
+}
+
+fn decode_legacy<C>(d: &mut cbor::Decoder<'_>, ctx: &mut C) -> Result<StakeEntry, cbor::decode::Error> {
+    let len = d.array()?;
+
+    let credential = StakeCredential::from_raw_address(d.bytes()?);
+    let lovelace = Value::decode_lovelace(d, ctx)?;
+
+    if let Some(len) = len {
+        if len > 2 {
+            d.skip()?;
+        }
+    } else {
+        if !cbor::decode_break(d, len)? {
+            d.skip()?;
+            if !cbor::decode_break(d, len)? {
+                return Err(cbor::decode::Error::message("expected break after legacy transaction output datum"));
+            }
+        }
+    }
+
+    Ok(StakeEntry { credential, lovelace })
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::{prelude::*, prop_oneof};
+
+    use crate::{
+        Address, StakeCredential, StakeEntry, any_legacy_output, any_modern_output, from_cbor, to_cbor,
+        traits::has_lovelace::HasLovelace,
+    };
+
+    proptest! {
+    #[test]
+        fn decode_memoized_output(output in prop_oneof![any_modern_output(), any_legacy_output()]) {
+            let StakeEntry { credential, lovelace } = from_cbor(&to_cbor(&output)).unwrap();
+
+            assert_eq!(lovelace, output.lovelace());
+
+            if let Address::Shelley(addr) = &output.address {
+                assert_eq!(credential, StakeCredential::try_from(*addr.delegation()).ok());
+            } else {
+                assert_eq!(credential, None)
+            }
+        }
+    }
+}

--- a/crates/amaru-kernel/src/cardano/stake_entry.rs
+++ b/crates/amaru-kernel/src/cardano/stake_entry.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Address, Lovelace, StakeCredential, Value, cbor};
+use crate::{Address, Lovelace, StakeCredential, Value, cbor, cbor::decode_bytes};
 
 /// A stake distribution entry corresponding to a single key/value mapping between a stake
 /// credential and an amount. This is decoded from a UTxO but in a way that circumvent allocations
@@ -44,7 +44,7 @@ fn decode_modern<C>(d: &mut cbor::Decoder<'_>, ctx: &mut C) -> Result<StakeEntry
         |d| d.u8(),
         |d, state, field| {
             match field {
-                0 => state.0 = Some(StakeCredential::from_raw_address(d.bytes()?)),
+                0 => state.0 = Some(StakeCredential::from_raw_address(&decode_bytes(d)?)),
                 1 => state.1 = Some(Value::decode_lovelace(d, ctx)?),
                 2 => d.skip()?,
                 3 => d.skip()?,
@@ -63,7 +63,7 @@ fn decode_modern<C>(d: &mut cbor::Decoder<'_>, ctx: &mut C) -> Result<StakeEntry
 fn decode_legacy<C>(d: &mut cbor::Decoder<'_>, ctx: &mut C) -> Result<StakeEntry, cbor::decode::Error> {
     let len = d.array()?;
 
-    let credential = StakeCredential::from_raw_address(d.bytes()?);
+    let credential = StakeCredential::from_raw_address(&decode_bytes(d)?);
     let lovelace = Value::decode_lovelace(d, ctx)?;
 
     if let Some(len) = len {

--- a/crates/amaru-kernel/src/cardano/value.rs
+++ b/crates/amaru-kernel/src/cardano/value.rs
@@ -30,6 +30,24 @@ pub enum Value {
     Multiasset(Lovelace, Multiasset<PositiveCoin>),
 }
 
+impl Value {
+    /// Partially decode a Value to only extract the lovelace amount, skipping the rest.
+    #[expect(clippy::wildcard_enum_match_arm)]
+    pub fn decode_lovelace<C>(d: &mut cbor::Decoder<'_>, ctx: &mut C) -> Result<Lovelace, cbor::decode::Error> {
+        use cbor::data::Type::*;
+
+        match d.datatype()? {
+            U8 | U16 | U32 | U64 => Ok(d.decode_with(ctx)?),
+            Array | ArrayIndef => cbor::heterogeneous_array(d, |d, _| {
+                let lovelace = d.decode_with(ctx)?;
+                d.skip()?;
+                Ok(lovelace)
+            }),
+            _ => Err(cbor::decode::Error::message("unknown cbor data type for Value")),
+        }
+    }
+}
+
 impl<C> cbor::encode::Encode<C> for Value {
     fn encode<W: cbor::encode::Write>(
         &self,

--- a/crates/amaru-kernel/src/data_structures.rs
+++ b/crates/amaru-kernel/src/data_structures.rs
@@ -20,3 +20,4 @@ pub mod non_empty_key_value_pairs;
 pub mod non_empty_set;
 pub mod non_empty_vec;
 pub mod non_zero_duration;
+pub mod sorted_pairs;

--- a/crates/amaru-kernel/src/data_structures/sorted_pairs.rs
+++ b/crates/amaru-kernel/src/data_structures/sorted_pairs.rs
@@ -1,0 +1,214 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{borrow::Borrow, collections::BTreeMap, fmt};
+
+/// A _near drop-in_ replacement for BTreeMap but with its internal based on a vector. The API is
+/// purposely crafted to reduce and control memory-allocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SortedPairs<K: Ord, V>(Vec<(K, V)>);
+
+/// Construct an empty sequence; should generally be avoided in favor of `Self::with_capacity`.
+impl<K: Ord, V> Default for SortedPairs<K, V> {
+    fn default() -> Self {
+        Self(Vec::default())
+    }
+}
+
+/// A From instance that is mostly convenient for testing, otherwise defies the purpose of the
+/// entire structure.
+impl<K: Ord, V> From<BTreeMap<K, V>> for SortedPairs<K, V> {
+    fn from(map: BTreeMap<K, V>) -> Self {
+        Self(map.into_iter().collect())
+    }
+}
+
+impl<K: Ord, V> SortedPairs<K, V> {
+    /// Like `Self::push`, but takes and give back ownership to help with builder-style API.
+    pub fn and_push(mut self, k: K, v: V) -> Self
+    where
+        K: fmt::Debug,
+    {
+        self.push(k, v);
+        self
+    }
+
+    /// Concatenate two pairs together.
+    ///
+    /// Panics if the first key of the right-hand side is not strictly after the last key of the
+    /// left-hand side.
+    pub fn append(mut self, mut rhs: Self) -> Self
+    where
+        K: fmt::Debug,
+    {
+        if let Some((lhs_last, _)) = self.0.last()
+            && let Some((rhs_first, _)) = rhs.0.first()
+        {
+            assert!(
+                rhs_first > lhs_last,
+                "invariant violation (SortedPairs.append): rhs' first element ({:?}) is not after lhs' last element ({:?})",
+                rhs_first,
+                lhs_last,
+            );
+        }
+
+        self.0.append(&mut rhs.0);
+        self
+    }
+
+    /// Returns true if the pairs contains a value for the specified key.
+    ///
+    /// The key may be any borrowed form of the pairs’ key type, but the ordering on the borrowed form must match the ordering on the key type.
+    pub fn contains_key<Q>(&self, k: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.binary_search(k).is_ok()
+    }
+
+    /// Returns a reference to the value corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the pairs’ key type, but the ordering on the borrowed
+    /// form must match the ordering on the key type.
+    pub fn get<Q>(&self, k: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        let ix = self.binary_search(k).ok()?;
+        Some(&self.0[ix].1)
+    }
+
+    /// Returns a **mutable** reference to the value corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the pairs’s key type, but the ordering on the borrowed
+    /// form must match the ordering on the key type.
+    pub fn get_mut<Q>(&mut self, k: &Q) -> Option<&mut V>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        let ix = self.binary_search(k).ok()?;
+        Some(&mut self.0[ix].1)
+    }
+
+    /// Insert at key/value pairs at the right location replacing any existing key.
+    ///
+    /// This method can be costly as it will need to re-allocate and move elements around for
+    /// values inserted in the middle of the sequence.
+    pub fn insert(&mut self, k: K, v: V) {
+        match self.binary_search(&k) {
+            Ok(ix) => {
+                self.0[ix].1 = v;
+            }
+            Err(ix) => {
+                self.0.insert(ix, (k, v));
+            }
+        }
+    }
+
+    /// Returns `true` if there are no pairs.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Gets an iterator over the entries of the pairs, sorted by key.
+    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.0.iter().map(|(k, v)| (k, v))
+    }
+
+    /// Gets an iterator over mutable entries of the pairs, sorted by key.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&K, &mut V)> {
+        self.0.iter_mut().map(|(k, v)| (&*k, v))
+    }
+
+    /// Gets an iterator over the keys of the pairs, in order by key.
+    pub fn keys(&self) -> impl Iterator<Item = &K> {
+        self.0.iter().map(|(k, _v)| k)
+    }
+
+    /// Returns the number of pairs.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Add a new key/value pair after existing keys.
+    ///
+    /// Panics if the key is not strictly after the last inserted one.
+    pub fn push(&mut self, k: K, v: V)
+    where
+        K: fmt::Debug,
+    {
+        if let Some((last, _)) = self.0.last() {
+            assert!(
+                &k > last,
+                "invariant violation (SortedPairs.push): pushed element ({k:?}) is not after last element ({last:?})",
+            );
+        }
+
+        self.0.push((k, v));
+    }
+
+    /// Gets an iterator over the values of the pairs, in order by key.
+    pub fn values(&self) -> impl Iterator<Item = &V> {
+        self.0.iter().map(|(_k, v)| v)
+    }
+
+    /// Constructs a new, empty `SortedPairs<K, V> with at least the specified capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(Vec::with_capacity(capacity))
+    }
+}
+
+impl<K: Ord, V> SortedPairs<K, V> {
+    fn binary_search<Q>(&self, k: &Q) -> Result<usize, usize>
+    where
+        K: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.0.binary_search_by_key(&k, |(k, _)| k.borrow())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::{collection::btree_map, prelude::*};
+
+    use crate::SortedPairs;
+
+    proptest! {
+        #[test]
+        fn behave_similar_to_btreemap(map in btree_map(any::<u8>(), any::<bool>(), 0..10)) {
+            let mut pairs = SortedPairs::with_capacity(map.len());
+            for (k, v) in map.iter() {
+                pairs.push(*k, *v);
+            }
+
+            prop_assert_eq!(&SortedPairs::from(map.clone()), &pairs, "from");
+
+            prop_assert_eq!(pairs.len(), map.len());
+            prop_assert_eq!(pairs.is_empty(), map.is_empty());
+
+            for (l, r) in map.iter().zip(pairs.iter()) {
+                prop_assert_eq!(map.contains_key(l.0), pairs.contains_key(l.0), ".contains_key");
+                prop_assert_eq!(pairs.get(r.0), Some(l.1), ".get");
+                prop_assert_eq!(l, r, ".iter/.zip");
+            }
+
+            prop_assert_eq!(map.keys().collect::<Vec<_>>(), pairs.keys().collect::<Vec<_>>(), ".keys");
+            prop_assert_eq!(map.values().collect::<Vec<_>>(), pairs.values().collect::<Vec<_>>(), ".values");
+        }
+    }
+}

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -44,6 +44,7 @@ pub use data_structures::{
     non_empty_set::{IntoNonEmptySetError, NonEmptySet},
     non_empty_vec::{IntoNonEmptyVecError, NonEmptyVec},
     non_zero_duration::{NonZeroDuration, ZeroDurationError},
+    sorted_pairs::SortedPairs,
 };
 
 pub mod cbor {

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -67,8 +67,8 @@ pub mod cardano;
 pub use cardano::{
     account::Account,
     address::{
-        self, Address, AddressPointer, ByronAddress, ShelleyAddress, ShelleyDelegationPart, ShelleyPaymentPart,
-        StakePayload,
+        self, Address, AddressPointer, AddressType, ByronAddress, ShelleyAddress, ShelleyDelegationPart,
+        ShelleyPaymentPart, StakePayload,
     },
     anchor::{self, Anchor},
     asset_name::{AssetName, EMPTY_ASSET_NAME},

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -176,6 +176,7 @@ pub use cardano::{
     stake_address::{self, PlutusStakeAddress, StakeAddress},
     stake_credential::{BorrowedStakeCredential, StakeCredential, parse_reward_account},
     stake_credential_kind::StakeCredentialKind,
+    stake_entry::{self, StakeEntry},
     time_range::TimeRange,
     tip::Tip,
     transaction::Transaction,

--- a/crates/amaru-ledger/src/epoch_transition/rewards_state.rs
+++ b/crates/amaru-ledger/src/epoch_transition/rewards_state.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    marker::PhantomData,
-    sync::Arc,
-};
+use std::{collections::BTreeSet, marker::PhantomData, sync::Arc};
 
-use amaru_kernel::{Lovelace, StakeCredential};
+use amaru_kernel::{Lovelace, SortedPairs, StakeCredential};
+
+use crate::AccountState;
 
 /// Captures the lifecycle of rewards calculation throughout block applications. Rewards are
 /// computed and later consumed/applied to accounts.
@@ -151,7 +149,7 @@ pub struct Rewards<STEP: KnownRewardState + Clone> {
     /// carves out the unclaimed ones through `unclaimed`. It is behind an `Arc` so that converting
     /// between `Effective` and `Computed` (and snapshotting the overlay for rollback recovery)
     /// shares this map rather than copying it.
-    accounts: Arc<BTreeMap<StakeCredential, Lovelace>>,
+    accounts: Arc<SortedPairs<StakeCredential, AccountState>>,
 
     /// Known (paid) pools owners at the time the rewards were calculated that received non-zero
     /// rewards.
@@ -182,7 +180,7 @@ impl Rewards<Computed> {
         delta_reserves: Lovelace,
         delta_treasury: Lovelace,
         total_rewards: Lovelace,
-        accounts: BTreeMap<StakeCredential, Lovelace>,
+        accounts: SortedPairs<StakeCredential, AccountState>,
         pools_owners: BTreeSet<StakeCredential>,
     ) -> Self {
         Self {
@@ -205,7 +203,10 @@ impl Rewards<Computed> {
         &self,
         unreachable_accounts: impl IntoIterator<Item = StakeCredential>,
     ) -> BTreeSet<StakeCredential> {
-        unreachable_accounts.into_iter().filter(|credential| self.accounts.contains_key(credential)).collect()
+        unreachable_accounts
+            .into_iter()
+            .filter(|credential| self.accounts.get(credential).is_some_and(|st| st.rewards > 0))
+            .collect()
     }
 }
 
@@ -238,13 +239,13 @@ impl Rewards<Effective> {
     /// The reward payable to a specific account: its computed reward if it is still registered, or
     /// `0` if it is unclaimed (in which case the amount goes to the treasury instead) or has none.
     pub fn reward_of(&self, account: &StakeCredential) -> Lovelace {
-        if self.unclaimed.contains(account) { 0 } else { self.accounts.get(account).copied().unwrap_or(0) }
+        if self.unclaimed.contains(account) { 0 } else { self.accounts.get(account).map(|st| st.rewards).unwrap_or(0) }
     }
 
     /// Total amount of rewards that couldn't be paid to accounts because they unregistered between
     /// the moment the rewards were calculated and the moment they needed to be paid out.
     pub fn total_unclaimed_rewards(&self) -> Lovelace {
-        self.unclaimed.iter().filter_map(|account| self.accounts.get(account)).sum()
+        self.unclaimed.iter().filter_map(|account| self.accounts.get(account).map(|st| st.rewards)).sum()
     }
 
     /// Total rewards of ALL accounts, including unclaimed ones.
@@ -286,6 +287,8 @@ impl From<Rewards<Effective>> for Rewards<Computed> {
 
 #[cfg(test)]
 mod test {
+    use std::collections::BTreeMap;
+
     use amaru_kernel::Hash;
 
     use super::*;
@@ -296,8 +299,8 @@ mod test {
         let unregistered = StakeCredential::ScriptHash(Hash::from([2u8; 28]));
 
         let mut accounts = BTreeMap::new();
-        accounts.insert(registered, 100);
-        accounts.insert(unregistered, 42);
+        accounts.insert(registered, AccountState::default().with_rewards(100));
+        accounts.insert(unregistered, AccountState::default().with_rewards(42));
 
         let delta_reserves = 1_000;
         let delta_treasury = 7;
@@ -305,8 +308,8 @@ mod test {
         let computed_rewards = Rewards::<Computed>::new(
             delta_reserves,
             delta_treasury,
-            accounts.values().sum(),
-            accounts,
+            accounts.values().map(|st| st.rewards).sum(),
+            SortedPairs::from(accounts),
             pools_owners.clone(),
         );
         let effective_rewards = Rewards::<Effective>::new(computed_rewards.clone(), BTreeSet::from([unregistered]));
@@ -332,7 +335,7 @@ mod test {
         let rewarded = StakeCredential::ScriptHash(Hash::from([1u8; 28]));
         let rewardless = StakeCredential::ScriptHash(Hash::from([2u8; 28]));
 
-        let accounts = BTreeMap::from([(rewarded, 42)]);
+        let accounts = SortedPairs::default().and_push(rewarded, AccountState::default().with_rewards(42));
         let computed_rewards = Rewards::<Computed>::new(1_000, 7, 42, accounts, Default::default());
 
         // The same credentials repeated, as chaining the unregistration sources may well do.

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -125,6 +125,7 @@ where
     /// Background computation calculating rewards and stake distributions
     rewards_join_handle: Option<JoinHandle<Result<RewardsSummary, StateError>>>,
 
+    /// A local debounced tip emitter avoid flooding logs with tip updates during sync
     tip_update_emitter: TipUpdateEmitter,
 }
 
@@ -1141,14 +1142,13 @@ where
         .map(|snapshot| {
             let epoch = snapshot.epoch();
             let mut printed = Instant::now();
-            compute_stake_summary(&snapshot, network, era_history, move |progress| {
+            compute_stake_distribution(&snapshot, network, era_history, None, |progress| {
                 let now = Instant::now();
                 if emit_progress_ticks && now.saturating_duration_since(printed) > Duration::from_millis(100) {
                     printed = now;
                     info!(ledger::stake_distribution::INITIAL_PROGRESS, epoch = epoch, progress);
                 }
             })
-            .map(|summary| summary.stake_distribution)
         })
         .collect::<Result<VecDeque<_>, _>>()
         .map_err(|err| StoreError::Internal(err.into()))?;
@@ -1161,15 +1161,25 @@ where
     Ok(stake_distributions)
 }
 
-fn compute_stake_summary(
+fn compute_stake_distribution(
     snapshot: &impl Snapshot,
     network: NetworkName,
     era_history: &EraHistory,
-    notify: impl FnMut(f64),
-) -> Result<StakeSummary, StateError> {
+    notify_observer: Option<&(dyn Fn(&crate::observers::LedgerStateSnapshot) + Send + Sync)>,
+    notify_progress: impl FnMut(f64),
+) -> Result<StakeDistribution, StateError> {
     info_span!(ledger::stake_distribution::COMPUTE, epoch = snapshot.epoch(),).in_scope(|| {
-        StakeSummary::new(snapshot, GovernanceSummary::new(snapshot, era_history)?, network, notify)
-            .map_err(StateError::Storage)
+        let summary =
+            StakeSummary::new(snapshot, GovernanceSummary::new(snapshot, era_history)?, network, notify_progress)
+                .map_err(StateError::Storage)?;
+
+        // Opt-in: show the full summary (incl. accounts) by reference before we only
+        // retain the slim in-memory distribution. Observer clones individual fields if needed.
+        if let Some(notify) = &notify_observer {
+            notify(&summary);
+        }
+
+        Ok(summary.stake_distribution)
     })
 }
 
@@ -1220,15 +1230,13 @@ impl<HS: HistoricalStores> BackgroundTasks<HS> {
             .unwrap_or(true);
 
         if should_push_summary {
-            let summary = compute_stake_summary(&snapshot, self.network, &self.era_history, |_| {})?;
-
-            // Opt-in: show the full summary (incl. accounts) by reference before we only
-            // retain the slim in-memory distribution. Observer clones individual fields if needed.
-            if let Some(notify) = &self.on_ledger_snapshot {
-                notify(&summary);
-            }
-
-            let distr = summary.stake_distribution;
+            let distr = compute_stake_distribution(
+                &snapshot,
+                self.network,
+                &self.era_history,
+                self.on_ledger_snapshot.as_deref(),
+                |_| {},
+            )?;
 
             let mut stake_distributions = self.stake_distributions.lock().unwrap();
 
@@ -1262,17 +1270,20 @@ impl<HS: HistoricalStores> BackgroundTasks<HS> {
             using_stake_distribution_from_epoch = stake_distribution_from
         )
         .in_scope(|| {
-            let stake_distribution = compute_stake_summary(
-                &self.snapshots.for_epoch(stake_distribution_from)?,
+            let snapshot = self.snapshots.for_epoch(stake_distribution_from).map_err(StateError::Storage)?;
+
+            let stake_summary = StakeSummary::new(
+                &snapshot,
+                GovernanceSummary::new(&snapshot, &self.era_history)?,
                 self.network,
-                &self.era_history,
                 |_| {},
-            )?;
+            )
+            .map_err(StateError::Storage)?;
 
             let previous_epoch = self.snapshots.for_epoch(self.epoch - 1)?;
 
             Ok(RewardsSummary::new(
-                stake_distribution,
+                stake_summary,
                 &self.global_parameters,
                 &self.protocol_parameters,
                 previous_epoch.iter_block_issuers().map_err(StateError::Storage)?.map(|(_, block)| block.slot_leader),

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -543,13 +543,14 @@ mod tests {
 
     use amaru_kernel::{
         ConstitutionalCommitteeUpdate, Epoch, Hash, PREPROD_DEFAULT_PROTOCOL_PARAMETERS, Point, SafeRatio, Slot,
-        StakeCredential, any_modern_output, any_transaction_input, utils::tests::run_strategy,
+        SortedPairs, StakeCredential, any_modern_output, any_transaction_input, utils::tests::run_strategy,
     };
     use num::Zero;
     use test_case::test_case;
 
     use super::*;
     use crate::{
+        AccountState,
         epoch_transition::{Computed, Effective, GovernanceUpdates, PoolsEpochTransitionUpdates, Rewards},
         state::volatile::{Bind, Resettable},
     };
@@ -1193,8 +1194,9 @@ mod tests {
     #[test]
     fn reward_balance_folds_in_the_pending_overlay_credit_during_the_straddle() {
         let mut db = VolatileDB::default();
-        let accounts = BTreeMap::from([(cred(1), 5_000_000)]);
-        let computed = Rewards::<Computed>::new(0, 0, accounts.values().sum(), accounts, Default::default());
+        let accounts = SortedPairs::default().and_push(cred(1), AccountState::default().with_rewards(5_000_000));
+        let computed =
+            Rewards::<Computed>::new(0, 0, accounts.values().map(|st| st.rewards).sum(), accounts, Default::default());
         let effective = Rewards::<Effective>::new(computed, BTreeSet::new());
 
         // The pending boundary credit is added on top of the stable base.
@@ -1304,7 +1306,7 @@ mod tests {
     #[test_case(None, None => Existence::Unknown; "untouched everywhere defers to the stable store")]
     fn resolve_committee_precedence(draining: Option<CommitteeAct>, current: Option<CommitteeAct>) -> Existence<bool> {
         let mut db = VolatileDB::default();
-        let computed = Rewards::<Computed>::new(0, 0, 0, BTreeMap::new(), Default::default());
+        let computed = Rewards::<Computed>::new(0, 0, 0, SortedPairs::default(), Default::default());
         let effective = Rewards::<Effective>::new(computed, BTreeSet::new());
         if let Some(act) = draining {
             db.push_back(committee_block(10, act));
@@ -1433,8 +1435,13 @@ mod tests {
     /// Effective boundary rewards crediting a single account, to give the overlay non-trivial,
     /// observable state (its pending reward credit surfaces through `resolve_account`).
     fn effective_reward(credential: StakeCredential, amount: u64) -> Rewards<Effective> {
-        let computed =
-            Rewards::<Computed>::new(0, 0, amount, BTreeMap::from([(credential, amount)]), Default::default());
+        let computed = Rewards::<Computed>::new(
+            0,
+            0,
+            amount,
+            SortedPairs::default().and_push(credential, AccountState::default().with_rewards(amount)),
+            Default::default(),
+        );
         Rewards::<Effective>::new(computed, BTreeSet::new())
     }
 

--- a/crates/amaru-ledger/src/state/volatile/overlay.rs
+++ b/crates/amaru-ledger/src/state/volatile/overlay.rs
@@ -449,7 +449,7 @@ mod test {
     use amaru_kernel::{Hash, PREPROD_DEFAULT_PROTOCOL_PARAMETERS, TreasuryDelta};
 
     use super::*;
-    use crate::epoch_transition::Computed;
+    use crate::{AccountState, epoch_transition::Computed};
 
     #[test]
     fn test_rollback() {
@@ -497,7 +497,11 @@ mod test {
             1_000,
             7,
             142,
-            BTreeMap::from([(credential(1), 100), (credential(2), 42)]),
+            BTreeMap::from([
+                (credential(1), AccountState::default().with_rewards(100)),
+                (credential(2), AccountState::default().with_rewards(42)),
+            ])
+            .into(),
             Default::default(),
         );
         Rewards::<Effective>::new(computed, BTreeSet::from([credential(2)]))

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -19,6 +19,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use amaru_kernel::StakeEntry;
 use amaru_kernel::{
     CertificatePointer,
     Constitution,
@@ -367,6 +368,16 @@ pub trait ReadStore {
     #[cfg(any(test, feature = "test-utils"))]
     fn iter_utxos(&self) -> Result<impl Iterator<Item = (utxo::Key, utxo::Value)>> {
         Err::<std::iter::Empty<(utxo::Key, utxo::Value)>, _>(default_read_store_error("ReadStore.iter_utxos()"))
+    }
+
+    /// A non-allocating and specialized version of iter_utxos bespoke to the stake distribution
+    /// calculations.
+    #[cfg(not(any(test, feature = "test-utils")))]
+    fn iter_stake_distribution(&self) -> Result<impl Iterator<Item = StakeEntry>>;
+
+    #[cfg(any(test, feature = "test-utils"))]
+    fn iter_stake_distribution(&self) -> Result<impl Iterator<Item = StakeEntry>> {
+        Err::<std::iter::Empty<StakeEntry>, _>(default_read_store_error("ReadStore.iter_stake_distribution()"))
     }
 
     /// Get details about all slot leaders

--- a/crates/amaru-ledger/src/store/columns/accounts.rs
+++ b/crates/amaru-ledger/src/store/columns/accounts.rs
@@ -35,7 +35,7 @@ pub enum Value {
 
 pub type Key = StakeCredential;
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub struct Row {
     pub pool: Option<(PoolId, CertificatePointer)>,
     pub deposit: Lovelace,

--- a/crates/amaru-ledger/src/store/columns/slots.rs
+++ b/crates/amaru-ledger/src/store/columns/slots.rs
@@ -25,7 +25,7 @@ pub type Value = Row;
 /// Iterator used to browse rows from the Pools column. Meant to be referenced using qualified imports.
 pub type Iter<'a, 'b> = IterBorrow<'a, 'b, Key, Option<Value>>;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Row {
     pub slot_leader: PoolId,
 }

--- a/crates/amaru-ledger/src/summary/mod.rs
+++ b/crates/amaru-ledger/src/summary/mod.rs
@@ -25,17 +25,25 @@ pub mod stake_distribution;
 
 // ---------------------------------------------------------------- AccountState
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct AccountState {
     pub balance: Lovelace,
+    pub rewards: Lovelace,
     pub pool: Option<PoolId>,
     pub drep: Option<DRep>,
+}
+
+impl AccountState {
+    pub fn with_rewards(self, rewards: Lovelace) -> Self {
+        Self { rewards, ..self }
+    }
 }
 
 impl ::serde::Serialize for AccountState {
     fn serialize<S: ::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut s = serializer.serialize_struct("AccountState", 3)?;
         s.serialize_field("balance", &self.balance)?;
+        // rewards are ignored in this serialization
         s.serialize_field("drep", &self.drep.as_ref().map(drep::AsJson))?;
         s.serialize_field("pool", &self.pool.as_ref().map(hex::encode))?;
         s.end()

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -694,10 +694,7 @@ mod test {
         }
     }
 
-    fn stake_summary(
-        pool: &PoolState,
-        accounts: BTreeMap<StakeCredential, AccountState>,
-    ) -> StakeSummary {
+    fn stake_summary(pool: &PoolState, accounts: BTreeMap<StakeCredential, AccountState>) -> StakeSummary {
         StakeSummary {
             stake_distribution: StakeDistribution {
                 epoch: Epoch::from(0),

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -604,7 +604,7 @@ mod test {
     #[test]
     fn a_leader_reward_is_credited_to_an_unregistered_reward_account() {
         let pool = pool(1);
-        let (accounts, _) = apply_leader_rewards(&pool, &stake_distribution(&pool, BTreeMap::new()));
+        let (accounts, _) = apply_leader_rewards(&pool, &stake_summary(&pool, BTreeMap::new()));
         assert!(accounts.contains_key(&credential(1)));
     }
 
@@ -618,7 +618,7 @@ mod test {
             AccountState { balance: STAKE, pool: Some(pool.parameters.id), drep: None },
         )]);
 
-        let (accounts, _) = apply_leader_rewards(&pool, &stake_distribution(&pool, delegators));
+        let (accounts, _) = apply_leader_rewards(&pool, &stake_summary(&pool, delegators));
 
         assert!(accounts.contains_key(&credential(1)));
     }
@@ -629,7 +629,7 @@ mod test {
     #[test]
     fn a_leader_reward_records_its_recipient() {
         let pool = pool(1);
-        let (_, leader_recipients) = apply_leader_rewards(&pool, &stake_distribution(&pool, BTreeMap::new()));
+        let (_, leader_recipients) = apply_leader_rewards(&pool, &stake_summary(&pool, BTreeMap::new()));
         assert_eq!(leader_recipients, BTreeSet::from([credential(1)]));
     }
 
@@ -638,7 +638,7 @@ mod test {
     #[test]
     fn a_pool_earning_no_leader_reward_records_no_recipient() {
         let pool = pool(1);
-        let stake_distribution = stake_distribution(&pool, BTreeMap::new());
+        let summary = stake_summary(&pool, BTreeMap::new());
 
         let mut accounts = BTreeMap::new();
         let mut leader_recipients = BTreeSet::new();
@@ -651,7 +651,7 @@ mod test {
             1,
             1_000_000_000,
             STAKE,
-            &stake_distribution,
+            &summary,
             &pool,
             &MAINNET_DEFAULT_PROTOCOL_PARAMETERS,
         );
@@ -694,7 +694,10 @@ mod test {
         }
     }
 
-    fn stake_distribution(pool: &PoolState, accounts: BTreeMap<StakeCredential, AccountState>) -> StakeSummary {
+    fn stake_summary(
+        pool: &PoolState,
+        accounts: BTreeMap<StakeCredential, AccountState>,
+    ) -> StakeSummary {
         StakeSummary {
             stake_distribution: StakeDistribution {
                 epoch: Epoch::from(0),
@@ -714,7 +717,7 @@ mod test {
     /// recipients were recorded.
     fn apply_leader_rewards(
         pool: &PoolState,
-        stake_distribution: &StakeSummary,
+        stake_summary: &StakeSummary,
     ) -> (BTreeMap<StakeCredential, Lovelace>, BTreeSet<StakeCredential>) {
         let mut accounts = BTreeMap::new();
         let mut leader_recipients = BTreeSet::new();
@@ -727,12 +730,13 @@ mod test {
             1,
             1_000_000_000,
             STAKE,
-            stake_distribution,
+            stake_summary,
             pool,
             &MAINNET_DEFAULT_PROTOCOL_PARAMETERS,
         );
 
         assert!(rewards.leader > 0, "the fixture should reward the leader");
+
         (accounts, leader_recipients)
     }
 }

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -110,8 +110,8 @@ certain mutations are applied to the system.
 use std::collections::{BTreeMap, BTreeSet};
 
 use amaru_kernel::{
-    Epoch, GlobalParameters, Lovelace, PoolId, ProtocolParameters, SafeRatio, StakeCredential, expect_stake_credential,
-    floor_to_lovelace, safe_ratio,
+    Epoch, GlobalParameters, Lovelace, PoolId, ProtocolParameters, SafeRatio, SortedPairs, StakeCredential,
+    expect_stake_credential, floor_to_lovelace, safe_ratio,
 };
 use amaru_observability::info;
 use num::{
@@ -131,7 +131,7 @@ impl PoolState {
         safe_ratio(self.stake, total_stake)
     }
 
-    pub fn owner_stake(&self, accounts: &BTreeMap<StakeCredential, AccountState>) -> Lovelace {
+    pub fn owner_stake(&self, accounts: &SortedPairs<StakeCredential, AccountState>) -> Lovelace {
         self.parameters.owners.iter().fold(0, |total, owner| {
             match accounts.get(&StakeCredential::AddrKeyhash(*owner)) {
                 Some(account) if account.pool == Some(self.parameters.id) => total + account.balance,
@@ -324,8 +324,8 @@ pub struct RewardsSummary {
     /// Various protocol money pots pertaining to the epoch at the beginning of the rewards calculation.
     pots: Pots,
 
-    /// Per-account rewards, determined from their relative stake and their delegatee.
-    accounts: BTreeMap<StakeCredential, Lovelace>,
+    /// Per-account state including their rewards.
+    accounts: SortedPairs<StakeCredential, AccountState>,
 
     /// Credentials credited a leader reward, as named by the stake distribution's pool parameters.
     leader_recipients: BTreeSet<StakeCredential>,
@@ -368,21 +368,21 @@ impl RewardsSummary {
 
         let total_stake: Lovelace = global_parameters.max_lovelace_supply - pots.reserves;
 
-        let mut delegators: BTreeMap<StakeCredential, Lovelace> = BTreeMap::new();
-
         let mut leader_recipients: BTreeSet<StakeCredential> = BTreeSet::new();
 
         let mut pools: BTreeMap<PoolId, PoolRewards> = BTreeMap::new();
 
-        let mut effective_rewards = stake_summary.pools.iter().fold(0, |effective_rewards, (pool_id, pool)| {
+        let StakeSummary { stake_distribution, mut accounts } = stake_summary;
+
+        let mut effective_rewards = stake_distribution.pools.iter().fold(0, |effective_rewards, (pool_id, pool)| {
             let pool_rewards = RewardsSummary::apply_leader_rewards(
-                &mut delegators,
+                &mut accounts,
                 &mut leader_recipients,
                 &mut blocks_per_pool,
                 blocks_count,
                 available_rewards,
+                stake_distribution.active_stake,
                 total_stake,
-                &stake_summary,
                 pool,
                 protocol_parameters,
             );
@@ -394,26 +394,19 @@ impl RewardsSummary {
             rewards
         });
 
-        let StakeSummary { stake_distribution, accounts } = stake_summary;
-
-        effective_rewards += accounts.into_iter().fold(0, |effective_rewards, (credential, account)| {
+        for (credential, account) in accounts.iter_mut() {
             let opt_pool = account.pool.as_ref().and_then(|pool_id| stake_distribution.pools.get(pool_id));
-
-            let member_rewards = if let Some(pool) = opt_pool {
+            effective_rewards += if let Some(pool) = opt_pool {
                 RewardsSummary::apply_member_rewards(
-                    &mut delegators,
+                    (credential, account),
                     pool,
                     pools.get(&pool.parameters.id),
                     total_stake,
-                    credential,
-                    account,
                 )
             } else {
                 0
             };
-
-            effective_rewards + member_rewards
-        });
+        }
 
         info!(
             ledger::rewards::SUMMARIZE,
@@ -435,7 +428,7 @@ impl RewardsSummary {
             available_rewards,
             effective_rewards,
             pots,
-            accounts: delegators,
+            accounts,
             leader_recipients,
         }
     }
@@ -497,17 +490,15 @@ impl RewardsSummary {
     }
 
     fn apply_member_rewards(
-        accounts: &mut BTreeMap<StakeCredential, Lovelace>,
+        (credential, account): (&StakeCredential, &mut AccountState),
         pool: &PoolState,
         pool_rewards: Option<&PoolRewards>,
         total_stake: Lovelace,
-        credential: StakeCredential,
-        st: AccountState,
     ) -> Lovelace {
         if let Some(PoolRewards { pot, .. }) = pool_rewards {
-            let member_rewards = pool.member_rewards(&credential, *pot, st.balance, total_stake);
+            let member_rewards = pool.member_rewards(credential, *pot, account.balance, total_stake);
             if member_rewards > 0 {
-                accounts.entry(credential).and_modify(|rewards| *rewards += member_rewards).or_insert(member_rewards);
+                account.rewards += member_rewards;
             }
             member_rewards
         } else {
@@ -517,22 +508,22 @@ impl RewardsSummary {
 
     #[expect(clippy::too_many_arguments)]
     fn apply_leader_rewards(
-        accounts: &mut BTreeMap<StakeCredential, Lovelace>,
+        accounts: &mut SortedPairs<StakeCredential, AccountState>,
         leader_recipients: &mut BTreeSet<StakeCredential>,
         blocks_per_pool: &mut BTreeMap<PoolId, u64>,
         blocks_count: u64,
         available_rewards: Lovelace,
+        active_stake: Lovelace,
         total_stake: Lovelace,
-        stake_summary: &StakeSummary,
         pool: &PoolState,
         protocol_parameters: &ProtocolParameters,
     ) -> PoolRewards {
-        let owner_stake = pool.owner_stake(&stake_summary.accounts);
+        let owner_stake = pool.owner_stake(accounts);
 
         let rewards_pot = pool.pool_rewards(
             safe_ratio(blocks_per_pool.remove(&pool.parameters.id).unwrap_or_default(), blocks_count),
             available_rewards,
-            stake_summary.active_stake,
+            active_stake,
             total_stake,
             owner_stake,
             protocol_parameters,
@@ -541,18 +532,22 @@ impl RewardsSummary {
         let rewards_leader = pool.leader_rewards(rewards_pot, owner_stake, total_stake);
 
         if rewards_leader > 0 {
-            // NOTE: the reward account needs not be a registered account
-            //
-            // Nothing above consults the reward account: the pledge is checked against the pool's
-            // *owners* and the performance against its *delegators*. So a pool can perfectly well
-            // earn a leader reward payable to a credential that has no account, in which case the
-            // reward is unclaimed and goes to the treasury instead. That is settled at the epoch
-            // boundary, against the recipients recorded here: the pool may change or drop its
-            // reward account before the payout, so the registry as it stands then no longer knows
-            // who was owed the reward.
             let credential = expect_stake_credential(&pool.parameters.reward_account);
             leader_recipients.insert(credential);
-            accounts.entry(credential).and_modify(|rewards| *rewards += rewards_leader).or_insert(rewards_leader);
+            if let Some(st) = accounts.get_mut(&credential) {
+                st.rewards += rewards_leader;
+            } else {
+                // NOTE: the reward account needs not be a registered account
+                //
+                // Nothing above consults the reward account: the pledge is checked against the pool's
+                // *owners* and the performance against its *delegators*. So a pool can perfectly well
+                // earn a leader reward payable to a credential that has no account, in which case the
+                // reward is unclaimed and goes to the treasury instead. That is settled at the epoch
+                // boundary, against the recipients recorded here: the pool may change or drop its
+                // reward account before the payout, so the registry as it stands then no longer knows
+                // who was owed the reward.
+                accounts.insert(credential, AccountState::default().with_rewards(rewards_leader))
+            }
         }
 
         PoolRewards { leader: rewards_leader, pot: rewards_pot }
@@ -569,7 +564,7 @@ impl RewardsSummary {
     }
 
     /// Rewards owed to each credential, whether or not that credential still has an account.
-    pub fn accounts(&self) -> &BTreeMap<StakeCredential, Lovelace> {
+    pub fn accounts(&self) -> &SortedPairs<StakeCredential, AccountState> {
         &self.accounts
     }
 
@@ -604,7 +599,7 @@ mod test {
     #[test]
     fn a_leader_reward_is_credited_to_an_unregistered_reward_account() {
         let pool = pool(1);
-        let (accounts, _) = apply_leader_rewards(&pool, &stake_summary(&pool, BTreeMap::new()));
+        let (accounts, _) = apply_leader_rewards(&pool, stake_summary(&pool, BTreeMap::new()));
         assert!(accounts.contains_key(&credential(1)));
     }
 
@@ -615,10 +610,10 @@ mod test {
         let pool = pool(1);
         let delegators = BTreeMap::from([(
             credential(1),
-            AccountState { balance: STAKE, pool: Some(pool.parameters.id), drep: None },
+            AccountState { balance: STAKE, pool: Some(pool.parameters.id), ..Default::default() },
         )]);
 
-        let (accounts, _) = apply_leader_rewards(&pool, &stake_summary(&pool, delegators));
+        let (accounts, _) = apply_leader_rewards(&pool, stake_summary(&pool, delegators));
 
         assert!(accounts.contains_key(&credential(1)));
     }
@@ -629,7 +624,7 @@ mod test {
     #[test]
     fn a_leader_reward_records_its_recipient() {
         let pool = pool(1);
-        let (_, leader_recipients) = apply_leader_rewards(&pool, &stake_summary(&pool, BTreeMap::new()));
+        let (_, leader_recipients) = apply_leader_rewards(&pool, stake_summary(&pool, BTreeMap::new()));
         assert_eq!(leader_recipients, BTreeSet::from([credential(1)]));
     }
 
@@ -638,27 +633,28 @@ mod test {
     #[test]
     fn a_pool_earning_no_leader_reward_records_no_recipient() {
         let pool = pool(1);
-        let summary = stake_summary(&pool, BTreeMap::new());
+        let mut summary = stake_summary(&pool, BTreeMap::new());
 
-        let mut accounts = BTreeMap::new();
         let mut leader_recipients = BTreeSet::new();
         let mut blocks_per_pool = BTreeMap::new();
 
+        let active_stake = summary.active_stake;
+
         let rewards = RewardsSummary::apply_leader_rewards(
-            &mut accounts,
+            &mut summary.accounts,
             &mut leader_recipients,
             &mut blocks_per_pool,
             1,
             1_000_000_000,
+            active_stake,
             STAKE,
-            &summary,
             &pool,
             &MAINNET_DEFAULT_PROTOCOL_PARAMETERS,
         );
 
         assert_eq!(rewards.leader, 0, "a pool with no block should earn no leader reward");
         assert!(leader_recipients.is_empty());
-        assert!(accounts.is_empty());
+        assert!(summary.accounts.values().all(|st| st.rewards == 0));
     }
 
     // HELPERS
@@ -706,7 +702,7 @@ mod test {
                 pools: BTreeMap::from([(pool.parameters.id, pool.clone())]),
                 dreps: BTreeMap::new(),
             },
-            accounts,
+            accounts: SortedPairs::from(accounts),
         }
     }
 
@@ -714,26 +710,27 @@ mod test {
     /// recipients were recorded.
     fn apply_leader_rewards(
         pool: &PoolState,
-        stake_summary: &StakeSummary,
-    ) -> (BTreeMap<StakeCredential, Lovelace>, BTreeSet<StakeCredential>) {
-        let mut accounts = BTreeMap::new();
+        mut stake_summary: StakeSummary,
+    ) -> (SortedPairs<StakeCredential, AccountState>, BTreeSet<StakeCredential>) {
         let mut leader_recipients = BTreeSet::new();
         let mut blocks_per_pool = BTreeMap::from([(pool.parameters.id, 1)]);
 
+        let active_stake = stake_summary.active_stake;
+
         let rewards = RewardsSummary::apply_leader_rewards(
-            &mut accounts,
+            &mut stake_summary.accounts,
             &mut leader_recipients,
             &mut blocks_per_pool,
             1,
             1_000_000_000,
+            active_stake,
             STAKE,
-            stake_summary,
             pool,
             &MAINNET_DEFAULT_PROTOCOL_PARAMETERS,
         );
 
         assert!(rewards.leader > 0, "the fixture should reward the leader");
 
-        (accounts, leader_recipients)
+        (stake_summary.accounts, leader_recipients)
     }
 }

--- a/crates/amaru-ledger/src/summary/stake_distribution.rs
+++ b/crates/amaru-ledger/src/summary/stake_distribution.rs
@@ -15,7 +15,7 @@
 use std::{collections::BTreeMap, ops::Deref};
 
 use amaru_kernel::{
-    DRep, Epoch, HasLovelace, Hash, Lovelace, NetworkName, PoolId, StakeCredential, expect_stake_credential, safe_ratio,
+    DRep, Epoch, Hash, Lovelace, NetworkName, PoolId, StakeCredential, expect_stake_credential, safe_ratio,
 };
 use amaru_observability::info;
 use serde::ser::SerializeStruct;
@@ -181,18 +181,19 @@ impl StakeSummary {
             notify(progress);
         };
 
-        db.iter_utxos()?.for_each(|(_, output)| {
-            if let Some(credential) = output.delegate() {
-                let balance = output.lovelace();
-                accounts.entry(credential).and_modify(|account| account.balance += balance);
+        db.iter_stake_distribution()?.for_each(|stake| {
+            if let Some(credential) = stake.credential {
+                accounts.entry(credential).and_modify(|account| account.balance += stake.lovelace);
             }
 
             processed_utxos += 1;
+
             if processed_utxos.saturating_sub(last_reported_utxos) >= PROGRESS_BATCH_SIZE {
                 last_reported_utxos = processed_utxos;
                 notify_progress(processed_utxos);
             }
         });
+
         if processed_utxos != last_reported_utxos {
             notify_progress(processed_utxos);
         }
@@ -230,7 +231,7 @@ impl StakeSummary {
 
         for pool in pools.values_mut() {
             let reward_account = expect_stake_credential(&pool.parameters.reward_account);
-            pool.fallback_drep = accounts.get(&reward_account).and_then(|account| account.drep.clone());
+            pool.fallback_drep = accounts.get(&reward_account).and_then(|account| account.drep);
         }
 
         db.iter_block_issuers()?.for_each(|(_, issuer)| {
@@ -419,7 +420,7 @@ pub mod tests {
 
             for pool in pools.values_mut() {
                 let reward_account = expect_stake_credential(&pool.parameters.reward_account);
-                pool.fallback_drep = accounts.get(&reward_account).and_then(|account| account.drep.clone());
+                pool.fallback_drep = accounts.get(&reward_account).and_then(|account| account.drep);
             }
 
             StakeDistribution {

--- a/crates/amaru-ledger/src/summary/stake_distribution.rs
+++ b/crates/amaru-ledger/src/summary/stake_distribution.rs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeMap, ops::Deref};
+use std::{
+    collections::BTreeMap,
+    ops::Deref,
+    sync::{OnceLock, atomic, atomic::AtomicUsize},
+};
 
 use amaru_kernel::{
-    DRep, Epoch, Hash, Lovelace, NetworkName, PoolId, StakeCredential, expect_stake_credential, safe_ratio,
+    DRep, Epoch, Hash, Lovelace, NetworkName, PoolId, SortedPairs, StakeCredential, expect_stake_credential, safe_ratio,
 };
 use amaru_observability::info;
 use serde::ser::SerializeStruct;
@@ -50,7 +54,7 @@ pub struct StakeSummary {
     /// Mapping of accounts' stake credentials to their respective state.
     ///
     /// Accounts that have stake but aren't delegated to any pools aren't present in the map.
-    pub accounts: BTreeMap<StakeCredential, AccountState>,
+    pub accounts: SortedPairs<StakeCredential, AccountState>,
 }
 
 impl Deref for StakeSummary {
@@ -145,28 +149,45 @@ impl StakeSummary {
             })
             .collect::<BTreeMap<PoolId, PoolState>>();
 
-        let mut accounts = db
-            .iter_accounts()?
-            .map(|(credential, row)| {
-                (
-                    credential,
-                    AccountState {
-                        balance: row.rewards,
-                        pool: row.pool.and_then(|(pool, since)| {
-                            let PoolState { registered_at, .. } = pools.get(&pool)?;
-                            if &since >= registered_at { Some(pool) } else { None }
-                        }),
-                        drep: row.drep.and_then(|(drep, since)| match drep {
-                            DRep::Abstain | DRep::NoConfidence => Some(drep),
-                            DRep::Key { .. } | DRep::Script { .. } => {
-                                let DRepState { registered_at, .. } = dreps.get(&drep)?;
-                                if &since >= registered_at { Some(drep) } else { None }
-                            }
-                        }),
-                    },
-                )
-            })
-            .collect::<BTreeMap<StakeCredential, AccountState>>();
+        let capacities = Capacity::get_or_init(db);
+        let mut key_accounts = SortedPairs::with_capacity(capacities.keys);
+        let mut script_accounts = SortedPairs::with_capacity(capacities.scripts);
+
+        for (credential, row) in db.iter_accounts()? {
+            let state = AccountState {
+                balance: row.rewards,
+                rewards: 0,
+                pool: row.pool.and_then(|(pool, since)| {
+                    let PoolState { registered_at, .. } = pools.get(&pool)?;
+                    if &since >= registered_at { Some(pool) } else { None }
+                }),
+                drep: row.drep.and_then(|(drep, since)| match drep {
+                    DRep::Abstain | DRep::NoConfidence => Some(drep),
+                    DRep::Key { .. } | DRep::Script { .. } => {
+                        let DRepState { registered_at, .. } = dreps.get(&drep)?;
+                        if &since >= registered_at { Some(drep) } else { None }
+                    }
+                }),
+            };
+            // NOTE: discrepancy between Ord and serialised ordering
+            //
+            // Weirdly enough, the variants of a StakeCredential comes with the script hash first,
+            // and then the key hash. However, they are serialised the other away around (key
+            // variant comes with tag index 0, whereas script is 1).
+            //
+            // RocksDB yields data in ascending order of the serialised key. So if we want to keep
+            // the ordering here, we have to accumulate them separately, and then concatenate the
+            // two arrays.
+            match credential {
+                StakeCredential::AddrKeyhash(..) => &mut key_accounts,
+                StakeCredential::ScriptHash(..) => &mut script_accounts,
+            }
+            .push(credential, state)
+        }
+
+        Capacity::update(key_accounts.len(), script_accounts.len());
+
+        let mut accounts = script_accounts.append(key_accounts);
 
         let accounts_len = accounts.len();
         let total_work = network.estimated_utxo_size().saturating_add(accounts_len.saturating_mul(2)).max(1);
@@ -182,8 +203,10 @@ impl StakeSummary {
         };
 
         db.iter_stake_distribution()?.for_each(|stake| {
-            if let Some(credential) = stake.credential {
-                accounts.entry(credential).and_modify(|account| account.balance += stake.lovelace);
+            if let Some(credential) = stake.credential
+                && let Some(account) = accounts.get_mut(&credential)
+            {
+                account.balance += stake.lovelace;
             }
 
             processed_utxos += 1;
@@ -335,6 +358,52 @@ impl serde::Serialize for StakeSummary {
     }
 }
 
+/// A type to inform of the ideal capacity for scripts and keys accounts in rewards.
+#[derive(Debug, Default, Clone, Copy)]
+struct Capacity<T> {
+    keys: T,
+    scripts: T,
+}
+
+static CAPACITY: OnceLock<Capacity<AtomicUsize>> = OnceLock::new();
+
+impl Capacity<usize> {
+    /// Record updated lengths as hints for the next query
+    fn update(keys: usize, scripts: usize) {
+        if let Some(capacity) = OnceLock::get(&CAPACITY) {
+            capacity.keys.store(keys, atomic::Ordering::Relaxed);
+            capacity.scripts.store(scripts, atomic::Ordering::Relaxed);
+        }
+    }
+
+    /// Get the value of the current capacities, or resolve it once from the database.
+    #[expect(clippy::panic)]
+    fn get_or_init(db: &impl Snapshot) -> Self {
+        let base_capacity = CAPACITY.get_or_init(|| {
+            let mut keys = 0;
+            let mut scripts = 0;
+
+            for (credential, _) in
+                db.iter_accounts().unwrap_or_else(|e| panic!("unable to initialize accounts capacities: {e}"))
+            {
+                match credential {
+                    StakeCredential::AddrKeyhash(..) => keys += 1,
+                    StakeCredential::ScriptHash(..) => scripts += 1,
+                }
+            }
+
+            Capacity { keys: AtomicUsize::new(keys), scripts: AtomicUsize::new(scripts) }
+        });
+
+        let keys = base_capacity.keys.load(atomic::Ordering::Relaxed);
+        let scripts = base_capacity.scripts.load(atomic::Ordering::Relaxed);
+
+        // We always return a little more than what's needed to cope with new accounts
+        // registrations and with unclaimed rewards.
+        Capacity { keys: keys + keys / 10, scripts: scripts + scripts / 10 }
+    }
+}
+
 #[cfg(any(test, feature = "test-utils"))]
 pub mod tests {
     use std::collections::BTreeMap;
@@ -445,7 +514,8 @@ pub mod tests {
             AccountState {
                 balance,
                 pool,
-                drep
+                drep,
+                rewards: 0,
             }
         }
     }

--- a/crates/amaru-stores/src/lib.rs
+++ b/crates/amaru-stores/src/lib.rs
@@ -105,7 +105,7 @@ pub mod tests {
         };
 
         let drep = match &account_row.drep {
-            Some(drep_pair) => Resettable::Set(drep_pair.clone()),
+            Some(drep_pair) => Resettable::Set(*drep_pair),
             None => Resettable::Reset,
         };
 
@@ -219,7 +219,7 @@ pub mod tests {
             let context = store.create_transaction();
             let mut result = None;
             context.with_accounts(|mut accounts| {
-                result = accounts.find(|(key, _)| *key == account_key).and_then(|(_, row)| row.borrow().clone());
+                result = accounts.find(|(key, _)| *key == account_key).and_then(|(_, row)| *row.borrow());
             })?;
             let value =
                 result.ok_or_else(|| StoreError::Internal("Failed to retrieve account after seeding".into()))?;

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -24,7 +24,7 @@ use amaru_iter_borrow::{self, IterBorrow, borrowable_proxy::BorrowableProxy};
 use amaru_kernel::{
     CertificatePointer, Constitution, ConstitutionalCommitteeStatus, Epoch, EraHistory, Lovelace,
     MemoizedTransactionOutput, Point, PoolId, ProposalId, ProposalsRoots, ProtocolParameters, RatificationStatus,
-    StakeCredential, TransactionInput, cbor,
+    StakeCredential, StakeEntry, TransactionInput, cbor,
 };
 use amaru_ledger::{
     epoch_transition::GovernanceActivity,
@@ -464,6 +464,13 @@ macro_rules! impl_ReadStore_body {
             ) -> Result<impl Iterator<Item = (scolumns::utxo::Key, scolumns::utxo::Value)>, StoreError>
             {
                 iter(
+                    |mode, opts| self.db.iterator_opt(mode, opts),
+                    utxo::PREFIX,
+                )
+            }
+
+            fn iter_stake_distribution(&self) -> Result<impl Iterator<Item = StakeEntry>, StoreError> {
+                iter_value::<scolumns::utxo::Key, StakeEntry, _, _>(
                     |mode, opts| self.db.iterator_opt(mode, opts),
                     utxo::PREFIX,
                 )
@@ -968,6 +975,40 @@ where
             });
             it.next();
             Some((k, v))
+        } else {
+            None
+        }
+    }))
+}
+
+#[expect(clippy::panic)]
+pub fn iter_value<'a, 'b, K, V, DB, F>(
+    db_iter_opt: F,
+    prefix: [u8; PREFIX_LEN],
+) -> Result<impl Iterator<Item = V> + 'a, StoreError>
+where
+    DB: 'a + 'b + DBAccess,
+    F: Fn(IteratorMode<'_>, ReadOptions) -> DBIteratorWithThreadMode<'b, DB> + 'a,
+    'b: 'a,
+    V: for<'d> cbor::Decode<'d, ()> + 'a,
+{
+    let mut opts = ReadOptions::default();
+    opts.set_prefix_same_as_start(true);
+    let mut it: rocksdb::DBRawIteratorWithThreadMode<'_, _> =
+        (db_iter_opt)(IteratorMode::From(prefix.as_ref(), Direction::Forward), opts).into();
+    Ok(std::iter::from_fn(move || {
+        if let Some((key, value)) = it.item() {
+            let v = cbor::decode(value).unwrap_or_else(|e| {
+                panic!(
+                    "unable to decode value {}::<{}> for key {}::<{}>: {e:?}",
+                    hex::encode(value),
+                    std::any::type_name::<V>(),
+                    hex::encode(key),
+                    std::any::type_name::<K>(),
+                )
+            });
+            it.next();
+            Some(v)
         } else {
             None
         }


### PR DESCRIPTION
  These little changes have noticeable effects on the transient
  allocations and pointless work that is done creating temporary
  structures; the reward calculation and stake distribution are
  significantly faster:

  - distribution build: 62.704s -> 37.453s
  - Rewards stake summary: 63.991s -> 36.205s
  - Rewards calculation: 102.687s -> 70.352s

  This effect is also visible throughout the whole sync, and provides
  ~10-12% performance increase for epoch sync:

  - Wall time: 2279.956s -> 1993.132s (-12.6%)
  - Mean epoch sync: 557.035s -> 489.954s (-12.0%)

  It also helps with the overall peak heap: 696.69 MiB -> 636.80 MiB
  (-8.6%), though has no observable effect on the RSS (mean or max);
  which was kind of the main driver for this change.

  So, probably good to keep around due to the other benefits without
  much counterpart (if only, a bit more code...).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added support for reading stake distribution entries in modern and legacy formats.
- Improved handling of Cardano address types, stake credentials, and lovelace values.
- Enhanced reward and account-state processing.

## Performance
- Reduced allocation overhead during stake distribution and rewards calculations.

## Bug Fixes
- Improved validation and error handling for malformed stake distribution data.
- Preserved compatibility with supported legacy data encodings.
- Improved the timeliness of state updates after successful block processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->