### PR TITLE
Tweak jemalloc configuration

### DIFF
--- a/.github/workflows/release-begin.yml
+++ b/.github/workflows/release-begin.yml
@@ -179,6 +179,7 @@ jobs:
         shell: bash
         env:
           BUILT_OVERRIDE_amaru_PKG_VERSION_PATCH: ${{ needs.build-metadata.outputs.release_patch }}
+          JEMALLOC_SYS_WITH_MALLOC_CONF: 'background_thread:true,narenas:2,dirty_decay_ms:250,muzzy_decay_ms:0,tcache_max:512'
         run: |
           set -euo pipefail
           if [[ -n "${{ matrix.environments.setup }}" ]]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3673,6 +3673,7 @@ dependencies = [
  "cc",
  "libc",
  "libz-sys",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -6172,9 +6173,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
 dependencies = [
  "cc",
  "libc",
@@ -6182,9 +6183,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.7.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ tar = "0.4.46"
 tempfile = "3.27.0"
 test-case = "3.3.1"
 thiserror = "2.0.19"
-tikv-jemallocator = { version = "0.7.0" }
+tikv-jemallocator = { version = "0.6.1" }
 tokio = { version = "1.53.0", features = ["sync"] }
 tokio-util = "0.7.18"
 toml = "1.1.3"

--- a/crates/amaru-stores/Cargo.toml
+++ b/crates/amaru-stores/Cargo.toml
@@ -25,7 +25,6 @@ required-features = ["rocksdb"]
 anyhow.workspace = true
 hex.workspace = true
 rand = { workspace = true, optional = true }
-rocksdb = { workspace = true, optional = true }
 tracing.workspace = true
 
 # Internal dependencies ───────────────────────────────────────────────────────┐
@@ -37,6 +36,10 @@ amaru-ouroboros-traits = { workspace = true, features = [] }
 
 [target.'cfg(all(not(target_family="wasm"), not(target_arch="riscv32")))'.dependencies]
 amaru-deps.workspace = true
+[target.'cfg(windows)'.dependencies]
+rocksdb = { workspace = true, optional = true }
+[target.'cfg(not(windows))'.dependencies]
+rocksdb = { workspace = true, optional = true, features = ["jemalloc"] }
 
 [dev-dependencies]
 # External dependencies ───────────────────────────────────────────────────────┐

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -81,11 +81,11 @@ amaru-pure-stage.workspace = true
 amaru-stores.workspace = true
 amaru-tui.workspace = true
 
+[target.'cfg(not(windows))'.dependencies]
+tikv-jemallocator.workspace = true
+
 [target.'cfg(all(not(target_family="wasm"), not(target_arch="riscv32")))'.dependencies]
 amaru-deps.workspace = true
-
-[target.'cfg(not(target_family="windows"))'.dependencies]
-tikv-jemallocator.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 rlimit = "0.10.2"


### PR DESCRIPTION
This magic line is the result of multiple benchmarks evaluating different configurations for isolated mainnet runs over 10 epochs. This gives a good balance between allocation time and memory management overall:

#### vanilla

```
- RSS max: `1.29 GiB`
- RSS mean: `797.84 MiB`
- Heap live max: `621.30 MiB`
- Heap live mean: `251.98 MiB`
- Heap peak: `696.69 MiB`
- Mean epoch sync time: `557.035 s`
- Median epoch sync time: `588.252 s`
- P95 epoch sync time: `595.890 s`
```

#### background_thread:true,narenas:2,dirty_decay_ms:250,muzzy_decay_ms:0,tcache_max:512

```
- RSS max: `1.16 GiB`
- RSS mean: `717.63 MiB`
- Heap live max: `620.61 MiB`
- Heap live mean: `252.21 MiB`
- Heap peak: `664.54 MiB`
- Mean epoch sync time: `581.295 s`
- Median epoch sync time: `597.157 s`
- P95 epoch sync time: `627.741 s`
```

(note that some of sync time is recovered with #1203)