### PR TITLE
fix(amaru-pure-stage): avoid unnecessary string allocation in pure-stage's try_cast and cast_ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Other guiding principles:
 - **amaru-ledger**: reject governance proposals whose previous action does not match the enacted root nor an in-flight proposal of the same purpose. ([#1090][], [#932][])
 - **amaru-kernel**: fix the decoding of data types that were not conforming to the specification ([#1172](https://github.com/pragma-org/amaru/issues/1172))
 - **amaru-ledger**: a transaction marked invalid that carries no Plutus script is no longer accepted. ([#894][])
+- **amaru-pure-stage**: avoid constructing short string errors when failing to cast types in pure-stage.
 
 ## [v10.11.20260807](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260807)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
  "clap_builder",
  "console",
  "criterion",
+ "crossbeam-utils",
  "digest 0.10.7",
  "digest 0.11.3",
  "ed25519 2.2.3",
@@ -648,6 +649,7 @@ dependencies = [
  "getrandom 0.3.4",
  "hex",
  "parking_lot",
+ "poolshark",
  "pretty_assertions",
  "rand 0.9.5",
  "serde",
@@ -2042,6 +2044,15 @@ name = "crossbeam-epoch"
 version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4040,6 +4051,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nohash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0f889fb66f7acdf83442c35775764b51fed3c606ab9cee51500dbde2cf528ca"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4594,6 +4611,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "poolshark"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d7d4c131ef23790ea2b6f5cd3f7eee5f41b0ba98f52d8cb880aaa7ee56dfc0"
+dependencies = [
+ "ahash",
+ "crossbeam-queue",
+ "indexmap 2.14.0",
+ "nohash",
+ "poolshark_derive",
+ "serde",
+ "serde_derive",
+ "triomphe",
+]
+
+[[package]]
+name = "poolshark_derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4b0a2610b718322d012c67426a17a7c21734cec3693ebc8e68f3e28119dba3"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6551,6 +6594,16 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "triomphe"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40688ea6389c8171614b25491f71d4a27946e0c7ce2da1c6de27e25abf1a0ae"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ opentelemetry_sdk = { version = "0.32.1", features = ["logs"] }
 ouroboros = "0.18.5"
 pallas-network = "0.34.0"
 parking_lot = "0.12.3"
+poolshark = "0.2.9"
 pretty_assertions = "1.4.1"
 proc-macro2 = "1.0.107"
 proptest = { version = "1.11.0", default-features = false, features = ["std"] }

--- a/crates/amaru-deps/Cargo.toml
+++ b/crates/amaru-deps/Cargo.toml
@@ -25,6 +25,7 @@ ignored = [
   "clap_builder",
   "console",
   "criterion",
+  "crossbeam-utils",
   "digest",
   "digest-93f6ce9d446188ac",
   "digest-a6292c17cd707f01",
@@ -107,6 +108,7 @@ clap = { version = "4", features = ["derive", "env", "wrap_help"] }
 clap_builder = { version = "4", default-features = false, features = ["color", "env", "std", "suggestions", "usage", "wrap_help"] }
 console = { version = "0.16", default-features = false, features = ["ansi-parsing", "std", "unicode-width"] }
 criterion = { version = "0.8", features = ["html_reports"] }
+crossbeam-utils = { version = "0.8" }
 digest-93f6ce9d446188ac = { package = "digest", version = "0.10", features = ["mac", "std"] }
 digest-a6292c17cd707f01 = { package = "digest", version = "0.11", features = ["alloc", "mac", "oid"] }
 ed25519 = { version = "2", default-features = false, features = ["alloc", "serde", "std"] }

--- a/crates/amaru-pure-stage/Cargo.toml
+++ b/crates/amaru-pure-stage/Cargo.toml
@@ -25,6 +25,7 @@ futures-util.workspace = true
 getrandom = { version = "0.3", features = ["wasm_js"] }
 hex.workspace = true
 parking_lot.workspace = true
+poolshark.workspace = true
 pretty_assertions.workspace = true
 rand = { workspace = true }
 serde = { workspace = true, features = ["derive", "alloc", "rc"] }

--- a/crates/amaru-pure-stage/src/types.rs
+++ b/crates/amaru-pure-stage/src/types.rs
@@ -24,6 +24,7 @@ use std::{
 
 use anyhow::Context;
 use cbor4ii::serde::from_slice;
+use poolshark::local::LPooled;
 use tokio::sync::mpsc;
 
 use crate::{
@@ -105,7 +106,7 @@ impl dyn SendData {
 
     /// Cast a message to a given concrete type.
     pub fn cast_ref<T: SendData>(&self) -> anyhow::Result<&T> {
-        (self as &dyn Any).downcast_ref::<T>().ok_or_else(|| CastError::anyhow::<T>(self))
+        (self as &dyn Any).downcast_ref::<T>().ok_or_else(|| CastError::new::<T>(self).into())
     }
 
     pub fn try_cast<T: SendData>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
@@ -119,7 +120,7 @@ impl dyn SendData {
 
     /// Cast a message to a given concrete type, yielding an informative error otherwise
     pub fn cast<T: SendData>(self: Box<Self>) -> anyhow::Result<Box<T>> {
-        self.try_cast::<T>().map_err(|b| CastError::anyhow::<T>(&b))
+        self.try_cast::<T>().map_err(|b| CastError::new::<T>(&b).into())
     }
 
     pub fn cast_deserialize<T>(self: Box<Self>) -> anyhow::Result<T>
@@ -174,23 +175,25 @@ impl PartialEq for dyn SendData {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("message type error: expected {expected}, got {got}")]
+#[error("message type error: expected {expected}, got {d} ({got})", d = debug.as_ref().map(|s| &***s).unwrap_or("_"))]
 pub struct CastError {
     expected: &'static str,
     got: &'static str,
+    debug: Option<LPooled<String>>,
 }
 
 impl CastError {
-    pub fn anyhow<T>(source: &dyn SendData) -> anyhow::Error {
-        if tracing::enabled!(target: "amaru_pure_stage", tracing::Level::TRACE) {
-            anyhow::anyhow!(
-                "message type error: expected {}, got {:?} ({})",
-                type_name::<T>(),
-                source,
-                source.typetag_name()
-            )
+    pub fn new<T>(source: &dyn SendData) -> Self {
+        if tracing::enabled!(target: "amaru_pure_stage", tracing::Level::DEBUG) {
+            let mut debug = LPooled::<String>::take();
+            #[expect(clippy::expect_used)]
+            {
+                use std::fmt::Write;
+                write!(&mut *debug, "{:?}", source).expect("writing to LPooled<String> should never fail");
+            }
+            Self { expected: type_name::<T>(), got: source.typetag_name(), debug: Some(debug) }
         } else {
-            anyhow::anyhow!(Self { expected: type_name::<T>(), got: source.typetag_name() })
+            Self { expected: type_name::<T>(), got: source.typetag_name(), debug: None }
         }
     }
 }
@@ -483,7 +486,7 @@ mod test {
         assert_eq!(format!("{s:?}"), "\"hello\"");
         assert_eq!(
             s.cast::<OsString>().unwrap_err().to_string(),
-            "message type error: expected std::ffi::os_str::OsString, got alloc::string::String"
+            "message type error: expected std::ffi::os_str::OsString, got _ (alloc::string::String)"
         );
 
         let s = Box::new("hello".to_owned()) as Box<dyn SendData>;

--- a/crates/amaru-pure-stage/src/types.rs
+++ b/crates/amaru-pure-stage/src/types.rs
@@ -105,14 +105,7 @@ impl dyn SendData {
 
     /// Cast a message to a given concrete type.
     pub fn cast_ref<T: SendData>(&self) -> anyhow::Result<&T> {
-        (self as &dyn Any).downcast_ref::<T>().ok_or_else(|| {
-            anyhow::anyhow!(
-                "message type error: expected {}, got {:?} ({})",
-                type_name::<T>(),
-                self,
-                self.typetag_name()
-            )
-        })
+        (self as &dyn Any).downcast_ref::<T>().ok_or_else(|| CastError::anyhow::<T>(self))
     }
 
     pub fn try_cast<T: SendData>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
@@ -126,9 +119,7 @@ impl dyn SendData {
 
     /// Cast a message to a given concrete type, yielding an informative error otherwise
     pub fn cast<T: SendData>(self: Box<Self>) -> anyhow::Result<Box<T>> {
-        self.try_cast::<T>().map_err(|b| {
-            anyhow::anyhow!("message type error: expected {}, got {:?} ({})", type_name::<T>(), b, b.typetag_name())
-        })
+        self.try_cast::<T>().map_err(|b| CastError::anyhow::<T>(&b))
     }
 
     pub fn cast_deserialize<T>(self: Box<Self>) -> anyhow::Result<T>
@@ -179,6 +170,28 @@ where
 impl PartialEq for dyn SendData {
     fn eq(&self, other: &dyn SendData) -> bool {
         self.test_eq(other)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("message type error: expected {expected}, got {got}")]
+pub struct CastError {
+    expected: &'static str,
+    got: &'static str,
+}
+
+impl CastError {
+    pub fn anyhow<T>(source: &dyn SendData) -> anyhow::Error {
+        if tracing::enabled!(target: "amaru_pure_stage", tracing::Level::TRACE) {
+            anyhow::anyhow!(
+                "message type error: expected {}, got {:?} ({})",
+                type_name::<T>(),
+                source,
+                source.typetag_name()
+            )
+        } else {
+            anyhow::anyhow!(Self { expected: type_name::<T>(), got: source.typetag_name() })
+        }
     }
 }
 
@@ -470,7 +483,7 @@ mod test {
         assert_eq!(format!("{s:?}"), "\"hello\"");
         assert_eq!(
             s.cast::<OsString>().unwrap_err().to_string(),
-            "message type error: expected std::ffi::os_str::OsString, got \"hello\" (alloc::string::String)"
+            "message type error: expected std::ffi::os_str::OsString, got alloc::string::String"
         );
 
         let s = Box::new("hello".to_owned()) as Box<dyn SendData>;


### PR DESCRIPTION
This commits does two things really:

  1. It avoids debug-serialiasing the entire type in the error message unless we are at the TRACE level
  2. It defines a proper CastError that carries type names instead of a string message; the message is only produced when the error is displayed (if displayed).

This was identified as the number 1 churn allocation cost center from a dhat's run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when message type casting fails.
  * Error details now identify the expected and received types by default.
  * Full source-value details are included only when trace logging is enabled.
  * Reduced unnecessary error-detail generation for shorter, more efficient failures.

* **Documentation**
  * Added a changelog entry describing the updated casting error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->