### PR TITLE
restore and unify spans in traces/logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Other guiding principles:
 
 ### Fixed
 
+- **amaru-observability**: restore wrapping-span identity on every product tracing stack (console, JSON, OTEL, TUI) and stop double-quoting CBOR string scalars such as header hashes. Each event inlines only its wrapping span's fields; `parents` is a name array; child lines refer to the parent by id. Console uses a Java-style abbreviated path (`e.t:g.r`). Encoding is specified in EDR-033. ([#1208](https://github.com/pragma-org/amaru/issues/1208))
 - **amaru-node**: when OTLP is enabled, `Telemetry` starts the same process/build gauges as the product binary (`process_*`, `cardano_node_metrics_cardano_*`) so embedders such as `run_until` satisfy the e2e metrics contract.
 - **amaru-consensus**: make `select_chain` handle already-validated tips idempotently so concurrent startup recovery cannot terminate the stage. ([#1124](https://github.com/pragma-org/amaru/pull/1124))
 - **amaru**: store nonces with both packaged bootstrap headers so the "nonces present ⇔ header validated" invariant holds after bootstrap. ([#1124](https://github.com/pragma-org/amaru/pull/1124))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,7 @@ dependencies = [
  "hex",
  "inventory",
  "opentelemetry",
+ "opentelemetry_sdk",
  "quote",
  "serde",
  "serde_json",

--- a/crates/amaru-node/src/lib.rs
+++ b/crates/amaru-node/src/lib.rs
@@ -102,9 +102,10 @@ pub fn default_peer_for_network(network: NetworkName) -> &'static str {
 /// fields (primitives + CBOR-encoded complex values) render correctly.
 pub mod observability {
     pub use amaru_observability::{
-        CborAwareMakeVisitor, CborDiagVisitor, CborJsonEventFormat, CborJsonFields, CborJsonSpanLayer,
-        CborOtelLogBridge, CborToStringVisit, CborTraceArrayLayer, SpanJsonFields, as_str_value, cbor_to_any_value,
-        cbor_to_trace_value, console_field_formatter, encode_cbor,
+        CborAwareMakeVisitor, CborConsoleEventFormat, CborDiagVisitor, CborJsonEventFormat, CborJsonFields,
+        CborJsonSpanLayer, CborOtelLogBridge, CborToStringVisit, CborTraceArrayLayer, HideTagFields, SpanJsonFields,
+        abbreviate_span_name, ancestor_span_names, as_str_value, cbor_to_any_value, cbor_to_trace_value,
+        console_field_formatter, encode_cbor, format_abbreviated_span_path,
     };
 }
 

--- a/crates/amaru-observability/Cargo.toml
+++ b/crates/amaru-observability/Cargo.toml
@@ -29,5 +29,8 @@ tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
 
+[dev-dependencies]
+opentelemetry_sdk = { workspace = true, features = ["logs", "testing", "trace"] }
+
 [lints]
 workspace = true

--- a/crates/amaru-observability/src/field.rs
+++ b/crates/amaru-observability/src/field.rs
@@ -35,6 +35,17 @@ use thiserror::Error;
 /// Maximum length of CBOR diagnostic / JSON fallback text printed to the console.
 pub const DIAG_TRUNCATION_LIMIT: usize = 512;
 
+/// Prefix for schema tag attributes (`amaru.tag.cpu`, `amaru.tag.db`, …).
+///
+/// Tags classify spans for filtering (see EDR-026 / EDR-033). Console and TUI
+/// hide them; JSON and OpenTelemetry keep them as ordinary attributes.
+pub const TAG_FIELD_PREFIX: &str = "amaru.tag.";
+
+/// Returns true when `name` is a schema tag attribute (`amaru.tag.*`).
+pub fn is_tag_field_name(name: &str) -> bool {
+    name.starts_with(TAG_FIELD_PREFIX)
+}
+
 /// Serialize `value` as CBOR for transport through `tracing` as `record_bytes`.
 ///
 /// Returns an owned `Box<[u8]>` so the result implements [`tracing::Value`] via

--- a/crates/amaru-observability/src/json_format.rs
+++ b/crates/amaru-observability/src/json_format.rs
@@ -19,12 +19,16 @@
 //! a structured [`SpanJsonFields`] extension populated by [`CborJsonSpanLayer`], with a
 //! `FormattedFields` string fallback when the layer is absent.
 //!
+//! Nested context is encoded as `span` `{name, target}`, `parents` (ancestor
+//! names, outermost first), and the wrapping span's fields inlined into `fields`
+//! (EDR-033). Ancestor span fields are not copied.
+//!
 //! This replaces the previous approach of running stock `Format<Json>`, re-parsing the
 //! whole line, splicing fields, and re-serializing.
 
-use std::{collections::BTreeMap, fmt, io};
+use std::{cell::RefCell, collections::BTreeMap, fmt, io};
 
-use serde::ser::{SerializeMap, Serializer as _};
+use serde::ser::{Serialize, SerializeMap, Serializer as _};
 use serde_json::{Serializer, Value as JsonValue};
 use tracing::{
     Event, Subscriber,
@@ -41,14 +45,7 @@ use tracing_subscriber::{
     registry::LookupSpan,
 };
 
-use crate::field::cbor_to_json;
-
-/// Root object keys reserved by the envelope; span fields must not overwrite them.
-const RESERVED_ROOT_KEYS: &[&str] = &["timestamp", "level", "fields", "target", "id", "parent_id", "span", "spans"];
-
-fn is_reserved_root_key(key: &str) -> bool {
-    RESERVED_ROOT_KEYS.contains(&key)
-}
+use crate::{field::cbor_to_json, span_encode::ancestor_span_names};
 
 // -----------------------------------------------------------------------------
 // Structured span field bag (extension)
@@ -56,10 +53,11 @@ fn is_reserved_root_key(key: &str) -> bool {
 
 /// CBOR-aware span fields stored as a JSON object map (not a serialized string).
 ///
+/// Keys are `'static` field names from `tracing` (no per-event `String` allocation).
 /// Populated by [`CborJsonSpanLayer`]. [`CborJsonEventFormat`] prefers this over
 /// re-parsing [`FormattedFields`].
 #[derive(Debug, Clone, Default)]
-pub struct SpanJsonFields(pub BTreeMap<String, JsonValue>);
+pub struct SpanJsonFields(pub BTreeMap<&'static str, JsonValue>);
 
 /// Layer that keeps [`SpanJsonFields`] in span extensions for zero-parse event formatting.
 #[derive(Debug, Default, Clone, Copy)]
@@ -107,29 +105,29 @@ where
 /// Visit that builds nested JSON values, decoding CBOR `record_bytes`.
 #[derive(Default)]
 pub(crate) struct CborJsonVisitor {
-    pub(crate) values: BTreeMap<String, JsonValue>,
+    pub(crate) values: BTreeMap<&'static str, JsonValue>,
 }
 
 impl Visit for CborJsonVisitor {
     fn record_f64(&mut self, field: &Field, value: f64) {
         if let Some(n) = serde_json::Number::from_f64(value) {
-            self.values.insert(field.name().to_owned(), JsonValue::Number(n));
+            self.values.insert(field.name(), JsonValue::Number(n));
         }
     }
 
     fn record_i64(&mut self, field: &Field, value: i64) {
-        self.values.insert(field.name().to_owned(), JsonValue::Number(value.into()));
+        self.values.insert(field.name(), JsonValue::Number(value.into()));
     }
 
     fn record_u64(&mut self, field: &Field, value: u64) {
-        self.values.insert(field.name().to_owned(), JsonValue::Number(value.into()));
+        self.values.insert(field.name(), JsonValue::Number(value.into()));
     }
 
     fn record_i128(&mut self, field: &Field, value: i128) {
         if let Ok(v) = i64::try_from(value) {
             self.record_i64(field, v);
         } else {
-            self.values.insert(field.name().to_owned(), JsonValue::String(value.to_string()));
+            self.values.insert(field.name(), JsonValue::String(value.to_string()));
         }
     }
 
@@ -137,31 +135,31 @@ impl Visit for CborJsonVisitor {
         if let Ok(v) = u64::try_from(value) {
             self.record_u64(field, v);
         } else {
-            self.values.insert(field.name().to_owned(), JsonValue::String(value.to_string()));
+            self.values.insert(field.name(), JsonValue::String(value.to_string()));
         }
     }
 
     fn record_bool(&mut self, field: &Field, value: bool) {
-        self.values.insert(field.name().to_owned(), JsonValue::Bool(value));
+        self.values.insert(field.name(), JsonValue::Bool(value));
     }
 
     fn record_str(&mut self, field: &Field, value: &str) {
-        self.values.insert(field.name().to_owned(), JsonValue::String(value.to_owned()));
+        self.values.insert(field.name(), JsonValue::String(value.to_owned()));
     }
 
     fn record_bytes(&mut self, field: &Field, value: &[u8]) {
         let json = cbor_to_json(value).unwrap_or_else(|_| JsonValue::String(hex::encode(value)));
-        self.values.insert(field.name().to_owned(), json);
+        self.values.insert(field.name(), json);
     }
 
     fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
-        self.values.insert(field.name().to_owned(), JsonValue::String(value.to_string()));
+        self.values.insert(field.name(), JsonValue::String(value.to_string()));
     }
 
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         let name = field.name();
         let key = name.strip_prefix("r#").unwrap_or(name);
-        self.values.insert(key.to_owned(), JsonValue::String(format!("{value:?}")));
+        self.values.insert(key, JsonValue::String(format!("{value:?}")));
     }
 }
 
@@ -199,10 +197,14 @@ impl<'writer> FormatFields<'writer> for CborJsonFields {
             return self.format_fields(current.as_writer(), fields);
         }
 
-        let existing: BTreeMap<String, JsonValue> = serde_json::from_str(current.as_str()).map_err(|_| fmt::Error)?;
-        let mut visitor = CborJsonVisitor { values: existing };
+        let mut existing: BTreeMap<String, JsonValue> =
+            serde_json::from_str(current.as_str()).map_err(|_| fmt::Error)?;
+        let mut visitor = CborJsonVisitor::default();
         fields.record(&mut visitor);
-        current.fields = serde_json::to_string(&visitor.values).map_err(|_| fmt::Error)?;
+        for (key, value) in visitor.values {
+            existing.insert(key.to_owned(), value);
+        }
+        current.fields = serde_json::to_string(&existing).map_err(|_| fmt::Error)?;
         Ok(())
     }
 }
@@ -213,9 +215,12 @@ impl<'writer> FormatFields<'writer> for CborJsonFields {
 
 /// JSON event formatter: one `SerializeMap` pass to the writer, CBOR-aware fields.
 ///
-/// Envelope: `timestamp`, `level`, `fields`, `target`, then current-span fields flattened
-/// into the root (skipping reserved keys), then optional `id` / `parent_id` for span
-/// lifecycle events.
+/// Envelope (see EDR-033):
+/// - `timestamp`, `level`, `fields`, `target`
+/// - wrapping-span fields inlined into `fields` (event fields win on collision)
+/// - `span`: `{ name, target }` of the wrapping span
+/// - `parents`: ancestor span names from outermost to the wrapping span's parent
+/// - `id` on span lifecycle events; `parent_id` when the wrapping span has a parent
 #[derive(Debug, Default, Clone, Copy)]
 pub struct CborJsonEventFormat;
 
@@ -248,6 +253,148 @@ impl io::Write for FmtWriteAdaptor<'_> {
     }
 }
 
+/// JSON value that is either owned (event field) or borrowed from the wrapping span bag.
+enum JsonRef<'a> {
+    Owned(JsonValue),
+    Borrowed(&'a JsonValue),
+}
+
+impl Serialize for JsonRef<'_> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Owned(value) => value.serialize(serializer),
+            Self::Borrowed(value) => value.serialize(serializer),
+        }
+    }
+}
+
+/// Event fields plus borrowed wrapping-span fields, for one serialize pass.
+#[derive(Default)]
+struct EventFields<'a> {
+    values: BTreeMap<&'a str, JsonRef<'a>>,
+}
+
+impl EventFields<'_> {
+    fn insert(&mut self, key: &'static str, value: JsonValue) {
+        self.values.insert(key, JsonRef::Owned(value));
+    }
+}
+
+impl Visit for EventFields<'_> {
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        if let Some(n) = serde_json::Number::from_f64(value) {
+            self.insert(field.name(), JsonValue::Number(n));
+        }
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.insert(field.name(), JsonValue::Number(value.into()));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.insert(field.name(), JsonValue::Number(value.into()));
+    }
+
+    fn record_i128(&mut self, field: &Field, value: i128) {
+        if let Ok(v) = i64::try_from(value) {
+            self.record_i64(field, v);
+        } else {
+            self.insert(field.name(), JsonValue::String(value.to_string()));
+        }
+    }
+
+    fn record_u128(&mut self, field: &Field, value: u128) {
+        if let Ok(v) = u64::try_from(value) {
+            self.record_u64(field, v);
+        } else {
+            self.insert(field.name(), JsonValue::String(value.to_string()));
+        }
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.insert(field.name(), JsonValue::Bool(value));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.insert(field.name(), JsonValue::String(value.to_owned()));
+    }
+
+    fn record_bytes(&mut self, field: &Field, value: &[u8]) {
+        let json = cbor_to_json(value).unwrap_or_else(|_| JsonValue::String(hex::encode(value)));
+        self.insert(field.name(), json);
+    }
+
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        self.insert(field.name(), JsonValue::String(value.to_string()));
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        let name = field.name();
+        self.insert(name.strip_prefix("r#").unwrap_or(name), JsonValue::String(format!("{value:?}")));
+    }
+}
+
+/// Wrapping-span fields, borrowed from [`SpanJsonFields`] when the layer is installed.
+enum CurrentSpanFields<'a> {
+    None,
+    Bag(&'a BTreeMap<&'static str, JsonValue>),
+    /// Fallback when only [`FormattedFields`] is present (parsed once, then borrowed).
+    Parsed(BTreeMap<String, JsonValue>),
+}
+
+impl CurrentSpanFields<'_> {
+    fn iter(&self) -> CurrentSpanIter<'_> {
+        match self {
+            Self::None => CurrentSpanIter::Empty,
+            Self::Bag(bag) => CurrentSpanIter::Bag(bag.iter()),
+            Self::Parsed(parsed) => CurrentSpanIter::Parsed(parsed.iter()),
+        }
+    }
+}
+
+enum CurrentSpanIter<'a> {
+    Empty,
+    Bag(std::collections::btree_map::Iter<'a, &'static str, JsonValue>),
+    Parsed(std::collections::btree_map::Iter<'a, String, JsonValue>),
+}
+
+impl<'a> Iterator for CurrentSpanIter<'a> {
+    type Item = (&'a str, &'a JsonValue);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Empty => None,
+            Self::Bag(iter) => iter.next().map(|(key, value)| (*key, value)),
+            Self::Parsed(iter) => iter.next().map(|(key, value)| (key.as_str(), value)),
+        }
+    }
+}
+
+/// Fields recorded on the wrapping span only (no ancestor walk, no clone of the bag).
+fn current_span_fields<'a, N>(extensions: &'a tracing_subscriber::registry::Extensions<'a>) -> CurrentSpanFields<'a>
+where
+    N: for<'fmt> FormatFields<'fmt> + 'static,
+{
+    if let Some(bag) = extensions.get::<SpanJsonFields>() {
+        return CurrentSpanFields::Bag(&bag.0);
+    }
+    if let Some(formatted) = extensions.get::<FormattedFields<N>>() {
+        let s = formatted.as_str().trim();
+        if !s.is_empty()
+            && let Ok(JsonValue::Object(parsed)) = serde_json::from_str(s)
+        {
+            return CurrentSpanFields::Parsed(parsed.into_iter().collect());
+        }
+    }
+    CurrentSpanFields::None
+}
+
+#[derive(serde::Serialize)]
+struct SpanIdent<'a> {
+    name: &'a str,
+    target: &'a str,
+}
+
 impl<S, N> FormatEvent<S, N> for CborJsonEventFormat
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
@@ -259,52 +406,37 @@ where
 
         let meta = event.metadata();
 
-        let mut event_fields = CborJsonVisitor::default();
-        event.record(&mut event_fields);
-
         let current = event.parent().and_then(|id| ctx.span(id)).or_else(|| ctx.lookup_current());
+        let extensions = current.as_ref().map(|span_ref| span_ref.extensions());
+        let span_fields =
+            extensions.as_ref().map(|ext| current_span_fields::<N>(ext)).unwrap_or(CurrentSpanFields::None);
 
-        // Span fields: prefer structured bag; fall back to FormattedFields JSON string.
-        let mut fallback_span_fields: Option<BTreeMap<String, JsonValue>> = None;
-        if let Some(ref span_ref) = current {
-            let extensions = span_ref.extensions();
-            if extensions.get::<SpanJsonFields>().is_none()
-                && let Some(formatted) = extensions.get::<FormattedFields<N>>()
-            {
-                let s = formatted.as_str().trim();
-                if !s.is_empty()
-                    && let Ok(JsonValue::Object(obj)) = serde_json::from_str(s)
-                {
-                    fallback_span_fields = Some(obj.into_iter().collect());
-                }
-            }
+        let mut fields = EventFields::default();
+        event.record(&mut fields);
+        for (key, value) in span_fields.iter() {
+            fields.values.entry(key).or_insert(JsonRef::Borrowed(value));
         }
 
-        let mut write_line = || -> Result<(), serde_json::Error> {
+        let parents = current
+            .as_ref()
+            .map(|leaf| ancestor_span_names(leaf.scope().from_root().map(|span| span.name())))
+            .unwrap_or_else(|| Box::new(std::iter::empty()));
+
+        let write_line = || -> Result<(), serde_json::Error> {
             let mut serializer = Serializer::new(FmtWriteAdaptor::new(&mut writer));
             let mut map = serializer.serialize_map(None)?;
 
             map.serialize_entry("timestamp", &timestamp)?;
             map.serialize_entry("level", meta.level().as_str())?;
-            map.serialize_entry("fields", &event_fields.values)?;
+            map.serialize_entry("fields", &fields.values)?;
             map.serialize_entry("target", meta.target())?;
 
             if let Some(ref span_ref) = current {
-                let extensions = span_ref.extensions();
-                if let Some(bag) = extensions.get::<SpanJsonFields>() {
-                    for (key, value) in &bag.0 {
-                        if !is_reserved_root_key(key) {
-                            map.serialize_entry(key, value)?;
-                        }
-                    }
-                } else if let Some(ref fields) = fallback_span_fields {
-                    for (key, value) in fields {
-                        if !is_reserved_root_key(key) {
-                            map.serialize_entry(key, value)?;
-                        }
-                    }
-                }
-
+                map.serialize_entry(
+                    "span",
+                    &SpanIdent { name: span_ref.name(), target: span_ref.metadata().target() },
+                )?;
+                map.serialize_entry("parents", &Parents::new(parents))?;
                 if meta.is_span() {
                     map.serialize_entry("id", &span_ref.id().into_u64())?;
                 }
@@ -319,6 +451,23 @@ where
 
         write_line().map_err(|_| fmt::Error)?;
         writeln!(writer)
+    }
+}
+
+struct Parents<'a>(RefCell<Box<dyn Iterator<Item = &'a str> + 'a>>);
+impl Serialize for Parents<'_> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(None)?;
+        for name in self.0.borrow_mut().as_mut() {
+            seq.serialize_element(name)?;
+        }
+        seq.end()
+    }
+}
+impl<'a> Parents<'a> {
+    fn new(iter: Box<dyn Iterator<Item = &'a str> + 'a>) -> Self {
+        Self(RefCell::new(iter))
     }
 }
 
@@ -408,8 +557,9 @@ mod tests {
         assert_eq!(fields["version"], "10.11.0");
         assert_eq!(fields["git_dirty"], true);
         assert_eq!(fields["peers"]["addresses"], serde_json::json!(["a:1", "b:2"]));
-        // Envelope keys only once — no nested stock rewrite artifacts required.
+        // Point event with no entered span: no span envelope.
         assert!(json.get("span").is_none());
+        assert!(json.get("parents").is_none());
     }
 
     #[test]
@@ -441,12 +591,14 @@ mod tests {
             output.contains("snapshot_count") && output.contains("continuous_ranges"),
             "expected merged span fields in JSON output:\n{output}"
         );
-        // Flattened onto root (not only under fields).
         let last = output.lines().rfind(|l| !l.is_empty()).expect("line");
         let json: JsonValue = serde_json::from_str(last).expect("json");
-        assert_eq!(json["snapshot_count"], 3);
-        assert_eq!(json["continuous_ranges"], 1);
-        assert_eq!(json["amaru.tag.db"], true);
+        assert_eq!(json["fields"]["snapshot_count"], 3);
+        assert_eq!(json["fields"]["continuous_ranges"], 1);
+        assert_eq!(json["fields"]["amaru.tag.db"], true);
+        assert_eq!(json["span"]["name"], "ledger.snapshots.validate");
+        assert!(json["span"].get("snapshot_count").is_none(), "span is identity only");
+        assert_eq!(json["parents"], serde_json::json!([]));
     }
 
     #[test]
@@ -468,7 +620,9 @@ mod tests {
         let output = writer.contents();
         let json: JsonValue = serde_json::from_str(output.lines().next().expect("line")).expect("json");
         assert_eq!(json["fields"]["message"], "hello");
-        assert_eq!(json["answer"], 42);
+        assert_eq!(json["fields"]["answer"], 42);
+        assert_eq!(json["span"]["name"], "parent");
+        assert_eq!(json["parents"], serde_json::json!([]));
     }
 
     #[test]
@@ -492,6 +646,37 @@ mod tests {
         let enter_line = output.lines().find(|l| l.contains("\"enter\"") || l.contains("enter")).expect("enter event");
         let json: JsonValue = serde_json::from_str(enter_line).expect("json");
         assert!(json.get("id").and_then(|v| v.as_u64()).is_some(), "expected id on span event: {enter_line}");
-        assert_eq!(json["n"], 1);
+        assert_eq!(json["fields"]["n"], 1);
+        assert_eq!(json["span"]["name"], "lifecycle");
+        assert!(json.get("parent_id").is_none());
+    }
+
+    #[test]
+    fn json_nested_spans_encode_ancestry() {
+        let writer = CaptureWriter::default();
+        let subscriber = json_subscriber(writer.clone());
+
+        tracing::subscriber::with_default(subscriber, || {
+            let outer = tracing::info_span!("epoch.transition", from = 599_u64, into = 600_u64);
+            let _outer = outer.enter();
+            let mid = tracing::info_span!("governance.ratify_proposals", epoch = 598_u64);
+            let _mid = mid.enter();
+            let inner = tracing::info_span!("ratification.round", votes = 372_u64);
+            let _inner = inner.enter();
+            tracing::info!(is_dormant_epoch = false, "ratification.summarize");
+        });
+
+        let output = writer.contents();
+        let line = output.lines().find(|l| l.contains("ratification.summarize")).expect("event line");
+        let json: JsonValue = serde_json::from_str(line).expect("json");
+        assert_eq!(json["fields"]["message"], "ratification.summarize");
+        assert_eq!(json["span"]["name"], "ratification.round");
+        assert_eq!(json["fields"]["votes"], 372);
+        assert!(json["span"].get("votes").is_none());
+        assert_eq!(json["parents"], serde_json::json!(["epoch.transition", "governance.ratify_proposals"]));
+        assert!(json["fields"].get("from").is_none(), "ancestor fields must not be inlined");
+        assert!(json["fields"].get("epoch").is_none(), "mid-level ancestor fields must not be inlined");
+        assert!(json.get("parent_id").and_then(|v| v.as_u64()).is_some());
+        assert!(json.get("id").is_none(), "point events do not carry their own span id");
     }
 }

--- a/crates/amaru-observability/src/layers.rs
+++ b/crates/amaru-observability/src/layers.rs
@@ -15,30 +15,46 @@
 //! CBOR-aware `tracing-subscriber` field formatters for console (and re-exports for JSON).
 //!
 //! Every `record_bytes` payload is treated as CBOR (project convention). Primitives
-//! recorded via typed visit methods pass through unchanged.
+//! recorded via typed visit methods pass through unchanged. Text scalars are
+//! unwrapped so the console does not Debug-quote diagnostic quotes.
+//!
+//! Compose [`console_field_formatter`] with [`CborConsoleEventFormat`] so nested
+//! spans render as an abbreviated path (`e.t:g.r`) plus the wrapping span's
+//! name and fields (EDR-033).
 //!
 //! JSON NDJSON formatting lives in [`crate::json_format`].
 
 use std::fmt;
 
-use tracing::field::{Field, Visit};
+use tracing::{
+    Event, Subscriber,
+    field::{Field, Visit},
+};
 use tracing_subscriber::{
     field::{MakeVisitor, VisitFmt, VisitOutput},
-    fmt::format::{DefaultFields, Writer},
+    fmt::{
+        FmtContext, FormatEvent, FormatFields, FormattedFields,
+        format::{DefaultFields, Writer},
+        time::{FormatTime, SystemTime},
+    },
+    registry::LookupSpan,
 };
 
-use crate::field::cbor_diagnostic;
 pub use crate::json_format::{CborJsonEventFormat, CborJsonFields, CborJsonSpanLayer, SpanJsonFields};
+use crate::{
+    field::{DecodedField, cbor_to_decoded_field, is_tag_field_name},
+    span_encode::{ancestor_span_names, write_abbreviated_span_path},
+};
 
 // -----------------------------------------------------------------------------
-// Console: decode CBOR bytes to diagnostic notation
+// Console: decode CBOR bytes to native visit types
 // -----------------------------------------------------------------------------
 
-/// [`MakeVisitor`] adapter: decode CBOR `record_bytes` to diagnostic text before
-/// delegating to an inner visitor (typically [`DefaultFields`]).
+/// [`MakeVisitor`] adapter: decode CBOR `record_bytes` before delegating.
 ///
-/// Compose with tag-hiding wrappers:
-/// `HideTagFields(CborAwareMakeVisitor(DefaultFields::new()))`.
+/// Scalars become the matching typed visit (`record_str` / `record_u64` / …);
+/// maps and arrays stay diagnostic text. Prefer [`console_field_formatter`]
+/// over composing this type by hand.
 #[derive(Debug, Clone)]
 pub struct CborAwareMakeVisitor<N>(pub N);
 
@@ -53,7 +69,7 @@ where
     }
 }
 
-/// Visit wrapper that turns CBOR bytes into diagnostic strings.
+/// Visit wrapper that decodes CBOR `record_bytes` onto the inner visitor.
 pub struct CborDiagVisitor<V>(pub V);
 
 impl<V: Visit> Visit for CborDiagVisitor<V> {
@@ -79,8 +95,7 @@ impl<V: Visit> Visit for CborDiagVisitor<V> {
         self.0.record_str(field, value);
     }
     fn record_bytes(&mut self, field: &Field, value: &[u8]) {
-        let diag = cbor_diagnostic(value);
-        self.0.record_str(field, &diag);
+        record_decoded_cbor(&mut self.0, field, value);
     }
     fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
         self.0.record_error(field, value);
@@ -106,10 +121,10 @@ impl<V: VisitFmt> VisitFmt for CborDiagVisitor<V> {
 // OTEL best-effort helper
 // -----------------------------------------------------------------------------
 
-/// Visit wrapper that stringifies CBOR bytes as diagnostic notation.
+/// Visit wrapper that decodes CBOR `record_bytes` onto the inner visitor.
 ///
-/// Use when collecting attributes for OTEL: nested structure becomes a string
-/// (OTEL trace attributes cannot hold nested maps). Typed primitives pass through.
+/// Scalars keep their native type. Maps and arrays become diagnostic text
+/// because classic OTEL trace attributes cannot hold nested maps.
 pub struct CborToStringVisit<V>(pub V);
 
 impl<V: Visit> Visit for CborToStringVisit<V> {
@@ -135,8 +150,7 @@ impl<V: Visit> Visit for CborToStringVisit<V> {
         self.0.record_str(field, value);
     }
     fn record_bytes(&mut self, field: &Field, value: &[u8]) {
-        let diag = cbor_diagnostic(value);
-        self.0.record_str(field, &diag);
+        record_decoded_cbor(&mut self.0, field, value);
     }
     fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
         self.0.record_error(field, value);
@@ -146,9 +160,227 @@ impl<V: Visit> Visit for CborToStringVisit<V> {
     }
 }
 
-/// Convenience: console field stack with CBOR diagnostic decoding.
-pub fn console_field_formatter() -> CborAwareMakeVisitor<DefaultFields> {
-    CborAwareMakeVisitor(DefaultFields::new())
+/// Dispatch a CBOR `record_bytes` payload onto `visitor` using native types.
+///
+/// Text scalars are recorded as `record_str` **without** RFC 8610 diagnostic quotes,
+/// so the console `DefaultFields` formatter does not wrap them in a second pair of
+/// quotes (`header_hash="abc"` rather than `header_hash="\"abc\""`).
+fn record_decoded_cbor(visitor: &mut impl Visit, field: &Field, bytes: &[u8]) {
+    match cbor_to_decoded_field(bytes) {
+        DecodedField::Bool(value) => visitor.record_bool(field, value),
+        DecodedField::I64(value) => visitor.record_i64(field, value),
+        DecodedField::U64(value) => visitor.record_u64(field, value),
+        DecodedField::F64(value) => visitor.record_f64(field, value),
+        DecodedField::Text(text) => visitor.record_str(field, &text),
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Hide `amaru.tag.*` from human-facing field formatters
+// -----------------------------------------------------------------------------
+
+/// Wraps a field formatter so that `amaru.tag.*` fields are skipped.
+///
+/// Tags classify spans for `EnvFilter` / OpenTelemetry backends. They have no
+/// value in the human-readable console log, and because formatters may append
+/// the fields of every span in scope, an inherited tag would otherwise repeat
+/// once per nested span.
+#[derive(Debug, Clone)]
+pub struct HideTagFields<N>(pub N);
+
+impl<'writer, N> MakeVisitor<Writer<'writer>> for HideTagFields<N>
+where
+    N: MakeVisitor<Writer<'writer>>,
+{
+    type Visitor = HideTagVisitor<N::Visitor>;
+
+    fn make_visitor(&self, target: Writer<'writer>) -> Self::Visitor {
+        HideTagVisitor(self.0.make_visitor(target))
+    }
+}
+
+/// Forwards every recorded value to the inner visitor except `amaru.tag.*`.
+pub struct HideTagVisitor<V>(V);
+
+impl<V: Visit> Visit for HideTagVisitor<V> {
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        if !is_tag_field_name(field.name()) {
+            self.0.record_f64(field, value);
+        }
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        if !is_tag_field_name(field.name()) {
+            self.0.record_i64(field, value);
+        }
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        if !is_tag_field_name(field.name()) {
+            self.0.record_u64(field, value);
+        }
+    }
+
+    fn record_i128(&mut self, field: &Field, value: i128) {
+        if !is_tag_field_name(field.name()) {
+            self.0.record_i128(field, value);
+        }
+    }
+
+    fn record_u128(&mut self, field: &Field, value: u128) {
+        if !is_tag_field_name(field.name()) {
+            self.0.record_u128(field, value);
+        }
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        if !is_tag_field_name(field.name()) {
+            self.0.record_bool(field, value);
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if !is_tag_field_name(field.name()) {
+            self.0.record_str(field, value);
+        }
+    }
+
+    fn record_bytes(&mut self, field: &Field, value: &[u8]) {
+        if !is_tag_field_name(field.name()) {
+            self.0.record_bytes(field, value);
+        }
+    }
+
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        if !is_tag_field_name(field.name()) {
+            self.0.record_error(field, value);
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if !is_tag_field_name(field.name()) {
+            self.0.record_debug(field, value);
+        }
+    }
+}
+
+impl<Out, V: VisitOutput<Out>> VisitOutput<Out> for HideTagVisitor<V> {
+    fn finish(self) -> Out {
+        self.0.finish()
+    }
+}
+
+impl<V: VisitFmt> VisitFmt for HideTagVisitor<V> {
+    fn writer(&mut self) -> &mut dyn fmt::Write {
+        self.0.writer()
+    }
+}
+
+/// Console field stack: decode CBOR, then hide schema tags.
+///
+/// Compose with [`CborConsoleEventFormat`] (EDR-033).
+pub fn console_field_formatter() -> HideTagFields<CborAwareMakeVisitor<DefaultFields>> {
+    HideTagFields(CborAwareMakeVisitor(DefaultFields::new()))
+}
+
+// -----------------------------------------------------------------------------
+// Console event format: abbreviated path + wrapping span only
+// -----------------------------------------------------------------------------
+
+/// Compact console event format (EDR-033).
+///
+/// Prints `e.t:g.r` for the span stack, then target, the wrapping span's full
+/// name, the event fields, the wrapping span's fields, and `id` / `parent_id`.
+/// Ancestor span fields are omitted so lines stay short.
+#[derive(Debug, Clone, Copy)]
+pub struct CborConsoleEventFormat {
+    ansi: Option<bool>,
+}
+
+impl Default for CborConsoleEventFormat {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CborConsoleEventFormat {
+    pub fn new() -> Self {
+        Self { ansi: None }
+    }
+
+    pub fn with_ansi(mut self, ansi: bool) -> Self {
+        self.ansi = Some(ansi);
+        self
+    }
+}
+
+fn write_level(writer: &mut Writer<'_>, level: &tracing::Level, ansi: bool) -> fmt::Result {
+    if ansi {
+        let color = match *level {
+            tracing::Level::ERROR => "\x1b[31m",
+            tracing::Level::WARN => "\x1b[33m",
+            tracing::Level::INFO => "\x1b[32m",
+            tracing::Level::DEBUG => "\x1b[34m",
+            tracing::Level::TRACE => "\x1b[35m",
+        };
+        write!(writer, "{color}{level:>5}\x1b[0m ")
+    } else {
+        write!(writer, "{level:>5} ")
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for CborConsoleEventFormat
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(&self, ctx: &FmtContext<'_, S, N>, mut writer: Writer<'_>, event: &Event<'_>) -> fmt::Result {
+        let ansi = self.ansi.unwrap_or_else(|| writer.has_ansi_escapes());
+
+        SystemTime.format_time(&mut writer)?;
+        write!(writer, " ")?;
+
+        let meta = event.metadata();
+        write_level(&mut writer, meta.level(), ansi)?;
+
+        write!(writer, "{}: ", meta.target())?;
+
+        let current = event.parent().and_then(|id| ctx.span(id)).or_else(|| ctx.lookup_current());
+        let names_from_root: Vec<&str> =
+            current.as_ref().map(|leaf| leaf.scope().from_root().map(|span| span.name()).collect()).unwrap_or_default();
+        let wrapping_name = names_from_root.last().copied();
+        let mut ancestors = ancestor_span_names(names_from_root).peekable();
+
+        if ancestors.peek().is_some() {
+            write_abbreviated_span_path(&mut writer, ancestors)?;
+            write!(writer, ":")?;
+        }
+
+        if let Some(name) = wrapping_name {
+            write!(writer, "{name} ")?;
+        }
+
+        ctx.format_fields(writer.by_ref(), event)?;
+
+        if let Some(ref span_ref) = current {
+            {
+                let extensions = span_ref.extensions();
+                if let Some(fields) = extensions.get::<FormattedFields<N>>()
+                    && !fields.is_empty()
+                {
+                    write!(writer, " {fields}")?;
+                }
+            }
+            if meta.is_span() {
+                write!(writer, " id={}", span_ref.id().into_u64())?;
+            }
+            if let Some(parent) = span_ref.parent() {
+                write!(writer, " parent_id={}", parent.id().into_u64())?;
+            }
+        }
+
+        writeln!(writer)
+    }
 }
 
 #[cfg(test)]
@@ -208,5 +440,58 @@ mod tests {
         assert!(output.contains("hello"), "output={output}");
         // cbor-data diagnostic for a string array must include the element text (quoted form ok).
         assert!(output.contains("a:1"), "expected decoded peers diagnostic content, got: {output}");
+    }
+
+    #[test]
+    fn console_cbor_text_scalar_is_not_double_quoted() {
+        let writer = CaptureWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(writer.clone())
+            .with_ansi(false)
+            .fmt_fields(console_field_formatter())
+            .event_format(CborConsoleEventFormat::new().with_ansi(false))
+            .with_max_level(tracing::Level::INFO)
+            .finish();
+
+        let hash = "3bc8f4b70575ead11872b035b6b95561b43bc7db5b5c0e304ba65e1f65eab5f2";
+        tracing::subscriber::with_default(subscriber, || {
+            let encoded = encode_cbor(&hash);
+            tracing::info!(header_hash = encoded.as_ref() as &[u8], "tip.adopt");
+        });
+
+        let output = writer.contents();
+        assert!(
+            output.contains(&format!("header_hash=\"{hash}\"")),
+            "expected a single-quoted hex string, got: {output}"
+        );
+        assert!(
+            !output.contains(&format!(r#"header_hash="\"{hash}\"""#)),
+            "must not Debug-quote diagnostic quotes: {output}"
+        );
+    }
+
+    #[test]
+    fn console_hides_tag_fields_from_nested_spans() {
+        let writer = CaptureWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(writer.clone())
+            .with_ansi(false)
+            .fmt_fields(console_field_formatter())
+            .event_format(CborConsoleEventFormat::new().with_ansi(false))
+            .with_max_level(tracing::Level::INFO)
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            let outer = tracing::info_span!("outer", "amaru.tag.cpu" = true);
+            let _outer = outer.enter();
+            let inner = tracing::info_span!("inner", "amaru.tag.cpu" = true, transaction_id = "abc");
+            let _inner = inner.enter();
+            tracing::info!("hello");
+        });
+
+        let output = writer.contents();
+        assert!(!output.contains("amaru.tag"), "tag markers must be hidden from the console: {output}");
+        assert!(output.contains(" transaction_id=\"abc\""), "ordinary span fields must be kept: {output}");
+        assert!(output.contains(" o:inner "), "abbreviated ancestors exclude the wrapping span: {output}");
     }
 }

--- a/crates/amaru-observability/src/lib.rs
+++ b/crates/amaru-observability/src/lib.rs
@@ -25,16 +25,21 @@ pub mod registry;
 // Include the schemas module which uses define_schemas! to generate
 // the amaru module with all schema constants and validation macros
 mod schemas;
+pub mod span_encode;
 pub mod telemetry_capture;
 mod trace_context;
 
 // Re-export the macros for convenient use
 pub use amaru_observability_macros::{define_schemas, trace_event as __trace_event, trace_record, trace_span};
 pub use field::{
-    DecodedField, as_str_value, cbor_to_any_value, cbor_to_decoded_field, cbor_to_trace_value, encode_cbor,
+    DecodedField, TAG_FIELD_PREFIX, as_str_value, cbor_to_any_value, cbor_to_decoded_field, cbor_to_trace_value,
+    encode_cbor, is_tag_field_name,
 };
 pub use json_format::{CborJsonEventFormat, CborJsonFields, CborJsonSpanLayer, SpanJsonFields};
-pub use layers::{CborAwareMakeVisitor, CborDiagVisitor, CborToStringVisit, console_field_formatter};
+pub use layers::{
+    CborAwareMakeVisitor, CborConsoleEventFormat, CborDiagVisitor, CborToStringVisit, HideTagFields,
+    console_field_formatter,
+};
 pub use opentelemetry;
 pub use otel_log_bridge::CborOtelLogBridge;
 pub use otel_trace_arrays::CborTraceArrayLayer;
@@ -42,6 +47,10 @@ pub use record_fields::RecordFields;
 pub use schemas::*;
 /// Re-export for schema macros that require `Serialize` on complex field types.
 pub use serde;
+pub use span_encode::{
+    abbreviate_span_name, ancestor_span_names, format_abbreviated_span_path, write_abbreviated_span_name,
+    write_abbreviated_span_path,
+};
 pub use telemetry_capture::{FieldValue, TelemetryCaptureLayer, TelemetryRecord, subscribe_telemetry};
 pub use trace_context::TraceContext;
 pub use tracing;

--- a/crates/amaru-observability/src/otel_log_bridge.rs
+++ b/crates/amaru-observability/src/otel_log_bridge.rs
@@ -33,8 +33,10 @@
 use opentelemetry::{
     Key,
     logs::{AnyValue, LogRecord, Logger, LoggerProvider, Severity},
+    trace::TraceContextExt,
 };
 use tracing::Level;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::Layer;
 
 use crate::field::cbor_to_any_value;
@@ -164,6 +166,18 @@ where
 
         let mut visitor = EventVisitor::new(&mut log_record);
         event.record(&mut visitor);
+
+        // Associate the log with the current OTEL span when one is entered, so
+        // Loki/Tempo (and similar) can join logs to the same nested span tree
+        // that traces already form natively.
+        let span_context = tracing::Span::current().context().span().span_context().clone();
+        if span_context.is_valid() {
+            log_record.set_trace_context(
+                span_context.trace_id(),
+                span_context.span_id(),
+                Some(span_context.trace_flags()),
+            );
+        }
 
         self.logger.emit(log_record);
     }

--- a/crates/amaru-observability/src/span_encode.rs
+++ b/crates/amaru-observability/src/span_encode.rs
@@ -1,0 +1,115 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Compact span-path encoding for human-facing sinks (EDR-033).
+
+use std::fmt::{self, Write};
+
+/// Write a Java-style abbreviation of a span name: `epoch.transition` → `e.t`.
+pub fn write_abbreviated_span_name(out: &mut impl Write, name: &str) -> fmt::Result {
+    let mut first = true;
+    for segment in name.split('.').filter(|segment| !segment.is_empty()) {
+        if !first {
+            out.write_char('.')?;
+        }
+        first = false;
+        if let Some(ch) = segment.chars().next() {
+            out.write_char(ch)?;
+        }
+    }
+    Ok(())
+}
+
+/// Write ancestor names as an abbreviated path: `e.t:g.r`.
+pub fn write_abbreviated_span_path<I, S>(out: &mut impl Write, names: I) -> fmt::Result
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut first = true;
+    for name in names {
+        if !first {
+            out.write_char(':')?;
+        }
+        first = false;
+        write_abbreviated_span_name(out, name.as_ref())?;
+    }
+    Ok(())
+}
+
+/// Abbreviate a tracing span name like a Java logger: `epoch.transition` → `e.t`.
+///
+/// Each `.`-separated segment keeps only its first character. A typical span
+/// level then costs four characters on the console once the `:` separator is
+/// included (`e.t:`).
+pub fn abbreviate_span_name(name: &str) -> String {
+    let mut out = String::new();
+    let _ = write_abbreviated_span_name(&mut out, name);
+    out
+}
+
+/// Ancestor names from a root-to-leaf list, excluding the wrapping (leaf) span.
+pub fn ancestor_span_names<'a, I, S>(names_from_root: I) -> Box<dyn Iterator<Item = S> + 'a>
+where
+    I: IntoIterator<Item = S> + 'a,
+{
+    let mut iter = names_from_root.into_iter().peekable();
+    Box::new(std::iter::from_fn(move || {
+        let ret = iter.next();
+        if iter.peek().is_none() { None } else { ret }
+    }))
+}
+
+/// Join span names as an abbreviated path: `epoch.transition` / `governance.ratify_proposals`
+/// → `e.t:g.r`.
+pub fn format_abbreviated_span_path<I, S>(names: I) -> String
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut out = String::new();
+    let _ = write_abbreviated_span_path(&mut out, names);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn abbreviates_dotted_span_names() {
+        assert_eq!(abbreviate_span_name("epoch.transition"), "e.t");
+        assert_eq!(abbreviate_span_name("governance.ratify_proposals"), "g.r");
+        assert_eq!(abbreviate_span_name("lifecycle"), "l");
+        assert_eq!(abbreviate_span_name(""), "");
+    }
+
+    #[test]
+    fn joins_abbreviated_levels_with_colons() {
+        assert_eq!(format_abbreviated_span_path(["epoch.transition", "governance.ratify_proposals"]), "e.t:g.r");
+        assert_eq!(format_abbreviated_span_path(["epoch.transition"]), "e.t");
+        assert_eq!(format_abbreviated_span_path(Vec::<&str>::new()), "");
+    }
+
+    #[test]
+    fn ancestor_list_drops_the_wrapping_span() {
+        assert_eq!(
+            ancestor_span_names(vec!["epoch.transition", "governance.ratify_proposals", "ratification.round"])
+                .collect::<Vec<_>>(),
+            vec!["epoch.transition", "governance.ratify_proposals"]
+        );
+        assert_eq!(ancestor_span_names(vec!["epoch.transition"]).collect::<Vec<_>>(), Vec::<&str>::new());
+        assert_eq!(ancestor_span_names(Vec::<&str>::new()).collect::<Vec<_>>(), Vec::<&str>::new());
+    }
+}

--- a/crates/amaru-observability/src/telemetry_capture.rs
+++ b/crates/amaru-observability/src/telemetry_capture.rs
@@ -32,9 +32,10 @@ use tracing::{
 };
 use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
 
-use crate::field::{DecodedField, cbor_to_decoded_field};
-
-const TAG_FIELD_PREFIX: &str = "amaru.tag.";
+use crate::{
+    field::{DecodedField, TAG_FIELD_PREFIX, cbor_to_decoded_field},
+    span_encode::ancestor_span_names,
+};
 
 /// A captured field value from a tracing event or span.
 #[derive(Debug, Clone, PartialEq)]
@@ -70,6 +71,14 @@ pub struct TelemetryRecord {
     pub fields: BTreeMap<String, FieldValue>,
     /// `None` for point events; `Some` when a span closed.
     pub duration: Option<std::time::Duration>,
+    /// Ancestor span names, outermost first, excluding the wrapping span.
+    pub parents: Vec<String>,
+    /// Name of the wrapping span (`None` when the record is outside any span).
+    pub span_name: Option<String>,
+    /// Present on closed-span records (the span's own id).
+    pub id: Option<u64>,
+    /// Id of the parent of the wrapping span, when that parent exists.
+    pub parent_id: Option<u64>,
 }
 
 /// `tracing-subscriber` layer that forwards events and closed spans to a channel.
@@ -106,9 +115,26 @@ impl<S> Layer<S> for TelemetryCaptureLayer
 where
     S: Subscriber + for<'span> LookupSpan<'span>,
 {
-    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
         let mut visitor = FieldVisitor::default();
         event.record(&mut visitor);
+
+        let mut parents = Vec::new();
+        let mut span_name = None;
+        let mut parent_id = None;
+        if let Some(scope) = ctx.event_scope(event) {
+            let spans: Vec<_> = scope.from_root().collect();
+            parents.extend(ancestor_span_names(spans.iter().map(|span| span.name().to_string())));
+            if let Some(leaf) = spans.last() {
+                span_name = Some(leaf.name().to_string());
+                parent_id = leaf.parent().map(|parent| parent.id().into_u64());
+                if let Some(state) = leaf.extensions().get::<CapturedSpan>() {
+                    for (key, value) in &state.fields {
+                        visitor.fields.entry(key.clone()).or_insert_with(|| value.clone());
+                    }
+                }
+            }
+        }
 
         self.emit(TelemetryRecord {
             level: *event.metadata().level(),
@@ -118,6 +144,10 @@ where
             wall_time: SystemTime::now(),
             fields: visitor.fields,
             duration: None,
+            parents,
+            span_name,
+            id: None,
+            parent_id,
         });
     }
 
@@ -157,8 +187,11 @@ where
             return;
         };
 
-        let mut extensions = span.extensions_mut();
-        let Some(state) = extensions.remove::<CapturedSpan>() else {
+        let parents =
+            ancestor_span_names(span.scope().from_root().map(|ancestor| ancestor.name().to_string())).collect();
+        let parent_id = span.parent().map(|parent| parent.id().into_u64());
+        let id = span.id().into_u64();
+        let Some(state) = span.extensions_mut().remove::<CapturedSpan>() else {
             return;
         };
 
@@ -166,11 +199,15 @@ where
         self.emit(TelemetryRecord {
             level: state.level,
             target: state.target,
+            span_name: Some(state.name.clone()),
             name: state.name,
             at: closed_at,
             wall_time: state.wall_time,
             fields: state.fields,
             duration: Some(closed_at.saturating_duration_since(state.opened_at)),
+            parents,
+            id: Some(id),
+            parent_id,
         });
     }
 }
@@ -274,6 +311,42 @@ mod tests {
         if let Some(FieldValue::Debug(s) | FieldValue::Str(s)) = record.fields.get("slot") {
             panic!("slot should be typed U64, got string-like {s:?}");
         }
+        assert!(record.parents.is_empty(), "point event outside a span has an empty path");
+        assert!(record.span_name.is_none());
+        assert!(record.parent_id.is_none());
+        assert!(record.id.is_none());
+    }
+
+    #[test]
+    fn events_inside_nested_spans_record_the_name_path() {
+        let (tx, rx) = sync_channel(4);
+        let subscriber = tracing_subscriber::registry().with(TelemetryCaptureLayer::new(tx));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let outer = tracing::info_span!("epoch.transition");
+            let _outer = outer.enter();
+            let inner = tracing::info_span!("governance.ratify_proposals");
+            let _inner = inner.enter();
+            tracing::info!("ratification.summarize");
+        });
+
+        let records: Vec<_> = rx.try_iter().collect();
+        let event = records
+            .iter()
+            .find(|r| r.duration.is_none() && !r.parents.is_empty())
+            .unwrap_or_else(|| panic!("event, got {records:#?}"));
+        assert_eq!(event.parents, vec!["epoch.transition".to_string()]);
+        assert_eq!(event.span_name.as_deref(), Some("governance.ratify_proposals"));
+        assert!(event.parent_id.is_some(), "child event refers to the outer span by id");
+        assert!(event.id.is_none());
+        let closed_inner = records
+            .iter()
+            .find(|r| r.name == "governance.ratify_proposals" && r.duration.is_some())
+            .expect("inner close");
+        assert_eq!(closed_inner.parents, vec!["epoch.transition".to_string()]);
+        assert_eq!(closed_inner.span_name.as_deref(), Some("governance.ratify_proposals"));
+        assert_eq!(closed_inner.parent_id, event.parent_id);
+        assert!(closed_inner.id.is_some());
     }
 
     #[test]

--- a/crates/amaru-observability/tests/tracing_stacks.rs
+++ b/crates/amaru-observability/tests/tracing_stacks.rs
@@ -1,0 +1,480 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shape contracts for each complete product tracing stack.
+//!
+//! These tests emit one shared nested-span fixture and assert the encoding
+//! documented in EDR-033. They compose the same layers the product binary uses:
+//!
+//! - console: [`console_field_formatter`] + [`CborConsoleEventFormat`]
+//! - JSON: [`CborJsonSpanLayer`] + [`CborJsonEventFormat`]
+//! - OTEL: `tracing-opentelemetry` + [`CborTraceArrayLayer`] + [`CborOtelLogBridge`]
+//! - TUI: [`TelemetryCaptureLayer`]
+
+use std::{
+    io::{self, Write},
+    sync::{Arc, Mutex},
+};
+
+use amaru_observability::{
+    CborConsoleEventFormat, CborJsonEventFormat, CborJsonFields, CborJsonSpanLayer, CborOtelLogBridge,
+    CborTraceArrayLayer, FieldValue, TelemetryCaptureLayer, TelemetryRecord, console_field_formatter, encode_cbor,
+};
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_sdk::{
+    logs::{InMemoryLogExporter, SdkLoggerProvider},
+    trace::{InMemorySpanExporter, SdkTracerProvider},
+};
+use tracing::Subscriber;
+use tracing_subscriber::{
+    Layer,
+    fmt::{MakeWriter, format::FmtSpan},
+    layer::SubscriberExt,
+};
+
+const HASH: &str = "3bc8f4b70575ead11872b035b6b95561b43bc7db5b5c0e304ba65e1f65eab5f2";
+const OUTER: &str = "epoch.transition";
+const MID: &str = "governance.ratify_proposals";
+const WRAP: &str = "ratification.round";
+const EVENT: &str = "ratification.summarize";
+
+/// Three nested spans + an event inside the innermost span.
+///
+/// Mirrors a typical ledger epoch-boundary sequence. Three levels are required
+/// so the abbreviated ancestor path is `e.t:g.r` once the wrapping span is
+/// excluded from `parents`.
+fn emit_nested_fixture() {
+    let hash = encode_cbor(&HASH);
+    let peers = encode_cbor(&vec!["a:1".to_string(), "b:2".to_string()]);
+    let outer = tracing::info_span!(OUTER, from = 599_u64, into = 600_u64, "amaru.tag.cpu" = true,);
+    let _outer = outer.enter();
+    let mid = tracing::info_span!(MID, epoch = 598_u64, "amaru.tag.cpu" = true,);
+    let _mid = mid.enter();
+    let wrap = tracing::info_span!(
+        WRAP,
+        header_hash = hash.as_ref() as &[u8],
+        votes = tracing::field::Empty,
+        "amaru.tag.cpu" = true,
+    );
+    let _wrap = wrap.enter();
+    wrap.record("votes", 372_u64);
+    tracing::info!(
+        target: "amaru::ledger",
+        is_dormant_epoch = false,
+        peers = peers.as_ref() as &[u8],
+        "{EVENT}"
+    );
+}
+
+#[derive(Clone, Default)]
+struct CaptureWriter {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl CaptureWriter {
+    fn lock_buf(&self) -> std::sync::MutexGuard<'_, Vec<u8>> {
+        self.buffer.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn contents(&self) -> String {
+        String::from_utf8_lossy(&self.lock_buf()).into_owned()
+    }
+}
+
+impl Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.lock_buf().write(buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+fn console_subscriber(writer: CaptureWriter) -> impl Subscriber + Send + Sync {
+    tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .with_writer(writer)
+            .with_ansi(false)
+            .fmt_fields(console_field_formatter())
+            .with_span_events(FmtSpan::CLOSE)
+            .event_format(CborConsoleEventFormat::new().with_ansi(false))
+            .with_filter(tracing_subscriber::filter::LevelFilter::INFO),
+    )
+}
+
+fn json_subscriber(writer: CaptureWriter) -> impl Subscriber + Send + Sync {
+    tracing_subscriber::registry().with(CborJsonSpanLayer::new()).with(
+        tracing_subscriber::fmt::layer()
+            .with_writer(writer)
+            .with_span_events(FmtSpan::ENTER | FmtSpan::EXIT)
+            .event_format(CborJsonEventFormat::new())
+            .fmt_fields(CborJsonFields::new())
+            .with_filter(tracing_subscriber::filter::LevelFilter::INFO),
+    )
+}
+
+#[test]
+fn console_stack_encodes_nested_spans_and_plain_hash() {
+    let writer = CaptureWriter::default();
+    let subscriber = console_subscriber(writer.clone());
+
+    tracing::subscriber::with_default(subscriber, emit_nested_fixture);
+
+    let output = writer.contents();
+    let event_line = output.lines().find(|l| l.contains(EVENT)).expect("event line");
+
+    assert!(event_line.contains("e.t:g.r"), "abbreviated ancestor path, got: {event_line}");
+    assert!(event_line.contains(WRAP), "wrapping span name in full, got: {event_line}");
+    assert!(
+        !event_line.contains("governance.ratify_proposals"),
+        "ancestor names must not be printed in full: {event_line}"
+    );
+    assert!(
+        event_line.contains(&format!("header_hash=\"{HASH}\"")),
+        "hash must be a single-quoted hex string, got: {event_line}"
+    );
+    assert!(
+        !event_line.contains(&format!(r#"header_hash="\"{HASH}\"""#)),
+        "hash must not be diagnostic-quoted then Debug-quoted: {event_line}"
+    );
+    assert!(!event_line.contains("amaru.tag"), "console hides schema tags: {event_line}");
+    assert!(!event_line.contains("from=599"), "ancestor fields stay on the parent span's own lines: {event_line}");
+    assert!(!event_line.contains("epoch=598"), "mid-level ancestor fields are not inlined: {event_line}");
+    assert!(event_line.contains("votes=372"), "wrapping span fields are inlined: {event_line}");
+    assert!(event_line.contains("is_dormant_epoch=false"), "event fields follow the span path: {event_line}");
+    assert!(event_line.contains("a:1"), "CBOR array renders as diagnostic text: {event_line}");
+    assert!(event_line.contains("parent_id="), "child lines refer to the parent by id: {event_line}");
+
+    let outer_close = output.lines().find(|l| l.contains("close") && l.contains("from=599")).expect("outer close");
+    assert!(!outer_close.contains("e.t"), "root span has no abbreviated ancestors: {outer_close}");
+    assert!(outer_close.contains(OUTER), "root span name in full: {outer_close}");
+    assert!(outer_close.contains("id="), "span's own close line carries id: {outer_close}");
+
+    // NOTE: whole-entry equality is not as robust as the property checks above;
+    // it documents the intended format and will need updating when that format changes.
+    assert_eq!(
+        redact_console_line(event_line),
+        concat!(
+            r#"<ts>  INFO amaru::ledger: e.t:g.r:ratification.round ratification.summarize "#,
+            r#"is_dormant_epoch=false peers="[\"a:1\", \"b:2\"]" "#,
+            r#"header_hash="3bc8f4b70575ead11872b035b6b95561b43bc7db5b5c0e304ba65e1f65eab5f2" "#,
+            r#"votes=372 parent_id=<parent_id>"#,
+        ),
+    );
+}
+
+#[test]
+fn json_stack_encodes_span_object_and_ancestry() {
+    let writer = CaptureWriter::default();
+    let subscriber = json_subscriber(writer.clone());
+
+    tracing::subscriber::with_default(subscriber, emit_nested_fixture);
+
+    let output = writer.contents();
+    let event_line = output.lines().find(|l| l.contains(EVENT)).expect("event line");
+    let json: serde_json::Value = serde_json::from_str(event_line).expect("json");
+
+    assert_eq!(json["target"], "amaru::ledger");
+    assert_eq!(json["fields"]["message"], EVENT);
+    assert_eq!(json["fields"]["is_dormant_epoch"], false);
+    assert_eq!(json["fields"]["peers"], serde_json::json!(["a:1", "b:2"]));
+
+    assert_eq!(json["span"]["name"], WRAP);
+    assert!(json["span"].get("target").and_then(|v| v.as_str()).is_some());
+    assert!(json["span"].get("votes").is_none(), "span is identity only");
+    assert_eq!(json["fields"]["header_hash"], HASH);
+    assert_eq!(json["fields"]["votes"], 372);
+    assert_eq!(json["fields"]["amaru.tag.cpu"], true);
+    assert!(json["fields"].get("from").is_none(), "ancestor fields are not inlined");
+    assert!(json["fields"].get("epoch").is_none(), "mid-level ancestor fields are not inlined");
+
+    assert_eq!(json["parents"], serde_json::json!([OUTER, MID]));
+    assert!(json.get("parent_id").and_then(|v| v.as_u64()).is_some());
+    assert!(json.get("id").is_none(), "point events do not carry their own span id");
+
+    let enter_wrap = output.lines().find(|l| l.contains("\"enter\"") && l.contains(WRAP)).expect("wrap enter");
+    let enter_json: serde_json::Value = serde_json::from_str(enter_wrap).expect("json");
+    assert!(enter_json.get("id").and_then(|v| v.as_u64()).is_some());
+    assert_eq!(enter_json.get("parent_id"), json.get("parent_id"));
+    assert_eq!(enter_json["span"]["name"], WRAP);
+    assert_eq!(enter_json["parents"], serde_json::json!([OUTER, MID]));
+    assert_eq!(enter_json["fields"]["header_hash"], HASH);
+
+    // NOTE: whole-entry equality is not as robust as the property checks above;
+    // it documents the intended format and will need updating when that format changes.
+    assert_eq!(
+        redact_json_line(event_line),
+        concat!(
+            r#"{"timestamp":"<ts>","level":"INFO","fields":{"amaru.tag.cpu":true,"#,
+            r#""header_hash":"3bc8f4b70575ead11872b035b6b95561b43bc7db5b5c0e304ba65e1f65eab5f2","#,
+            r#""is_dormant_epoch":false,"message":"ratification.summarize","peers":["a:1","b:2"],"votes":372},"#,
+            r#""target":"amaru::ledger","span":{"name":"ratification.round","target":"tracing_stacks"},"#,
+            r#""parents":["epoch.transition","governance.ratify_proposals"],"parent_id":<parent_id>}"#,
+        ),
+    );
+}
+
+#[test]
+fn otel_stack_preserves_parent_child_and_plain_hash() {
+    let span_exporter = InMemorySpanExporter::default();
+    let log_exporter = InMemoryLogExporter::default();
+    let tracer_provider = SdkTracerProvider::builder().with_simple_exporter(span_exporter.clone()).build();
+    let logger_provider = SdkLoggerProvider::builder().with_simple_exporter(log_exporter.clone()).build();
+    let tracer = tracer_provider.tracer("amaru-test");
+
+    let subscriber = tracing_subscriber::registry()
+        .with(tracing_opentelemetry::layer().with_tracer(tracer).with_level(true).with_target(true))
+        .with(CborTraceArrayLayer::new())
+        .with(CborOtelLogBridge::new(&logger_provider));
+
+    tracing::subscriber::with_default(subscriber, emit_nested_fixture);
+
+    tracer_provider.force_flush().expect("flush traces");
+    logger_provider.force_flush().expect("flush logs");
+
+    let spans = span_exporter.get_finished_spans().expect("spans");
+    let outer = spans.iter().find(|s| s.name == OUTER).expect("outer span");
+    let mid = spans.iter().find(|s| s.name == MID).expect("mid span");
+    let wrap = spans.iter().find(|s| s.name == WRAP).expect("wrap span");
+    assert_eq!(mid.parent_span_id, outer.span_context.span_id());
+    assert_eq!(wrap.parent_span_id, mid.span_context.span_id());
+    assert_eq!(wrap.span_context.trace_id(), outer.span_context.trace_id());
+
+    // Stock tracing-opentelemetry may also store a hex dump of the CBOR bytes.
+    // CborTraceArrayLayer appends the upgraded value; exporters keep the last key.
+    let header = wrap
+        .attributes
+        .iter()
+        .rev()
+        .find(|kv| kv.key.as_str() == "header_hash")
+        .map(|kv| kv.value.as_str().to_string())
+        .expect("header_hash attribute");
+    assert_eq!(header, HASH, "OTEL hash must be the plain hex string, not diagnostic quotes");
+    assert!(!header.contains('\\') && !header.contains('"'), "hash must not be quoted: {header}");
+
+    let epoch = mid.attributes.iter().find(|kv| kv.key.as_str() == "epoch").map(|kv| kv.value.clone());
+    assert!(epoch.is_some(), "typed span fields become OTEL attributes");
+
+    let logs = log_exporter.get_emitted_logs().expect("logs");
+    let event = logs.iter().find(|l| l.record.body().is_some_and(any_value_is_string(EVENT))).expect("event log");
+    let trace_context = event.record.trace_context().expect("log joined to current span");
+    assert_eq!(trace_context.trace_id, wrap.span_context.trace_id());
+    assert_eq!(trace_context.span_id, wrap.span_context.span_id());
+
+    let peers = event
+        .record
+        .attributes_iter()
+        .find(|(k, _)| k.as_str() == "peers")
+        .map(|(_, v)| v.clone())
+        .expect("peers attr");
+    let opentelemetry::logs::AnyValue::ListAny(list) = peers else {
+        panic!("peers must be a nested list, got {peers:?}");
+    };
+    assert_eq!(list.len(), 2);
+
+    // NOTE: whole-entry equality is not as robust as the property checks above;
+    // it documents the intended format and will need updating when that format changes.
+    assert_eq!(
+        format_otel_example(wrap, &event.record),
+        concat!(
+            "span name=ratification.round\n",
+            "  header_hash=3bc8f4b70575ead11872b035b6b95561b43bc7db5b5c0e304ba65e1f65eab5f2\n",
+            "  votes=372\n",
+            "  amaru.tag.cpu=true\n",
+            "log body=ratification.summarize target=amaru::ledger\n",
+            "  is_dormant_epoch=false\n",
+            "  peers=[a:1, b:2]\n",
+            "  trace_id=<trace_id> span_id=<span_id>",
+        ),
+    );
+}
+
+fn any_value_is_string(expected: &'static str) -> impl Fn(&opentelemetry::logs::AnyValue) -> bool {
+    move |value| match value {
+        opentelemetry::logs::AnyValue::String(s) => s.as_str() == expected,
+        opentelemetry::logs::AnyValue::Int(_)
+        | opentelemetry::logs::AnyValue::Double(_)
+        | opentelemetry::logs::AnyValue::Boolean(_)
+        | opentelemetry::logs::AnyValue::Bytes(_)
+        | opentelemetry::logs::AnyValue::ListAny(_)
+        | opentelemetry::logs::AnyValue::Map(_) => false,
+        // AnyValue is non-exhaustive
+        _ => false,
+    }
+}
+
+#[test]
+fn tui_stack_records_parents_and_inlined_fields() {
+    let (tx, rx) = std::sync::mpsc::sync_channel(16);
+    let subscriber = tracing_subscriber::registry().with(TelemetryCaptureLayer::new(tx));
+
+    tracing::subscriber::with_default(subscriber, emit_nested_fixture);
+
+    let records: Vec<_> = rx.try_iter().collect();
+    let event = records
+        .iter()
+        .find(|r| r.duration.is_none() && r.fields.contains_key("is_dormant_epoch"))
+        .unwrap_or_else(|| panic!("event, got {records:#?}"));
+    assert_eq!(event.parents, vec![OUTER.to_string(), MID.to_string()]);
+    assert_eq!(event.span_name.as_deref(), Some(WRAP));
+    assert_eq!(event.fields.get("is_dormant_epoch"), Some(&FieldValue::Bool(false)));
+    assert_eq!(event.fields.get("votes"), Some(&FieldValue::U64(372)), "wrapping span fields are inlined");
+    assert!(!event.fields.contains_key("from"), "ancestor fields are not inlined");
+    assert!(!event.fields.contains_key("epoch"), "mid-level ancestor fields are not inlined");
+    assert!(event.parent_id.is_some());
+    assert!(event.id.is_none());
+    match event.fields.get("peers") {
+        Some(FieldValue::Str(s)) => assert!(s.contains("a:1"), "peers diagnostic={s}"),
+        other => panic!("peers should be diagnostic text, got {other:?}"),
+    }
+    assert!(!event.fields.keys().any(|k| k.starts_with("amaru.tag.")));
+
+    let closed_wrap = records.iter().find(|r| r.name == WRAP && r.duration.is_some()).expect("wrap close");
+    assert_eq!(closed_wrap.parents, vec![OUTER.to_string(), MID.to_string()]);
+    assert_eq!(closed_wrap.span_name.as_deref(), Some(WRAP));
+    assert_eq!(closed_wrap.fields.get("header_hash"), Some(&FieldValue::Str(HASH.into())));
+    assert_eq!(closed_wrap.fields.get("votes"), Some(&FieldValue::U64(372)));
+    assert_eq!(closed_wrap.parent_id, event.parent_id);
+    assert!(closed_wrap.id.is_some());
+    assert!(!closed_wrap.fields.keys().any(|k| k.starts_with("amaru.tag.")));
+
+    // NOTE: whole-entry equality is not as robust as the property checks above;
+    // it documents the intended format and will need updating when that format changes.
+    assert_eq!(
+        format_tui_example(event),
+        concat!(
+            "parents=[epoch.transition, governance.ratify_proposals] span_name=ratification.round\n",
+            "  message=ratification.summarize is_dormant_epoch=false ",
+            r#"peers=["a:1", "b:2"] "#,
+            "header_hash=3bc8f4b70575ead11872b035b6b95561b43bc7db5b5c0e304ba65e1f65eab5f2 votes=372\n",
+            "  parent_id=<parent_id>",
+        ),
+    );
+}
+
+fn redact_leading_ts(line: &str) -> String {
+    match line.find('Z') {
+        Some(end) => format!("<ts>{}", &line[end + 1..]),
+        None => line.to_string(),
+    }
+}
+
+fn redact_numeric_field(s: &str, name: &str) -> String {
+    let needle = format!("{name}=");
+    let Some(pos) = s.find(&needle) else {
+        return s.to_string();
+    };
+    let start = pos + needle.len();
+    let digits = s[start..].bytes().take_while(u8::is_ascii_digit).count();
+    format!("{}<{name}>{}", &s[..start], &s[start + digits..])
+}
+
+fn redact_console_line(line: &str) -> String {
+    redact_numeric_field(&redact_leading_ts(line), "parent_id")
+}
+
+fn redact_json_line(line: &str) -> String {
+    let timestamp = "\"timestamp\":\"";
+    let Some(ts_at) = line.find(timestamp) else {
+        return line.to_string();
+    };
+    let ts_value = ts_at + timestamp.len();
+    let Some(ts_end) = line[ts_value..].find('"') else {
+        return line.to_string();
+    };
+    let with_ts = format!("{}<ts>{}", &line[..ts_value], &line[ts_value + ts_end..]);
+
+    let parent = "\"parent_id\":";
+    let Some(id_at) = with_ts.find(parent) else {
+        return with_ts;
+    };
+    let id_value = id_at + parent.len();
+    let digits = with_ts[id_value..].bytes().take_while(u8::is_ascii_digit).count();
+    format!("{}<parent_id>{}", &with_ts[..id_value], &with_ts[id_value + digits..])
+}
+
+fn last_span_attr(span: &opentelemetry_sdk::trace::SpanData, key: &str) -> String {
+    span.attributes
+        .iter()
+        .rev()
+        .find(|kv| kv.key.as_str() == key)
+        .map(|kv| match &kv.value {
+            opentelemetry::Value::Bool(value) => value.to_string(),
+            opentelemetry::Value::I64(value) => value.to_string(),
+            opentelemetry::Value::F64(value) => value.to_string(),
+            opentelemetry::Value::String(value) => value.as_str().to_string(),
+            other @ opentelemetry::Value::Array(_) | other => format!("{other:?}"),
+        })
+        .unwrap_or_default()
+}
+
+fn any_value_example(value: &opentelemetry::logs::AnyValue) -> String {
+    match value {
+        opentelemetry::logs::AnyValue::Boolean(value) => value.to_string(),
+        opentelemetry::logs::AnyValue::Int(value) => value.to_string(),
+        opentelemetry::logs::AnyValue::Double(value) => value.to_string(),
+        opentelemetry::logs::AnyValue::String(value) => value.as_str().to_string(),
+        opentelemetry::logs::AnyValue::ListAny(list) => {
+            let items = list.iter().map(any_value_example).collect::<Vec<_>>().join(", ");
+            format!("[{items}]")
+        }
+        other @ opentelemetry::logs::AnyValue::Bytes(_) | other @ opentelemetry::logs::AnyValue::Map(_) | other => {
+            format!("{other:?}")
+        }
+    }
+}
+
+fn log_attr<'a>(
+    record: &'a opentelemetry_sdk::logs::SdkLogRecord,
+    key: &str,
+) -> Option<&'a opentelemetry::logs::AnyValue> {
+    record.attributes_iter().find(|(k, _)| k.as_str() == key).map(|(_, value)| value)
+}
+
+fn format_otel_example(
+    wrap: &opentelemetry_sdk::trace::SpanData,
+    record: &opentelemetry_sdk::logs::SdkLogRecord,
+) -> String {
+    let body = record.body().map(any_value_example).unwrap_or_default();
+    let target = record.target().map(|t| t.as_ref()).unwrap_or_default();
+    let dormant = log_attr(record, "is_dormant_epoch").map(any_value_example).unwrap_or_default();
+    let peers = log_attr(record, "peers").map(any_value_example).unwrap_or_default();
+    format!(
+        "span name={}\n  header_hash={}\n  votes={}\n  amaru.tag.cpu={}\nlog body={body} target={target}\n  is_dormant_epoch={dormant}\n  peers={peers}\n  trace_id=<trace_id> span_id=<span_id>",
+        wrap.name,
+        last_span_attr(wrap, "header_hash"),
+        last_span_attr(wrap, "votes"),
+        last_span_attr(wrap, "amaru.tag.cpu"),
+    )
+}
+
+fn format_tui_example(event: &TelemetryRecord) -> String {
+    let message = event.fields.get("message").map(ToString::to_string).unwrap_or_default();
+    let dormant = event.fields.get("is_dormant_epoch").map(ToString::to_string).unwrap_or_default();
+    let peers = event.fields.get("peers").map(ToString::to_string).unwrap_or_default();
+    let hash = event.fields.get("header_hash").map(ToString::to_string).unwrap_or_default();
+    let votes = event.fields.get("votes").map(ToString::to_string).unwrap_or_default();
+    let span_name = event.span_name.as_deref().unwrap_or_default();
+    format!(
+        "parents=[{}] span_name={span_name}\n  message={message} is_dormant_epoch={dormant} peers={peers} header_hash={hash} votes={votes}\n  parent_id=<parent_id>",
+        event.parents.join(", "),
+    )
+}

--- a/crates/amaru-tui/src/capture.rs
+++ b/crates/amaru-tui/src/capture.rs
@@ -30,6 +30,10 @@ pub fn from_observability(record: ObsTelemetryRecord) -> TelemetryRecord {
         at: record.duration.map(|d| record.at.checked_sub(d).unwrap_or(record.at)).unwrap_or(record.at),
         wall_time: record.wall_time,
         fields: convert_fields(record.fields),
+        parents: record.parents,
+        span_name: record.span_name,
+        id: record.id,
+        parent_id: record.parent_id,
     }
 }
 
@@ -109,5 +113,30 @@ mod tests {
         );
         assert_eq!(record.fields.get(ledger::tip::UPDATE::FIELD_EPOCH), Some(&FieldValue::U64(1)));
         let _ = Message::Telemetry(record);
+    }
+
+    #[test]
+    fn event_inside_nested_spans_keeps_parents() {
+        let (tx, rx) = sync_channel(4);
+        let subscriber = tracing_subscriber::registry().with(TelemetryCaptureLayer::new(tx));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let outer = info_span!(ledger::epoch_transition::COMPUTE, from = Epoch::new(599), into = Epoch::new(600),);
+            let _outer = outer.enter();
+            let inner = info_span!(ledger::governance::RATIFY_PROPOSALS, epoch = Epoch::new(598),);
+            let _inner = inner.enter();
+            info!(ledger::ratification::SUMMARIZE, is_dormant_epoch = false);
+        });
+
+        let records: Vec<_> = rx.try_iter().map(from_observability).collect();
+        let event = records.iter().find(|r| r.name == ledger::ratification::SUMMARIZE::NAME).expect("summarize event");
+        assert_eq!(event.parents, vec![ledger::epoch_transition::COMPUTE::NAME.to_string()]);
+        assert_eq!(event.span_name.as_deref(), Some(ledger::governance::RATIFY_PROPOSALS::NAME));
+        let expected_ancestors =
+            amaru_observability::format_abbreviated_span_path([ledger::epoch_transition::COMPUTE::NAME]);
+        assert_eq!(event.parents_label().as_deref(), Some(expected_ancestors.as_str()));
+        let expected_path = format!("{expected_ancestors}:{}", ledger::governance::RATIFY_PROPOSALS::NAME);
+        assert_eq!(event.span_path_label().as_deref(), Some(expected_path.as_str()));
+        assert!(event.parent_id.is_some());
     }
 }

--- a/crates/amaru-tui/src/events/telemetry_record.rs
+++ b/crates/amaru-tui/src/events/telemetry_record.rs
@@ -30,6 +30,12 @@ pub struct TelemetryRecord {
     pub at: Instant,
     pub wall_time: SystemTime,
     pub fields: BTreeMap<String, FieldValue>,
+    /// Ancestor span names, outermost first, excluding the wrapping span.
+    pub parents: Vec<String>,
+    /// Name of the wrapping span (`None` when the record is outside any span).
+    pub span_name: Option<String>,
+    pub id: Option<u64>,
+    pub parent_id: Option<u64>,
 }
 
 impl TelemetryRecord {
@@ -49,6 +55,41 @@ impl TelemetryRecord {
         match self.message() {
             Some(message) if message != self.name => message,
             _ => &self.name,
+        }
+    }
+
+    /// Abbreviated ancestry (`e.t:g.r`), wrapping span excluded.
+    pub fn parents_label(&self) -> Option<String> {
+        if self.parents.is_empty() {
+            None
+        } else {
+            Some(amaru_observability::format_abbreviated_span_path(self.parents.iter()))
+        }
+    }
+
+    /// Console-style path: abbreviated ancestors plus the wrapping span's full name.
+    pub fn span_path_label(&self) -> Option<String> {
+        match (self.parents_label(), self.span_name.as_deref()) {
+            (Some(mut ancestors), Some(wrap)) => {
+                ancestors.push(':');
+                ancestors.push_str(wrap);
+                Some(ancestors)
+            }
+            (None, Some(wrap)) => Some(wrap.to_owned()),
+            (Some(ancestors), None) => Some(ancestors),
+            (None, None) => None,
+        }
+    }
+
+    /// Label shown in the TUI log pane: path, then the event/span label.
+    ///
+    /// Span-close records (`id` set) omit a repeated wrapping-span name. Point
+    /// events keep their label even when it matches the wrapping span name.
+    pub fn log_label(&self) -> String {
+        match self.span_path_label() {
+            Some(path) if self.id.is_some() && self.span_name.as_deref() == Some(self.primary_label()) => path,
+            Some(path) => format!("{} {}", path, self.primary_label()),
+            None => self.primary_label().to_string(),
         }
     }
 
@@ -87,5 +128,59 @@ impl RecordFields for TelemetryRecord {
 
     fn u64(&self, name: &str) -> Option<u64> {
         self.field(name).and_then(FieldValue::as_u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(
+        name: &str,
+        message: Option<&str>,
+        span_name: Option<&str>,
+        parents: &[&str],
+        id: Option<u64>,
+    ) -> TelemetryRecord {
+        let mut fields = BTreeMap::new();
+        if let Some(message) = message {
+            fields.insert("message".into(), FieldValue::String(message.into()));
+        }
+        TelemetryRecord {
+            level: Level::INFO,
+            target: "amaru::ledger".into(),
+            name: name.into(),
+            at: Instant::now(),
+            wall_time: SystemTime::UNIX_EPOCH,
+            fields,
+            parents: parents.iter().map(|parent| (*parent).to_string()).collect(),
+            span_name: span_name.map(str::to_string),
+            id,
+            parent_id: None,
+        }
+    }
+
+    #[test]
+    fn log_label_keeps_point_event_when_message_matches_wrapping_span() {
+        let event = record(
+            "event",
+            Some("governance.ratify_proposals"),
+            Some("governance.ratify_proposals"),
+            &["epoch.transition"],
+            None,
+        );
+        assert_eq!(event.log_label(), "e.t:governance.ratify_proposals governance.ratify_proposals");
+    }
+
+    #[test]
+    fn log_label_omits_repeated_name_on_span_close() {
+        let close = record(
+            "governance.ratify_proposals",
+            None,
+            Some("governance.ratify_proposals"),
+            &["epoch.transition"],
+            Some(1),
+        );
+        assert_eq!(close.log_label(), "e.t:governance.ratify_proposals");
     }
 }

--- a/crates/amaru-tui/src/model.rs
+++ b/crates/amaru-tui/src/model.rs
@@ -201,6 +201,10 @@ mod tests {
             at,
             wall_time: std::time::SystemTime::UNIX_EPOCH,
             fields: fields.into_iter().map(|(name, value)| (name.into(), value)).collect(),
+            parents: Vec::new(),
+            span_name: None,
+            id: None,
+            parent_id: None,
         }
     }
 

--- a/crates/amaru-tui/src/ui/components/logs.rs
+++ b/crates/amaru-tui/src/ui/components/logs.rs
@@ -140,6 +140,7 @@ fn log_toggle_label(model: &Model) -> &'static str {
 
 fn log_record_line(record: &TelemetryRecord) -> Line<'static> {
     let fields = crate::model::render_fields(record);
+    let label = record.log_label();
     let mut spans = vec![
         Span::styled(format_log_wall_time(record.wall_time), muted()),
         Span::raw(" "),
@@ -147,7 +148,7 @@ fn log_record_line(record: &TelemetryRecord) -> Line<'static> {
         Span::raw(" "),
         Span::styled(record.target.clone(), style_for_target(&record.target).add_modifier(Modifier::BOLD)),
         Span::raw(" "),
-        Span::styled(record.primary_label().to_string(), super::super::theme::emphasis_white()),
+        Span::styled(label, super::super::theme::emphasis_white()),
     ];
 
     if !fields.is_empty() {

--- a/crates/amaru/src/observability.rs
+++ b/crates/amaru/src/observability.rs
@@ -15,7 +15,6 @@
 use std::{
     env::{VarError, var},
     error::Error,
-    fmt,
     io::{self, IsTerminal},
     str::FromStr,
     sync::atomic::{AtomicU64, Ordering},
@@ -24,8 +23,8 @@ use std::{
 
 use amaru_metrics::{METRICS_METER_NAME, Meter};
 use amaru_observability::{
-    CborJsonEventFormat, CborJsonFields, CborJsonSpanLayer, CborOtelLogBridge, CborTraceArrayLayer,
-    TelemetryCaptureLayer, console_field_formatter, info, warn,
+    CborConsoleEventFormat, CborJsonEventFormat, CborJsonFields, CborJsonSpanLayer, CborOtelLogBridge,
+    CborTraceArrayLayer, TelemetryCaptureLayer, console_field_formatter, info, warn,
 };
 use opentelemetry::{Key, KeyValue, metrics::MeterProvider, trace::TracerProvider};
 use opentelemetry_sdk::{
@@ -35,21 +34,11 @@ use opentelemetry_sdk::{
     trace::SdkTracerProvider,
 };
 use opentelemetry_semantic_conventions::resource::{SERVICE_INSTANCE_ID, SERVICE_NAME};
-use tracing::{
-    Metadata, Subscriber,
-    field::{Field, Visit},
-    level_filters::LevelFilter,
-    span,
-    subscriber::Interest,
-};
+use tracing::{Metadata, Subscriber, level_filters::LevelFilter, span, subscriber::Interest};
 use tracing_subscriber::{
     EnvFilter, Registry,
-    field::{MakeVisitor, VisitFmt, VisitOutput},
     filter::Filtered,
-    fmt::{
-        Layer,
-        format::{FmtSpan, Writer},
-    },
+    fmt::{Layer, format::FmtSpan},
     layer::{Context, Filter, Layered, SubscriberExt},
     prelude::*,
     util::SubscriberInitExt,
@@ -103,118 +92,10 @@ type LocalTelemetryLayer<S> = Layered<LocalTelemetryFilter<S>, S>;
 
 type DelayedWarning = Option<Box<dyn FnOnce()>>;
 
-// -----------------------------------------------------------------------------
-// HideTagFields
-//
-// The `amaru.tag.<name>` boolean attributes categorize spans (cpu/io/setup) for
-// OpenTelemetry backends. They carry no value in the human-readable console log,
-// and because the compact formatter appends the fields of every span in scope,
-// an inherited tag would otherwise repeat once per nested span. This field
-// formatter drops them from the console output while leaving OpenTelemetry spans
-// and JSON traces untouched.
-// -----------------------------------------------------------------------------
-
-const TAG_FIELD_PREFIX: &str = "amaru.tag.";
-
-fn is_tag_field(field: &Field) -> bool {
-    field.name().starts_with(TAG_FIELD_PREFIX)
-}
-
-/// Wraps a field formatter so that `amaru.tag.*` fields are skipped.
-struct HideTagFields<N>(N);
-
-impl<'writer, N> MakeVisitor<Writer<'writer>> for HideTagFields<N>
-where
-    N: MakeVisitor<Writer<'writer>>,
-{
-    type Visitor = HideTagVisitor<N::Visitor>;
-
-    fn make_visitor(&self, target: Writer<'writer>) -> Self::Visitor {
-        HideTagVisitor(self.0.make_visitor(target))
-    }
-}
-
-/// Forwards every recorded value to the inner visitor except `amaru.tag.*`
-/// fields, which are dropped. Each typed method is forwarded individually so the
-/// inner visitor keeps its per-type formatting.
-struct HideTagVisitor<V>(V);
-
-impl<V: Visit> Visit for HideTagVisitor<V> {
-    fn record_f64(&mut self, field: &Field, value: f64) {
-        if !is_tag_field(field) {
-            self.0.record_f64(field, value);
-        }
-    }
-
-    fn record_i64(&mut self, field: &Field, value: i64) {
-        if !is_tag_field(field) {
-            self.0.record_i64(field, value);
-        }
-    }
-
-    fn record_u64(&mut self, field: &Field, value: u64) {
-        if !is_tag_field(field) {
-            self.0.record_u64(field, value);
-        }
-    }
-
-    fn record_i128(&mut self, field: &Field, value: i128) {
-        if !is_tag_field(field) {
-            self.0.record_i128(field, value);
-        }
-    }
-
-    fn record_u128(&mut self, field: &Field, value: u128) {
-        if !is_tag_field(field) {
-            self.0.record_u128(field, value);
-        }
-    }
-
-    fn record_bool(&mut self, field: &Field, value: bool) {
-        if !is_tag_field(field) {
-            self.0.record_bool(field, value);
-        }
-    }
-
-    fn record_str(&mut self, field: &Field, value: &str) {
-        if !is_tag_field(field) {
-            self.0.record_str(field, value);
-        }
-    }
-
-    fn record_bytes(&mut self, field: &Field, value: &[u8]) {
-        if !is_tag_field(field) {
-            self.0.record_bytes(field, value);
-        }
-    }
-
-    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
-        if !is_tag_field(field) {
-            self.0.record_error(field, value);
-        }
-    }
-
-    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-        if !is_tag_field(field) {
-            self.0.record_debug(field, value);
-        }
-    }
-}
-
-impl<Out, V: VisitOutput<Out>> VisitOutput<Out> for HideTagVisitor<V> {
-    fn finish(self) -> Out {
-        self.0.finish()
-    }
-}
-
-impl<V: VisitFmt> VisitFmt for HideTagVisitor<V> {
-    fn writer(&mut self) -> &mut dyn fmt::Write {
-        self.0.writer()
-    }
-}
-
 // JSON event formatting (single-pass CBOR-aware NDJSON) lives in
-// `amaru_observability::json_format`.
+// `amaru_observability::json_format`. Console field formatting (CBOR decode +
+// tag hiding) lives in `amaru_observability::layers`. Nested-span encoding
+// across stacks is specified in EDR-033.
 
 #[derive(Default)]
 pub enum TracingSubscriber<S> {
@@ -301,9 +182,10 @@ impl TracingSubscriber<Registry> {
                     .with(
                         tracing_subscriber::fmt::layer()
                             .with_writer(io::stderr as fn() -> io::Stderr)
-                            .fmt_fields(HideTagFields(console_field_formatter()))
-                            .event_format(tracing_subscriber::fmt::format().with_ansi(color).compact())
+                            .with_ansi(color)
+                            .fmt_fields(console_field_formatter())
                             .with_span_events(FmtSpan::CLOSE)
+                            .event_format(CborConsoleEventFormat::new().with_ansi(color))
                             .with_filter(default_filter),
                     )
                     .init();
@@ -315,9 +197,10 @@ impl TracingSubscriber<Registry> {
                     .with(
                         tracing_subscriber::fmt::layer()
                             .with_writer(io::stderr as fn() -> io::Stderr)
-                            .fmt_fields(HideTagFields(console_field_formatter()))
-                            .event_format(tracing_subscriber::fmt::format().with_ansi(color).compact())
+                            .with_ansi(color)
+                            .fmt_fields(console_field_formatter())
                             .with_span_events(FmtSpan::CLOSE)
+                            .event_format(CborConsoleEventFormat::new().with_ansi(color))
                             .with_filter(default_filter),
                     )
                     .init();
@@ -719,36 +602,7 @@ mod tests {
         atomic::{AtomicUsize, Ordering as AtomicOrdering},
     };
 
-    use tracing_subscriber::fmt::format::DefaultFields;
-
     use super::*;
-
-    /// The compact console formatter appends the fields of every span in scope to
-    /// each event. When several nested spans each carry an `amaru.tag.*` marker
-    /// (as all ledger spans do), the tag would otherwise repeat once per span.
-    /// `HideTagFields` must strip those markers while keeping ordinary fields.
-    #[test]
-    fn console_hides_tag_fields_from_nested_spans() {
-        let buffer = Arc::new(Mutex::new(Vec::new()));
-        let layer = tracing_subscriber::fmt::layer()
-            .with_writer(BufferWriter(Arc::clone(&buffer)))
-            .with_ansi(false)
-            .fmt_fields(HideTagFields(DefaultFields::new()))
-            .event_format(tracing_subscriber::fmt::format().with_ansi(false).compact());
-        let subscriber = tracing_subscriber::registry().with(layer);
-
-        tracing::subscriber::with_default(subscriber, || {
-            let outer = tracing::info_span!("outer", "amaru.tag.cpu" = true);
-            let _outer = outer.enter();
-            let inner = tracing::info_span!("inner", "amaru.tag.cpu" = true, transaction_id = "abc");
-            let _inner = inner.enter();
-            tracing::info!("hello");
-        });
-
-        let output = String::from_utf8(buffer.lock().unwrap().clone()).unwrap();
-        assert!(!output.contains("amaru.tag.cpu"), "tag markers must be hidden from the console: {output}");
-        assert!(output.contains("transaction_id=\"abc\""), "ordinary span fields must be kept: {output}");
-    }
 
     #[test]
     fn otel_target_is_recognised_as_internal() {
@@ -871,30 +725,6 @@ mod tests {
     }
 
     // HELPERS
-
-    /// A `MakeWriter` that accumulates everything written into a shared buffer,
-    /// so a test can inspect the formatted output.
-    #[derive(Clone)]
-    struct BufferWriter(Arc<Mutex<Vec<u8>>>);
-
-    impl io::Write for BufferWriter {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.0.lock().unwrap().extend_from_slice(buf);
-            Ok(buf.len())
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
-
-    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for BufferWriter {
-        type Writer = BufferWriter;
-
-        fn make_writer(&'a self) -> Self::Writer {
-            self.clone()
-        }
-    }
 
     /// Builds a subscriber that wraps a `ThrottledEnvFilter` and counts how
     /// many events pass the filter.  Installing it as the default inside a

--- a/engineering-decision-records/007-observability.md
+++ b/engineering-decision-records/007-observability.md
@@ -32,6 +32,9 @@ We would like the codebase to organize the metrics it tracks in a simple, consis
 
     - We will make judicious use of [Spans](https://opentelemetry.io/docs/concepts/observability-primer/#spans) to expose the structured nature of the workload the Amaru node performs.
 
+- How nested span context is encoded on each product sink (console, JSON, OpenTelemetry, TUI)
+  is specified in [EDR-033](./033-tracing-stack-span-encoding.md).
+
 - We define the frontier between logs and traces by following a simple rule:
     - Any event at the DEBUG level or above is considered a log
     - Any event at the TRACE level is considered a trace

--- a/engineering-decision-records/033-tracing-stack-span-encoding.md
+++ b/engineering-decision-records/033-tracing-stack-span-encoding.md
@@ -1,0 +1,198 @@
+---
+type: architecture
+status: accepted
+---
+
+# Tracing stack span encoding
+
+## Motivation
+
+Amaru emits the same `tracing` events onto four product stacks: console (stderr),
+JSON NDJSON, OpenTelemetry (traces + logs), and the in-process TUI capture layer.
+[EDR-007](./007-observability.md) and [EDR-026](./026-tracing-span-design.md)
+define *what* we instrument. They do not define how a **nested span context**
+is presented on each sink.
+
+After the structured-logging work, JSON lines dropped the span name, console
+hashes were diagnostic-quoted then Debug-quoted (`header_hash="\"abc…\""`),
+and neither JSON nor the TUI recorded which span an event belonged to.
+
+Repeating the full ancestor chain with every span's fields on every line
+(the stock "full" fmt format) makes console lines too long and inflates
+log volume. Operators already have process-local span ids: a child line can
+point at its parent, and the parent's own enter/exit/close line is where
+that parent's fields belong.
+
+This record is the encoding contract. Unit tests in
+`amaru-observability/tests/tracing_stacks.rs` emit one shared nested-span
+fixture through each complete stack and assert the shapes below.
+
+## Decision
+
+### Shared principles
+
+These rules apply to console, JSON, and TUI. OpenTelemetry keeps its native
+span tree (see below).
+
+1. **An event carries only its wrapping span.** That is the current span at
+   the event (including synthetic `enter` / `exit` / `close` events). The
+   event records that span's **name** and **target**. Ancestor spans are
+   not expanded into fields.
+2. **The wrapping span's fields are inlined with the event fields.** Event
+   fields win if a key collides. Ancestor fields are not copied: they
+   appear only on that ancestor's own lifecycle lines.
+3. **`parents` is names only**, outermost → parent of the wrapping span.
+   The wrapping span itself is already in `span.name` and is not repeated.
+4. **Ids are how you walk up.** A span's own lifecycle events carry `.id`.
+   Child events (and child-span lifecycle events) carry `.parent_id` equal
+   to the wrapping span's *parent*. Search the log for that id to recover
+   the next level up. OpenTelemetry uses its own span/trace ids.
+5. **String scalars are not Debug-quoted.** Schema types such as
+   `HeaderHash` travel as CBOR text (hex). Sinks present the hex once
+   (`"3bc8…"`), never `"\"3bc8…\""`.
+6. **Schema tags (`amaru.tag.*`) are filter attributes.** JSON and
+   OpenTelemetry keep them. Console and TUI hide them.
+7. **CBOR `record_bytes` decodes to the richest type the sink can hold:**
+   nested JSON / OTEL log `AnyValue` for maps and arrays; homogeneous OTEL
+   *trace* arrays when possible; diagnostic text otherwise.
+
+### Console
+
+Use [`CborConsoleEventFormat`](../crates/amaru-observability/src/layers.rs)
+with `console_field_formatter()` (CBOR decode + tag hiding). Do **not** use
+the stock full or compact formats.
+
+The span stack is abbreviated like a Java logger name: each `.`-separated
+segment keeps its first character, and levels are joined with `:`.
+`epoch.transition` → `e.t`, so a level typically costs four characters
+including the separator (`e.t:`).
+
+```text
+TIMESTAMP  INFO e.t:g.r amaru::ledger: ratification.round ratification.summarize is_dormant_epoch=false header_hash="3bc8…" votes=372 parent_id=6756…
+TIMESTAMP  INFO e.t amaru::ledger: governance.ratify_proposals close epoch=598 id=6980… parent_id=6756…
+TIMESTAMP  INFO amaru::ledger: epoch.transition close from=599 into=600 id=6756…
+```
+
+- Abbreviated path shows depth without repeating full ancestor names.
+- The wrapping span's full name is printed so lines stay grepable.
+- Wrapping-span fields are inlined after the event fields.
+- Ancestor fields appear only on that ancestor's own `close` (or other
+  lifecycle) line, together with `.id`.
+- Child lines carry `parent_id=` so an operator can search upward.
+- Tags do not appear.
+- Product console still uses `FmtSpan::CLOSE` only, to keep volume down.
+
+### JSON
+
+Each NDJSON object has this envelope:
+
+| Key | Meaning |
+| --- | --- |
+| `timestamp`, `level`, `target` | Event envelope. |
+| `fields` | Event fields **plus** the wrapping span's fields (event wins on collision). |
+| `span` | `{ "name", "target" }` of the wrapping span. Identity only. |
+| `parents` | Array of ancestor span **names**, outermost first, excluding the wrapping span. |
+| `id` | Present on span lifecycle events (`enter` / `exit` / `close`) only. |
+| `parent_id` | Present when the wrapping span has a parent. |
+
+Example (elided timestamp):
+
+```json
+{
+  "level": "INFO",
+  "fields": {
+    "message": "ratification.summarize",
+    "is_dormant_epoch": false,
+    "header_hash": "3bc8…",
+    "votes": 372
+  },
+  "target": "amaru::ledger",
+  "span": { "name": "ratification.round", "target": "amaru::ledger" },
+  "parents": ["epoch.transition", "governance.ratify_proposals"],
+  "parent_id": 69806618857963521
+}
+```
+
+The wrapping span's `enter` line has the same `parent_id` and also `"id": <wrap>`.
+`governance.ratify_proposals` enter/close has `"id": 69806618857963521` and
+`parent_id` of `epoch.transition`. The outer span's lifecycle has
+`"id": 6756224074776578` and no `parent_id`. Ancestor fields (`from`,
+`into`, `epoch`) live only on those ancestor lines.
+
+### OpenTelemetry
+
+OTEL already has a native parent/child span tree. We do not invent a
+parallel encoding:
+
+- Tracing span names become OTEL span names.
+- Entered nested spans form a parent/child pair that share a `trace_id`.
+- Span fields become attributes (homogeneous arrays when CBOR allows;
+  diagnostic text otherwise). String scalars are the plain value.
+- Tags remain attributes (`amaru.tag.cpu=true`) so backends can filter.
+- OTEL **logs** produced by `CborOtelLogBridge` set `trace_context` from the
+  current entered span so log records join the same tree. Event fields become
+  log attributes / body; span fields stay on the span.
+
+Spans that are created but never entered keep the documented
+`CborTraceArrayLayer` limitation (CBOR upgrades apply on enter).
+
+### TUI
+
+`TelemetryCaptureLayer` records the same model:
+
+- `parents: Vec<String>` — ancestor names, outermost first, excluding the wrapping span
+- `span_name: Option<String>` — the wrapping span (`None` outside any span)
+- wrapping-span fields inlined into `fields` on point events
+- `id` on closed-span records; `parent_id` when the wrapping span has a parent
+
+The TUI log line shows abbreviated ancestors plus the wrapping span's full
+name (`e.t:g.r:ratification.round`), then the event label and fields. Tags
+are omitted from `fields`. Schema matching continues to use `target` +
+`name` (event or closed-span identity), not `parents`.
+
+### Tests as the contract
+
+`amaru-observability/tests/tracing_stacks.rs` composes each stack the way the
+product binary does and asserts the shapes above against one fixture:
+
+- outer `epoch.transition` (`from`, `into`, tag)
+- mid `governance.ratify_proposals` (epoch, tag)
+- wrapping `ratification.round` (CBOR hash, late `votes` record, tag)
+- event `ratification.summarize` (bool + CBOR string array)
+
+Treat a failing stack test as a break of this EDR, not as a snapshot to
+refresh casually.
+
+## Consequences
+
+- Console lines stay short: abbreviated path + one full wrapping name +
+  wrapping fields only. Log volume no longer grows with unused ancestor
+  field bags.
+- Reconstructing a parent span means searching for `id=<parent_id>` (JSON
+  and console) rather than reading fields off the child line.
+- JSON consumers that grepped flattened root keys such as `.epoch` must
+  read `.fields.epoch` instead. Ancestry is `.parents` (names) plus
+  `.parent_id`.
+- Embedder `amaru-node::Telemetry` still uses stock `fmt` / `.json()` helpers.
+  Embedders that want this contract should compose the same
+  `amaru-observability` layers the product uses.
+- Changing the encoding requires updating this EDR and the stack tests
+  together.
+
+## Discussion points
+
+- Inlining wrapping-span fields into `fields` (instead of a fat `span`
+  object plus root flattening) keeps one map and avoids duplicating keys.
+- Abbreviating every path segment (`epoch.transition` → `e.t`) is preferred
+  over printing a depth count (`^2`). Collisions such as `effects.timeout`
+  vs `epoch.transition` are accepted; the full wrapping name sits next to
+  the path for grep.
+- Console emits `close` only. The span id is stable, so searching `id=`
+  still finds the parent; JSON `enter` has the id earlier.
+
+## References
+
+- [Issue #1208](https://github.com/pragma-org/amaru/issues/1208)
+- [EDR-007 Observability](./007-observability.md)
+- [EDR-026 Tracing span design](./026-tracing-span-design.md)
+- [EDR-030 Embedded terminal observability UI](./030-embedded-terminal-observability-ui.md)


### PR DESCRIPTION
fixes #1208

The PR contains some initial work on reducing allocations, but there is still a ton of improvement potential that will need to be done in follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved observability output across console, JSON, OpenTelemetry, and TUI views.
  * Added abbreviated nested-span paths, parent/child relationships, and trace identifiers.
  * TUI logs now display span ancestry for clearer event context.
  * CBOR scalar values render with native types and readable text.
  * Tagged fields can be hidden from console output.

* **Bug Fixes**
  * Restored wrapping-span identity and improved field placement and precedence.
  * Added consistent nested-span encoding across tracing outputs.
  * OpenTelemetry logs now include trace context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->