### PR TITLE
chore: add a clippy rule for using decode_bytes

### DIFF
--- a/.cargo/clippy.toml
+++ b/.cargo/clippy.toml
@@ -4,13 +4,14 @@ allow-unwrap-in-tests = true
 type-complexity-threshold = 600
 enum-variant-size-threshold = 1024
 disallowed-types = [
-    "std::collections::HashSet",
-    "std::collections::HashMap"
+  "std::collections::HashSet",
+  "std::collections::HashMap"
 ]
 disallowed-methods = [
-    "slot_arithmetic::EraHistory::slot_to_relative_time_unchecked_horizon",
-    "slot_arithmetic::EraHistory::slot_to_epoch_unchecked_horizon",
-    "slot_arithmetic::EraHistory::next_epoch_first_slot_unchecked_horizon",
-    "slot_arithmetic::EraHistory::era_first_epoch_unchecked_horizon",
-    "slot_arithmetic::EraHistory::epoch_bounds_unchecked_horizon"
+  "slot_arithmetic::EraHistory::slot_to_relative_time_unchecked_horizon",
+  "slot_arithmetic::EraHistory::slot_to_epoch_unchecked_horizon",
+  "slot_arithmetic::EraHistory::next_epoch_first_slot_unchecked_horizon",
+  "slot_arithmetic::EraHistory::era_first_epoch_unchecked_horizon",
+  "slot_arithmetic::EraHistory::epoch_bounds_unchecked_horizon",
+  { path = "minicbor::decode::Decoder::bytes", reason = "does not handle indefinite-length byte strings; use amaru_minicbor_extra::decode_bytes instead" }
 ]

--- a/crates/amaru-bootstrap/src/cardano_node/tvar.rs
+++ b/crates/amaru-bootstrap/src/cardano_node/tvar.rs
@@ -157,7 +157,9 @@ where
                 }
 
                 let mut probe = d.probe();
-                let io = probe.bytes().and_then(|input| probe.bytes().map(|output| (input.to_vec(), output.to_vec())));
+                let io = cbor::decode_bytes(&mut probe).and_then(|input| {
+                    cbor::decode_bytes(&mut probe).map(|output| (input.into_owned(), output.into_owned()))
+                });
 
                 if let Ok((input, output)) = io {
                     chunk_size += 1;

--- a/crates/amaru-kernel/src/cardano/memoized/script.rs
+++ b/crates/amaru-kernel/src/cardano/memoized/script.rs
@@ -133,6 +133,10 @@ impl BorrowedScript<'_> {
     /// A `BorrowedScript::Native` is treated `unreachable` since there are no redeemers for NativeScript
     /// and they are not flat-encoded bytes.
     pub fn to_bytes(&self) -> Result<Vec<u8>, cbor::decode::Error> {
+        // Conformance: plutus-ledger-api extracts the flat payload with cborg's `decodeBytes`, which
+        // rejects indefinite-length byte strings; accepting them here would change phase-2 validation
+        // outcomes.
+        #[allow(clippy::disallowed_methods)]
         fn decode_cbor_bytes(cbor: &[u8]) -> Result<Vec<u8>, cbor::decode::Error> {
             cbor::decode::Decoder::new(cbor).bytes().map(|b| b.to_vec())
         }

--- a/crates/amaru-kernel/src/cardano/plutus_script.rs
+++ b/crates/amaru-kernel/src/cardano/plutus_script.rs
@@ -20,6 +20,10 @@ pub struct PlutusScript<const VERSION: usize>(#[n(0)] pub Bytes);
 
 /// Unwrap the CBOR bytestring envelope to get the raw flat-encoded program bytes.
 impl<const V: usize> ToBytes for PlutusScript<V> {
+    // Conformance: plutus-ledger-api extracts the flat payload with cborg's `decodeBytes`, which
+    // rejects indefinite-length byte strings; accepting them here would change phase-2 validation
+    // outcomes.
+    #[allow(clippy::disallowed_methods)]
     fn to_bytes(&self) -> Result<&[u8], cbor::decode::Error> {
         cbor::Decoder::new(&self.0).bytes()
     }

--- a/crates/amaru-minicbor-extra/src/decode.rs
+++ b/crates/amaru-minicbor-extra/src/decode.rs
@@ -62,6 +62,7 @@ pub fn decode_bytes<'b>(d: &mut cbor::Decoder<'b>) -> Result<Cow<'b, [u8]>, deco
         return Ok(Cow::Owned(bytes));
     }
 
+    #[allow(clippy::disallowed_methods)]
     Ok(Cow::Borrowed(d.bytes()?))
 }
 
@@ -208,7 +209,7 @@ pub fn check_tagged_array_length(label: usize, actual: Option<u64>, expected: u6
 ///     |d| d.u8(),
 ///     |d, state, field| {
 ///         match field {
-///             0 => state.0 = Some(decode_address(d.bytes()?),
+///             0 => state.0 = Some(decode_address(&decode_bytes(d)?),
 ///             1 => state.1 = Some(d.decode()?),
 ///             2 => state.2 = decode_datum()?,
 ///             3 => state.3 = decode_reference_script()?,

--- a/crates/amaru-protocols/src/blockfetch/messages.rs
+++ b/crates/amaru-protocols/src/blockfetch/messages.rs
@@ -111,6 +111,9 @@ impl<'b> cbor::Decode<'b, ()> for Message {
                     )));
                 }
 
+                // Conformance: the Haskell node unwraps CBOR-in-CBOR with cborg's `decodeBytes`,
+                // which rejects indefinite-length byte strings, so we reject them too.
+                #[allow(clippy::disallowed_methods)]
                 let body = d.bytes()?;
                 Ok(Message::Block { body: Vec::from(body) })
             }

--- a/crates/amaru-protocols/src/chainsync/messages.rs
+++ b/crates/amaru-protocols/src/chainsync/messages.rs
@@ -197,6 +197,9 @@ impl<'b> cbor::Decode<'b, ()> for HeaderContent {
                 let (a, b): (u8, u64) = d.decode()?;
 
                 d.tag()?;
+                // Conformance: the Haskell node unwraps CBOR-in-CBOR with cborg's `decodeBytes`,
+                // which rejects indefinite-length byte strings, so we reject them too.
+                #[allow(clippy::disallowed_methods)]
                 let bytes = d.bytes()?;
 
                 Ok(HeaderContent { variant, byron_prefix: Some((a, b)), cbor: Vec::from(bytes) })
@@ -210,6 +213,9 @@ impl<'b> cbor::Decode<'b, ()> for HeaderContent {
             | EraName::Dijkstra => {
                 cbor::check_tagged_array_length(variant.header_variant().into(), len, 2)?;
                 d.tag()?;
+                // Conformance: the Haskell node unwraps CBOR-in-CBOR with cborg's `decodeBytes`,
+                // which rejects indefinite-length byte strings, so we reject them too.
+                #[allow(clippy::disallowed_methods)]
                 let bytes = d.bytes()?;
                 Ok(HeaderContent { variant, byron_prefix: None, cbor: Vec::from(bytes) })
             }

--- a/crates/amaru-protocols/src/tx_submission/messages.rs
+++ b/crates/amaru-protocols/src/tx_submission/messages.rs
@@ -243,6 +243,9 @@ impl<'b> cbor::Decode<'b, ()> for EraTaggedTx {
                 tag
             )));
         }
+        // Conformance: the Haskell node unwraps CBOR-in-CBOR with cborg's `decodeBytes`,
+        // which rejects indefinite-length byte strings, so we reject them too.
+        #[allow(clippy::disallowed_methods)]
         let tx = decode_tx(d.bytes()?)?;
         Ok(EraTaggedTx { era, tx })
     }
@@ -429,6 +432,8 @@ mod tests {
         let era = decode_era_tag(&mut d).unwrap();
         assert_eq!(era, EraName::Conway);
         assert_eq!(d.tag().unwrap(), cbor::IanaTag::Cbor.tag()); // cbor-in-cbor tag
+        // Mirrors the strict definite-length read of the production decoder.
+        #[allow(clippy::disallowed_methods)]
         let tx_bytes = d.bytes().unwrap();
 
         assert_eq!(tx_bytes[0], 0x84); // definite-length array of size 4

--- a/crates/amaru-uplc/benches/turbo/main.rs
+++ b/crates/amaru-uplc/benches/turbo/main.rs
@@ -20,6 +20,7 @@ use std::{
 };
 
 use amaru_kernel::{PROTOCOL_VERSION_10, PlutusVersion};
+use amaru_minicbor_extra::decode_bytes;
 use amaru_uplc::{arena::Arena, binder::DeBruijn, flat, machine::ExBudget};
 use bumpalo::Bump;
 use divan::Bencher;
@@ -44,8 +45,8 @@ struct CborWrapped(Vec<u8>);
 
 impl<'d, C> minicbor::Decode<'d, C> for CborWrapped {
     fn decode(d: &mut minicbor::Decoder<'d>, _ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
-        let bytes = d.bytes()?;
-        Ok(CborWrapped(bytes.to_vec()))
+        let bytes = decode_bytes(d)?;
+        Ok(CborWrapped(bytes.into_owned()))
     }
 }
 

--- a/crates/amaru-uplc/benches/use_cases/turbo.rs
+++ b/crates/amaru-uplc/benches/use_cases/turbo.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use amaru_minicbor_extra::decode_bytes;
 use amaru_uplc::{arena::Arena, binder::DeBruijn, flat, machine::PlutusVersion};
 use bumpalo::Bump;
 use criterion::{criterion_group, Criterion};
@@ -40,8 +41,8 @@ impl<'d, C> minicbor::Decode<'d, C> for CborWrapped {
         d: &mut minicbor::Decoder<'d>,
         _ctx: &mut C,
     ) -> Result<Self, minicbor::decode::Error> {
-        let bytes = d.bytes()?;
-        Ok(CborWrapped(bytes.to_vec()))
+        let bytes = decode_bytes(d)?;
+        Ok(CborWrapped(bytes.into_owned()))
     }
 }
 


### PR DESCRIPTION
This PR adds a lint to clippy in order to warn for the use of `d.bytes()` when decoding bytes that can potentially accept definite and indefinite length bytes.

I adjusted some call sites to what the Haskell node is doing pre-version 12 (some places aren't strict anymore in v12) but this will have to be revisited when we support v12 in the future.

Skip-Changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized CBOR byte decoding across import, protocol, script, and benchmark workflows.
  * Byte data is handled with owned buffers, improving consistency and reducing unnecessary copying.
  * Clarified conformance behavior for unsupported indefinite-length CBOR byte strings.

* **Documentation**
  * Added guidance and examples for the recommended byte-decoding approach.
  * Documented existing validation behavior across supported decoding paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->