### PR TITLE
feat: support run-until-then-test with # of epochs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ run-until: ## &test Synchronize Amaru until a target epoch $RUN_UNTIL_TARGET_EPO
 		echo "RUN_UNTIL_TARGET_EPOCH must be set" >&2; \
 		exit 1; \
 	fi; \
-	./scripts/run-until $(BUILD_PROFILE) $(RUN_UNTIL_TARGET_EPOCH)
+	./scripts/run-until $(BUILD_PROFILE) --epoch $(RUN_UNTIL_TARGET_EPOCH)
 
 check-rust-toolchain-version: ## &test Verify rust-toolchain.toml and Cargo.toml rust-version stay aligned
 	@./scripts/check-rust-toolchain-version

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -18,7 +18,7 @@ They are executed via `cargo test`.
 To run Amaru until a target epoch, use:
 
 ```
-make RUN_UNTIL_TARGET_EPOCH=999 AMARU_MAX_EXTRA_LEDGER_SNAPSHOTS=all run-until
+AMARU_MAX_EXTRA_LEDGER_SNAPSHOTS=all ./scripts/run-until release 999
 ```
 
 Note that this requires a trace severity of at least INFO since the detection of the target is based on the traces.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -18,8 +18,10 @@ They are executed via `cargo test`.
 To run Amaru until a target epoch, use:
 
 ```
-AMARU_MAX_EXTRA_LEDGER_SNAPSHOTS=all ./scripts/run-until release 999
+./scripts/run-until release --epoch 999
 ```
+
+To run for a number of epochs from the ledger database's current starting epoch, use `--epochs 10` instead.
 
 Note that this requires a trace severity of at least INFO since the detection of the target is based on the traces.
 

--- a/scripts/lib/ledger-epoch.sh
+++ b/scripts/lib/ledger-epoch.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+is_epoch_number() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+epoch_after() {
+  local start_epoch="$1"
+  local extra_epochs="$2"
+
+  if ! is_epoch_number "$start_epoch" || ! is_epoch_number "$extra_epochs"; then
+    echo "Error: start_epoch and extra_epochs must be non-negative integers." >&2
+    return 1
+  fi
+
+  start_epoch=$((10#$start_epoch))
+  extra_epochs=$((10#$extra_epochs))
+  echo $((start_epoch + extra_epochs))
+}
+
+infer_ledger_start_epoch() {
+  local ledger_dir="$1"
+  local latest_snapshot_epoch=""
+  local snapshot_dir
+  local snapshot_epoch
+
+  for snapshot_dir in "$ledger_dir"/*; do
+    [ -d "$snapshot_dir" ] || continue
+    snapshot_epoch="${snapshot_dir##*/}"
+    is_epoch_number "$snapshot_epoch" || continue
+    snapshot_epoch=$((10#$snapshot_epoch))
+
+    if [ -z "$latest_snapshot_epoch" ] || (( snapshot_epoch > latest_snapshot_epoch )); then
+      latest_snapshot_epoch="$snapshot_epoch"
+    fi
+  done
+
+  if [ -z "$latest_snapshot_epoch" ]; then
+    echo "Error: could not infer the starting epoch from '$ledger_dir'." >&2
+    return 1
+  fi
+
+  epoch_after "$latest_snapshot_epoch" 1
+}

--- a/scripts/run-until
+++ b/scripts/run-until
@@ -4,56 +4,87 @@
 # When AMARU_WITH_OPEN_TELEMETRY=true, the example installs OTLP via
 # amaru_node::Telemetry so e2e metrics reach the collector on :8889.
 
-set -u
+set -euo pipefail
 
-function status() {
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$script_dir/lib/ledger-epoch.sh"
+
+status() {
   printf '%b\n' "$*" >&2
 }
 
-exitWithUsage () {
-  status "\033[1;31mError: missing argument(s)!\033[00m\n"
-  status "\033[1;32mUsage:\033[00m\n    $0 BUILD_PROFILE TARGET_EPOCH\n"
-  status "\033[1mExamples:\033[00m \n    $0 release 173"
-  exit 1
+usage() {
+  cat <<EOF
+Usage: $0 <build_profile> --epoch <target_epoch>
+       $0 <build_profile> --epochs <extra_epochs>
+
+Run until an absolute target epoch, or for a number of epochs after the
+starting epoch inferred from the ledger database.
+
+Examples:
+  $0 release --epoch 173
+  $0 release --epochs 10
+EOF
 }
 
-if [ $# != 2 ]; then
-    exitWithUsage
+if [ "$#" -eq 1 ] && { [ "$1" = "--help" ] || [ "$1" = "-h" ]; }; then
+  usage
+  exit 0
 fi
 
-BUILD_PROFILE=$1
-if [ -z "$BUILD_PROFILE" ]; then
-  exitWithUsage
+if [ "$#" -ne 3 ]; then
+  usage >&2
+  exit 1
 fi
 
-TARGET_EPOCH=$2
-if [ -z "$TARGET_EPOCH" ]; then
-  exitWithUsage
+build_profile="$1"
+target_kind="$2"
+target_value="$3"
+
+if [ -z "$build_profile" ] || ! is_epoch_number "$target_value"; then
+  usage >&2
+  exit 1
 fi
 
-status "      \033[1;32mTarget\033[00m epoch $TARGET_EPOCH"
+case "$target_kind" in
+  --epoch)
+    target_epoch=$((10#$target_value))
+    ;;
+  --epochs)
+    network="${AMARU_NETWORK:-preprod}"
+    ledger_dir="${AMARU_LEDGER_DIR:-ledger.${network}.db}"
+    start_epoch="$(infer_ledger_start_epoch "$ledger_dir")"
+    target_epoch="$(epoch_after "$start_epoch" "$target_value")"
+    status "      \033[1;32mStart\033[00m epoch $start_epoch + $target_value epoch(s)"
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac
+
+status "      \033[1;32mTarget\033[00m epoch $target_epoch"
 
 export AMARU_TRACE="${AMARU_TRACE:-amaru=info}"
 
 # Thin embedder: observe adopted blocks and stop when the target epoch is reached.
 # No JSON log scraping; lifecycle owned by the example binary (EDR 031).
-extra_args=()
+run_until_args=(--epoch "$target_epoch")
 if [ -n "${AMARU_NETWORK:-}" ]; then
-  extra_args+=(--network "$AMARU_NETWORK")
+  run_until_args+=(--network "$AMARU_NETWORK")
 fi
 if [ -n "${AMARU_LEDGER_DIR:-}" ]; then
-  extra_args+=(--ledger-dir "$AMARU_LEDGER_DIR")
+  run_until_args+=(--ledger-dir "$AMARU_LEDGER_DIR")
 fi
 if [ -n "${AMARU_CHAIN_DIR:-}" ]; then
-  extra_args+=(--chain-dir "$AMARU_CHAIN_DIR")
+  run_until_args+=(--chain-dir "$AMARU_CHAIN_DIR")
 fi
 if [ -n "${AMARU_PEER_ADDRESS:-}" ]; then
-  extra_args+=(--peer-address "$AMARU_PEER_ADDRESS")
+  run_until_args+=(--peer-address "$AMARU_PEER_ADDRESS")
 fi
 if [ -n "${AMARU_UPSTREAM_PEERS:-}" ]; then
-  extra_args+=(--upstream-peers "$AMARU_UPSTREAM_PEERS")
+  run_until_args+=(--upstream-peers "$AMARU_UPSTREAM_PEERS")
 fi
 
-cargo run --profile "$BUILD_PROFILE" --locked -p amaru-node --example run_until -- \
-  --epoch "$TARGET_EPOCH" \
-  "${extra_args[@]}"
+cargo run --profile "$build_profile" --locked -p amaru-node --example run_until -- \
+  "${run_until_args[@]}"

--- a/scripts/run-until-then-test
+++ b/scripts/run-until-then-test
@@ -4,14 +4,17 @@ set -euo pipefail
 
 usage() {
   cat <<EOF
-Usage: $0 [--force] <bootstrap_epoch> <last_test_epoch>
+Usage: $0 [--force] <extra_epochs>
+       $0 [--force] <bootstrap_epoch> <last_test_epoch>
 
 Bootstrap Amaru, synchronize far enough to retain ledger snapshots through
-last_test_epoch, and compare snapshots from bootstrap_epoch through
-last_test_epoch with Haskell-node stake-distribution fixtures. Stable ledger
-snapshots trail epoch transitions by two epochs, so the node runs through
-last_test_epoch + 2. Use --force to delete existing ledger and chain databases
-for the selected network.
+last_test_epoch, and compare the snapshots with Haskell-node
+stake-distribution fixtures. With one argument, bootstrap from the latest
+available snapshots and test through extra_epochs after the resulting
+bootstrap epoch. With two arguments, bootstrap_epoch and last_test_epoch are
+absolute epochs. Stable ledger snapshots trail epoch transitions by two
+epochs, so the node runs through last_test_epoch + 2. Use --force to delete
+existing ledger and chain databases for the selected network.
 
 Environment:
   AMARU_NETWORK                Network to test (default: preprod)
@@ -44,23 +47,35 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
   usage >&2
   exit 1
 fi
 
-if ! [[ "$1" =~ ^[0-9]+$ && "$2" =~ ^[0-9]+$ ]]; then
-  echo "Error: bootstrap_epoch and target_epoch must be non-negative integers." >&2
-  exit 1
-fi
+bootstrap_epoch=""
+target_epoch=""
+extra_epochs=""
 
-bootstrap_epoch=$((10#$1))
-target_epoch=$((10#$2))
-run_until_epoch=$((target_epoch + 2))
+if [ "$#" -eq 1 ]; then
+  if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+    echo "Error: extra_epochs must be a non-negative integer." >&2
+    exit 1
+  fi
 
-if (( target_epoch <= bootstrap_epoch )); then
-  echo "Error: target_epoch must be greater than bootstrap_epoch." >&2
-  exit 1
+  extra_epochs=$((10#$1))
+else
+  if ! [[ "$1" =~ ^[0-9]+$ && "$2" =~ ^[0-9]+$ ]]; then
+    echo "Error: bootstrap_epoch and last_test_epoch must be non-negative integers." >&2
+    exit 1
+  fi
+
+  bootstrap_epoch=$((10#$1))
+  target_epoch=$((10#$2))
+
+  if (( target_epoch <= bootstrap_epoch )); then
+    echo "Error: last_test_epoch must be greater than bootstrap_epoch." >&2
+    exit 1
+  fi
 fi
 
 network="${AMARU_NETWORK:-preprod}"
@@ -86,6 +101,30 @@ chain_dir="chain.${network}.db"
 fixtures_dir="crates/amaru/tests/conformance/stake-distributions/${network}"
 require_command curl
 
+infer_bootstrap_epoch() {
+  local latest_snapshot_epoch=""
+  local snapshot_dir
+  local snapshot_epoch
+
+  for snapshot_dir in "$ledger_dir"/*; do
+    [ -d "$snapshot_dir" ] || continue
+    snapshot_epoch="${snapshot_dir##*/}"
+    [[ "$snapshot_epoch" =~ ^[0-9]+$ ]] || continue
+    snapshot_epoch=$((10#$snapshot_epoch))
+
+    if [ -z "$latest_snapshot_epoch" ] || (( snapshot_epoch > latest_snapshot_epoch )); then
+      latest_snapshot_epoch="$snapshot_epoch"
+    fi
+  done
+
+  if [ -z "$latest_snapshot_epoch" ]; then
+    echo "Error: could not infer the bootstrap epoch from '$ledger_dir'." >&2
+    return 1
+  fi
+
+  echo $((latest_snapshot_epoch + 1))
+}
+
 download_fixtures() {
   local epoch="$bootstrap_epoch"
   local fixture
@@ -110,9 +149,22 @@ stop_fixture_download() {
   fi
 }
 
-download_fixtures &
-fixtures_pid=$!
-trap stop_fixture_download EXIT
+start_fixture_download() {
+  download_fixtures &
+  fixtures_pid=$!
+  trap stop_fixture_download EXIT
+}
+
+bootstrap_node() {
+  AMARU_NETWORK="$network" \
+  AMARU_LEDGER_DIR="$ledger_dir" \
+  AMARU_CHAIN_DIR="$chain_dir" \
+  cargo run --profile "$build_profile" --locked --bin amaru -- node bootstrap "$@"
+}
+
+if [ -n "$target_epoch" ]; then
+  start_fixture_download
+fi
 
 if [ "$force" = "true" ]; then
   echo "==> Removing existing $network node databases"
@@ -122,11 +174,22 @@ if [ "$force" = "true" ]; then
   cargo run --profile "$build_profile" --locked --bin amaru -- node rm --wipe-all-dbs
 fi
 
-echo "==> Bootstrapping $network at epoch $bootstrap_epoch"
-AMARU_NETWORK="$network" \
-AMARU_LEDGER_DIR="$ledger_dir" \
-AMARU_CHAIN_DIR="$chain_dir" \
-cargo run --profile "$build_profile" --locked --bin amaru -- node bootstrap --epoch "$bootstrap_epoch"
+if [ -n "$bootstrap_epoch" ]; then
+  echo "==> Bootstrapping $network at epoch $bootstrap_epoch"
+  bootstrap_node --epoch "$bootstrap_epoch"
+else
+  echo "==> Bootstrapping $network at the latest available epoch"
+  (unset AMARU_EPOCH; bootstrap_node)
+fi
+
+if [ -n "$extra_epochs" ]; then
+  bootstrap_epoch="$(infer_bootstrap_epoch)"
+  target_epoch=$((bootstrap_epoch + extra_epochs))
+  echo "==> Bootstrap starts at epoch $bootstrap_epoch; testing $extra_epochs extra epoch(s) through epoch $target_epoch"
+  start_fixture_download
+fi
+
+run_until_epoch=$((target_epoch + 2))
 
 echo "==> Running $network until epoch $run_until_epoch to retain snapshots through epoch $target_epoch"
 AMARU_NETWORK="$network" \
@@ -142,6 +205,13 @@ wait "$fixtures_pid"
 fixtures_pid=""
 trap - EXIT
 
-echo "==> Validating $network ledger snapshots with available E2E fixtures"
-test_filter="compare_${network}_stake_distribution_with_haskell_node"
-env AMARU_NETWORK="$network" cargo test --profile "$build_profile" --locked -p amaru --test summary "$test_filter"
+echo "==> Validating $network ledger snapshots for epochs $bootstrap_epoch through $target_epoch"
+test_filters=()
+test_epoch="$bootstrap_epoch"
+while (( test_epoch <= target_epoch )); do
+  test_filters+=("compare_${network}_stake_distribution_with_haskell_node::epoch_${test_epoch}")
+  test_epoch=$((test_epoch + 1))
+done
+
+env AMARU_NETWORK="$network" \
+cargo test --profile "$build_profile" --locked -p amaru --test summary -- --exact "${test_filters[@]}"

--- a/scripts/run-until-then-test
+++ b/scripts/run-until-then-test
@@ -4,17 +4,18 @@ set -euo pipefail
 
 usage() {
   cat <<EOF
-Usage: $0 [--force] <extra_epochs>
-       $0 [--force] <bootstrap_epoch> <last_test_epoch>
+Usage: $0 [--bootstrap] <extra_epochs>
+       $0 [--bootstrap] <bootstrap_epoch> <target_epoch>
 
-Bootstrap Amaru, synchronize far enough to retain ledger snapshots through
-last_test_epoch, and compare the snapshots with Haskell-node
-stake-distribution fixtures. With one argument, bootstrap from the latest
-available snapshots and test through extra_epochs after the resulting
-bootstrap epoch. With two arguments, bootstrap_epoch and last_test_epoch are
-absolute epochs. Stable ledger snapshots trail epoch transitions by two
-epochs, so the node runs through last_test_epoch + 2. Use --force to delete
-existing ledger and chain databases for the selected network.
+Synchronize Amaru through target_epoch and compare its stable ledger snapshots
+with Haskell-node stake-distribution fixtures. Existing ledger and chain
+databases are reused by default. With one argument, infer their bootstrap epoch
+and synchronize extra_epochs after it. With two arguments, bootstrap_epoch and
+target_epoch are absolute epochs. Use --bootstrap to create the databases
+instead, from the latest available snapshots with one argument or at
+bootstrap_epoch with two. Stable ledger snapshots trail epoch transitions by
+two epochs, so snapshots are tested through target_epoch - 2. The script never
+deletes existing databases.
 
 Environment:
   AMARU_NETWORK                Network to test (default: preprod)
@@ -23,11 +24,11 @@ Environment:
 EOF
 }
 
-force=false
+bootstrap=false
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --force)
-      force=true
+    --bootstrap)
+      bootstrap=true
       shift
       ;;
     --help | -h)
@@ -54,6 +55,7 @@ fi
 
 bootstrap_epoch=""
 target_epoch=""
+last_test_epoch=""
 extra_epochs=""
 
 if [ "$#" -eq 1 ]; then
@@ -63,17 +65,21 @@ if [ "$#" -eq 1 ]; then
   fi
 
   extra_epochs=$((10#$1))
+  if (( extra_epochs < 2 )); then
+    echo "Error: extra_epochs must be at least 2 to produce a stable snapshot." >&2
+    exit 1
+  fi
 else
   if ! [[ "$1" =~ ^[0-9]+$ && "$2" =~ ^[0-9]+$ ]]; then
-    echo "Error: bootstrap_epoch and last_test_epoch must be non-negative integers." >&2
+    echo "Error: bootstrap_epoch and target_epoch must be non-negative integers." >&2
     exit 1
   fi
 
   bootstrap_epoch=$((10#$1))
   target_epoch=$((10#$2))
 
-  if (( target_epoch <= bootstrap_epoch )); then
-    echo "Error: last_test_epoch must be greater than bootstrap_epoch." >&2
+  if (( target_epoch < bootstrap_epoch + 2 )); then
+    echo "Error: target_epoch must be at least 2 epochs after bootstrap_epoch." >&2
     exit 1
   fi
 fi
@@ -100,6 +106,16 @@ ledger_dir="ledger.${network}.db"
 chain_dir="chain.${network}.db"
 fixtures_dir="crates/amaru/tests/conformance/stake-distributions/${network}"
 require_command curl
+
+directory_is_populated() (
+  local directory="$1"
+  local -a entries
+
+  [ -d "$directory" ] || return 1
+  shopt -s dotglob nullglob
+  entries=("$directory"/*)
+  [ "${#entries[@]}" -gt 0 ]
+)
 
 infer_bootstrap_epoch() {
   local latest_snapshot_epoch=""
@@ -130,8 +146,8 @@ download_fixtures() {
   local fixture
   local json_fixture
 
-  echo "==> Downloading missing $network E2E fixtures for epochs $bootstrap_epoch through $target_epoch"
-  while (( epoch <= target_epoch )); do
+  echo "==> Downloading missing $network E2E fixtures for epochs $bootstrap_epoch through $last_test_epoch"
+  while (( epoch <= last_test_epoch )); do
     fixture="$fixtures_dir/epoch_${epoch}.json.zst"
     json_fixture="${fixture%.zst}"
     if [ ! -f "$fixture" ] && [ ! -f "$json_fixture" ]; then
@@ -162,56 +178,101 @@ bootstrap_node() {
   cargo run --profile "$build_profile" --locked --bin amaru -- node bootstrap "$@"
 }
 
+existing_bootstrap_epoch=""
+if [ "$bootstrap" = "false" ]; then
+  ledger_is_populated=false
+  chain_is_populated=false
+  directory_is_populated "$ledger_dir" && ledger_is_populated=true
+  directory_is_populated "$chain_dir" && chain_is_populated=true
+
+  if [ "$ledger_is_populated" = "false" ] && [ "$chain_is_populated" = "false" ]; then
+    echo "Error: expected populated '$ledger_dir' and '$chain_dir'; pass --bootstrap to create them." >&2
+    exit 1
+  elif [ "$ledger_is_populated" = "false" ]; then
+    echo "Error: '$ledger_dir' is missing or empty while '$chain_dir' is populated." >&2
+    exit 1
+  elif [ "$chain_is_populated" = "false" ]; then
+    echo "Error: '$chain_dir' is missing or empty while '$ledger_dir' is populated." >&2
+    exit 1
+  fi
+
+  existing_bootstrap_epoch="$(infer_bootstrap_epoch)"
+  if [ -n "$bootstrap_epoch" ] && (( existing_bootstrap_epoch != bootstrap_epoch )); then
+    echo "Error: existing databases start at epoch $existing_bootstrap_epoch, not requested epoch $bootstrap_epoch." >&2
+    exit 1
+  fi
+fi
+
 if [ -n "$target_epoch" ]; then
+  last_test_epoch=$((target_epoch - 2))
   start_fixture_download
 fi
 
-if [ "$force" = "true" ]; then
-  echo "==> Removing existing $network node databases"
-  AMARU_NETWORK="$network" \
-  AMARU_LEDGER_DIR="$ledger_dir" \
-  AMARU_CHAIN_DIR="$chain_dir" \
-  cargo run --profile "$build_profile" --locked --bin amaru -- node rm --wipe-all-dbs
-fi
-
-if [ -n "$bootstrap_epoch" ]; then
-  echo "==> Bootstrapping $network at epoch $bootstrap_epoch"
-  bootstrap_node --epoch "$bootstrap_epoch"
+if [ "$bootstrap" = "true" ]; then
+  if [ -n "$bootstrap_epoch" ]; then
+    echo "==> Bootstrapping $network at epoch $bootstrap_epoch"
+    bootstrap_node --epoch "$bootstrap_epoch"
+  else
+    echo "==> Bootstrapping $network at the latest available epoch"
+    (unset AMARU_EPOCH; bootstrap_node)
+  fi
 else
-  echo "==> Bootstrapping $network at the latest available epoch"
-  (unset AMARU_EPOCH; bootstrap_node)
+  echo "==> Reusing existing $network node databases at epoch $existing_bootstrap_epoch"
 fi
 
 if [ -n "$extra_epochs" ]; then
-  bootstrap_epoch="$(infer_bootstrap_epoch)"
+  if [ "$bootstrap" = "true" ]; then
+    bootstrap_epoch="$(infer_bootstrap_epoch)"
+  else
+    bootstrap_epoch="$existing_bootstrap_epoch"
+  fi
   target_epoch=$((bootstrap_epoch + extra_epochs))
-  echo "==> Bootstrap starts at epoch $bootstrap_epoch; testing $extra_epochs extra epoch(s) through epoch $target_epoch"
+  last_test_epoch=$((target_epoch - 2))
+  echo "==> Bootstrap starts at epoch $bootstrap_epoch; synchronizing $extra_epochs extra epoch(s) through epoch $target_epoch"
   start_fixture_download
 fi
 
-run_until_epoch=$((target_epoch + 2))
-
-echo "==> Running $network until epoch $run_until_epoch to retain snapshots through epoch $target_epoch"
+echo "==> Running $network until epoch $target_epoch to retain snapshots through epoch $last_test_epoch"
 AMARU_NETWORK="$network" \
 AMARU_LEDGER_DIR="$ledger_dir" \
 AMARU_CHAIN_DIR="$chain_dir" \
 AMARU_MAX_EXTRA_LEDGER_SNAPSHOTS=all \
 AMARU_UPSTREAM_PEERS="${AMARU_UPSTREAM_PEERS:-1}" \
 AMARU_TRACE="${AMARU_TRACE:-amaru=info}" \
-"$script_dir/run-until" "$build_profile" "$run_until_epoch"
+"$script_dir/run-until" "$build_profile" "$target_epoch"
 
 echo "==> Waiting for $network E2E fixture downloads"
 wait "$fixtures_pid"
 fixtures_pid=""
 trap - EXIT
 
-echo "==> Validating $network ledger snapshots for epochs $bootstrap_epoch through $target_epoch"
 test_filters=()
 test_epoch="$bootstrap_epoch"
-while (( test_epoch <= target_epoch )); do
-  test_filters+=("compare_${network}_stake_distribution_with_haskell_node::epoch_${test_epoch}")
+while (( test_epoch <= last_test_epoch )); do
+  test_filters+=("compare_${network}_stake_distribution_with_haskell_node::_${test_epoch}_expects")
   test_epoch=$((test_epoch + 1))
 done
 
+echo "==> Verifying requested $network E2E test cases"
+test_list="$(
+  env AMARU_NETWORK="$network" \
+  cargo test --profile "$build_profile" --locked -p amaru --test summary -- \
+    --list --exact "${test_filters[@]}"
+)"
+
+missing_test_filters=()
+for test_filter in "${test_filters[@]}"; do
+  if ! grep -Fqx -- "${test_filter}: test" <<<"$test_list"; then
+    missing_test_filters+=("$test_filter")
+  fi
+done
+
+if (( ${#missing_test_filters[@]} > 0 )); then
+  echo "Error: requested E2E test cases are missing:" >&2
+  printf '  %s\n' "${missing_test_filters[@]}" >&2
+  exit 1
+fi
+
+echo "==> Validating $network ledger snapshots for epochs $bootstrap_epoch through $last_test_epoch"
 env AMARU_NETWORK="$network" \
 cargo test --profile "$build_profile" --locked -p amaru --test summary -- --exact "${test_filters[@]}"

--- a/scripts/run-until-then-test
+++ b/scripts/run-until-then-test
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$script_dir/lib/ledger-epoch.sh"
+
 usage() {
   cat <<EOF
 Usage: $0 [--bootstrap] <extra_epochs>
@@ -59,7 +62,7 @@ last_test_epoch=""
 extra_epochs=""
 
 if [ "$#" -eq 1 ]; then
-  if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+  if ! is_epoch_number "$1"; then
     echo "Error: extra_epochs must be a non-negative integer." >&2
     exit 1
   fi
@@ -70,7 +73,7 @@ if [ "$#" -eq 1 ]; then
     exit 1
   fi
 else
-  if ! [[ "$1" =~ ^[0-9]+$ && "$2" =~ ^[0-9]+$ ]]; then
+  if ! is_epoch_number "$1" || ! is_epoch_number "$2"; then
     echo "Error: bootstrap_epoch and target_epoch must be non-negative integers." >&2
     exit 1
   fi
@@ -98,7 +101,6 @@ require_command() {
 
 require_command cargo
 
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
 cd "$repo_root"
 
@@ -116,30 +118,6 @@ directory_is_populated() (
   entries=("$directory"/*)
   [ "${#entries[@]}" -gt 0 ]
 )
-
-infer_bootstrap_epoch() {
-  local latest_snapshot_epoch=""
-  local snapshot_dir
-  local snapshot_epoch
-
-  for snapshot_dir in "$ledger_dir"/*; do
-    [ -d "$snapshot_dir" ] || continue
-    snapshot_epoch="${snapshot_dir##*/}"
-    [[ "$snapshot_epoch" =~ ^[0-9]+$ ]] || continue
-    snapshot_epoch=$((10#$snapshot_epoch))
-
-    if [ -z "$latest_snapshot_epoch" ] || (( snapshot_epoch > latest_snapshot_epoch )); then
-      latest_snapshot_epoch="$snapshot_epoch"
-    fi
-  done
-
-  if [ -z "$latest_snapshot_epoch" ]; then
-    echo "Error: could not infer the bootstrap epoch from '$ledger_dir'." >&2
-    return 1
-  fi
-
-  echo $((latest_snapshot_epoch + 1))
-}
 
 download_fixtures() {
   local epoch="$bootstrap_epoch"
@@ -196,7 +174,7 @@ if [ "$bootstrap" = "false" ]; then
     exit 1
   fi
 
-  existing_bootstrap_epoch="$(infer_bootstrap_epoch)"
+  existing_bootstrap_epoch="$(infer_ledger_start_epoch "$ledger_dir")"
   if [ -n "$bootstrap_epoch" ] && (( existing_bootstrap_epoch != bootstrap_epoch )); then
     echo "Error: existing databases start at epoch $existing_bootstrap_epoch, not requested epoch $bootstrap_epoch." >&2
     exit 1
@@ -205,6 +183,7 @@ fi
 
 if [ -n "$target_epoch" ]; then
   last_test_epoch=$((target_epoch - 2))
+  run_until_target=(--epoch "$target_epoch")
   start_fixture_download
 fi
 
@@ -222,12 +201,13 @@ fi
 
 if [ -n "$extra_epochs" ]; then
   if [ "$bootstrap" = "true" ]; then
-    bootstrap_epoch="$(infer_bootstrap_epoch)"
+    bootstrap_epoch="$(infer_ledger_start_epoch "$ledger_dir")"
   else
     bootstrap_epoch="$existing_bootstrap_epoch"
   fi
-  target_epoch=$((bootstrap_epoch + extra_epochs))
+  target_epoch="$(epoch_after "$bootstrap_epoch" "$extra_epochs")"
   last_test_epoch=$((target_epoch - 2))
+  run_until_target=(--epochs "$extra_epochs")
   echo "==> Bootstrap starts at epoch $bootstrap_epoch; synchronizing $extra_epochs extra epoch(s) through epoch $target_epoch"
   start_fixture_download
 fi
@@ -236,10 +216,9 @@ echo "==> Running $network until epoch $target_epoch to retain snapshots through
 AMARU_NETWORK="$network" \
 AMARU_LEDGER_DIR="$ledger_dir" \
 AMARU_CHAIN_DIR="$chain_dir" \
-AMARU_MAX_EXTRA_LEDGER_SNAPSHOTS=all \
 AMARU_UPSTREAM_PEERS="${AMARU_UPSTREAM_PEERS:-1}" \
 AMARU_TRACE="${AMARU_TRACE:-amaru=info}" \
-"$script_dir/run-until" "$build_profile" "$target_epoch"
+"$script_dir/run-until" "$build_profile" "${run_until_target[@]}"
 
 echo "==> Waiting for $network E2E fixture downloads"
 wait "$fixtures_pid"


### PR DESCRIPTION
Drop make run-until and use `run-until-then-test` for CI so that snapshot tests are performed there too.
`run-until-then-test` is also improved so that it can be launched with just a number of epoch to test. Starting epoch is then inferred from local dbs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flexible epoch targeting using either an absolute epoch or a specified number of epochs.
  * Added automatic epoch inference from existing ledger snapshots.
  * Added database bootstrap support and validation for reusable populated databases.
  * Added clear input validation and help output for epoch-running commands.

* **Documentation**
  * Updated end-to-end testing instructions with the new epoch options and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->