### PR TITLE
CommitteeUnknown + CommitteeHasPreviouslyResigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Other guiding principles:
 - **amaru-ledger**: compute the size of a value using the same encoding as the Haskell node.
 - **amaru-ledger**: validate voters in a transaction actually exist in ledger state. ([#1138][], [#923][])
 - **amaru-ledger**: reduce churn allocations during stake distribution and rewards calculations.
+- **amaru-ledger**: prevent CC action of resigned members.
 
 ## v10.11.20260813 _[unreleased; planned for 2026-08-13]_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Other guiding principles:
 - **amaru-ledger**: validate voters in a transaction actually exist in ledger state. ([#1138][], [#923][])
 - **amaru-ledger**: reduce churn allocations during stake distribution and rewards calculations.
 - **amaru-ledger**: prevent CC action of resigned members.
+- **amaru-ledger**: resolve and control CC member cold credentials following ratification or in-flight proposals.
 
 ## v10.11.20260813 _[unreleased; planned for 2026-08-13]_
 

--- a/crates/amaru-ledger/src/rules/transaction/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/fixture.rs
@@ -92,20 +92,6 @@ where
     cbor::decode(&bytes).map_err(serde::de::Error::custom)
 }
 
-fn deserialize_optional_cbor_hex<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-    T: for<'b> cbor::Decode<'b, ()>,
-{
-    match Option::<String>::deserialize(deserializer)? {
-        None => Ok(None),
-        Some(hex) => {
-            let bytes = hex::decode(hex).map_err(serde::de::Error::custom)?;
-            cbor::decode(&bytes).map(Some).map_err(serde::de::Error::custom)
-        }
-    }
-}
-
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PoolDelegationProxy {
@@ -198,8 +184,8 @@ where
 struct CommitteeMemberProxy {
     #[serde(deserialize_with = "deserialize_cbor_hex")]
     cold_credential: StakeCredential,
-    #[serde(default, deserialize_with = "deserialize_optional_cbor_hex")]
-    status: Option<ConstitutionalCommitteeMemberStatus>,
+    #[serde(default)]
+    status: Option<String>,
     #[serde(default)]
     valid_until: Option<Epoch>,
 }
@@ -212,10 +198,22 @@ where
     Ok(entries
         .into_iter()
         .map(|entry| {
-            let member = CCMember { status: entry.status, valid_until: entry.valid_until };
-            (entry.cold_credential, member)
+            let status = if let Some(st) = entry.status {
+                Some(if st == "resigned" {
+                    ConstitutionalCommitteeMemberStatus::Resigned
+                } else {
+                    let hot_credential = cbor::from_cbor(&hex::decode(&st).map_err(serde::de::Error::custom)?)
+                        .ok_or_else(|| serde::de::Error::custom("unable to decode hot credential"))?;
+                    ConstitutionalCommitteeMemberStatus::DelegatedToHotCredential(hot_credential)
+                })
+            } else {
+                None
+            };
+
+            let member = CCMember { status, valid_until: entry.valid_until };
+            Ok((entry.cold_credential, member))
         })
-        .collect())
+        .collect::<Result<_, _>>()?)
 }
 
 #[derive(Debug)]
@@ -264,6 +262,7 @@ pub(super) enum Predicate {
     BabbageNonDisjointRefInputs,
     BabbageOutputTooSmallUTxO,
     BadInputsUTxO,
+    CommitteeHasPreviouslyResigned,
     CommitteeIsUnknown,
     ConflictingMetadataHash,
     ConwayTxRefScriptsSizeTooBig,
@@ -429,6 +428,9 @@ impl From<PhaseOneError> for Predicate {
             PhaseOneError::Certificates(InvalidCertificates::CCMemberInvalidDelegation(
                 DelegateError::UnknownSource(_),
             )) => Predicate::CommitteeIsUnknown,
+            PhaseOneError::Certificates(InvalidCertificates::CCMemberInvalidDelegation(
+                DelegateError::AlreadyResigned,
+            )) => Predicate::CommitteeHasPreviouslyResigned,
             PhaseOneError::Certificates(InvalidCertificates::StakeCredentialAlreadyRegistered(_)) => {
                 Predicate::StakeKeyRegistered
             }

--- a/crates/amaru-ledger/src/rules/transaction/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/fixture.rs
@@ -194,8 +194,7 @@ fn deserialize_committee<'de, D>(deserializer: D) -> Result<BTreeMap<StakeCreden
 where
     D: serde::Deserializer<'de>,
 {
-    let entries = Vec::<CommitteeMemberProxy>::deserialize(deserializer)?;
-    Ok(entries
+    Vec::<CommitteeMemberProxy>::deserialize(deserializer)?
         .into_iter()
         .map(|entry| {
             let status = if let Some(st) = entry.status {
@@ -213,7 +212,7 @@ where
             let member = CCMember { status, valid_until: entry.valid_until };
             Ok((entry.cold_credential, member))
         })
-        .collect::<Result<_, _>>()?)
+        .collect::<Result<_, _>>()
 }
 
 #[derive(Debug)]

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00204-fail-hot-key-authorization-for-a-cold-credential-absent-from-the-committee.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00204-fail-hot-key-authorization-for-a-cold-credential-absent-from-the-committee.json
@@ -1,0 +1,27 @@
+{
+  "title": "hot key authorization for a cold credential absent from the committee",
+  "description": "A transaction carrying an AuthCommitteeHot certificate for a cold credential absent from the committee.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "8258209aaa3bd8eb3a86816639c5a620f283ef66940dea7a2a623bcf9951526212a37b00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00989680"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d90102818258209aaa3bd8eb3a86816639c5a620f283ef66940dea7a2a623bcf9951526212a37b000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00958940021a00030d4004d9010281830e8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd88200581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec0f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584099dadd89b271ed62dbad08b7443f06e55a84a8a240f1d977b8eb3bdedfd5f1c6d4ff68b1c951a48063ffea51afd7484b83ba520b9a5b3b1b4247d1fbe409e80ef5f6",
+  "expected": {
+    "predicate": "CommitteeIsUnknown"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00205-fail-resignation-for-a-cold-credential-the-same-transaction-proposes-to-elect.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00205-fail-resignation-for-a-cold-credential-the-same-transaction-proposes-to-elect.json
@@ -1,0 +1,34 @@
+{
+  "title": "resignation for a cold credential the same transaction proposes to elect",
+  "description": "A transaction resigning a cold credential absent from the committee, carrying an UpdateCommittee proposal that adds that same cold credential.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "8258207c0622678cf7b9dda7fca199eed5008a8888ffd5dde75ee07636fb418c56c2b100",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b0000001748c64080"
+      }
+    ],
+    "accounts": [
+      {
+        "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "deposit": 2000000
+      }
+    ],
+    "committee": []
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a600d90102818258207c0622678cf7b9dda7fca199eed5008a8888ffd5dde75ee07636fb418c56c2b1000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40021a00030d4004d9010281830f8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8f60f0014d9010281841b000000174876e800581de093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd88504f6d9010280a18200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd81a000186a0d81e820102827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258403f29559cd43d77f4b6167eeded4a61f281f7120e30313917a267c2bc830bd6d1f5119babf9767032f404f0904aa3fa1cb737d9079a3744ced004459d6e703809f5f6",
+  "expected": {
+    "predicate": "CommitteeIsUnknown"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00206-fail-hot-key-authorization-for-a-member-that-has-resigned.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00206-fail-hot-key-authorization-for-a-member-that-has-resigned.json
@@ -1,0 +1,34 @@
+{
+  "title": "hot key authorization for a member that has resigned",
+  "description": "A transaction carrying an AuthCommitteeHot certificate for an elected committee member whose recorded status is a resignation.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "82582081411b62d9d9a051c809d25678d6e1b0d67da4f231ce7d53a618387237024acf00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00989680"
+      }
+    ],
+    "committee": [
+      {
+        "coldCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "status": "resigned",
+        "validUntil": 200
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d901028182582081411b62d9d9a051c809d25678d6e1b0d67da4f231ce7d53a618387237024acf000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00958940021a00030d4004d9010281830e8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd88200581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec0f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840524949a90a252dd366d50e65ec038b5b6df677091137cd562669d8925051d5a56a76393cdb2296087a9ee4e781b8265fefb1823f530654a4569e2f9e58bf240df5f6",
+  "expected": {
+    "predicate": "CommitteeHasPreviouslyResigned"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00207-fail-resignation-for-a-member-that-has-already-resigned.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00207-fail-resignation-for-a-member-that-has-already-resigned.json
@@ -1,0 +1,34 @@
+{
+  "title": "resignation for a member that has already resigned",
+  "description": "A transaction carrying a ResignCommitteeCold certificate for an elected committee member whose recorded status is a resignation.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820de8b61011b578c8f85f07c27834d3c328aeb26a86e9a4e73e2325d8d331e42b400",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00989680"
+      }
+    ],
+    "committee": [
+      {
+        "coldCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "status": "resigned",
+        "validUntil": 200
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820de8b61011b578c8f85f07c27834d3c328aeb26a86e9a4e73e2325d8d331e42b4000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00958940021a00030d4004d9010281830f8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8f60f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258409ea64509b7b1b2a23175c7f105796cd4b747a5e618654aa8ea1e4bb9684c94810fed618126a85a5c1e4b5fcbdb5fa71a750c4418f0560651ca836884a2eb2e00f5f6",
+  "expected": {
+    "predicate": "CommitteeHasPreviouslyResigned"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00208-fail-hot-key-authorization-for-a-member-that-resigned-earlier-in-the-same-transaction.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00208-fail-hot-key-authorization-for-a-member-that-resigned-earlier-in-the-same-transaction.json
@@ -1,0 +1,34 @@
+{
+  "title": "hot key authorization for a member that resigned earlier in the same transaction",
+  "description": "A transaction carrying a ResignCommitteeCold certificate for an elected committee member, followed by an AuthCommitteeHot certificate for the same member.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820dd5a3925f51289f19f77abca43e7efd5aca15b27308c2d07f907ea91819e7b9200",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00989680"
+      }
+    ],
+    "committee": [
+      {
+        "coldCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "status": "8200581c2e06285720a42375de8c91a3f9f27d89516f93a2f60ad638ef30eea6",
+        "validUntil": 200
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820dd5a3925f51289f19f77abca43e7efd5aca15b27308c2d07f907ea91819e7b92000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00958940021a00030d4004d9010282830f8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8f6830e8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd88200581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec0f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584041c5b5617533c7c3ed32f18b58a506f71d10009f5212c201cb81c409b428c5b1d1792d4c951edf201f824d951ec8d82b8bf20a75ad7897c3374e39e6f0da880af5f6",
+  "expected": {
+    "predicate": "CommitteeHasPreviouslyResigned"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00209-fail-second-resignation-for-a-member-that-resigned-earlier-in-the-same-transaction.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00209-fail-second-resignation-for-a-member-that-resigned-earlier-in-the-same-transaction.json
@@ -1,0 +1,34 @@
+{
+  "title": "second resignation for a member that resigned earlier in the same transaction",
+  "description": "A transaction carrying two ResignCommitteeCold certificates for the same elected committee member, the second with an anchor.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820072fad40c65919c78ad880359452dfd6fed30ea8d2366b11720c82791539450400",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00989680"
+      }
+    ],
+    "committee": [
+      {
+        "coldCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "status": "8200581c2e06285720a42375de8c91a3f9f27d89516f93a2f60ad638ef30eea6",
+        "validUntil": 200
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820072fad40c65919c78ad880359452dfd6fed30ea8d2366b11720c827915394504000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00958940021a00030d4004d9010282830f8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8f6830f8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8827368747470733a2f2f6578616d706c652e636f6d582000000000000000000000000000000000000000000000000000000000000000000f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584013bfc4b02cc928dcb66fdfc291a0303c55e0ccd78a8377017d26000a80d87d153800000e16b69f6ea2ea8008c2c2679cb294c7fc48693da933ab9d4e095ab405f5f6",
+  "expected": {
+    "predicate": "CommitteeHasPreviouslyResigned"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00210-fail-hot-key-authorization-for-an-unelected-member-that-has-resigned.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00210-fail-hot-key-authorization-for-an-unelected-member-that-has-resigned.json
@@ -1,0 +1,34 @@
+{
+  "title": "hot key authorization for an unelected member that has resigned",
+  "description": "A transaction carrying an AuthCommitteeHot certificate for a committee member holding no term whose recorded status is a resignation.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "8258201c028e55f8c29fa027ecfaa645f9f472c09177c76f15a72fcd9f96650186f50400",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00989680"
+      }
+    ],
+    "committee": [
+      {
+        "coldCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "status": "resigned",
+        "validUntil": null
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d90102818258201c028e55f8c29fa027ecfaa645f9f472c09177c76f15a72fcd9f96650186f504000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00958940021a00030d4004d9010281830e8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd88200581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec0f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584084faa600276065b8e628a43b5ae6c2f49d3f6f73421b82ed00c36c2dca3719a77df297c4fb88d9024ddc3b17f7e073f55c69ad04dc672cf21cd163abd9e4fe00f5f6",
+  "expected": {
+    "predicate": "CommitteeHasPreviouslyResigned"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00211-pass-hot-key-authorization-for-a-member-holding-no-term.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00211-pass-hot-key-authorization-for-a-member-holding-no-term.json
@@ -1,0 +1,32 @@
+{
+  "title": "hot key authorization for a member holding no term",
+  "description": "A transaction carrying an AuthCommitteeHot certificate for a committee member holding no term and no hot credential.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820a20797e05da3392a38d45049a7210983bf032a710d67daf65fabb486556d5c0900",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00989680"
+      }
+    ],
+    "committee": [
+      {
+        "coldCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "status": null,
+        "validUntil": null
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820a20797e05da3392a38d45049a7210983bf032a710d67daf65fabb486556d5c09000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00958940021a00030d4004d9010281830e8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd88200581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec0f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584058551fc1ae184485c1822da47959721442b4c9800e306252b009b3300f504cba80df0dceb54c537f7f56327b1f00c267be951d37e371465d0d1c036f5bfaf407f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00212-pass-resignation-for-a-member-holding-no-term.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00212-pass-resignation-for-a-member-holding-no-term.json
@@ -1,0 +1,32 @@
+{
+  "title": "resignation for a member holding no term",
+  "description": "A transaction carrying a ResignCommitteeCold certificate for a committee member holding no term and no hot credential.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "8258203654f02beeca9e4406532a4872cde3e6f9b77851878e9788bda79edfe134913b00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00989680"
+      }
+    ],
+    "committee": [
+      {
+        "coldCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "status": null,
+        "validUntil": null
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d90102818258203654f02beeca9e4406532a4872cde3e6f9b77851878e9788bda79edfe134913b000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00958940021a00030d4004d9010281830f8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8f60f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258406a540fcfb147753eeba1476be4e9ea80d8265228bcb821f8ef363c05b5fba209bd55ea0725e500dbb1fd20f8f7ecfc733c92a2e60f8357f6a8792eacc5ca300df5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00213-pass-hot-key-rotation-for-a-member-with-an-authorized-hot-key.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00213-pass-hot-key-rotation-for-a-member-with-an-authorized-hot-key.json
@@ -1,0 +1,32 @@
+{
+  "title": "hot key rotation for a member with an authorized hot key",
+  "description": "A transaction carrying an AuthCommitteeHot certificate naming a hot credential different from the one the elected member already authorized.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820e721860828c3e423be75dbf1dfe7b730255bdf0931afca28e0d775199b8c7d5100",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00989680"
+      }
+    ],
+    "committee": [
+      {
+        "coldCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "status": "8200581c2e06285720a42375de8c91a3f9f27d89516f93a2f60ad638ef30eea6",
+        "validUntil": 200
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820e721860828c3e423be75dbf1dfe7b730255bdf0931afca28e0d775199b8c7d51000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00958940021a00030d4004d9010281830e8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd88200581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec0f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258404aad7861b60a7011a6c5a2f13816cdf489b4d8b19c8fa61edf22d9509149b6006146224c532d40c79ed445421c6e4cb50998e4feda881692edae08143ca7bc0cf5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00214-pass-resignation-for-a-member-with-an-authorized-hot-key.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00214-pass-resignation-for-a-member-with-an-authorized-hot-key.json
@@ -1,0 +1,32 @@
+{
+  "title": "resignation for a member with an authorized hot key",
+  "description": "A transaction carrying a ResignCommitteeCold certificate for an elected committee member that has authorized a hot credential.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "82582050462597dd2b4a47cece4c8f3639bf140e6bfd236f404695b83cf7e10dfa2b2f00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00989680"
+      }
+    ],
+    "committee": [
+      {
+        "coldCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "status": "8200581c2e06285720a42375de8c91a3f9f27d89516f93a2f60ad638ef30eea6",
+        "validUntil": 200
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d901028182582050462597dd2b4a47cece4c8f3639bf140e6bfd236f404695b83cf7e10dfa2b2f000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00958940021a00030d4004d9010281830f8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8f60f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840dbf0f4b9547745fc1d1c752fd91d279dd3fc6fe9a7aba7d0b67a59ae8436900bfb56e625a3b61721d361d949b6c0acf3aebbf5c73f516b90f146e8d02b0d590af5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00215-pass-two-hot-key-authorizations-for-the-same-member.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00215-pass-two-hot-key-authorizations-for-the-same-member.json
@@ -1,0 +1,32 @@
+{
+  "title": "two hot key authorizations for the same member",
+  "description": "A transaction carrying two AuthCommitteeHot certificates for the same elected committee member, naming different hot credentials.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820145dbddb90423611f01366971cf824bfe3493dba931387ace1ac76f8a4f0f94900",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00989680"
+      }
+    ],
+    "committee": [
+      {
+        "coldCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "status": null,
+        "validUntil": 200
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820145dbddb90423611f01366971cf824bfe3493dba931387ace1ac76f8a4f0f949000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00958940021a00030d4004d9010282830e8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd88200581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec830e8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd88200581c2e06285720a42375de8c91a3f9f27d89516f93a2f60ad638ef30eea60f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258407e9e3778fca10cec80c311ea63c171fb7cc1c62a16f45a1e66102c9c615682f7176cfe306a53534b725c615e53b9b31553e8036035cb51b0531f9800b82cf20ef5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00216-pass-hot-key-authorization-for-a-member-whose-term-has-expired.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00216-pass-hot-key-authorization-for-a-member-whose-term-has-expired.json
@@ -1,0 +1,32 @@
+{
+  "title": "hot key authorization for a member whose term has expired",
+  "description": "A transaction carrying an AuthCommitteeHot certificate for a committee member whose term ended before the current epoch.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "82582073ddc31e2eaac6344446b1a06d0ca60946a939745805f6b7979830bb5f8a57d800",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00989680"
+      }
+    ],
+    "committee": [
+      {
+        "coldCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "status": null,
+        "validUntil": 2
+      }
+    ]
+  },
+  "point": {
+    "slot": 2160000,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d901028182582073ddc31e2eaac6344446b1a06d0ca60946a939745805f6b7979830bb5f8a57d8000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00958940021a00030d4004d9010281830e8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd88200581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec0f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840c21dc2a949b39154b6b0e37e4c7267ce023b2a795236bce93b3192df459e5aaa26a59de64f71517b05c346549dc200c3db86625dacb9146a7fc20e2d1d90ab04f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00217-fail-resignation-for-an-unelected-member-that-has-resigned.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00217-fail-resignation-for-an-unelected-member-that-has-resigned.json
@@ -1,0 +1,34 @@
+{
+  "title": "resignation for an unelected member that has resigned",
+  "description": "A transaction carrying a ResignCommitteeCold certificate for a committee member holding no term whose recorded status is a resignation.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "8258202dc4feba3f183472ef4026374a8e89c79e8319b584f64ebcc2169add3223d4f700",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00989680"
+      }
+    ],
+    "committee": [
+      {
+        "coldCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "status": "resigned",
+        "validUntil": null
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d90102818258202dc4feba3f183472ef4026374a8e89c79e8319b584f64ebcc2169add3223d4f7000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00958940021a00030d4004d9010281830f8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8f60f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258401dd0412ed4b3bfdb6e75003d82b400f4f4624e55df8608aef80c16e2784a4d9d33b6fd3a8cb1b60756524b6e8f6322b7e715785740c857be07cb3b314b6f7b0ff5f6",
+  "expected": {
+    "predicate": "CommitteeHasPreviouslyResigned"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00218-pass-hot-key-authorization-for-a-member-with-no-hot-credential.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00218-pass-hot-key-authorization-for-a-member-with-no-hot-credential.json
@@ -1,0 +1,32 @@
+{
+  "title": "hot key authorization for a member with no hot credential",
+  "description": "A transaction carrying an AuthCommitteeHot certificate for an elected committee member that has authorized no hot credential.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820dd125e9bfe3e7b51890df450083f47fd744220b09010543459b7f9f4f09c10bd00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00989680"
+      }
+    ],
+    "committee": [
+      {
+        "coldCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "status": null,
+        "validUntil": 200
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820dd125e9bfe3e7b51890df450083f47fd744220b09010543459b7f9f4f09c10bd000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00958940021a00030d4004d9010281830e8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd88200581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253cec0f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840540bd625a07cd3baebd19e423ec8d914bcb1cfe44af07c7bd4805e6aaf997ec033774910ba5b911982bb09c91149182aa060adca2a5f9060188cd3730fd3fc0df5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00219-pass-resignation-for-a-member-with-no-hot-credential.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00219-pass-resignation-for-a-member-with-no-hot-credential.json
@@ -1,0 +1,32 @@
+{
+  "title": "resignation for a member with no hot credential",
+  "description": "A transaction carrying a ResignCommitteeCold certificate for an elected committee member that has authorized no hot credential.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "8258207eebaa96f7e37bec906d893ae8b3447d6d66a1ffa084ae729ae537cb895ff31700",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00989680"
+      }
+    ],
+    "committee": [
+      {
+        "coldCredential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "status": null,
+        "validUntil": 200
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d90102818258207eebaa96f7e37bec906d893ae8b3447d6d66a1ffa084ae729ae537cb895ff317000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00958940021a00030d4004d9010281830f8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8f60f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840f0a14e692a1a6c6eb1d4fe1fe38d0fced6894704513a847dd103ecd565ffc836dcbedff7507b135c4e3a88a50d2d1200f911e3787163e0787f3c624c2ea2bb01f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00220-fail-resignation-for-a-cold-credential-absent-from-the-committee.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00220-fail-resignation-for-a-cold-credential-absent-from-the-committee.json
@@ -1,0 +1,27 @@
+{
+  "title": "resignation for a cold credential absent from the committee",
+  "description": "A transaction carrying a ResignCommitteeCold certificate for a cold credential absent from the committee.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820b8da3d526960cabf0922d2800f4346088b7e6abe38d79783630e8be6a76b73ae00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00989680"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820b8da3d526960cabf0922d2800f4346088b7e6abe38d79783630e8be6a76b73ae000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00958940021a00030d4004d9010281830f8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8f60f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258404b776584f926ef14f4b6d501aebb2a97ecb4cb2b6398581abea9d3fa1e8090e01e62590d24e3fde8dcd7ec5a42a8152caf1701fad33d3406bd88e23c0d7d9c04f5f6",
+  "expected": {
+    "predicate": "CommitteeIsUnknown"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/schema.json
+++ b/crates/amaru-ledger/tests/data/transaction/schema.json
@@ -268,8 +268,16 @@
           "description": "Hex-encoded CBOR of StakeCredential. The cold credential keying the member."
         },
         "status": {
-          "$ref": "#/$defs/HexCbor",
-          "description": "Hex-encoded CBOR of a member's status. The authorized hot credential or resignation, which is the identity a vote carries. Absent for a member that has never authorized one or has resigned."
+          "oneOf": [
+            {
+              "$ref": "#/$defs/HexCbor",
+              "description": "Hex-encoded CBOR of a hot StakeCredential the member has delegated to."
+            },
+            {
+              "type": "string",
+              "enum": ["resigned"]
+            }
+          ]
         },
         "validUntil": {
           "type": "integer",

--- a/crates/amaru/tests/conformance/validation-rules/src/Command/ValidatePhaseOne/Run.hs
+++ b/crates/amaru/tests/conformance/validation-rules/src/Command/ValidatePhaseOne/Run.hs
@@ -479,6 +479,8 @@ normalizeGovCertFailure = \case
         "DRepAlreadyRegistered"
     ConwayCommitteeIsUnknown{} ->
         "CommitteeIsUnknown"
+    ConwayCommitteeHasPreviouslyResigned{} ->
+        "CommitteeHasPreviouslyResigned"
     otherFailure ->
         "unsupported:" <> showText otherFailure
 

--- a/crates/amaru/tests/conformance/validation-rules/src/Data/Fixture/InitialState.hs
+++ b/crates/amaru/tests/conformance/validation-rules/src/Data/Fixture/InitialState.hs
@@ -101,7 +101,7 @@ import Cardano.Ledger.Shelley.LedgerState
     )
 import Cardano.Ledger.State
     ( ChainAccountState (..)
-    , CommitteeAuthorization (CommitteeHotCredential)
+    , CommitteeAuthorization (..)
     , CommitteeState (CommitteeState)
     , DState (..)
     , PState (..)
@@ -109,7 +109,7 @@ import Cardano.Ledger.State
     , spsDepositL
     )
 import Cardano.Ledger.TxIn
-    ( TxId
+    ( TxId (..)
     , TxIn
     )
 import Command.ValidatePhaseOne.Error
@@ -135,7 +135,8 @@ import Data.Default.Class
     ( Default (def)
     )
 import Data.Fixture.Common
-    ( compactCoin
+    ( boundedRatio
+    , compactCoin
     , compactCoinOrError
     , parseCborHex
     , parsePoolId
@@ -415,8 +416,6 @@ buildNewEpochState pparams eraHistory initialState point = do
     accountEntries <- traverse toLedgerAccountEntry accounts
     dRepEntries <- traverse toLedgerDRepEntry dreps
     currentEpoch <- pointEpochNo eraHistory point
-    let proposalStates = map (toGovActionState pparams currentEpoch) proposals
-    seededProposals <- buildProposals proposalsRoots proposalStates
 
     let accountsMap = Map.fromList accountEntries
     let dRepDelegators =
@@ -457,6 +456,19 @@ buildNewEpochState pparams eraHistory initialState point = do
                 [ (poolId, defaultStakePoolState (Coin (poolDepositAmount pparams)))
                 | poolId <- pools
                 ]
+
+    let proposalStates = map (toGovActionState pparams currentEpoch) proposals
+
+    let orphanAuthorizations =
+            ((Map.keysSet committeeAuthorizations) `Set.difference` (Map.keysSet electedCommitteeMembers))
+            <>
+            Set.fromList
+              [ coldCredential
+              | CommitteeMember{ coldCredential, status = Nothing, validUntil = Nothing } <- committee
+              ]
+
+    seededProposals <- buildProposals proposalsRoots proposalStates orphanAuthorizations
+
     let deposited =
             Coin
                 ( sum
@@ -476,6 +488,7 @@ buildNewEpochState pparams eraHistory initialState point = do
                         , let Coin proposalDepositValue = gasDeposit proposalState
                         ]
                 )
+
     let govState =
             emptyGovState
                 & curPParamsGovStateL .~ pparams
@@ -632,9 +645,11 @@ toGovAction = \case
 buildProposals
     :: GovRelation StrictMaybe
     -> [GovActionState ConwayEra]
+    -> Set (Credential ColdCommitteeRole)
     -> Either Error (Proposals ConwayEra)
-buildProposals roots =
-    foldlM addAction (def & pRootsL .~ fromPrevGovActionIds roots)
+buildProposals roots states orphans = do
+    syntheticProposal <- buildOrphanCommitteeProposal roots states orphans
+    foldlM addAction (def & pRootsL .~ fromPrevGovActionIds roots) (states <> maybeToList syntheticProposal)
   where
     addAction acc proposalState =
         maybe (Left (unplaceable proposalState)) Right (proposalsAddAction proposalState acc)
@@ -644,6 +659,73 @@ buildProposals roots =
                 <> showText (gasId proposalState)
                 <> " does not follow an enacted root or an earlier initial proposal"
             )
+
+buildOrphanCommitteeProposal
+    :: GovRelation StrictMaybe
+    -> [GovActionState ConwayEra]
+    -> Set (Credential ColdCommitteeRole)
+    -> Either Error (Maybe (GovActionState ConwayEra))
+buildOrphanCommitteeProposal roots states orphans
+    | Set.null orphans =
+        pure Nothing
+    | otherwise = do
+        committeeThreshold <- first UnsupportedFixture (boundedRatio "synthetic committee threshold" 1)
+        syntheticId <- nextSyntheticGovActionId states
+        pure
+            ( Just
+                GovActionState
+                    { gasId = syntheticId
+                    , gasCommitteeVotes = mempty
+                    , gasDRepVotes = mempty
+                    , gasStakePoolVotes = mempty
+                    , gasProposalProcedure =
+                        templateProposalProcedure
+                            { pProcGovAction =
+                                UpdateCommittee
+                                    (grCommittee roots)
+                                    mempty
+                                    orphanMembers
+                                    committeeThreshold
+                            }
+                    , gasProposedIn = proposedIn
+                    , gasExpiresAfter = expiresAfter
+                    }
+            )
+  where
+    templateProposalProcedure =
+        maybe
+            ProposalProcedure
+                { pProcDeposit = Coin 0
+                , pProcReturnAddr = def
+                , pProcGovAction = InfoAction
+                , pProcAnchor = def
+                }
+            gasProposalProcedure
+            (listToMaybe states)
+
+    proposedIn =
+        maybe (phaseOneEpochNo 0) gasProposedIn (listToMaybe states)
+
+    expiresAfter =
+        maybe (phaseOneEpochNo maxBound) gasExpiresAfter (listToMaybe states)
+
+    orphanMembers =
+        Map.fromSet (const expiresAfter) orphans
+
+nextSyntheticGovActionId :: [GovActionState ConwayEra] -> Either Error GovActionId
+nextSyntheticGovActionId states =
+    maybe
+        (Left (UnsupportedFixture "failed to allocate a synthetic governance action id for orphan committee authorizations"))
+        Right
+        (find (`Set.notMember` usedIdentifiers) candidates)
+  where
+    usedIdentifiers =
+        Set.fromList (map gasId states)
+
+    candidates =
+        [ GovActionId (TxId def) (GovActionIx proposalIndex)
+        | proposalIndex <- [0 .. maxBound]
+        ]
 
 defaultStakePoolState :: Coin -> StakePoolState
 defaultStakePoolState depositCoin =
@@ -666,9 +748,11 @@ toDRepCredential =
 
 parseCommitteeAuthorization :: Value -> Parser CommitteeAuthorization
 parseCommitteeAuthorization =
-    withText "CommitteeAuthorization" $ \hexText ->
-        parseCborHex "CommitteeAuthorization" hexText
-            <|> (CommitteeHotCredential <$> parseCborHex "HotCommitteeCredential" hexText)
+    withText "CommitteeAuthorization" $ \text ->
+        if text == "resigned" then
+            pure (CommitteeMemberResigned empty)
+        else
+            parseCborHex "CommitteeAuthorization" text <|> (CommitteeHotCredential <$> parseCborHex "HotCommitteeCredential" text)
 
 parseProtocolVersion :: Text -> Either Text ProtVer
 parseProtocolVersion versionText =


### PR DESCRIPTION
Closes #920 and #921

This PR introduces the final two predicates (that we have issues for, we have not completed the audit yet). It was mostly tests, but also needed a DB change to handle the proposed committee members for multiple epochs.

It also includes Haskell changes to update the harness. As always, the Haskell changes are claude-ed, and I would love a real Haskeller to review/modify them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented resigned committee members from authorizing hot-key actions or resigning again.
  * Correctly rejected actions for credentials absent from the committee.
  * Improved handling of committee credentials after ratification and during in-flight proposals.
  * Preserved valid authorization, rotation, and resignation scenarios for eligible members.

* **Tests**
  * Added comprehensive validation scenarios covering resigned, unelected, expired, inactive, and credential-less committee members.
  * Updated validation fixtures to recognize resigned committee status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->