### PR TITLE
feat: make sure missing snapshots fail tests

### DIFF
--- a/crates/amaru/build/stake_distribution.rs
+++ b/crates/amaru/build/stake_distribution.rs
@@ -27,7 +27,8 @@ use crate::{emit_rerun_if_changed, write_if_changed};
 ///
 /// Availability of the local `ledger.<network>.db` snapshot is **not** checked here: that path is
 /// a live RocksDB for node runs, so watching it would rebuild `amaru` on every SST/LOG write.
-/// The generated tests check snapshot presence at runtime and soft-skip when missing.
+/// The generated tests validate snapshot presence at runtime and fail when the matching snapshot
+/// is missing.
 pub(crate) fn write_stake_distribution_test_cases_file(network: &str) -> Result<()> {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
     let fixtures_root = manifest_dir.join("tests").join("conformance").join("stake-distributions");
@@ -82,7 +83,7 @@ fn stake_distribution_epoch(path: &Path) -> Option<u64> {
 
 /// Render one active test function comparing stake distributions for every fixture epoch.
 ///
-/// Missing local ledger snapshots are handled at test runtime (warn + soft success), not via
+/// Missing local ledger snapshots are reported as test failures at runtime, rather than encoded as
 /// build-time `#[ignore]`.
 fn stake_distribution_test_cases_source(network: &str, epochs: &[u64]) -> Result<String> {
     if epochs.is_empty() {
@@ -110,7 +111,7 @@ fn render_stake_distribution_test_function(network: &str, network_variant: &str,
     let mut contents = String::new();
 
     for epoch in epochs {
-        contents.push_str(&format!("#[test_case::test_case({epoch})]\n"));
+        contents.push_str(&format!("#[test_case::test_case({epoch}; \"epoch_{epoch}\")]\n"));
     }
 
     contents.push_str(&format!(

--- a/crates/amaru/tests/conformance/stake-distributions/README.md
+++ b/crates/amaru/tests/conformance/stake-distributions/README.md
@@ -32,13 +32,13 @@ The extractor README documents the exact command-line usage and validation flow.
 
 [build.rs](../../../build/build.rs) scans `tests/conformance/stake-distributions/<network>/` for `epoch_*.json` and `epoch_*.json.zst` files and generates the matching `test_case` entries automatically. There is no manually-maintained test list anymore. The fixture directory is watched by cargo so tests regenerate when snapshots are added, removed, or replaced.
 
-Availability of the matching epoch in the local `ledger.<network>.db` is **not** decided at build time (watching that live RocksDB would rebuild `amaru` on every node write). Each generated test checks for the snapshot at runtime: if it is missing, the test succeeds after printing a warning (visible with `--nocapture`).
+Availability of the matching epoch in the local `ledger.<network>.db` is **not** decided at build time (watching that live RocksDB would rebuild `amaru` on every node write). Each generated test checks for the snapshot at runtime and fails if it is missing, so every selected fixture epoch requires a corresponding local snapshot.
 
 To list or run the generated comparison tests for a given network:
 
 ```console
 cargo test -p amaru --test summary -- --list
-cargo test -p amaru --test summary --nocapture
+cargo test -p amaru --test summary compare_preview_stake_distribution_with_haskell_node
 ```
 
 Those tests compare the extracted JSON fixtures against stake distributions computed by Amaru from the local `ledger.<network>.db` store at the repository root, for example `ledger.preview.db`.

--- a/crates/amaru/tests/summary.rs
+++ b/crates/amaru/tests/summary.rs
@@ -18,7 +18,7 @@ use std::{
     env,
     fmt::Write,
     fs::File,
-    io::Read,
+    io::{self, Read},
     path::{Path, PathBuf},
     sync::{Arc, LazyLock, Mutex},
 };
@@ -48,9 +48,17 @@ fn ledger_dir_from_tests(network: NetworkName) -> PathBuf {
     PathBuf::from(format!("../../ledger.{}.db", network.to_string().to_lowercase()))
 }
 
-/// Whether `ledger_dir` contains a RocksDB snapshot directory for `epoch`.
-fn has_ledger_snapshot(ledger_dir: &Path, epoch: Epoch) -> bool {
-    ledger_dir.join(epoch.to_string()).is_dir()
+/// Require `ledger_dir` to contain a RocksDB snapshot directory for `epoch`.
+fn require_ledger_snapshot(ledger_dir: &Path, network: NetworkName, epoch: Epoch) -> io::Result<()> {
+    let snapshot_dir = ledger_dir.join(epoch.to_string());
+    if !snapshot_dir.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("missing local ledger snapshot for {network} epoch {epoch}: {}", snapshot_dir.display()),
+        ));
+    }
+
+    Ok(())
 }
 
 #[expect(clippy::panic)]
@@ -84,16 +92,7 @@ fn compare_stake_distribution_with_haskell_node(
     epoch: Epoch,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let ledger_dir = ledger_dir_from_tests(network);
-    if !has_ledger_snapshot(&ledger_dir, epoch) {
-        // Soft-skip: missing snapshots used to be `#[ignore]`d at build time. Print a warning so
-        // `--nocapture` (or harness failure logs) still surfaces the gap.
-        eprintln!(
-            "warning: skipping stake distribution comparison for {network} epoch {epoch}; \
-             local ledger snapshot missing at {}",
-            ledger_dir.join(epoch.to_string()).display()
-        );
-        return Ok(());
-    }
+    require_ledger_snapshot(&ledger_dir, network, epoch)?;
 
     let snapshot = load_snapshot(network, epoch);
 
@@ -104,6 +103,22 @@ fn compare_stake_distribution_with_haskell_node(
     let stake_summary = StakeSummary::new(snapshot.as_ref(), dreps, network, |_| {})?;
 
     assert_json_snapshot(network, epoch, &stake_summary)
+}
+
+#[test]
+fn require_ledger_snapshot_fails_when_snapshot_is_missing() {
+    let ledger_dir = tempfile::tempdir().expect("temporary ledger directory");
+    let network = NetworkName::Mainnet;
+    let epoch = Epoch::from(602);
+    let snapshot_dir = ledger_dir.path().join(epoch.to_string());
+
+    let error = require_ledger_snapshot(ledger_dir.path(), network, epoch).expect_err("missing snapshot must fail");
+
+    assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    assert_eq!(
+        error.to_string(),
+        format!("missing local ledger snapshot for {network} epoch {epoch}: {}", snapshot_dir.display())
+    );
 }
 
 #[test]


### PR DESCRIPTION
To avoid false positives, make sure stake tests fails if associated snapshot is missing.