### PR TITLE
add pure-stage tracking of external effect time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Other guiding principles:
 
 ## v10.11.20260820 _[unreleased; planned for 2026-08-20]_
 
+### Added
+
+- **amaru-pure-stage**: simulate how long an `ExternalEffect` occupies time (`DurationDist`: zero, constant, uniform, or until the effect future resolves). Sampled durations are scheduled when the effect is issued; `SimulationBuilder::run` now takes a Tokio `Handle` so a still-pending `run()` can be forced at that deadline. ([#1224](https://github.com/pragma-org/amaru/pull/1224))
+
 ### Fixed
 
 - **amaru-tui**: calculate reported block and transaction throughput using the interval between system-metric samples.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/amaru-consensus/src/effects/ledger_effects.rs
+++ b/crates/amaru-consensus/src/effects/ledger_effects.rs
@@ -22,7 +22,7 @@ use amaru_ouroboros_traits::{
     HasStakePools, Nonces, PoolSummaries, TransactionValidationError,
 };
 use amaru_protocols::store_effects::ResourceHeaderStore;
-use amaru_pure_stage::{BoxFuture, Effects, ExternalEffect, ExternalEffectAPI, Resources, SendData, Void};
+use amaru_pure_stage::{BoxFuture, Effects, ExternalEffectAPI, Resources, SendData, Void};
 use anyhow::anyhow;
 use opentelemetry::trace::FutureExt;
 
@@ -134,10 +134,12 @@ impl PartialEq for ValidateTxEffect {
     }
 }
 
-impl ExternalEffect for ValidateTxEffect {
+impl ExternalEffectAPI for ValidateTxEffect {
+    type Response = Result<(), TransactionValidationError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let validator = resources
                 .get::<ResourceTxValidation>()
                 .expect("ValidateTxEffect requires a ResourceTxValidation resource")
@@ -145,10 +147,6 @@ impl ExternalEffect for ValidateTxEffect {
             validator.validate_tx(&self.tx)
         })
     }
-}
-
-impl ExternalEffectAPI for ValidateTxEffect {
-    type Response = Result<(), TransactionValidationError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -168,11 +166,13 @@ impl ValidateBlockEffect {
     }
 }
 
-impl ExternalEffect for ValidateBlockEffect {
+impl ExternalEffectAPI for ValidateBlockEffect {
+    type Response = Result<Result<LedgerMetrics, BlockValidationError>, BlockValidationError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let Self { point, trace_context } = *self;
-        Self::wrap(
+        self.wrap(|this| {
+            let Self { point, trace_context } = this;
             async move {
                 let store = resources
                     .get::<ResourceHeaderStore>()
@@ -190,13 +190,9 @@ impl ExternalEffect for ValidateBlockEffect {
                     .clone();
                 validator.roll_forward_block(block).await
             }
-            .with_context(trace_context.context()),
-        )
+            .with_context(trace_context.context())
+        })
     }
-}
-
-impl ExternalEffectAPI for ValidateBlockEffect {
-    type Response = Result<Result<LedgerMetrics, BlockValidationError>, BlockValidationError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -216,10 +212,12 @@ impl ValidateHeaderEffect {
     }
 }
 
-impl ExternalEffect for ValidateHeaderEffect {
+impl ExternalEffectAPI for ValidateHeaderEffect {
+    type Response = Result<Nonces, ValidateHeaderError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let _guard = self.trace_context.attach();
 
             let consensus_parameters = resources
@@ -250,10 +248,6 @@ impl ExternalEffect for ValidateHeaderEffect {
     }
 }
 
-impl ExternalEffectAPI for ValidateHeaderEffect {
-    type Response = Result<Nonces, ValidateHeaderError>;
-}
-
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SwitchToForkEffect {
     tip: Point,
@@ -271,11 +265,13 @@ impl SwitchToForkEffect {
     }
 }
 
-impl ExternalEffect for SwitchToForkEffect {
+impl ExternalEffectAPI for SwitchToForkEffect {
+    type Response = Result<ForkSwitchOutcome, BlockValidationError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let Self { tip, trace_context } = *self;
-        Self::wrap(
+        self.wrap(|this| {
+            let Self { tip, trace_context } = this;
             async move {
                 let store = resources
                     .get::<ResourceHeaderStore>()
@@ -307,22 +303,20 @@ impl ExternalEffect for SwitchToForkEffect {
 
                 validator.switch_to_fork(&fork_point, &tip)
             }
-            .with_context(trace_context.context()),
-        )
+            .with_context(trace_context.context())
+        })
     }
-}
-
-impl ExternalEffectAPI for SwitchToForkEffect {
-    type Response = Result<ForkSwitchOutcome, BlockValidationError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct TipEffect;
 
-impl ExternalEffect for TipEffect {
+impl ExternalEffectAPI for TipEffect {
+    type Response = Point;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let ledger = resources
                 .get::<ResourceBlockValidation>()
                 .expect("TipEffect requires a ResourceBlockValidation resource")
@@ -332,17 +326,15 @@ impl ExternalEffect for TipEffect {
     }
 }
 
-impl ExternalEffectAPI for TipEffect {
-    type Response = Point;
-}
-
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct VolatileTipEffect;
 
-impl ExternalEffect for VolatileTipEffect {
+impl ExternalEffectAPI for VolatileTipEffect {
+    type Response = Point;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let ledger = resources
                 .get::<ResourceBlockValidation>()
                 .expect("VolatileTipPointEffect requires a ResourceBlockValidation resource")
@@ -352,17 +344,15 @@ impl ExternalEffect for VolatileTipEffect {
     }
 }
 
-impl ExternalEffectAPI for VolatileTipEffect {
-    type Response = Point;
-}
-
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct RegisteredRelaySocketAddrsEffect;
 
-impl ExternalEffect for RegisteredRelaySocketAddrsEffect {
+impl ExternalEffectAPI for RegisteredRelaySocketAddrsEffect {
+    type Response = Result<BTreeSet<SocketAddr>, BlockValidationError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let stake_pools = resources
                 .get::<ResourceHasStakePools>()
                 .expect("RegisteredRelaySocketAddrsEffect requires a ResourceHasStakePools resource")
@@ -370,8 +360,4 @@ impl ExternalEffect for RegisteredRelaySocketAddrsEffect {
             stake_pools.registered_relay_socket_addrs()
         })
     }
-}
-
-impl ExternalEffectAPI for RegisteredRelaySocketAddrsEffect {
-    type Response = Result<BTreeSet<SocketAddr>, BlockValidationError>;
 }

--- a/crates/amaru-consensus/src/effects/random_effects.rs
+++ b/crates/amaru-consensus/src/effects/random_effects.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_pure_stage::{BoxFuture, ExternalEffect, ExternalEffectAPI, Resources, SendData};
+use amaru_pure_stage::{BoxFuture, ExternalEffectAPI, Resources, SendData};
 use rand::Rng;
 
 /// External effect that produces a fresh 256-bit random seed.
@@ -24,12 +24,10 @@ use rand::Rng;
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct GenerateRandomSeed;
 
-impl ExternalEffect for GenerateRandomSeed {
-    fn run(self: Box<Self>, _resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync(rand::rng().random::<[u8; 32]>())
-    }
-}
-
 impl ExternalEffectAPI for GenerateRandomSeed {
     type Response = [u8; 32];
+
+    fn run(self: Box<Self>, _resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        self.wrap_sync(rand::rng().random::<[u8; 32]>())
+    }
 }

--- a/crates/amaru-consensus/src/effects/store_effects.rs
+++ b/crates/amaru-consensus/src/effects/store_effects.rs
@@ -15,25 +15,12 @@
 use amaru_kernel::{HeaderHash, IsHeader, ORIGIN_HASH};
 use amaru_ouroboros::ReadChainStore;
 use amaru_protocols::store_effects::ResourceHeaderStore;
-use amaru_pure_stage::{BoxFuture, ExternalEffect, ExternalEffectAPI, Resources, SendData};
+use amaru_pure_stage::{BoxFuture, ExternalEffectAPI, Resources, SendData};
 
 use crate::{errors::ConsensusError, stages::select_chain::cmp_tip};
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct FindBestCandidate;
-
-impl ExternalEffect for FindBestCandidate {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        #[expect(clippy::expect_used)]
-        Self::wrap_sync_f(|| {
-            let store = resources
-                .get::<ResourceHeaderStore>()
-                .expect("FindBestCandidate requires a ResourceHeaderStore")
-                .clone();
-            find_best_candidate(store.as_ref())
-        })
-    }
-}
 
 pub fn find_best_candidate(store: &dyn ReadChainStore) -> Result<HeaderHash, ConsensusError> {
     let snapshot = store.snapshot();
@@ -74,4 +61,15 @@ pub fn find_best_candidate(store: &dyn ReadChainStore) -> Result<HeaderHash, Con
 
 impl ExternalEffectAPI for FindBestCandidate {
     type Response = Result<HeaderHash, ConsensusError>;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        #[expect(clippy::expect_used)]
+        self.wrap_sync_f(|| {
+            let store = resources
+                .get::<ResourceHeaderStore>()
+                .expect("FindBestCandidate requires a ResourceHeaderStore")
+                .clone();
+            find_best_candidate(store.as_ref())
+        })
+    }
 }

--- a/crates/amaru-consensus/src/performance/effects.rs
+++ b/crates/amaru-consensus/src/performance/effects.rs
@@ -28,7 +28,7 @@ use std::{sync::Arc, time::Duration};
 
 use amaru_kernel::{BlockHeight, HeaderHash, Peer, Point};
 use amaru_protocols::metrics_effects::ResourceMeter;
-use amaru_pure_stage::{BoxFuture, ExternalEffect, ExternalEffectAPI, Instant, Resources, SendData};
+use amaru_pure_stage::{BoxFuture, ExternalEffectAPI, Instant, Resources, SendData};
 use tokio::sync::oneshot;
 
 use super::{
@@ -256,17 +256,15 @@ pub struct RecordIntersectionEffect {
     pub(crate) at: Instant,
 }
 
-impl ExternalEffect for RecordIntersectionEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            enqueue(&perf, PerformanceOp::RecordIntersection { effect: *self });
-        })
-    }
-}
-
 impl ExternalEffectAPI for RecordIntersectionEffect {
     type Response = ();
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        self.wrap_sync({
+            let perf = require_perf(&resources);
+            enqueue(&perf, PerformanceOp::RecordIntersection { effect: self.as_ref().clone() });
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -279,17 +277,15 @@ pub struct RecordHeaderAnnouncementEffect {
     pub(crate) slot_start_to_header_micros: u64,
 }
 
-impl ExternalEffect for RecordHeaderAnnouncementEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            enqueue(&perf, PerformanceOp::RecordHeaderAnnouncement { effect: *self });
-        })
-    }
-}
-
 impl ExternalEffectAPI for RecordHeaderAnnouncementEffect {
     type Response = ();
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        self.wrap_sync({
+            let perf = require_perf(&resources);
+            enqueue(&perf, PerformanceOp::RecordHeaderAnnouncement { effect: self.as_ref().clone() });
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -298,17 +294,15 @@ pub struct RecordBlocksRequestedEffect {
     pub(crate) requested_at: Instant,
 }
 
-impl ExternalEffect for RecordBlocksRequestedEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            enqueue(&perf, PerformanceOp::RecordBlocksRequested { effect: *self });
-        })
-    }
-}
-
 impl ExternalEffectAPI for RecordBlocksRequestedEffect {
     type Response = ();
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        self.wrap_sync({
+            let perf = require_perf(&resources);
+            enqueue(&perf, PerformanceOp::RecordBlocksRequested { effect: self.as_ref().clone() });
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -322,17 +316,15 @@ pub struct RecordBlockDeliveryEffect {
     pub(crate) bytes: u64,
 }
 
-impl ExternalEffect for RecordBlockDeliveryEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            enqueue(&perf, PerformanceOp::RecordBlockDelivery { effect: *self });
-        })
-    }
-}
-
 impl ExternalEffectAPI for RecordBlockDeliveryEffect {
     type Response = ();
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        self.wrap_sync({
+            let perf = require_perf(&resources);
+            enqueue(&perf, PerformanceOp::RecordBlockDelivery { effect: self.as_ref().clone() });
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -341,17 +333,15 @@ pub struct RecordFetchFailureEffect {
     pub(crate) at: Instant,
 }
 
-impl ExternalEffect for RecordFetchFailureEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            enqueue(&perf, PerformanceOp::RecordFetchFailure { effect: *self });
-        })
-    }
-}
-
 impl ExternalEffectAPI for RecordFetchFailureEffect {
     type Response = ();
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        self.wrap_sync({
+            let perf = require_perf(&resources);
+            enqueue(&perf, PerformanceOp::RecordFetchFailure { effect: self.as_ref().clone() });
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -361,17 +351,15 @@ pub struct RecordKeepaliveRttEffect {
     pub(crate) at: Instant,
 }
 
-impl ExternalEffect for RecordKeepaliveRttEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            enqueue(&perf, PerformanceOp::RecordKeepaliveRtt { effect: *self });
-        })
-    }
-}
-
 impl ExternalEffectAPI for RecordKeepaliveRttEffect {
     type Response = ();
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        self.wrap_sync({
+            let perf = require_perf(&resources);
+            enqueue(&perf, PerformanceOp::RecordKeepaliveRtt { effect: self.as_ref().clone() });
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -381,17 +369,15 @@ pub struct RecordAdvertisabilityEffect {
     pub(crate) at: Instant,
 }
 
-impl ExternalEffect for RecordAdvertisabilityEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            enqueue(&perf, PerformanceOp::RecordAdvertisability { effect: *self });
-        })
-    }
-}
-
 impl ExternalEffectAPI for RecordAdvertisabilityEffect {
     type Response = ();
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        self.wrap_sync({
+            let perf = require_perf(&resources);
+            enqueue(&perf, PerformanceOp::RecordAdvertisability { effect: self.as_ref().clone() });
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -400,17 +386,15 @@ pub struct RecordConnectionFailureEffect {
     pub(crate) at: Instant,
 }
 
-impl ExternalEffect for RecordConnectionFailureEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            enqueue(&perf, PerformanceOp::RecordConnectionFailure { effect: *self });
-        })
-    }
-}
-
 impl ExternalEffectAPI for RecordConnectionFailureEffect {
     type Response = ();
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        self.wrap_sync({
+            let perf = require_perf(&resources);
+            enqueue(&perf, PerformanceOp::RecordConnectionFailure { effect: self.as_ref().clone() });
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -418,17 +402,15 @@ pub struct ClearPeerAvailabilityEffect {
     pub(crate) peer: Peer,
 }
 
-impl ExternalEffect for ClearPeerAvailabilityEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            enqueue(&perf, PerformanceOp::ClearPeerAvailability { effect: *self });
-        })
-    }
-}
-
 impl ExternalEffectAPI for ClearPeerAvailabilityEffect {
     type Response = ();
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        self.wrap_sync({
+            let perf = require_perf(&resources);
+            enqueue(&perf, PerformanceOp::ClearPeerAvailability { effect: self.as_ref().clone() });
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -437,17 +419,15 @@ pub struct PeerAdversarialEffect {
     pub(crate) at: Instant,
 }
 
-impl ExternalEffect for PeerAdversarialEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            enqueue(&perf, PerformanceOp::PeerAdversarial { effect: *self });
-        })
-    }
-}
-
 impl ExternalEffectAPI for PeerAdversarialEffect {
     type Response = ();
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        self.wrap_sync({
+            let perf = require_perf(&resources);
+            enqueue(&perf, PerformanceOp::PeerAdversarial { effect: self.as_ref().clone() });
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -456,18 +436,16 @@ pub struct PruneBelowEffect {
     pub(crate) now: Instant,
 }
 
-impl ExternalEffect for PruneBelowEffect {
+impl ExternalEffectAPI for PruneBelowEffect {
+    type Response = ();
+
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
         let perf = require_perf(&resources);
         let meter = optional_meter(&resources);
-        Self::wrap(async move {
-            enqueue_and_emit_telemetry(&perf, meter, |reply| PerformanceOp::PruneBelow { effect: *self, reply }).await
+        self.wrap(|this| async move {
+            enqueue_and_emit_telemetry(&perf, meter, |reply| PerformanceOp::PruneBelow { effect: this, reply }).await
         })
     }
-}
-
-impl ExternalEffectAPI for PruneBelowEffect {
-    type Response = ();
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -475,17 +453,15 @@ pub struct SelectPeersForFetchEffect {
     pub(crate) params: SelectPeersParams,
 }
 
-impl ExternalEffect for SelectPeersForFetchEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let perf = require_perf(&resources);
-        Self::wrap(async move {
-            enqueue_query(&perf, |reply| PerformanceOp::SelectPeersForFetch { effect: *self, reply }).await
-        })
-    }
-}
-
 impl ExternalEffectAPI for SelectPeersForFetchEffect {
     type Response = FetchPeerSet;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        self.wrap(|this| async move {
+            enqueue_query(&perf, |reply| PerformanceOp::SelectPeersForFetch { effect: this, reply }).await
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -494,17 +470,15 @@ pub struct PeerCoversFragmentEffect {
     pub(crate) need: Vec<HeaderHash>,
 }
 
-impl ExternalEffect for PeerCoversFragmentEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let perf = require_perf(&resources);
-        Self::wrap(async move {
-            enqueue_query(&perf, |reply| PerformanceOp::PeerCoversFragment { effect: *self, reply }).await
-        })
-    }
-}
-
 impl ExternalEffectAPI for PeerCoversFragmentEffect {
     type Response = bool;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        self.wrap(|this| async move {
+            enqueue_query(&perf, |reply| PerformanceOp::PeerCoversFragment { effect: this, reply }).await
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -512,17 +486,15 @@ pub struct DirectClaimantsEffect {
     pub(crate) hash: HeaderHash,
 }
 
-impl ExternalEffect for DirectClaimantsEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let perf = require_perf(&resources);
-        Self::wrap(async move {
-            enqueue_query(&perf, |reply| PerformanceOp::DirectClaimants { effect: *self, reply }).await
-        })
-    }
-}
-
 impl ExternalEffectAPI for DirectClaimantsEffect {
     type Response = Vec<(Peer, Instant, ClaimKind)>;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        self.wrap(|this| async move {
+            enqueue_query(&perf, |reply| PerformanceOp::DirectClaimants { effect: this, reply }).await
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -530,17 +502,15 @@ pub struct FirstAnnouncedAtEffect {
     pub(crate) hash: HeaderHash,
 }
 
-impl ExternalEffect for FirstAnnouncedAtEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let perf = require_perf(&resources);
-        Self::wrap(async move {
-            enqueue_query(&perf, |reply| PerformanceOp::FirstAnnouncedAt { effect: *self, reply }).await
-        })
-    }
-}
-
 impl ExternalEffectAPI for FirstAnnouncedAtEffect {
     type Response = Option<(Peer, Instant)>;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        self.wrap(|this| async move {
+            enqueue_query(&perf, |reply| PerformanceOp::FirstAnnouncedAt { effect: this, reply }).await
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -549,17 +519,15 @@ pub struct RankPeersForChurnEffect {
     pub(crate) now: Instant,
 }
 
-impl ExternalEffect for RankPeersForChurnEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let perf = require_perf(&resources);
-        Self::wrap(async move {
-            enqueue_query(&perf, |reply| PerformanceOp::RankPeersForChurn { effect: *self, reply }).await
-        })
-    }
-}
-
 impl ExternalEffectAPI for RankPeersForChurnEffect {
     type Response = Vec<(Peer, PeerScores)>;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        self.wrap(|this| async move {
+            enqueue_query(&perf, |reply| PerformanceOp::RankPeersForChurn { effect: this, reply }).await
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -567,15 +535,15 @@ pub struct ScoresEffect {
     pub(crate) peer: Peer,
 }
 
-impl ExternalEffect for ScoresEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let perf = require_perf(&resources);
-        Self::wrap(async move { enqueue_query(&perf, |reply| PerformanceOp::Scores { effect: *self, reply }).await })
-    }
-}
-
 impl ExternalEffectAPI for ScoresEffect {
     type Response = PeerScores;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        self.wrap(
+            |this| async move { enqueue_query(&perf, |reply| PerformanceOp::Scores { effect: this, reply }).await },
+        )
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -583,17 +551,15 @@ pub struct ShareFlagsEffect {
     pub(crate) peer: Peer,
 }
 
-impl ExternalEffect for ShareFlagsEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let perf = require_perf(&resources);
-        Self::wrap(
-            async move { enqueue_query(&perf, |reply| PerformanceOp::ShareFlags { effect: *self, reply }).await },
-        )
-    }
-}
-
 impl ExternalEffectAPI for ShareFlagsEffect {
     type Response = Option<PeerShareFlags>;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        self.wrap(|this| async move {
+            enqueue_query(&perf, |reply| PerformanceOp::ShareFlags { effect: this, reply }).await
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -601,15 +567,15 @@ pub struct SnapshotEffect {
     pub(crate) peer: Peer,
 }
 
-impl ExternalEffect for SnapshotEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let perf = require_perf(&resources);
-        Self::wrap(async move { enqueue_query(&perf, |reply| PerformanceOp::Snapshot { effect: *self, reply }).await })
-    }
-}
-
 impl ExternalEffectAPI for SnapshotEffect {
     type Response = Option<PeerSnapshot>;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        self.wrap(
+            |this| async move { enqueue_query(&perf, |reply| PerformanceOp::Snapshot { effect: this, reply }).await },
+        )
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -618,17 +584,15 @@ pub struct OkForSharingEffect {
     pub(crate) now: Instant,
 }
 
-impl ExternalEffect for OkForSharingEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let perf = require_perf(&resources);
-        Self::wrap(
-            async move { enqueue_query(&perf, |reply| PerformanceOp::OkForSharing { effect: *self, reply }).await },
-        )
-    }
-}
-
 impl ExternalEffectAPI for OkForSharingEffect {
     type Response = bool;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        self.wrap(|this| async move {
+            enqueue_query(&perf, |reply| PerformanceOp::OkForSharing { effect: this, reply }).await
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -636,17 +600,15 @@ pub struct SetLedgerCandidatesEffect {
     pub(crate) candidates: std::collections::BTreeSet<Peer>,
 }
 
-impl ExternalEffect for SetLedgerCandidatesEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            enqueue(&perf, PerformanceOp::SetLedgerCandidates { effect: *self });
-        })
-    }
-}
-
 impl ExternalEffectAPI for SetLedgerCandidatesEffect {
     type Response = ();
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        self.wrap_sync({
+            let perf = require_perf(&resources);
+            enqueue(&perf, PerformanceOp::SetLedgerCandidates { effect: self.as_ref().clone() });
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -655,17 +617,15 @@ pub struct IngestSharedPeersEffect {
     pub(crate) peers: Vec<std::net::SocketAddr>,
 }
 
-impl ExternalEffect for IngestSharedPeersEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let perf = require_perf(&resources);
-        Self::wrap(async move {
-            enqueue_query(&perf, |reply| PerformanceOp::IngestSharedPeers { effect: *self, reply }).await
-        })
-    }
-}
-
 impl ExternalEffectAPI for IngestSharedPeersEffect {
     type Response = SharedIngestResult;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        self.wrap(|this| async move {
+            enqueue_query(&perf, |reply| PerformanceOp::IngestSharedPeers { effect: this, reply }).await
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -673,17 +633,15 @@ pub struct SelectOutboundEffect {
     pub(crate) params: SelectOutboundParams,
 }
 
-impl ExternalEffect for SelectOutboundEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let perf = require_perf(&resources);
-        Self::wrap(
-            async move { enqueue_query(&perf, |reply| PerformanceOp::SelectOutbound { effect: *self, reply }).await },
-        )
-    }
-}
-
 impl ExternalEffectAPI for SelectOutboundEffect {
     type Response = Vec<Peer>;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        self.wrap(|this| async move {
+            enqueue_query(&perf, |reply| PerformanceOp::SelectOutbound { effect: this, reply }).await
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -693,17 +651,15 @@ pub struct SelectSharePeersEffect {
     pub(crate) now: Instant,
 }
 
-impl ExternalEffect for SelectSharePeersEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let perf = require_perf(&resources);
-        Self::wrap(async move {
-            enqueue_query(&perf, |reply| PerformanceOp::SelectSharePeers { effect: *self, reply }).await
-        })
-    }
-}
-
 impl ExternalEffectAPI for SelectSharePeersEffect {
     type Response = Vec<std::net::SocketAddr>;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        self.wrap(|this| async move {
+            enqueue_query(&perf, |reply| PerformanceOp::SelectSharePeers { effect: this, reply }).await
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -711,33 +667,29 @@ pub struct IsStaticPeerEffect {
     pub(crate) peer: Peer,
 }
 
-impl ExternalEffect for IsStaticPeerEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let perf = require_perf(&resources);
-        Self::wrap(
-            async move { enqueue_query(&perf, |reply| PerformanceOp::IsStaticPeer { effect: *self, reply }).await },
-        )
-    }
-}
-
 impl ExternalEffectAPI for IsStaticPeerEffect {
     type Response = bool;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        self.wrap(|this| async move {
+            enqueue_query(&perf, |reply| PerformanceOp::IsStaticPeer { effect: this, reply }).await
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct StaticPeersEffect;
 
-impl ExternalEffect for StaticPeersEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let perf = require_perf(&resources);
-        Self::wrap(
-            async move { enqueue_query(&perf, |reply| PerformanceOp::StaticPeers { effect: *self, reply }).await },
-        )
-    }
-}
-
 impl ExternalEffectAPI for StaticPeersEffect {
     type Response = std::collections::BTreeSet<Peer>;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        self.wrap(|this| async move {
+            enqueue_query(&perf, |reply| PerformanceOp::StaticPeers { effect: this, reply }).await
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -745,33 +697,29 @@ pub struct SharedContainsEffect {
     pub(crate) peer: Peer,
 }
 
-impl ExternalEffect for SharedContainsEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let perf = require_perf(&resources);
-        Self::wrap(
-            async move { enqueue_query(&perf, |reply| PerformanceOp::SharedContains { effect: *self, reply }).await },
-        )
-    }
-}
-
 impl ExternalEffectAPI for SharedContainsEffect {
     type Response = bool;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        self.wrap(|this| async move {
+            enqueue_query(&perf, |reply| PerformanceOp::SharedContains { effect: this, reply }).await
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SourceCountsEffect;
 
-impl ExternalEffect for SourceCountsEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        let perf = require_perf(&resources);
-        Self::wrap(
-            async move { enqueue_query(&perf, |reply| PerformanceOp::SourceCounts { effect: *self, reply }).await },
-        )
-    }
-}
-
 impl ExternalEffectAPI for SourceCountsEffect {
     type Response = crate::performance::SourceCounts;
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        let perf = require_perf(&resources);
+        self.wrap(|this| async move {
+            enqueue_query(&perf, |reply| PerformanceOp::SourceCounts { effect: this, reply }).await
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -782,17 +730,15 @@ pub struct RecordRollbackEffect {
     pub(crate) at: Instant,
 }
 
-impl ExternalEffect for RecordRollbackEffect {
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let perf = require_perf(&resources);
-            enqueue(&perf, PerformanceOp::RecordRollback { effect: *self });
-        })
-    }
-}
-
 impl ExternalEffectAPI for RecordRollbackEffect {
     type Response = ();
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        self.wrap_sync({
+            let perf = require_perf(&resources);
+            enqueue(&perf, PerformanceOp::RecordRollback { effect: self.as_ref().clone() });
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -800,18 +746,16 @@ pub struct RecordHeaderRejectedEffect {
     pub(crate) outcome: HeaderLifecycleOutcome,
 }
 
-impl ExternalEffect for RecordHeaderRejectedEffect {
+impl ExternalEffectAPI for RecordHeaderRejectedEffect {
+    type Response = ();
+
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             // NOTE: No worker state; emit directly on the effect path (never on the performance thread).
             let meter = optional_meter(&resources);
             HeaderPerformance::apply_header_rejected(self.outcome).emit(meter.as_deref());
         })
     }
-}
-
-impl ExternalEffectAPI for RecordHeaderRejectedEffect {
-    type Response = ();
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -820,22 +764,20 @@ pub struct RecordHeaderAbandonedEffect {
     pub(crate) now: Instant,
 }
 
-impl ExternalEffect for RecordHeaderAbandonedEffect {
+impl ExternalEffectAPI for RecordHeaderAbandonedEffect {
+    type Response = ();
+
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
         let perf = require_perf(&resources);
         let meter = optional_meter(&resources);
-        Self::wrap(async move {
+        self.wrap(|this| async move {
             enqueue_and_emit_telemetry(&perf, meter, |reply| PerformanceOp::RecordHeaderAbandoned {
-                effect: *self,
+                effect: this,
                 reply,
             })
             .await
         })
     }
-}
-
-impl ExternalEffectAPI for RecordHeaderAbandonedEffect {
-    type Response = ();
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -844,19 +786,17 @@ pub struct RecordForkStartedEffect {
     pub(crate) started_at: Instant,
 }
 
-impl ExternalEffect for RecordForkStartedEffect {
+impl ExternalEffectAPI for RecordForkStartedEffect {
+    type Response = ();
+
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
         let perf = require_perf(&resources);
         let meter = optional_meter(&resources);
-        Self::wrap(async move {
-            enqueue_and_emit_telemetry(&perf, meter, |reply| PerformanceOp::RecordForkStarted { effect: *self, reply })
+        self.wrap(|this| async move {
+            enqueue_and_emit_telemetry(&perf, meter, |reply| PerformanceOp::RecordForkStarted { effect: this, reply })
                 .await
         })
     }
-}
-
-impl ExternalEffectAPI for RecordForkStartedEffect {
-    type Response = ();
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -867,19 +807,17 @@ pub struct RecordBlockValidEffect {
     pub(crate) syncing: bool,
 }
 
-impl ExternalEffect for RecordBlockValidEffect {
+impl ExternalEffectAPI for RecordBlockValidEffect {
+    type Response = ();
+
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
         let perf = require_perf(&resources);
         let meter = optional_meter(&resources);
-        Self::wrap(async move {
-            enqueue_and_emit_telemetry(&perf, meter, |reply| PerformanceOp::RecordBlockValid { effect: *self, reply })
+        self.wrap(|this| async move {
+            enqueue_and_emit_telemetry(&perf, meter, |reply| PerformanceOp::RecordBlockValid { effect: this, reply })
                 .await
         })
     }
-}
-
-impl ExternalEffectAPI for RecordBlockValidEffect {
-    type Response = ();
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -891,17 +829,15 @@ pub struct RecordBlockPrunedEffect {
     pub(crate) syncing: bool,
 }
 
-impl ExternalEffect for RecordBlockPrunedEffect {
+impl ExternalEffectAPI for RecordBlockPrunedEffect {
+    type Response = ();
+
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
         let perf = require_perf(&resources);
         let meter = optional_meter(&resources);
-        Self::wrap(async move {
-            enqueue_and_emit_telemetry(&perf, meter, |reply| PerformanceOp::RecordBlockPruned { effect: *self, reply })
+        self.wrap(|this| async move {
+            enqueue_and_emit_telemetry(&perf, meter, |reply| PerformanceOp::RecordBlockPruned { effect: this, reply })
                 .await
         })
     }
-}
-
-impl ExternalEffectAPI for RecordBlockPrunedEffect {
-    type Response = ();
 }

--- a/crates/amaru-consensus/src/stages/adopt_chain/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/adopt_chain/test_setup.rs
@@ -32,7 +32,7 @@ use amaru_pure_stage::{
     simulation::{SimulationBuilder, SimulationRunning},
     trace_buffer::{TraceBuffer, TraceEntry},
 };
-use tokio::runtime::{Builder, Runtime};
+use tokio::runtime::Runtime;
 use tracing::Level;
 use tracing_subscriber::util::SubscriberInitExt;
 
@@ -160,7 +160,7 @@ pub fn test_prep(consensus_security_param: u64) -> TestPrep {
     let state = AdoptChain::new(downstream, block_source, mempool, consensus_security_param, Point::Origin);
     TestPrep {
         state,
-        rt: Builder::new_current_thread().build().unwrap(),
+        rt: crate::stages::test_utils::test_runtime(),
         headers,
         store: Arc::new(InMemoryChainStore::new()),
     }

--- a/crates/amaru-consensus/src/stages/adopt_chain/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/adopt_chain/test_setup.rs
@@ -190,8 +190,8 @@ pub fn setup(prep: &TestPrep, msg: AdoptChainMsg) -> (SimulationRunning, Deseria
     let ac = network.wire_up(ac, prep.state.clone());
     network.preload(&ac, [msg]).unwrap();
 
-    let mut running = network.run();
-    running.run_until_blocked_incl_effects(prep.rt.handle());
+    let mut running = network.run(prep.rt.handle());
+    running.run_until_blocked_incl_effects();
 
     (running, guards, logs.logs())
 }

--- a/crates/amaru-consensus/src/stages/block_source/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/block_source/test_setup.rs
@@ -71,8 +71,8 @@ pub fn setup(prep: &TestPrep, msgs: &[BlockSourceMsg]) -> (SimulationRunning, De
     let bs = network.wire_up(bs, prep.state.clone());
     network.preload(&bs, msgs.iter().cloned()).expect("preload");
 
-    let mut running = network.run();
-    running.run_until_blocked_incl_effects(prep.rt.handle());
+    let mut running = network.run(prep.rt.handle());
+    running.run_until_blocked_incl_effects();
 
     (running, guards, logs.logs())
 }

--- a/crates/amaru-consensus/src/stages/block_source/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/block_source/test_setup.rs
@@ -18,7 +18,7 @@ use amaru_pure_stage::{
     simulation::{SimulationBuilder, SimulationRunning},
     trace_buffer::{TraceBuffer, TraceEntry},
 };
-use tokio::runtime::{Builder, Runtime};
+use tokio::runtime::Runtime;
 use tracing::Level;
 use tracing_subscriber::util::SubscriberInitExt;
 
@@ -36,7 +36,7 @@ pub struct TestPrep {
 pub fn test_prep(adopted_tip: Point, max_tip_distance: u64) -> TestPrep {
     let invalid_sink = StageRef::named_for_tests("invalid_sink");
     let state = BlockSource::new(adopted_tip, max_tip_distance, invalid_sink);
-    TestPrep { state, rt: Builder::new_current_thread().build().unwrap() }
+    TestPrep { state, rt: crate::stages::test_utils::test_runtime() }
 }
 
 pub fn register_guards() -> DeserializerGuards {

--- a/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/test_setup.rs
@@ -30,7 +30,7 @@ use amaru_pure_stage::{
     DeserializerGuards, Effect, Instant, Name, ScheduleId, ScheduleIds, StageGraph, StageRef,
     simulation::SimulationRunning, trace_buffer::TraceEntry,
 };
-use tokio::runtime::{Builder, Runtime};
+use tokio::runtime::Runtime;
 
 use super::*;
 use crate::stages::{
@@ -167,7 +167,7 @@ pub fn test_prep() -> TestPrep {
 
     TestPrep {
         state,
-        rt: Builder::new_current_thread().build().unwrap(),
+        rt: crate::stages::test_utils::test_runtime(),
         cleanup_replies,
         headers: HeaderChain::new(),
         store: Arc::new(InMemoryChainStore::new()),

--- a/crates/amaru-consensus/src/stages/mempool/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/mempool/test_setup.rs
@@ -90,8 +90,8 @@ pub fn setup(prep: &TestPrep) -> (SimulationRunning, DeserializerGuards, Logs) {
     let mempool = network.wire_up(mempool, MempoolStageState::default());
     network.preload(&mempool, [prep.msg.clone()]).unwrap();
 
-    let mut running = network.run();
-    running.run_until_blocked_incl_effects(prep.rt.handle());
+    let mut running = network.run(prep.rt.handle());
+    running.run_until_blocked_incl_effects();
 
     (running, guards, logs.logs())
 }

--- a/crates/amaru-consensus/src/stages/mempool/tests.rs
+++ b/crates/amaru-consensus/src/stages/mempool/tests.rs
@@ -22,7 +22,6 @@ use amaru_ouroboros::{
 };
 use amaru_ouroboros_traits::TxSubmissionMempool;
 use amaru_pure_stage::StageRef;
-use tokio::runtime::Builder;
 use tracing::Level;
 
 use crate::stages::{
@@ -87,7 +86,7 @@ fn new_tip_invalidates_transactions_against_current_ledger_state() {
     mempool.insert(tx_2.clone(), TxOrigin::Local);
     let prep = TestPrep {
         msg: MempoolMsg::NewTip(amaru_kernel::Point::Origin),
-        rt: Builder::new_current_thread().build().unwrap(),
+        rt: crate::stages::test_utils::test_runtime(),
         mempool: mempool.clone(),
         validator: Arc::new(reject_tx_1),
     };
@@ -107,7 +106,7 @@ pub fn make_insert_batch_example() -> TestPrep {
 
     TestPrep {
         msg: MempoolMsg::InsertBatch { txs, origin: TxOrigin::Local, caller },
-        rt: Builder::new_current_thread().build().unwrap(),
+        rt: crate::stages::test_utils::test_runtime(),
         mempool: Arc::new(InMemoryMempool::<Transaction>::default()),
         validator: Arc::new(reject_tx_1),
     }

--- a/crates/amaru-consensus/src/stages/peer_selection/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/test_setup.rs
@@ -21,7 +21,7 @@ use amaru_pure_stage::{
     simulation::{SimulationRunning, running::OverrideResult},
     trace_buffer::TraceEntry,
 };
-use tokio::runtime::{Builder, Runtime};
+use tokio::runtime::Runtime;
 
 use super::*;
 pub use crate::stages::test_utils::TraceMatch;
@@ -132,7 +132,7 @@ pub fn test_prep_with_snapshot(static_names: &[&str], snapshot_names: &[&str]) -
     let state = PeerSelection::new(manager, 3, 10, COOLDOWN_SECS);
     TestPrep {
         state,
-        rt: Builder::new_current_thread().build().unwrap(),
+        rt: crate::stages::test_utils::test_runtime(),
         static_peers,
         snapshot_candidates,
         ledger_candidates: BTreeSet::new(),

--- a/crates/amaru-consensus/src/stages/peer_selection/tests.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/tests.rs
@@ -665,7 +665,7 @@ fn test_reban_later_deadline_survives_early_timer() {
     assert_eq!(running.now(), intermediate);
 
     running.enqueue_msg(peer_selection_stage(), [PeerSelectionMsg::adversarial(p.clone())]);
-    running.run_until_blocked_incl_effects(prep.rt.handle());
+    running.run_until_blocked_incl_effects();
 
     assert_trace_contains(
         &running,

--- a/crates/amaru-consensus/src/stages/select_chain/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/test_setup.rs
@@ -24,7 +24,7 @@ use amaru_protocols::store_effects::{
 use amaru_pure_stage::{
     DeserializerGuards, Effect, StageGraph, StageRef, simulation::SimulationRunning, trace_buffer::TraceEntry,
 };
-use tokio::runtime::{Builder, Runtime};
+use tokio::runtime::Runtime;
 
 use super::*;
 use crate::stages::test_utils::{Logs, run_simulation};
@@ -144,7 +144,7 @@ pub fn test_prep() -> TestPrep {
     state.may_fetch_blocks = true;
     TestPrep {
         state,
-        rt: Builder::new_current_thread().build().unwrap(),
+        rt: crate::stages::test_utils::test_runtime(),
         downstream,
         headers: HeaderTree::new(),
         store: Arc::new(InMemoryChainStore::new()),

--- a/crates/amaru-consensus/src/stages/test_utils.rs
+++ b/crates/amaru-consensus/src/stages/test_utils.rs
@@ -23,7 +23,12 @@ use amaru_pure_stage::{
     trace_buffer::{TraceBuffer, TraceEntry},
 };
 use parking_lot::Mutex;
-use tokio::runtime::Handle;
+use tokio::runtime::{Builder, Handle, Runtime};
+
+/// Current-thread runtime with IO and time, required to force pending external effects.
+pub fn test_runtime() -> Runtime {
+    Builder::new_current_thread().enable_all().build().expect("current-thread tokio runtime")
+}
 use tracing::{Level, subscriber::DefaultGuard};
 use tracing_subscriber::util::SubscriberInitExt;
 

--- a/crates/amaru-consensus/src/stages/test_utils.rs
+++ b/crates/amaru-consensus/src/stages/test_utils.rs
@@ -297,13 +297,13 @@ where
 
     let network = build_network(network);
 
-    let mut running = network.run();
+    let mut running = network.run(rt);
     running.use_virtual_child_stages(true);
     setup_overrides(&mut running);
 
     match mode {
         SimulationRunMode::UntilBlocked => {
-            running.run_until_blocked_incl_effects(rt);
+            running.run_until_blocked_incl_effects();
         }
         SimulationRunMode::UntilSleeping => {
             while let amaru_pure_stage::simulation::Blocked::Busy { .. } = running.run_until_sleeping_or_blocked() {

--- a/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/test_setup.rs
@@ -36,7 +36,7 @@ use amaru_pure_stage::{
     simulation::{SimulationRunning, running::OverrideResult},
     trace_buffer::TraceEntry,
 };
-use tokio::runtime::{Builder, Handle, Runtime};
+use tokio::runtime::{Handle, Runtime};
 
 use super::{NewTip, TrackPeers, TrackPeersMsg, stage};
 use crate::{
@@ -142,7 +142,7 @@ pub fn test_prep_with_max_peer_lead(max_peer_lead: u64) -> TestPrep {
         max_peer_lead,
         start_times.epoch.checked_sub(Epoch::TWO).unwrap(),
     );
-    let rt = Builder::new_current_thread().build().unwrap();
+    let rt = crate::stages::test_utils::test_runtime();
     let handler = StageRef::<InitiatorMessage>::named_for_tests("handler");
     let conn_id = ConnectionId::initial();
     let h1 = make_block_header(1, 1, None);

--- a/crates/amaru-consensus/src/stages/validate_block/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/validate_block/test_setup.rs
@@ -29,7 +29,7 @@ use amaru_pure_stage::{
     DeserializerGuards, Effect, Name, StageGraph, StageRef, TerminationReason, simulation::SimulationRunning,
     trace_buffer::TraceEntry,
 };
-use tokio::runtime::{Builder, Runtime};
+use tokio::runtime::Runtime;
 
 use super::*;
 pub use crate::stages::test_utils::assert_trace;
@@ -166,7 +166,7 @@ pub fn test_prep() -> TestPrep {
 
     TestPrep {
         state,
-        rt: Builder::new_current_thread().build().unwrap(),
+        rt: crate::stages::test_utils::test_runtime(),
         headers: HeaderTree::new(),
         store: Arc::new(InMemoryChainStore::new()),
         block_validator,

--- a/crates/amaru-node/src/tests/setup.rs
+++ b/crates/amaru-node/src/tests/setup.rs
@@ -49,7 +49,11 @@ use crate::{
 /// Create simulated nodes based on a list of configurations.
 /// The random generator is used to generate the test data that is injected into upstream nodes.
 ///
-pub fn create_nodes(rng: &mut RandStdRng, configs: Vec<NodeTestConfig>) -> anyhow::Result<Nodes> {
+pub fn create_nodes(
+    rng: &mut RandStdRng,
+    configs: Vec<NodeTestConfig>,
+    tokio_handle: &tokio::runtime::Handle,
+) -> anyhow::Result<Nodes> {
     let connections: ConnectionsResource = Arc::new(InMemoryConnectionProvider::default());
     let mut nodes = vec![];
 
@@ -65,7 +69,7 @@ pub fn create_nodes(rng: &mut RandStdRng, configs: Vec<NodeTestConfig>) -> anyho
         let config = config.with_connections(connections.clone());
         let test_node_stages = create_node(&config, &mut stage_graph)?;
 
-        let mut running = stage_graph.run();
+        let mut running = stage_graph.run(tokio_handle);
         // Don't validate the generated headers, we just want to check the mini-protocols communication.
         running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| {
             OverrideResult::handled(Ok(Nonces::for_tests()))

--- a/crates/amaru-node/src/tests/test_cases.rs
+++ b/crates/amaru-node/src/tests/test_cases.rs
@@ -33,12 +33,14 @@ fn test_connect_nodes_in_memory() -> anyhow::Result<()> {
     let root_point = NetworkPoint::Specific(conway_start_slot, Hash::new([0u8; 32]));
     let headers = run_strategy(any_headers_chain_with_root(5, root_point.with_height(BlockHeight::from(0))));
     let mut rng = RandStdRng::from_seed(42);
+    let rt = tokio::runtime::Runtime::new()?;
     let mut nodes = create_nodes(
         &mut rng,
         vec![
             NodeTestConfig::initiator().with_chain_length(5).with_validated_blocks(vec![headers[0].clone()]),
             NodeTestConfig::responder().with_chain_length(5).with_validated_blocks(headers),
         ],
+        rt.handle(),
     )?;
     nodes.run(&mut rng);
 

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -464,6 +464,7 @@ pub fn register_deserializers() -> DeserializerGuards {
 mod tests {
     use amaru_kernel::PREPROD_ERA_HISTORY;
     use amaru_pure_stage::{Effect, StageGraph, simulation::SimulationBuilder};
+    use tokio::runtime::Runtime;
 
     use super::*;
 
@@ -514,7 +515,8 @@ mod tests {
         let msg = make_msg(&mut network);
         network.preload(&connection_stage, [msg]).unwrap();
 
-        let mut running = network.run();
+        let rt = Runtime::new().unwrap();
+        let mut running = network.run(rt.handle());
         let start_time = running.now();
 
         let stage_name = connection_stage.name().clone();

--- a/crates/amaru-protocols/src/handshake/tests.rs
+++ b/crates/amaru-protocols/src/handshake/tests.rs
@@ -87,12 +87,12 @@ fn test_against_node() {
         )
         .unwrap();
 
-    let mut running = network.run();
+    let mut running = network.run(rt.handle());
 
     running
         .breakpoint("output", move |eff| matches!(eff, Effect::External { at_stage, .. } if at_stage == output.name()));
 
-    let output = running.run_until_blocked_incl_effects(rt.handle()).assert_breakpoint("output");
+    let output = running.run_until_blocked_incl_effects().assert_breakpoint("output");
     running.handle_effect(output);
     rt.block_on(running.await_external_effect()).unwrap();
     let result = rx.try_next().unwrap();

--- a/crates/amaru-protocols/src/manager/connector.rs
+++ b/crates/amaru-protocols/src/manager/connector.rs
@@ -150,7 +150,8 @@ mod tests {
     fn runs_connects_in_parallel_up_to_pool_limit() {
         let timeout = Duration::from_secs(10);
         let (network, connector, _rx) = setup_connector(timeout);
-        let mut running = network.run();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut running = network.run(rt.handle());
 
         running.breakpoint(
             "connect",
@@ -199,7 +200,8 @@ mod tests {
     fn delay_does_not_occupy_a_worker() {
         let timeout = Duration::from_secs(10);
         let (network, connector, _rx) = setup_connector(timeout);
-        let mut running = network.run();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut running = network.run(rt.handle());
 
         running.breakpoint(
             "connect",
@@ -229,15 +231,15 @@ mod tests {
     fn forwards_connection_result_to_manager() {
         let timeout = Duration::from_secs(10);
         let (network, connector, mut rx) = setup_connector(timeout);
-        let mut running = network.run();
         let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut running = network.run(rt.handle());
 
         let conn_id = ConnectionId::initial();
         running.override_external_effect::<ConnectEffect>(usize::MAX, move |_| OverrideResult::handled(Ok(conn_id)));
 
         let peer = Peer::new("127.0.0.1:4000");
         running.enqueue_msg(&connector, [ConnectorMsg::Connect { peer: peer.clone(), delay: Duration::ZERO }]);
-        running.run_until_blocked_incl_effects(rt.handle()).assert_idle();
+        running.run_until_blocked_incl_effects().assert_idle();
 
         let msgs: Vec<_> = rx.drain().collect();
         assert_eq!(msgs, vec![ManagerMessage::ConnectionResult(peer, Ok(conn_id))]);

--- a/crates/amaru-protocols/src/mempool_effects.rs
+++ b/crates/amaru-protocols/src/mempool_effects.rs
@@ -17,7 +17,7 @@ use std::fmt::Debug;
 use amaru_kernel::{Transaction, TransactionId};
 use amaru_ouroboros::ResourceMempool;
 use amaru_ouroboros_traits::{MempoolSeqNo, MempoolState, TxInsertResult, TxOrigin, TxSubmissionMempool};
-use amaru_pure_stage::{BoxFuture, Effects, ExternalEffect, ExternalEffectAPI, Resources, SendData, Void};
+use amaru_pure_stage::{BoxFuture, Effects, ExternalEffectAPI, Resources, SendData, Void};
 use serde::{Deserialize, Serialize};
 
 /// Implementation of Mempool effects using amaru_pure_stage::Effects.
@@ -215,18 +215,16 @@ impl Insert {
     }
 }
 
-impl ExternalEffect for Insert {
-    #[expect(clippy::expect_used)]
-    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
-            let mempool = resources.get::<ResourceMempool<Transaction>>().expect("ResourceMempool requires a mempool");
-            mempool.insert(self.tx, self.tx_origin)
-        })
-    }
-}
-
 impl ExternalEffectAPI for Insert {
     type Response = TxInsertResult;
+
+    #[expect(clippy::expect_used)]
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        self.wrap_sync({
+            let mempool = resources.get::<ResourceMempool<Transaction>>().expect("ResourceMempool requires a mempool");
+            mempool.insert(self.tx.clone(), self.tx_origin.clone())
+        })
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -240,18 +238,16 @@ impl GetTx {
     }
 }
 
-impl ExternalEffect for GetTx {
+impl ExternalEffectAPI for GetTx {
+    type Response = Option<Transaction>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let mempool = resources.get::<ResourceMempool<Transaction>>().expect("ResourceMempool requires a mempool");
             mempool.get_tx(&self.tx_id)
         })
     }
-}
-
-impl ExternalEffectAPI for GetTx {
-    type Response = Option<Transaction>;
 }
 
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -265,18 +261,16 @@ impl ContainsTx {
     }
 }
 
-impl ExternalEffect for ContainsTx {
+impl ExternalEffectAPI for ContainsTx {
+    type Response = bool;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let mempool = resources.get::<ResourceMempool<Transaction>>().expect("ResourceMempool requires a mempool");
             mempool.contains(&self.tx_id)
         })
     }
-}
-
-impl ExternalEffectAPI for ContainsTx {
-    type Response = bool;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -291,18 +285,16 @@ impl TxIdsSince {
     }
 }
 
-impl ExternalEffect for TxIdsSince {
+impl ExternalEffectAPI for TxIdsSince {
+    type Response = Vec<(TransactionId, u32, MempoolSeqNo)>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let mempool = resources.get::<ResourceMempool<Transaction>>().expect("ResourceMempool requires a mempool");
             mempool.tx_ids_since(self.mempool_seqno, self.limit)
         })
     }
-}
-
-impl ExternalEffectAPI for TxIdsSince {
-    type Response = Vec<(TransactionId, u32, MempoolSeqNo)>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -316,35 +308,31 @@ impl GetTxsForIds {
     }
 }
 
-impl ExternalEffect for GetTxsForIds {
+impl ExternalEffectAPI for GetTxsForIds {
+    type Response = Vec<Transaction>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let mempool = resources.get::<ResourceMempool<Transaction>>().expect("ResourceMempool requires a mempool");
             mempool.get_txs_for_ids(&self.tx_ids)
         })
     }
 }
 
-impl ExternalEffectAPI for GetTxsForIds {
-    type Response = Vec<Transaction>;
-}
-
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 struct MempoolTxs;
 
-impl ExternalEffect for MempoolTxs {
+impl ExternalEffectAPI for MempoolTxs {
+    type Response = Vec<Transaction>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let mempool = resources.get::<ResourceMempool<Transaction>>().expect("ResourceMempool requires a mempool");
             mempool.mempool_txs()
         })
     }
-}
-
-impl ExternalEffectAPI for MempoolTxs {
-    type Response = Vec<Transaction>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -358,35 +346,31 @@ impl RemoveTxs {
     }
 }
 
-impl ExternalEffect for RemoveTxs {
+impl ExternalEffectAPI for RemoveTxs {
+    type Response = ();
+
     #[expect(clippy::expect_used, clippy::unit_arg)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let mempool = resources.get::<ResourceMempool<Transaction>>().expect("ResourceMempool requires a mempool");
             mempool.remove_txs(&self.tx_ids)
         })
     }
 }
 
-impl ExternalEffectAPI for RemoveTxs {
-    type Response = ();
-}
-
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 struct LastSeqNo;
 
-impl ExternalEffect for LastSeqNo {
+impl ExternalEffectAPI for LastSeqNo {
+    type Response = MempoolSeqNo;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let mempool = resources.get::<ResourceMempool<Transaction>>().expect("ResourceMempool requires a mempool");
             mempool.last_seq_no()
         })
     }
-}
-
-impl ExternalEffectAPI for LastSeqNo {
-    type Response = MempoolSeqNo;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -394,35 +378,31 @@ struct IsNearCapacity {
     additional_bytes: u64,
 }
 
-impl ExternalEffect for IsNearCapacity {
+impl ExternalEffectAPI for IsNearCapacity {
+    type Response = bool;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let mempool = resources.get::<ResourceMempool<Transaction>>().expect("ResourceMempool requires a mempool");
             mempool.is_near_capacity(self.additional_bytes)
         })
     }
 }
 
-impl ExternalEffectAPI for IsNearCapacity {
-    type Response = bool;
-}
-
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 struct State;
 
-impl ExternalEffect for State {
+impl ExternalEffectAPI for State {
+    type Response = MempoolState;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let mempool = resources.get::<ResourceMempool<Transaction>>().expect("ResourceMempool requires a mempool");
             mempool.state()
         })
     }
-}
-
-impl ExternalEffectAPI for State {
-    type Response = MempoolState;
 }
 
 #[cfg(test)]

--- a/crates/amaru-protocols/src/metrics_effects.rs
+++ b/crates/amaru-protocols/src/metrics_effects.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use amaru_metrics::{Meter, MetricRecorder, MetricsEvent};
-use amaru_pure_stage::{BoxFuture, Effects, ExternalEffect, ExternalEffectAPI, Resources, SendData};
+use amaru_pure_stage::{BoxFuture, Effects, ExternalEffectAPI, Resources, SendData};
 
 /// Metrics operations available to a stage. This allows a stage to record a MetricsEvent that
 /// will be collected via OpenTelemetry.
@@ -60,19 +60,17 @@ impl RecordMetricsEffect {
 
 pub type ResourceMeter = Arc<Meter>;
 
-impl ExternalEffect for RecordMetricsEffect {
+impl ExternalEffectAPI for RecordMetricsEffect {
+    type Response = ();
+
     #[allow(clippy::unit_arg)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             if let Ok(meter) = resources.get::<ResourceMeter>() {
                 self.event.record_to_meter(&meter);
             }
         })
     }
-}
-
-impl ExternalEffectAPI for RecordMetricsEffect {
-    type Response = ();
 }
 
 #[test]

--- a/crates/amaru-protocols/src/mux.rs
+++ b/crates/amaru-protocols/src/mux.rs
@@ -683,7 +683,7 @@ mod tests {
 
         graph.resources().put::<ConnectionsResource>(Arc::new(network));
 
-        let mut running = graph.run();
+        let mut running = graph.run(&tokio::runtime::Handle::current());
         let join_handle = tokio::spawn(async move {
             loop {
                 let blocked = running.run_until_blocked();
@@ -772,7 +772,8 @@ mod tests {
             ),
         );
 
-        let mut running = network.run();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut running = network.run(rt.handle());
         let running = &mut running;
 
         // set breakpoints to capture interactions with outside world

--- a/crates/amaru-protocols/src/network_effects.rs
+++ b/crates/amaru-protocols/src/network_effects.rs
@@ -22,7 +22,7 @@ use std::{
 
 use amaru_kernel::{NonEmptyBytes, Peer};
 use amaru_ouroboros::{ConnectionId, ConnectionsResource, ToSocketAddrs};
-use amaru_pure_stage::{BoxFuture, Effects, ExternalEffect, ExternalEffectAPI, Resources, SendData};
+use amaru_pure_stage::{BoxFuture, DurationDist, Effects, ExternalEffectAPI, Resources, SendData};
 
 pub fn register_deserializers() -> amaru_pure_stage::DeserializerGuards {
     vec![
@@ -93,19 +93,17 @@ pub struct ListenEffect {
     pub addr: SocketAddr,
 }
 
-impl ExternalEffect for ListenEffect {
+impl ExternalEffectAPI for ListenEffect {
+    type Response = Result<SocketAddr, ListenError>;
+
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap(async move {
+        self.wrap(|this| async move {
             #[expect(clippy::expect_used)]
             let resource =
                 resources.get::<ConnectionsResource>().expect("ListenEffect requires a ConnectionsResource").clone();
-            resource.listen(self.addr).await.map_err(|e| ListenError(format!("{e}")))
+            resource.listen(this.addr).await.map_err(|e| ListenError(format!("{e}")))
         })
     }
-}
-
-impl ExternalEffectAPI for ListenEffect {
-    type Response = Result<SocketAddr, ListenError>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -123,23 +121,22 @@ pub struct AcceptEffect {
     pub listener_addr: SocketAddr,
 }
 
-impl ExternalEffect for AcceptEffect {
+impl ExternalEffectAPI for AcceptEffect {
+    type Response = Result<(Peer, ConnectionId), AcceptError>;
+    const SIMULATED_DURATION: DurationDist = DurationDist::UntilResolved;
+
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap(async move {
+        self.wrap(|this| async move {
             #[expect(clippy::expect_used)]
             let resource =
                 resources.get::<ConnectionsResource>().expect("AcceptEffect requires a ConnectionsResource").clone();
             #[expect(clippy::wildcard_enum_match_arm)]
-            resource.accept(self.listener_addr).await.map_err(|e| match e.kind() {
+            resource.accept(this.listener_addr).await.map_err(|e| match e.kind() {
                 ErrorKind::ConnectionAborted => AcceptError::ConnectionAborted,
                 other => AcceptError::Other(format!("{other}")),
             })
         })
     }
-}
-
-impl ExternalEffectAPI for AcceptEffect {
-    type Response = Result<(Peer, ConnectionId), AcceptError>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -164,22 +161,21 @@ pub struct ConnectEffect {
     pub timeout: Duration,
 }
 
-impl ExternalEffect for ConnectEffect {
+impl ExternalEffectAPI for ConnectEffect {
+    type Response = Result<ConnectionId, ConnectError>;
+    const SIMULATED_DURATION: DurationDist = DurationDist::UntilResolved;
+
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap(async move {
+        self.wrap(|this| async move {
             #[expect(clippy::expect_used)]
             let resource =
                 resources.get::<ConnectionsResource>().expect("ConnectEffect requires a ConnectionsResource").clone();
             resource
-                .connect_addrs(self.addr.clone(), self.timeout)
+                .connect_addrs(this.addr.clone(), this.timeout)
                 .await
-                .map_err(|e| ConnectError { addr: self.addr, error: format!("{e}") })
+                .map_err(|e| ConnectError { addr: this.addr, error: format!("{e}") })
         })
     }
-}
-
-impl ExternalEffectAPI for ConnectEffect {
-    type Response = Result<ConnectionId, ConnectError>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -201,19 +197,18 @@ pub struct SendEffect {
     pub data: NonEmptyBytes,
 }
 
-impl ExternalEffect for SendEffect {
+impl ExternalEffectAPI for SendEffect {
+    type Response = Result<(), SendError>;
+    const SIMULATED_DURATION: DurationDist = DurationDist::UntilResolved;
+
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap(async move {
+        self.wrap(|this| async move {
             #[expect(clippy::expect_used)]
             let resource =
                 resources.get::<ConnectionsResource>().expect("SendEffect requires a ConnectionsResource").clone();
-            resource.send(self.conn, self.data).await.map_err(|e| SendError { conn: self.conn, error: format!("{e}") })
+            resource.send(this.conn, this.data).await.map_err(|e| SendError { conn: this.conn, error: format!("{e}") })
         })
     }
-}
-
-impl ExternalEffectAPI for SendEffect {
-    type Response = Result<(), SendError>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -235,22 +230,21 @@ pub struct RecvEffect {
     pub bytes: NonZeroUsize,
 }
 
-impl ExternalEffect for RecvEffect {
+impl ExternalEffectAPI for RecvEffect {
+    type Response = Result<NonEmptyBytes, ReceiveError>;
+    const SIMULATED_DURATION: DurationDist = DurationDist::UntilResolved;
+
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap(async move {
+        self.wrap(|this| async move {
             #[expect(clippy::expect_used)]
             let resource =
                 resources.get::<ConnectionsResource>().expect("RecvEffect requires a ConnectionsResource").clone();
             resource
-                .recv(self.conn, self.bytes)
+                .recv(this.conn, this.bytes)
                 .await
-                .map_err(|e| ReceiveError { conn: self.conn, error: format!("{e}") })
+                .map_err(|e| ReceiveError { conn: this.conn, error: format!("{e}") })
         })
     }
-}
-
-impl ExternalEffectAPI for RecvEffect {
-    type Response = Result<NonEmptyBytes, ReceiveError>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -271,19 +265,17 @@ pub struct CloseEffect {
     pub conn: ConnectionId,
 }
 
-impl ExternalEffect for CloseEffect {
+impl ExternalEffectAPI for CloseEffect {
+    type Response = Result<(), CloseError>;
+
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap(async move {
+        self.wrap(|this| async move {
             #[expect(clippy::expect_used)]
             let resource =
                 resources.get::<ConnectionsResource>().expect("CloseEffect requires a ConnectionsResource").clone();
-            resource.close(self.conn).await.map_err(|e| CloseError { conn: self.conn, error: format!("{e}") })
+            resource.close(this.conn).await.map_err(|e| CloseError { conn: this.conn, error: format!("{e}") })
         })
     }
-}
-
-impl ExternalEffectAPI for CloseEffect {
-    type Response = Result<(), CloseError>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/crates/amaru-protocols/src/store_effects.rs
+++ b/crates/amaru-protocols/src/store_effects.rs
@@ -20,9 +20,7 @@ use amaru_ouroboros_traits::{
     ChainStore, FindAncestorOnBestChainResult, FindCommonAncestorResult, MissingBlocksResult, NextBestChainHeader,
     Nonces, SampleAncestorPointsResult, StoreError,
 };
-use amaru_pure_stage::{
-    BoxFuture, DeserializerGuards, Effects, ExternalEffect, ExternalEffectAPI, Resources, SendData, Void,
-};
+use amaru_pure_stage::{BoxFuture, DeserializerGuards, Effects, ExternalEffectAPI, Resources, SendData, Void};
 
 /// Factory for chain-store external effects.
 ///
@@ -366,10 +364,12 @@ impl StoreValidatedHeaderEffect {
     }
 }
 
-impl ExternalEffect for StoreValidatedHeaderEffect {
+impl ExternalEffectAPI for StoreValidatedHeaderEffect {
+    type Response = Result<(), StoreError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store = resources
                 .get::<ResourceHeaderStore>()
                 .expect("StoreValidatedHeaderEffect requires a chain store")
@@ -377,10 +377,6 @@ impl ExternalEffect for StoreValidatedHeaderEffect {
             store.store_validated_header(&self.header, &self.nonces)
         })
     }
-}
-
-impl ExternalEffectAPI for StoreValidatedHeaderEffect {
-    type Response = Result<(), StoreError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -395,19 +391,17 @@ impl StoreBlockEffect {
     }
 }
 
-impl ExternalEffect for StoreBlockEffect {
+impl ExternalEffectAPI for StoreBlockEffect {
+    type Response = Result<(), StoreError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store =
                 resources.get::<ResourceHeaderStore>().expect("StoreBlockEffect requires a chain store").clone();
             store.store_block(&self.hash, &self.block)
         })
     }
-}
-
-impl ExternalEffectAPI for StoreBlockEffect {
-    type Response = Result<(), StoreError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -421,19 +415,17 @@ impl SetAnchorPointEffect {
     }
 }
 
-impl ExternalEffect for SetAnchorPointEffect {
+impl ExternalEffectAPI for SetAnchorPointEffect {
+    type Response = Result<(), StoreError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store =
                 resources.get::<ResourceHeaderStore>().expect("SetAnchorPointEffect requires a chain store").clone();
             store.set_anchor_point(&self.point)
         })
     }
-}
-
-impl ExternalEffectAPI for SetAnchorPointEffect {
-    type Response = Result<(), StoreError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -447,19 +439,17 @@ impl SetBestChainTipEffect {
     }
 }
 
-impl ExternalEffect for SetBestChainTipEffect {
+impl ExternalEffectAPI for SetBestChainTipEffect {
+    type Response = Result<(), StoreError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store =
                 resources.get::<ResourceHeaderStore>().expect("SetBestChainTipEffect requires a chain store").clone();
             store.set_best_chain_tip(&self.tip)
         })
     }
-}
-
-impl ExternalEffectAPI for SetBestChainTipEffect {
-    type Response = Result<(), StoreError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -474,18 +464,16 @@ impl PutNoncesEffect {
     }
 }
 
-impl ExternalEffect for PutNoncesEffect {
+impl ExternalEffectAPI for PutNoncesEffect {
+    type Response = Result<(), StoreError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store = resources.get::<ResourceHeaderStore>().expect("PutNoncesEffect requires a chain store").clone();
             store.put_nonces(&self.hash, &self.nonces)
         })
     }
-}
-
-impl ExternalEffectAPI for PutNoncesEffect {
-    type Response = Result<(), StoreError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -499,18 +487,16 @@ impl HasHeaderEffect {
     }
 }
 
-impl ExternalEffect for HasHeaderEffect {
+impl ExternalEffectAPI for HasHeaderEffect {
+    type Response = bool;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store = resources.get::<ResourceHeaderStore>().expect("HasHeaderEffect requires a chain store").clone();
             store.has_header(&self.hash)
         })
     }
-}
-
-impl ExternalEffectAPI for HasHeaderEffect {
-    type Response = bool;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -524,19 +510,17 @@ impl IsOnBestChainEffect {
     }
 }
 
-impl ExternalEffect for IsOnBestChainEffect {
+impl ExternalEffectAPI for IsOnBestChainEffect {
+    type Response = bool;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store =
                 resources.get::<ResourceHeaderStore>().expect("IsOnBestChainEffect requires a chain store").clone();
             store.is_on_best_chain(self.point)
         })
     }
-}
-
-impl ExternalEffectAPI for IsOnBestChainEffect {
-    type Response = bool;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -550,19 +534,17 @@ impl NextBestChainEffect {
     }
 }
 
-impl ExternalEffect for NextBestChainEffect {
+impl ExternalEffectAPI for NextBestChainEffect {
+    type Response = Option<Point>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store =
                 resources.get::<ResourceHeaderStore>().expect("NextBestChainEffect requires a chain store").clone();
             store.next_best_chain(&self.point)
         })
     }
-}
-
-impl ExternalEffectAPI for NextBestChainEffect {
-    type Response = Option<Point>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -576,10 +558,12 @@ impl NextBestChainHeaderEffect {
     }
 }
 
-impl ExternalEffect for NextBestChainHeaderEffect {
+impl ExternalEffectAPI for NextBestChainHeaderEffect {
+    type Response = Result<NextBestChainHeader, StoreError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store = resources
                 .get::<ResourceHeaderStore>()
                 .expect("NextBestChainHeaderEffect requires a chain store")
@@ -587,10 +571,6 @@ impl ExternalEffect for NextBestChainHeaderEffect {
             store.next_best_chain_header(&self.point)
         })
     }
-}
-
-impl ExternalEffectAPI for NextBestChainHeaderEffect {
-    type Response = Result<NextBestChainHeader, StoreError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -604,19 +584,17 @@ impl LoadHeaderEffect {
     }
 }
 
-impl ExternalEffect for LoadHeaderEffect {
+impl ExternalEffectAPI for LoadHeaderEffect {
+    type Response = Option<Header>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store =
                 resources.get::<ResourceHeaderStore>().expect("LoadHeaderEffect requires a chain store").clone();
             store.load_header(&self.hash)
         })
     }
-}
-
-impl ExternalEffectAPI for LoadHeaderEffect {
-    type Response = Option<Header>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -636,19 +614,17 @@ impl LoadPointEffect {
     }
 }
 
-impl ExternalEffect for LoadPointEffect {
+impl ExternalEffectAPI for LoadPointEffect {
+    type Response = Option<Point>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let _guard = self.trace_context.attach();
             let store = resources.get::<ResourceHeaderStore>().expect("LoadPointEffect requires a chain store").clone();
             store.load_point(&self.hash)
         })
     }
-}
-
-impl ExternalEffectAPI for LoadPointEffect {
-    type Response = Option<Point>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -662,10 +638,12 @@ impl LoadHeaderWithValidityEffect {
     }
 }
 
-impl ExternalEffect for LoadHeaderWithValidityEffect {
+impl ExternalEffectAPI for LoadHeaderWithValidityEffect {
+    type Response = Option<(Header, Option<bool>)>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store = resources
                 .get::<ResourceHeaderStore>()
                 .expect("LoadHeaderWithValidityEffect requires a chain store")
@@ -673,10 +651,6 @@ impl ExternalEffect for LoadHeaderWithValidityEffect {
             store.load_header_with_validity(&self.hash)
         })
     }
-}
-
-impl ExternalEffectAPI for LoadHeaderWithValidityEffect {
-    type Response = Option<(Header, Option<bool>)>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -691,19 +665,17 @@ impl SetBlockValidEffect {
     }
 }
 
-impl ExternalEffect for SetBlockValidEffect {
+impl ExternalEffectAPI for SetBlockValidEffect {
+    type Response = Result<(), StoreError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store =
                 resources.get::<ResourceHeaderStore>().expect("SetBlockValidEffect requires a chain store").clone();
             store.set_block_valid(&self.hash, self.valid)
         })
     }
-}
-
-impl ExternalEffectAPI for SetBlockValidEffect {
-    type Response = Result<(), StoreError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -717,19 +689,17 @@ impl GetChildrenEffect {
     }
 }
 
-impl ExternalEffect for GetChildrenEffect {
+impl ExternalEffectAPI for GetChildrenEffect {
+    type Response = Vec<HeaderHash>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store =
                 resources.get::<ResourceHeaderStore>().expect("GetChildrenEffect requires a chain store").clone();
             store.get_children(&self.hash)
         })
     }
-}
-
-impl ExternalEffectAPI for GetChildrenEffect {
-    type Response = Vec<HeaderHash>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -742,19 +712,17 @@ impl GetAnchorHashEffect {
     }
 }
 
-impl ExternalEffect for GetAnchorHashEffect {
+impl ExternalEffectAPI for GetAnchorHashEffect {
+    type Response = HeaderHash;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store =
                 resources.get::<ResourceHeaderStore>().expect("GetAnchorHashEffect requires a chain store").clone();
             store.get_anchor_hash()
         })
     }
-}
-
-impl ExternalEffectAPI for GetAnchorHashEffect {
-    type Response = HeaderHash;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -767,19 +735,17 @@ impl GetBestChainHashEffect {
     }
 }
 
-impl ExternalEffect for GetBestChainHashEffect {
+impl ExternalEffectAPI for GetBestChainHashEffect {
+    type Response = HeaderHash;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store =
                 resources.get::<ResourceHeaderStore>().expect("GetBestChainHashEffect requires a chain store").clone();
             store.get_best_chain_hash()
         })
     }
-}
-
-impl ExternalEffectAPI for GetBestChainHashEffect {
-    type Response = HeaderHash;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -792,19 +758,17 @@ impl GetBestChainTipEffect {
     }
 }
 
-impl ExternalEffect for GetBestChainTipEffect {
+impl ExternalEffectAPI for GetBestChainTipEffect {
+    type Response = Point;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store =
                 resources.get::<ResourceHeaderStore>().expect("GetBestChainTipEffect requires a chain store").clone();
             store.get_best_chain_tip()
         })
     }
-}
-
-impl ExternalEffectAPI for GetBestChainTipEffect {
-    type Response = Point;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -818,18 +782,16 @@ impl LoadBlockEffect {
     }
 }
 
-impl ExternalEffect for LoadBlockEffect {
+impl ExternalEffectAPI for LoadBlockEffect {
+    type Response = Result<Option<RawBlock>, StoreError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store = resources.get::<ResourceHeaderStore>().expect("LoadBlockEffect requires a chain store").clone();
             store.load_block(&self.hash)
         })
     }
-}
-
-impl ExternalEffectAPI for LoadBlockEffect {
-    type Response = Result<Option<RawBlock>, StoreError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -843,18 +805,16 @@ impl HasBlockEffect {
     }
 }
 
-impl ExternalEffect for HasBlockEffect {
+impl ExternalEffectAPI for HasBlockEffect {
+    type Response = Result<bool, StoreError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store = resources.get::<ResourceHeaderStore>().expect("HasBlockEffect requires a chain store").clone();
             store.has_block(&self.hash)
         })
     }
-}
-
-impl ExternalEffectAPI for HasBlockEffect {
-    type Response = Result<bool, StoreError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -868,18 +828,16 @@ impl GetNoncesEffect {
     }
 }
 
-impl ExternalEffect for GetNoncesEffect {
+impl ExternalEffectAPI for GetNoncesEffect {
+    type Response = Option<Nonces>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store = resources.get::<ResourceHeaderStore>().expect("GetNoncesEffect requires a chain store").clone();
             store.get_nonces(&self.hash)
         })
     }
-}
-
-impl ExternalEffectAPI for GetNoncesEffect {
-    type Response = Option<Nonces>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -894,19 +852,17 @@ impl SwitchToForkEffect {
     }
 }
 
-impl ExternalEffect for SwitchToForkEffect {
+impl ExternalEffectAPI for SwitchToForkEffect {
+    type Response = Result<(), StoreError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store =
                 resources.get::<ResourceHeaderStore>().expect("SwitchToForkEffect requires a chain store").clone();
             store.switch_to_fork(&self.fork_point, &self.forward_points)
         })
     }
-}
-
-impl ExternalEffectAPI for SwitchToForkEffect {
-    type Response = Result<(), StoreError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -920,19 +876,17 @@ impl RollForwardChainEffect {
     }
 }
 
-impl ExternalEffect for RollForwardChainEffect {
+impl ExternalEffectAPI for RollForwardChainEffect {
+    type Response = Result<(), StoreError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store =
                 resources.get::<ResourceHeaderStore>().expect("RollForwardChainEffect requires a chain store").clone();
             store.roll_forward_chain(&self.point)
         })
     }
-}
-
-impl ExternalEffectAPI for RollForwardChainEffect {
-    type Response = Result<(), StoreError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -946,10 +900,12 @@ impl UnvalidatedAncestorHashesEffect {
     }
 }
 
-impl ExternalEffect for UnvalidatedAncestorHashesEffect {
+impl ExternalEffectAPI for UnvalidatedAncestorHashesEffect {
+    type Response = (Vec<HeaderHash>, bool);
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store = resources
                 .get::<ResourceHeaderStore>()
                 .expect("UnvalidatedAncestorHashesEffect requires a chain store")
@@ -957,10 +913,6 @@ impl ExternalEffect for UnvalidatedAncestorHashesEffect {
             store.unvalidated_ancestor_hashes(self.start)
         })
     }
-}
-
-impl ExternalEffectAPI for UnvalidatedAncestorHashesEffect {
-    type Response = (Vec<HeaderHash>, bool);
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -981,20 +933,18 @@ impl AncestorsBetweenEffect {
     }
 }
 
-impl ExternalEffect for AncestorsBetweenEffect {
+impl ExternalEffectAPI for AncestorsBetweenEffect {
+    type Response = Option<Vec<Point>>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let _guard = self.trace_context.attach();
             let store =
                 resources.get::<ResourceHeaderStore>().expect("AncestorsBetweenEffect requires a chain store").clone();
             store.ancestors_between(&self.from, self.to)
         })
     }
-}
-
-impl ExternalEffectAPI for AncestorsBetweenEffect {
-    type Response = Option<Vec<Point>>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -1008,10 +958,12 @@ impl FindAncestorOnBestChainEffect {
     }
 }
 
-impl ExternalEffect for FindAncestorOnBestChainEffect {
+impl ExternalEffectAPI for FindAncestorOnBestChainEffect {
+    type Response = Result<FindAncestorOnBestChainResult, StoreError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store = resources
                 .get::<ResourceHeaderStore>()
                 .expect("FindAncestorOnBestChainEffect requires a chain store")
@@ -1019,10 +971,6 @@ impl ExternalEffect for FindAncestorOnBestChainEffect {
             store.find_ancestor_on_best_chain(self.start)
         })
     }
-}
-
-impl ExternalEffectAPI for FindAncestorOnBestChainEffect {
-    type Response = Result<FindAncestorOnBestChainResult, StoreError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -1036,10 +984,12 @@ impl FindAnchorAtHeightEffect {
     }
 }
 
-impl ExternalEffect for FindAnchorAtHeightEffect {
+impl ExternalEffectAPI for FindAnchorAtHeightEffect {
+    type Response = Option<Point>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store = resources
                 .get::<ResourceHeaderStore>()
                 .expect("FindAnchorAtHeightEffect requires a chain store")
@@ -1047,10 +997,6 @@ impl ExternalEffect for FindAnchorAtHeightEffect {
             store.find_anchor_at_height(self.target_height)
         })
     }
-}
-
-impl ExternalEffectAPI for FindAnchorAtHeightEffect {
-    type Response = Option<Point>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -1065,10 +1011,12 @@ impl FindCommonAncestorEffect {
     }
 }
 
-impl ExternalEffect for FindCommonAncestorEffect {
+impl ExternalEffectAPI for FindCommonAncestorEffect {
+    type Response = Result<FindCommonAncestorResult, StoreError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store = resources
                 .get::<ResourceHeaderStore>()
                 .expect("FindCommonAncestorEffect requires a chain store")
@@ -1076,10 +1024,6 @@ impl ExternalEffect for FindCommonAncestorEffect {
             store.find_common_ancestor(self.hash_a, self.hash_b)
         })
     }
-}
-
-impl ExternalEffectAPI for FindCommonAncestorEffect {
-    type Response = Result<FindCommonAncestorResult, StoreError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -1093,21 +1037,19 @@ impl FindIntersectPointEffect {
     }
 }
 
-impl ExternalEffect for FindIntersectPointEffect {
+impl ExternalEffectAPI for FindIntersectPointEffect {
+    type Response = Option<Point>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store = resources
                 .get::<ResourceHeaderStore>()
                 .expect("FindIntersectPointEffect requires a chain store")
                 .clone();
-            store.find_intersect_point(self.points)
+            store.find_intersect_point(self.points.clone())
         })
     }
-}
-
-impl ExternalEffectAPI for FindIntersectPointEffect {
-    type Response = Option<Point>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -1120,10 +1062,12 @@ impl SampleAncestorPointsEffect {
     }
 }
 
-impl ExternalEffect for SampleAncestorPointsEffect {
+impl ExternalEffectAPI for SampleAncestorPointsEffect {
+    type Response = Result<SampleAncestorPointsResult, StoreError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store = resources
                 .get::<ResourceHeaderStore>()
                 .expect("SampleAncestorPointsEffect requires a chain store")
@@ -1131,10 +1075,6 @@ impl ExternalEffect for SampleAncestorPointsEffect {
             store.sample_ancestor_points()
         })
     }
-}
-
-impl ExternalEffectAPI for SampleAncestorPointsEffect {
-    type Response = Result<SampleAncestorPointsResult, StoreError>;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -1149,17 +1089,15 @@ impl FindMissingBlocksEffect {
     }
 }
 
-impl ExternalEffect for FindMissingBlocksEffect {
+impl ExternalEffectAPI for FindMissingBlocksEffect {
+    type Response = Result<MissingBlocksResult, StoreError>;
+
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
-        Self::wrap_sync({
+        self.wrap_sync({
             let store =
                 resources.get::<ResourceHeaderStore>().expect("FindMissingBlocksEffect requires a chain store").clone();
             store.find_missing_blocks(self.start, self.limit)
         })
     }
-}
-
-impl ExternalEffectAPI for FindMissingBlocksEffect {
-    type Response = Result<MissingBlocksResult, StoreError>;
 }

--- a/crates/amaru-pure-stage/src/duration_dist.rs
+++ b/crates/amaru-pure-stage/src/duration_dist.rs
@@ -21,15 +21,15 @@ use rand::Rng;
 /// The Tokio runtime ignores this. The simulation samples (or declines to sample) when the
 /// effect is *issued*, not when its `Future` later completes. Real CPU time is never used as `δ`.
 ///
-/// - [`Zero`], [`Constant`], [`Uniform`]: `δ` is known at issue time. The simulator enqueues a
-///   wakeup at `now + δ` immediately. The stage resumes only once that time has been reached
-///   *and* the effect result is available.
-/// - [`UntilResolved`]: there is no `δ`. The stage stays suspended until the effect `Future`
-///   is resolved. This is how a later world runner delivers a network receive at a time of
-///   its choosing.
+/// - [`DurationDist::Zero`], [`DurationDist::Constant`], [`DurationDist::Uniform`]: `δ` is
+///   known at issue time. The simulator enqueues a wakeup at `now + δ` immediately. The
+///   stage resumes only once that time has been reached *and* the effect result is available.
+/// - [`DurationDist::UntilResolved`]: there is no `δ`. The stage stays suspended until the
+///   effect `Future` is resolved. This is how a later world runner delivers a network receive
+///   at a time of its choosing.
 ///
-/// Start every effect at [`DurationDist::Zero`]. Pick [`UntilResolved`] for completions the
-/// simulation drives; pick a sampled variant for local work (store, validation, …).
+/// Start every effect at [`DurationDist::Zero`]. Pick [`DurationDist::UntilResolved`] for
+/// completions the simulation drives; pick a sampled variant for local work (store, validation, …).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize)]
 pub enum DurationDist {
     /// The effect occupies no simulated time. Resume as soon as the result is available.
@@ -55,7 +55,7 @@ impl DurationDist {
 
     /// Draw a finite `δ` if this distribution has one.
     ///
-    /// Returns `None` for [`UntilResolved`] — that variant has no duration to sample.
+    /// Returns `None` for [`DurationDist::UntilResolved`] — that variant has no duration to sample.
     ///
     /// # Panics
     ///
@@ -77,8 +77,9 @@ impl DurationDist {
 
     /// Wall-clock bound when forcing `run()` at a sampled deadline: `1.5 × max + 1s`.
     ///
-    /// `max` is zero for [`Zero`], the constant for [`Constant`], and the upper end for
-    /// [`Uniform`]. [`UntilResolved`] has no force bound (that variant is never forced).
+    /// `max` is zero for [`DurationDist::Zero`], the constant for [`DurationDist::Constant`],
+    /// and the upper end for [`DurationDist::Uniform`]. [`DurationDist::UntilResolved`] has
+    /// no force bound (that variant is never forced).
     pub fn force_timeout(self) -> Option<Duration> {
         let max = match self {
             Self::Zero => Duration::ZERO,

--- a/crates/amaru-pure-stage/src/duration_dist.rs
+++ b/crates/amaru-pure-stage/src/duration_dist.rs
@@ -1,0 +1,159 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use rand::Rng;
+
+/// How an [`ExternalEffect`](crate::ExternalEffect) occupies simulated time.
+///
+/// The Tokio runtime ignores this. The simulation samples (or declines to sample) when the
+/// effect is *issued*, not when its `Future` later completes. Real CPU time is never used as `δ`.
+///
+/// - [`Zero`], [`Constant`], [`Uniform`]: `δ` is known at issue time. The simulator enqueues a
+///   wakeup at `now + δ` immediately. The stage resumes only once that time has been reached
+///   *and* the effect result is available.
+/// - [`UntilResolved`]: there is no `δ`. The stage stays suspended until the effect `Future`
+///   is resolved. This is how a later world runner delivers a network receive at a time of
+///   its choosing.
+///
+/// Start every effect at [`DurationDist::Zero`]. Pick [`UntilResolved`] for completions the
+/// simulation drives; pick a sampled variant for local work (store, validation, …).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize)]
+pub enum DurationDist {
+    /// The effect occupies no simulated time. Resume as soon as the result is available.
+    #[default]
+    Zero,
+    /// The effect always occupies exactly this duration, scheduled when the effect is issued.
+    Constant(Duration),
+    /// The effect occupies a duration drawn uniformly from `[min, max]` (inclusive).
+    ///
+    /// Sampled when the effect is issued. `min` must not exceed `max`;
+    /// [`sample`](Self::sample) panics otherwise.
+    Uniform { min: Duration, max: Duration },
+    /// Occupy time until the effect `Future` resolves.
+    ///
+    /// No wakeup is scheduled. A network receive uses this so the world runner can complete
+    /// the future when that transmission should arrive.
+    UntilResolved,
+}
+
+impl DurationDist {
+    /// The default distribution: no simulated time.
+    pub const ZERO: Self = Self::Zero;
+
+    /// Draw a finite `δ` if this distribution has one.
+    ///
+    /// Returns `None` for [`UntilResolved`] — that variant has no duration to sample.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this is [`Uniform`](Self::Uniform) and `min > max`, or if a bound
+    /// exceeds `u64::MAX` nanoseconds (about 584 years).
+    pub fn sample(self, rng: &mut impl Rng) -> Option<Duration> {
+        match self {
+            Self::Zero => Some(Duration::ZERO),
+            Self::Constant(duration) => Some(duration),
+            Self::Uniform { min, max } => {
+                let min_nanos = nanos_u64(min, "Uniform.min");
+                let max_nanos = nanos_u64(max, "Uniform.max");
+                assert!(min_nanos <= max_nanos, "DurationDist::Uniform min ({min:?}) exceeds max ({max:?})");
+                Some(Duration::from_nanos(rng.random_range(min_nanos..=max_nanos)))
+            }
+            Self::UntilResolved => None,
+        }
+    }
+
+    /// Wall-clock bound when forcing `run()` at a sampled deadline: `1.5 × max + 1s`.
+    ///
+    /// `max` is zero for [`Zero`], the constant for [`Constant`], and the upper end for
+    /// [`Uniform`]. [`UntilResolved`] has no force bound (that variant is never forced).
+    pub fn force_timeout(self) -> Option<Duration> {
+        let max = match self {
+            Self::Zero => Duration::ZERO,
+            Self::Constant(duration) => duration,
+            Self::Uniform { max, .. } => max,
+            Self::UntilResolved => return None,
+        };
+        Some(max.saturating_add(max / 2).saturating_add(Duration::from_secs(1)))
+    }
+}
+
+fn nanos_u64(duration: Duration, what: &str) -> u64 {
+    let nanos = duration.as_nanos();
+    assert!(nanos <= u64::MAX as u128, "{what} ({duration:?}) exceeds the 584-year simulation limit");
+    nanos as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{SeedableRng, rngs::StdRng};
+
+    use super::*;
+
+    #[test]
+    fn zero_and_constant_are_deterministic() {
+        let mut rng = StdRng::seed_from_u64(1);
+        assert_eq!(DurationDist::Zero.sample(&mut rng), Some(Duration::ZERO));
+        assert_eq!(DurationDist::Constant(Duration::from_millis(7)).sample(&mut rng), Some(Duration::from_millis(7)));
+        assert_eq!(DurationDist::UntilResolved.sample(&mut rng), None);
+    }
+
+    #[test]
+    fn uniform_equal_bounds_is_constant() {
+        let mut rng = StdRng::seed_from_u64(1);
+        let d = Duration::from_secs(3);
+        assert_eq!(DurationDist::Uniform { min: d, max: d }.sample(&mut rng), Some(d));
+    }
+
+    #[test]
+    fn uniform_stays_inside_inclusive_bounds() {
+        let mut rng = StdRng::seed_from_u64(7);
+        let min = Duration::from_millis(5);
+        let max = Duration::from_millis(15);
+        let dist = DurationDist::Uniform { min, max };
+        for _ in 0..1000 {
+            let sample = dist.sample(&mut rng).expect("Uniform has a finite δ");
+            assert!(sample >= min && sample <= max, "{sample:?} not in [{min:?}, {max:?}]");
+        }
+    }
+
+    #[test]
+    fn uniform_is_deterministic_for_a_seed() {
+        let dist = DurationDist::Uniform { min: Duration::from_millis(1), max: Duration::from_secs(1) };
+        let samples = |seed| {
+            let mut rng = StdRng::seed_from_u64(seed);
+            (0..20).map(|_| dist.sample(&mut rng)).collect::<Vec<_>>()
+        };
+        assert_eq!(samples(99), samples(99));
+    }
+
+    #[test]
+    fn force_timeout_is_one_and_a_half_max_plus_one_second() {
+        assert_eq!(DurationDist::Zero.force_timeout(), Some(Duration::from_secs(1)));
+        assert_eq!(DurationDist::Constant(Duration::from_secs(10)).force_timeout(), Some(Duration::from_secs(16)));
+        assert_eq!(
+            DurationDist::Uniform { min: Duration::from_secs(5), max: Duration::from_secs(10) }.force_timeout(),
+            Some(Duration::from_secs(16))
+        );
+        assert_eq!(DurationDist::UntilResolved.force_timeout(), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds max")]
+    fn uniform_rejects_inverted_bounds() {
+        let mut rng = StdRng::seed_from_u64(1);
+        DurationDist::Uniform { min: Duration::from_secs(2), max: Duration::from_secs(1) }.sample(&mut rng);
+    }
+}

--- a/crates/amaru-pure-stage/src/effect.rs
+++ b/crates/amaru-pure-stage/src/effect.rs
@@ -465,24 +465,17 @@ impl CanSupervise {
 ///
 /// The [`run`](ExternalEffect::run) method is used to perform the effect unless a
 /// simulator chooses differently. The latter can be done by downcasting to the concrete type.
+///
+/// Prefer implementing [`ExternalEffectAPI`]: a blanket impl provides [`ExternalEffect`]
+/// and wires [`simulated_duration_dist`](Self::simulated_duration_dist) to
+/// [`ExternalEffectAPI::SIMULATED_DURATION`].
 pub trait ExternalEffect: SendData {
     /// Distribution of simulated time this effect occupies in
     /// [`crate::simulation::SimulationRunning`].
     ///
-    /// The Tokio runtime ignores this. Defaults to [`DurationDist::Zero`] so existing
-    /// effects keep today's traces. Use [`DurationDist::UntilResolved`] when the
-    /// simulation (not a sampled `δ`) decides when the effect Future completes — e.g.
-    /// a network receive.
-    ///
-    /// An associated `const` cannot live on this trait: it would make `dyn ExternalEffect`
-    /// illegal. Declare [`ExternalEffectAPI::SIMULATED_DURATION`] on the concrete type and
-    /// return it from this method:
-    ///
-    /// ```ignore
-    /// fn simulated_duration_dist(&self) -> DurationDist {
-    ///     <Self as ExternalEffectAPI>::SIMULATED_DURATION
-    /// }
-    /// ```
+    /// The Tokio runtime ignores this. Types that implement [`ExternalEffectAPI`] inherit
+    /// [`ExternalEffectAPI::SIMULATED_DURATION`]. Direct implementors default to
+    /// [`DurationDist::Zero`].
     fn simulated_duration_dist(&self) -> DurationDist {
         DurationDist::ZERO
     }
@@ -494,37 +487,6 @@ pub trait ExternalEffect: SendData {
     ///
     /// This can be overridden in simulation using [`SimulationRunning::handle_effect`](crate::simulation::SimulationRunning::handle_effect).
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>>;
-
-    /// Helper method for implementers of ExternalEffect.
-    fn wrap(
-        f: impl Future<Output = <Self as ExternalEffectAPI>::Response> + Send + 'static,
-    ) -> BoxFuture<'static, Box<dyn SendData>>
-    where
-        Self: Sized + ExternalEffectAPI,
-    {
-        Box::pin(async move {
-            let response = f.await;
-            Box::new(response) as Box<dyn SendData>
-        })
-    }
-
-    /// Helper method for implementers of ExternalEffect that have a synchronous response.
-    fn wrap_sync(response: <Self as ExternalEffectAPI>::Response) -> BoxFuture<'static, Box<dyn SendData>>
-    where
-        Self: Sized + ExternalEffectAPI,
-    {
-        Box::pin(future::ready(Box::new(response) as Box<dyn SendData>))
-    }
-
-    /// Helper method for implementers of ExternalEffect that have a synchronous response.
-    fn wrap_sync_f(
-        response: impl FnOnce() -> <Self as ExternalEffectAPI>::Response,
-    ) -> BoxFuture<'static, Box<dyn SendData>>
-    where
-        Self: Sized + ExternalEffectAPI,
-    {
-        Box::pin(future::ready(Box::new(response()) as Box<dyn SendData>))
-    }
 }
 
 impl Display for dyn ExternalEffect {
@@ -537,16 +499,83 @@ impl Display for dyn ExternalEffect {
 /// Separate trait for fixing the response type of an external effect.
 ///
 /// This cannot be included in [`ExternalEffect`] because it would require a type parameter, which
-/// in turn would make that trait non-object-safe.
-pub trait ExternalEffectAPI: ExternalEffect {
+/// in turn would make that trait non-object-safe. Implement this trait only: a blanket impl
+/// supplies [`ExternalEffect`].
+pub trait ExternalEffectAPI: SendData {
     type Response: SendData + DeserializeOwned;
 
     /// Type-level declaration of the simulated duration distribution.
     ///
-    /// This is the associated constant that cannot sit on [`ExternalEffect`] (that trait
-    /// must remain a trait object). Return it from
-    /// [`ExternalEffect::simulated_duration_dist`] so the simulator can see it.
+    /// A blanket [`ExternalEffect`] impl reports this as
+    /// [`ExternalEffect::simulated_duration_dist`]. Use [`DurationDist::UntilResolved`] when
+    /// the simulation (not a sampled `δ`) decides when the effect Future completes.
     const SIMULATED_DURATION: DurationDist = DurationDist::ZERO;
+
+    /// Instance view of [`Self::SIMULATED_DURATION`]. Override only if the distribution
+    /// depends on the effect value; keep it equal to the const so [`Self::wrap`] stays honest.
+    fn simulated_duration_dist(&self) -> DurationDist {
+        Self::SIMULATED_DURATION
+    }
+
+    /// Run the effect in production mode.
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>>;
+
+    /// Helper for implementers of [`ExternalEffect::run`].
+    ///
+    /// Pass a closure so this method can assert
+    /// [`ExternalEffect::simulated_duration_dist`] matches [`Self::SIMULATED_DURATION`]
+    /// before `self` is moved into the future.
+    fn wrap<F, Fut>(self, f: F) -> BoxFuture<'static, Box<dyn SendData>>
+    where
+        Self: Sized,
+        F: FnOnce(Self) -> Fut + Send + 'static,
+        Fut: Future<Output = Self::Response> + Send + 'static,
+    {
+        assert_simulated_duration(&self);
+        Box::pin(async move {
+            let response = f(self).await;
+            Box::new(response) as Box<dyn SendData>
+        })
+    }
+
+    /// Helper for implementers of [`ExternalEffect::run`] with a synchronous response.
+    fn wrap_sync(&self, response: Self::Response) -> BoxFuture<'static, Box<dyn SendData>>
+    where
+        Self: Sized,
+    {
+        assert_simulated_duration(self);
+        Box::pin(future::ready(Box::new(response) as Box<dyn SendData>))
+    }
+
+    /// Helper for implementers of [`ExternalEffect::run`] with a synchronous response.
+    fn wrap_sync_f(&self, response: impl FnOnce() -> Self::Response) -> BoxFuture<'static, Box<dyn SendData>>
+    where
+        Self: Sized,
+    {
+        assert_simulated_duration(self);
+        Box::pin(future::ready(Box::new(response()) as Box<dyn SendData>))
+    }
+}
+
+impl<T: ExternalEffectAPI> ExternalEffect for T {
+    fn simulated_duration_dist(&self) -> DurationDist {
+        ExternalEffectAPI::simulated_duration_dist(self)
+    }
+
+    fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
+        ExternalEffectAPI::run(self, resources)
+    }
+}
+
+fn assert_simulated_duration<E: ExternalEffectAPI>(effect: &E) {
+    debug_assert_eq!(
+        effect.simulated_duration_dist(),
+        E::SIMULATED_DURATION,
+        "{}: ExternalEffect::simulated_duration_dist() must return ExternalEffectAPI::SIMULATED_DURATION ({:?}), got {:?}",
+        type_name::<E>(),
+        E::SIMULATED_DURATION,
+        effect.simulated_duration_dist(),
+    );
 }
 
 impl dyn ExternalEffect {
@@ -577,14 +606,12 @@ impl serde::Serialize for dyn ExternalEffect {
     }
 }
 
-impl ExternalEffect for () {
+impl ExternalEffectAPI for () {
+    type Response = ();
+
     fn run(self: Box<Self>, _resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
         Box::pin(async { Box::new(()) as Box<dyn SendData> })
     }
-}
-
-impl ExternalEffectAPI for () {
-    type Response = ();
 }
 
 /// Generic deserialization result of external effects.

--- a/crates/amaru-pure-stage/src/effect.rs
+++ b/crates/amaru-pure-stage/src/effect.rs
@@ -32,7 +32,7 @@ use parking_lot::Mutex;
 use serde::de::DeserializeOwned;
 
 use crate::{
-    BLACKHOLE_NAME, BoxFuture, Instant, Name, Resources, ScheduleId, SendData, StageBuildRef, StageRef,
+    BLACKHOLE_NAME, BoxFuture, DurationDist, Instant, Name, Resources, ScheduleId, SendData, StageBuildRef, StageRef,
     effect_box::{EffectBox, airlock_effect},
     serde::{NoDebug, SendDataValue, never, to_cbor},
     simulation::Transition,
@@ -466,6 +466,27 @@ impl CanSupervise {
 /// The [`run`](ExternalEffect::run) method is used to perform the effect unless a
 /// simulator chooses differently. The latter can be done by downcasting to the concrete type.
 pub trait ExternalEffect: SendData {
+    /// Distribution of simulated time this effect occupies in
+    /// [`crate::simulation::SimulationRunning`].
+    ///
+    /// The Tokio runtime ignores this. Defaults to [`DurationDist::Zero`] so existing
+    /// effects keep today's traces. Use [`DurationDist::UntilResolved`] when the
+    /// simulation (not a sampled `δ`) decides when the effect Future completes — e.g.
+    /// a network receive.
+    ///
+    /// An associated `const` cannot live on this trait: it would make `dyn ExternalEffect`
+    /// illegal. Declare [`ExternalEffectAPI::SIMULATED_DURATION`] on the concrete type and
+    /// return it from this method:
+    ///
+    /// ```ignore
+    /// fn simulated_duration_dist(&self) -> DurationDist {
+    ///     <Self as ExternalEffectAPI>::SIMULATED_DURATION
+    /// }
+    /// ```
+    fn simulated_duration_dist(&self) -> DurationDist {
+        DurationDist::ZERO
+    }
+
     /// Run the effect in production mode.
     ///
     /// Implementations typically retrieve shared services via typed lookups
@@ -519,6 +540,13 @@ impl Display for dyn ExternalEffect {
 /// in turn would make that trait non-object-safe.
 pub trait ExternalEffectAPI: ExternalEffect {
     type Response: SendData + DeserializeOwned;
+
+    /// Type-level declaration of the simulated duration distribution.
+    ///
+    /// This is the associated constant that cannot sit on [`ExternalEffect`] (that trait
+    /// must remain a trait object). Return it from
+    /// [`ExternalEffect::simulated_duration_dist`] so the simulator can see it.
+    const SIMULATED_DURATION: DurationDist = DurationDist::ZERO;
 }
 
 impl dyn ExternalEffect {

--- a/crates/amaru-pure-stage/src/lib.rs
+++ b/crates/amaru-pure-stage/src/lib.rs
@@ -16,6 +16,7 @@
 
 mod adapter;
 pub mod drop_guard;
+mod duration_dist;
 mod effect;
 mod effect_box;
 mod logging;
@@ -34,6 +35,7 @@ mod types;
 
 pub mod simulation;
 
+pub use duration_dist::DurationDist;
 pub use effect::{
     Effect, Effects, ExternalEffect, ExternalEffectAPI, ScheduleIds, StageResponse, UnknownExternalEffect,
 };
@@ -50,8 +52,9 @@ pub use stagegraph::{ScheduleId, StageGraph, StageGraphRunning, stage_name};
 pub use time::{Clock, EPOCH, Instant};
 pub use trace_buffer::TerminationReason;
 pub use trace_match::{
-    TraceMatch, assert_trace_contains, assert_trace_does_not_contain, assert_trace_match, tm_add_stage,
-    tm_external_effect, tm_external_effect_match, tm_input, tm_send, tm_state, tm_terminate, tm_terminated,
+    TraceMatch, assert_trace_contains, assert_trace_does_not_contain, assert_trace_match, tm_add_stage, tm_clock,
+    tm_clock_between, tm_external_effect, tm_external_effect_match, tm_input, tm_send, tm_state, tm_terminate,
+    tm_terminated,
 };
 pub use types::{
     BLACKHOLE_NAME, BoxFuture, Name, OrTerminateWith, PRIORITY_MAILBOX_SIZE, SendData, TryInStage, Void, err, warn,

--- a/crates/amaru-pure-stage/src/output.rs
+++ b/crates/amaru-pure-stage/src/output.rs
@@ -16,7 +16,7 @@ use std::fmt;
 
 use tokio::sync::mpsc;
 
-use crate::{ExternalEffect, ExternalEffectAPI, Name, Resources, SendData, types::MpscSender};
+use crate::{ExternalEffectAPI, Name, Resources, SendData, types::MpscSender};
 
 /// An effect that sends a message to an output channel.
 ///
@@ -58,10 +58,12 @@ impl<Msg: SendData + PartialEq> PartialEq for OutputEffect<Msg> {
     }
 }
 
-impl<Msg> ExternalEffect for OutputEffect<Msg>
+impl<Msg> ExternalEffectAPI for OutputEffect<Msg>
 where
     Msg: SendData + PartialEq + serde::Serialize + serde::de::DeserializeOwned,
 {
+    type Response = ();
+
     fn run(self: Box<Self>, _resources: Resources) -> crate::BoxFuture<'static, Box<dyn SendData>> {
         Box::pin(async move {
             if let Err(e) = self.sender.send(self.msg).await {
@@ -70,11 +72,4 @@ where
             Box::new(()) as Box<dyn SendData>
         })
     }
-}
-
-impl<Msg> ExternalEffectAPI for OutputEffect<Msg>
-where
-    Msg: SendData + PartialEq + serde::Serialize + serde::de::DeserializeOwned,
-{
-    type Response = ();
 }

--- a/crates/amaru-pure-stage/src/simulation/running/mod.rs
+++ b/crates/amaru-pure-stage/src/simulation/running/mod.rs
@@ -360,7 +360,7 @@ impl SimulationRunning {
     /// If the future is not already ready, `block_on` is bounded by
     /// [`DurationDist::force_timeout`] (`1.5 × max + 1s`). Exceeding that is a bug.
     fn force_scheduled_computation(&mut self, at_stage: &Name) {
-        let Some(fut) = self.pending_computations.remove(at_stage) else {
+        let Some(mut fut) = self.pending_computations.remove(at_stage) else {
             return;
         };
         let timeout = self
@@ -368,10 +368,18 @@ impl SimulationRunning {
             .get(at_stage)
             .and_then(|pending| pending.dist.force_timeout())
             .expect("force only for sampled DurationDist");
-        let result = self
-            .tokio_handle
-            .block_on(tokio::time::timeout(timeout, fut))
-            .expect("external effect on `{at_stage}` exceeded force timeout {timeout:?}");
+        // Poll first so already-ready `run()` (typical wrap_sync) never enters the runtime.
+        // `timeout` must be constructed inside `block_on`: current-thread test runtimes
+        // have no ambient reactor, and `tokio::time::timeout` requires one.
+        let result = match std::future::Future::poll(fut.as_mut(), &mut Context::from_waker(Waker::noop())) {
+            Poll::Ready(result) => result,
+            Poll::Pending => match self.tokio_handle.block_on(async { tokio::time::timeout(timeout, fut).await }) {
+                Ok(result) => result,
+                Err(_elapsed) => {
+                    panic!("external effect on `{at_stage}` exceeded force timeout {timeout:?}")
+                }
+            },
+        };
         self.provide_external_result(at_stage.clone(), result);
     }
 
@@ -379,12 +387,15 @@ impl SimulationRunning {
         pending: &mut BTreeMap<Name, BoxFuture<'static, Box<dyn SendData>>>,
         cx: &mut Context<'_>,
     ) -> Option<(Name, Box<dyn SendData>)> {
-        for (name, fut) in pending.iter_mut() {
+        let names: Vec<Name> = pending.keys().cloned().collect();
+        for name in names {
+            let Some(fut) = pending.get_mut(&name) else {
+                continue;
+            };
             match std::future::Future::poll(fut.as_mut(), cx) {
                 Poll::Ready(result) => {
-                    let name = name.clone();
                     pending.remove(&name);
-                    return Some((name.clone(), result));
+                    return Some((name, result));
                 }
                 Poll::Pending => {}
             }
@@ -598,7 +609,7 @@ impl SimulationRunning {
     pub fn run_until_blocked_incl_effects(&mut self) -> Blocked {
         loop {
             match self.run_until_sleeping_or_blocked() {
-                Blocked::Busy { .. } => {
+                Blocked::Busy { external_effects, .. } if external_effects > 0 => {
                     self.tokio_handle.clone().block_on(self.await_external_effect());
                 }
                 Blocked::Sleeping { .. } => {
@@ -1277,7 +1288,12 @@ impl SimulationRunning {
     /// Panics if the stage name does not exist (which may also happen due to termination).
     pub fn resume_external_box(&mut self, at_stage: impl AsRef<Name>, result: Box<dyn SendData>) -> anyhow::Result<()> {
         let at_stage = at_stage.as_ref().clone();
-        self.stages.get_mut(&at_stage).assert_stage("which cannot receive external effects");
+        {
+            let data = self.stages.get_mut(&at_stage).assert_stage("which cannot receive external effects");
+            if !matches!(data.waiting, Some(StageEffect::External(_))) {
+                anyhow::bail!("stage `{at_stage}` was not waiting for an external effect, but {:?}", data.waiting);
+            }
+        }
         self.provide_external_result(at_stage, result);
         Ok(())
     }
@@ -1293,7 +1309,12 @@ impl SimulationRunning {
         result: Eff::Response,
     ) -> anyhow::Result<()> {
         let at_stage = at_stage.as_ref().clone();
-        self.stages.get_mut(&at_stage).assert_stage("which cannot receive external effects");
+        {
+            let data = self.stages.get_mut(&at_stage).assert_stage("which cannot receive external effects");
+            if !matches!(data.waiting, Some(StageEffect::External(_))) {
+                anyhow::bail!("stage `{at_stage}` was not waiting for an external effect, but {:?}", data.waiting);
+            }
+        }
         self.provide_external_result(at_stage, Box::new(result));
         Ok(())
     }

--- a/crates/amaru-pure-stage/src/simulation/running/mod.rs
+++ b/crates/amaru-pure-stage/src/simulation/running/mod.rs
@@ -23,14 +23,14 @@ use std::{
 };
 
 use either::Either::{Left, Right};
-use futures_util::{StreamExt, stream::FuturesUnordered};
 use override_external_effect::OverrideExternalEffect;
 use parking_lot::Mutex;
+use rand::rngs::StdRng;
 use tokio::{runtime::Handle, select, sync::watch};
 
 use crate::{
-    BLACKHOLE_NAME, BoxFuture, Effect, ExternalEffect, ExternalEffectAPI, Instant, Name, Resources, ScheduleId,
-    SendData, StageRef, StageResponse,
+    BLACKHOLE_NAME, BoxFuture, DurationDist, Effect, ExternalEffect, ExternalEffectAPI, Instant, Name, Resources,
+    ScheduleId, SendData, StageRef, StageResponse,
     adapter::{Adapter, StageOrAdapter, find_recipient},
     effect::{CallExtra, CanSupervise, ScheduleIds, StageEffect},
     effect_box::EffectBox,
@@ -87,15 +87,33 @@ pub struct SimulationRunning {
     schedule_ids: ScheduleIds,
     trace_buffer: Arc<Mutex<TraceBuffer>>,
     eval_strategy: Box<dyn EvalStrategy>,
+    duration_rng: StdRng,
     terminate: watch::Sender<bool>,
     termination: watch::Receiver<bool>,
-    external_effects: FuturesUnordered<BoxFuture<'static, (Name, Box<dyn SendData>)>>,
+    /// `ExternalEffect::run` futures, keyed by stage. Timed effects are forced at their deadline.
+    pending_computations: BTreeMap<Name, BoxFuture<'static, Box<dyn SendData>>>,
+    /// In-flight external effects: `δ` is scheduled when the effect is issued; the result may arrive later.
+    external_inflight: BTreeMap<Name, PendingExternal>,
+    /// Drives still-pending `run()` futures to completion when a sampled deadline fires.
+    tokio_handle: Handle,
     /// When true, AddStage/WireStage effects (dynamic child stage creation via `eff.stage` + `eff.wire_up`)
     /// succeed for the parent (responses are delivered, effects traced) but no real child stage is
     /// materialized in the simulation. Subsequent sends to the child's StageRef are dropped (NotFound).
     /// This is intended for testing parent stage orchestration logic without having to implement
     /// or override effects for the child stages.
     virtual_child_stages: bool,
+}
+
+/// An external effect whose `δ` was fixed when the effect was issued.
+struct PendingExternal {
+    result: Option<Box<dyn SendData>>,
+    /// `true` once the sampled deadline has been reached, or the dist has no `δ`
+    /// ([`DurationDist::Zero`] or [`DurationDist::UntilResolved`]).
+    time_ready: bool,
+    /// When time is ready and no result is stored, poll/`block_on` the scheduled `run()`.
+    /// `false` for [`DurationDist::UntilResolved`]: the world runner owns completion.
+    force_on_ready: bool,
+    dist: DurationDist,
 }
 
 impl SimulationRunning {
@@ -112,6 +130,8 @@ impl SimulationRunning {
         trace_buffer: Arc<Mutex<TraceBuffer>>,
         eval_strategy: Box<dyn EvalStrategy>,
         global_epoch_offset: Duration,
+        duration_rng: StdRng,
+        tokio_handle: Handle,
     ) -> Self {
         let (terminate, termination) = watch::channel(false);
         Self {
@@ -131,9 +151,12 @@ impl SimulationRunning {
             schedule_ids,
             trace_buffer,
             eval_strategy,
+            duration_rng,
             terminate,
             termination,
-            external_effects: FuturesUnordered::new(),
+            pending_computations: BTreeMap::new(),
+            external_inflight: BTreeMap::new(),
+            tokio_handle,
             virtual_child_stages: false,
         }
     }
@@ -156,7 +179,7 @@ impl SimulationRunning {
 
     /// Return true if there are any effects to be run.
     pub fn has_effects(&self) -> bool {
-        !self.external_effects.is_empty()
+        !self.pending_computations.is_empty()
     }
 
     /// Install a breakpoint that will be hit when an effect matching the given predicate is encountered.
@@ -285,6 +308,120 @@ impl SimulationRunning {
         self.scheduled.schedule(id, Box::new(wakeup));
     }
 
+    /// Record an external effect at the moment it is issued: sample `δ` now and enqueue
+    /// the wakeup. The result may arrive later; the stage resumes only when both are ready.
+    ///
+    /// [`DurationDist::UntilResolved`] and a sampled `δ` of zero schedule nothing: completion
+    /// is the result (the Future, or a manual / override resume).
+    fn begin_external(&mut self, at_stage: Name, dist: DurationDist) {
+        if self.external_inflight.contains_key(&at_stage) {
+            return;
+        }
+        let delta = dist.sample(&mut self.duration_rng);
+        // UntilResolved has no δ: the world runner completes the Future. Sampled δ
+        // (including zero) means the computation is scheduled and must be forced when due.
+        let force_on_ready = delta.is_some();
+        let time_ready = match delta {
+            None => true,
+            Some(d) if d.is_zero() => true,
+            Some(delta) => {
+                let now = self.clock.now(self.global_epoch_offset);
+                let id = self.schedule_ids.next_at(now + delta);
+                let name = at_stage.clone();
+                self.schedule_wakeup(id, move |sim| {
+                    if let Some(pending) = sim.external_inflight.get_mut(&name) {
+                        pending.time_ready = true;
+                    }
+                    sim.try_deliver_external(&name);
+                });
+                false
+            }
+        };
+        self.external_inflight.insert(at_stage, PendingExternal { result: None, time_ready, force_on_ready, dist });
+    }
+
+    /// Offer the computed result of an in-flight external effect. Resumes the stage if
+    /// the scheduled time has already been reached (or there was no `δ`).
+    fn provide_external_result(&mut self, at_stage: Name, result: Box<dyn SendData>) {
+        let pending = self.external_inflight.entry(at_stage.clone()).or_insert(PendingExternal {
+            result: None,
+            // No `begin_external` (manual resume without going through `try_effect`): treat as UntilResolved.
+            time_ready: true,
+            force_on_ready: false,
+            dist: DurationDist::UntilResolved,
+        });
+        pending.result = Some(result);
+        self.try_deliver_external(&at_stage);
+    }
+
+    /// Drive `run()` to completion now. Called only when a sampled deadline has been reached
+    /// (or `δ` was zero), so wall-clock compute cannot slip past other simulated events.
+    ///
+    /// If the future is not already ready, `block_on` is bounded by
+    /// [`DurationDist::force_timeout`] (`1.5 × max + 1s`). Exceeding that is a bug.
+    fn force_scheduled_computation(&mut self, at_stage: &Name) {
+        let Some(fut) = self.pending_computations.remove(at_stage) else {
+            return;
+        };
+        let timeout = self
+            .external_inflight
+            .get(at_stage)
+            .and_then(|pending| pending.dist.force_timeout())
+            .expect("force only for sampled DurationDist");
+        let result = self
+            .tokio_handle
+            .block_on(tokio::time::timeout(timeout, fut))
+            .expect("external effect on `{at_stage}` exceeded force timeout {timeout:?}");
+        self.provide_external_result(at_stage.clone(), result);
+    }
+
+    fn poll_ready_computations(
+        pending: &mut BTreeMap<Name, BoxFuture<'static, Box<dyn SendData>>>,
+        cx: &mut Context<'_>,
+    ) -> Option<(Name, Box<dyn SendData>)> {
+        for (name, fut) in pending.iter_mut() {
+            match std::future::Future::poll(fut.as_mut(), cx) {
+                Poll::Ready(result) => {
+                    let name = name.clone();
+                    pending.remove(&name);
+                    return Some((name.clone(), result));
+                }
+                Poll::Pending => {}
+            }
+        }
+        None
+    }
+
+    fn try_deliver_external(&mut self, at_stage: &Name) {
+        let Some(pending) = self.external_inflight.get(at_stage) else {
+            return;
+        };
+        if !pending.time_ready {
+            return;
+        }
+        if pending.result.is_none() && pending.force_on_ready {
+            self.force_scheduled_computation(at_stage);
+            return;
+        }
+        if pending.result.is_none() {
+            return;
+        }
+        let pending = self.external_inflight.remove(at_stage).expect("just checked");
+        let Some(data) = self.stages.get_mut(at_stage) else {
+            tracing::warn!(name = %at_stage, "stage was terminated, skipping external effect delivery");
+            return;
+        };
+        resume_external_internal(
+            data.assert_stage("which cannot receive external effects"),
+            pending.result.expect("just checked"),
+            &mut |name, response| {
+                tracing::debug!(%name, ?response, "enqueuing stage");
+                self.runnable.push_back((name, response));
+            },
+        )
+        .expect("external effect is always runnable");
+    }
+
     /// Place messages in the given stage’s mailbox, but don’t resume it.
     /// The next message will be consumed when resuming an [`Effect::Receive`]
     /// for this stage.
@@ -371,6 +508,12 @@ impl SimulationRunning {
             self.trace_buffer.lock().push_suspend(&effect);
         }
 
+        if let Effect::External { at_stage, effect } = &effect {
+            let at_stage = at_stage.clone();
+            let dist = effect.simulated_duration_dist();
+            self.begin_external(at_stage, dist);
+        }
+
         Ok(effect)
     }
 
@@ -411,29 +554,35 @@ impl SimulationRunning {
     /// When external effects are currently unresolved, await either the resolution of an effect
     /// or the arrival of a new external input message.
     pub async fn await_external_effect(&mut self) -> Option<Name> {
-        if self.external_effects.is_empty() {
+        if self.pending_computations.is_empty() {
             return None;
         }
-        let (at_stage, result) = select! {
-            x = self.external_effects.next() => x?,
-            env = self.inputs.next() => {
-                self.inputs.put_back(env);
-                return None;
+        if let Some((name, result)) =
+            Self::poll_ready_computations(&mut self.pending_computations, &mut Context::from_waker(Waker::noop()))
+        {
+            self.provide_external_result(name.clone(), result);
+            return Some(name);
+        }
+        if self.pending_computations.is_empty() {
+            return None;
+        }
+
+        let pending = &mut self.pending_computations;
+        let inputs = &mut self.inputs;
+        let ready = select! {
+            env = inputs.next() => {
+                inputs.put_back(env);
+                None
             }
+            ready = std::future::poll_fn(|cx| match Self::poll_ready_computations(pending, cx) {
+                Some(ready) => Poll::Ready(Some(ready)),
+                None if pending.is_empty() => Poll::Ready(None),
+                None => Poll::Pending,
+            }) => ready,
         };
-
-        let runnable = &mut self.runnable;
-        let run = &mut |name, response| {
-            runnable.push_back((name, response));
-        };
-
-        let Some(data) = self.stages.get_mut(&at_stage) else {
-            tracing::warn!(name = %at_stage, "stage was terminated, skipping external effect delivery");
-            return Some(at_stage);
-        };
-        let data = data.assert_stage("which cannot receive external effects");
-        resume_external_internal(data, result, run).expect("external effect is always runnable");
-        Some(at_stage)
+        let (name, result) = ready?;
+        self.provide_external_result(name.clone(), result);
+        Some(name)
     }
 
     /// Wait for a message to be enqueued via an external input to the simulation.
@@ -446,11 +595,11 @@ impl SimulationRunning {
     /// Keep alternating between [`Self::run_until_blocked`] and
     /// [`Self::await_external_effect`] until the simulation is blocked
     /// without waiting for external effects to be resolved.
-    pub fn run_until_blocked_incl_effects(&mut self, rt: &Handle) -> Blocked {
+    pub fn run_until_blocked_incl_effects(&mut self) -> Blocked {
         loop {
             match self.run_until_sleeping_or_blocked() {
                 Blocked::Busy { .. } => {
-                    rt.block_on(self.await_external_effect());
+                    self.tokio_handle.clone().block_on(self.await_external_effect());
                 }
                 Blocked::Sleeping { .. } => {
                     assert!(self.skip_to_next_wakeup(None));
@@ -497,11 +646,11 @@ impl SimulationRunning {
         }
     }
 
-    pub fn run_until_blocked_or_time_incl_effects(&mut self, time: Instant, rt: &Handle) -> Blocked {
+    pub fn run_until_blocked_or_time_incl_effects(&mut self, time: Instant) -> Blocked {
         loop {
             match self.run_until_sleeping_or_blocked() {
                 Blocked::Busy { external_effects, .. } if external_effects > 0 => {
-                    rt.block_on(self.await_external_effect());
+                    self.tokio_handle.clone().block_on(self.await_external_effect());
                 }
                 Blocked::Sleeping { next_wakeup } => {
                     if !self.skip_to_next_wakeup(Some(time)) {
@@ -529,11 +678,11 @@ impl SimulationRunning {
     }
 
     // TODO: shouldn’t this have a clock ceiling?
-    pub fn run_one_step(&mut self, rt: &Handle) -> Option<Blocked> {
+    pub fn run_one_step(&mut self) -> Option<Blocked> {
         self.receive_inputs();
         match self.run_effect() {
             Some(Blocked::Busy { .. }) => {
-                rt.block_on(self.await_external_effect());
+                self.tokio_handle.clone().block_on(self.await_external_effect());
                 None
             }
             Some(Blocked::Sleeping { .. }) => {
@@ -778,7 +927,6 @@ impl SimulationRunning {
                     .expect("cancel_schedule effect is always runnable");
             }
             Effect::External { at_stage, mut effect } => {
-                let mut result = None;
                 let mut idx = 0;
                 while idx < self.overrides.len() {
                     use override_external_effect::OverrideResult::*;
@@ -789,13 +937,11 @@ impl SimulationRunning {
                             idx += 1;
                         }
                         Handled(msg) => {
-                            result = Some(msg);
-                            // dummy effect value since we moved out of `effect` and need it later in the other case
-                            effect = Box::new(());
                             if over.register_use_and_get_removal() {
                                 self.overrides.remove(idx);
                             }
-                            break;
+                            self.provide_external_result(at_stage, msg);
+                            return None;
                         }
                         Replaced(effect2) => {
                             effect = effect2;
@@ -807,17 +953,10 @@ impl SimulationRunning {
                         }
                     }
                 }
-                if let Some(result) = result {
-                    let data = self
-                        .stages
-                        .get_mut(&at_stage)
-                        .log_termination(&at_stage)?
-                        .assert_stage("which cannot receive external effects");
-                    resume_external_internal(data, result, run).expect("external effect is always runnable");
-                    return None;
-                }
                 let resources = self.resources.clone();
-                self.external_effects.push(Box::pin(async move { (at_stage, effect.run(resources).await) }));
+                let name = at_stage.clone();
+                self.pending_computations.insert(name.clone(), effect.run(resources));
+                self.try_deliver_external(&name);
             }
             Effect::Terminate { at_stage } => {
                 tracing::info!(stage = %at_stage, "terminated");
@@ -914,6 +1053,8 @@ impl SimulationRunning {
 
         // clean up simulation state for this stage
         self.runnable.retain(|(n, _)| n != &at_stage);
+        self.external_inflight.remove(&at_stage);
+        self.pending_computations.remove(&at_stage);
 
         let runnable = &mut self.runnable;
         let run = &mut |name, response| {
@@ -1135,11 +1276,10 @@ impl SimulationRunning {
     ///
     /// Panics if the stage name does not exist (which may also happen due to termination).
     pub fn resume_external_box(&mut self, at_stage: impl AsRef<Name>, result: Box<dyn SendData>) -> anyhow::Result<()> {
-        let data = self.stages.get_mut(at_stage.as_ref()).assert_stage("which cannot receive external effects");
-        resume_external_internal(data, result, &mut |name, response| {
-            tracing::debug!(%name, ?response, "enqueuing stage");
-            self.runnable.push_back((name, response));
-        })
+        let at_stage = at_stage.as_ref().clone();
+        self.stages.get_mut(&at_stage).assert_stage("which cannot receive external effects");
+        self.provide_external_result(at_stage, result);
+        Ok(())
     }
 
     /// Resume an [`Effect::External`].
@@ -1152,11 +1292,10 @@ impl SimulationRunning {
         at_stage: impl AsRef<Name>,
         result: Eff::Response,
     ) -> anyhow::Result<()> {
-        let data = self.stages.get_mut(at_stage.as_ref()).assert_stage("which cannot receive external effects");
-        resume_external_internal(data, Box::new(result), &mut |name, response| {
-            tracing::debug!(%name, ?response, "enqueuing stage");
-            self.runnable.push_back((name, response));
-        })
+        let at_stage = at_stage.as_ref().clone();
+        self.stages.get_mut(&at_stage).assert_stage("which cannot receive external effects");
+        self.provide_external_result(at_stage, Box::new(result));
+        Ok(())
     }
 
     /// Resume an [`Effect::AddStage`].
@@ -1425,13 +1564,18 @@ fn block_reason(sim: &SimulationRunning) -> Blocked {
             }
             StageEffect::Receive => {}
             StageEffect::Wait(..) => sleep.push(k.clone()),
+            StageEffect::External(_) => match sim.external_inflight.get(k) {
+                // Deadline not yet reached: sleep even if the Future is still running.
+                Some(pending) if !pending.time_ready => sleep.push(k.clone()),
+                _ => busy.push(k.clone()),
+            },
             StageEffect::Call(_, _, CallExtra::Scheduled(id)) if sim.scheduled.contains(id) => sleep.push(k.clone()),
             _ => busy.push(k.clone()),
         }
     }
 
     if !busy.is_empty() {
-        Blocked::Busy { stages: busy, external_effects: sim.external_effects.len() }
+        Blocked::Busy { stages: busy, external_effects: sim.pending_computations.len() }
     } else if !sleep.is_empty() {
         Blocked::Sleeping { next_wakeup: sim.next_wakeup().expect("stages are waiting for a wait effect") }
     } else if !send.is_empty() {
@@ -1564,7 +1708,8 @@ fn simulation_invariants() {
     });
 
     let stage = network.wire_up(stage, false);
-    let mut sim = network.run();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mut sim = network.run(rt.handle());
 
     #[expect(clippy::type_complexity)]
     let ops: [(

--- a/crates/amaru-pure-stage/src/simulation/simulation_builder.rs
+++ b/crates/amaru-pure-stage/src/simulation/simulation_builder.rs
@@ -181,7 +181,8 @@ impl SimulationBuilder {
     }
 
     pub fn with_seed(mut self, seed: u64) -> Self {
-        self.duration_rng = StdRng::seed_from_u64(seed);
+        // Distinct derived stream so duration samples do not share the eval-strategy sequence.
+        self.duration_rng = StdRng::seed_from_u64(seed.wrapping_add(0x9E37_79B9_7F4A_7C15));
         self.with_eval_strategy(RandStdRng(StdRng::seed_from_u64(seed)))
     }
 

--- a/crates/amaru-pure-stage/src/simulation/simulation_builder.rs
+++ b/crates/amaru-pure-stage/src/simulation/simulation_builder.rs
@@ -46,7 +46,7 @@ use std::{
 
 use parking_lot::Mutex;
 use rand::{SeedableRng, prelude::StdRng};
-use tokio::runtime::Builder;
+use tokio::runtime::{Builder, Handle};
 
 use crate::{
     BLACKHOLE_NAME, Clock, EPOCH, Instant, Name, PRIORITY_MAILBOX_SIZE, Resources, ScheduleIds, SendData, Sender,
@@ -91,8 +91,8 @@ use crate::{
 /// let (output, mut rx) = network.output("output", 10);
 /// let stage = network.wire_up(stage, (1u32, output.clone()));
 ///
-/// let mut running = network.run();
 /// let rt = tokio::runtime::Runtime::new().unwrap();
+/// let mut running = network.run(rt.handle());
 ///
 /// // first check that the stages start out suspended on Receive
 /// running.try_effect().unwrap_err().assert_idle();
@@ -127,6 +127,7 @@ pub struct SimulationBuilder {
     inputs: Inputs,
     trace_buffer: Arc<Mutex<TraceBuffer>>,
     eval_strategy: Box<dyn EvalStrategy>,
+    duration_rng: StdRng,
 }
 
 impl SimulationBuilder {
@@ -179,7 +180,8 @@ impl SimulationBuilder {
         self
     }
 
-    pub fn with_seed(self, seed: u64) -> Self {
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.duration_rng = StdRng::seed_from_u64(seed);
         self.with_eval_strategy(RandStdRng(StdRng::seed_from_u64(seed)))
     }
 
@@ -216,7 +218,11 @@ impl SimulationBuilder {
         Replay::new(stages, self.effect, self.trace_buffer, self.schedule_ids)
     }
 
-    pub fn run(self) -> SimulationRunning {
+    /// Start the simulation.
+    ///
+    /// `tokio_handle` is required so a sampled external-effect deadline can force `run()`
+    /// to completion at that simulated instant (wall-clock compute must not reorder events).
+    pub fn run(self, tokio_handle: &Handle) -> SimulationRunning {
         let Self {
             stages: s,
             stage_counter,
@@ -230,6 +236,7 @@ impl SimulationBuilder {
             schedule_ids,
             trace_buffer,
             eval_strategy,
+            duration_rng,
         } = self;
 
         debug_assert_eq!(stage_counter, s.len());
@@ -279,6 +286,8 @@ impl SimulationBuilder {
             trace_buffer,
             eval_strategy,
             global_epoch_offset,
+            duration_rng,
+            tokio_handle.clone(),
         )
     }
 }
@@ -301,6 +310,7 @@ impl Default for SimulationBuilder {
             // default is a TraceBuffer that drops all messages
             trace_buffer: Arc::new(Mutex::new(TraceBuffer::new(0, 0))),
             eval_strategy: Box::new(Fifo),
+            duration_rng: StdRng::seed_from_u64(0),
         }
     }
 }
@@ -468,8 +478,8 @@ where
     let stage = network.wire_up(stage, None);
     network.preload(&stage, [msg]).unwrap();
 
-    let mut running = network.run();
-    running.run_until_blocked_incl_effects(runtime.handle()).assert_idle();
+    let mut running = network.run(runtime.handle());
+    running.run_until_blocked_incl_effects().assert_idle();
 
     running.get_state(&stage).cloned().flatten()
 }

--- a/crates/amaru-pure-stage/src/trace_match.rs
+++ b/crates/amaru-pure-stage/src/trace_match.rs
@@ -285,6 +285,21 @@ pub fn tm_clock(instant: Duration) -> TraceMatch<'static> {
     )
 }
 
+/// Matches a [`TraceEntry::Clock`] whose sim-elapsed time lies in `[min, max]` inclusive.
+pub fn tm_clock_between(min: Duration, max: Duration) -> TraceMatch<'static> {
+    let description = format!("Clock(between {:?} and {:?})", min, max);
+    TraceMatch::Property(
+        Box::new(move |entry| {
+            let TraceEntry::Clock(i) = entry else {
+                return false;
+            };
+            let elapsed = i.inner.saturating_duration_since(*EPOCH);
+            elapsed >= min && elapsed <= max
+        }),
+        description,
+    )
+}
+
 // =============================================================================
 // Assertion helpers
 // =============================================================================

--- a/crates/amaru-pure-stage/src/types.rs
+++ b/crates/amaru-pure-stage/src/types.rs
@@ -524,7 +524,8 @@ mod test {
             network.stage("stage", async |_: u32, msg: Option<u32>, eff| msg.or_terminate(&eff, async |_| ()).await);
         let stage = network.wire_up(stage, 0);
 
-        let mut sim = network.run();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut sim = network.run(rt.handle());
 
         sim.enqueue_msg(&stage, [Some(1)]);
         sim.run_until_blocked();
@@ -561,7 +562,8 @@ mod test {
         });
         let stage = network.wire_up(stage, 0);
 
-        let mut sim = network.run();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut sim = network.run(rt.handle());
 
         sim.enqueue_msg(&stage, [Ok(1)]);
         sim.run_until_blocked();

--- a/crates/amaru-pure-stage/tests/duration_dist.rs
+++ b/crates/amaru-pure-stage/tests/duration_dist.rs
@@ -1,0 +1,348 @@
+#![expect(clippy::unwrap_used, clippy::wildcard_enum_match_arm)]
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Simulated duration of [`ExternalEffect`]: sampled `δ` is scheduled when the effect is
+//! issued; [`DurationDist::UntilResolved`] waits for the Future instead.
+
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
+
+use amaru_pure_stage::{
+    DeserializerGuards, DurationDist, ExternalEffect, ExternalEffectAPI, Resources, StageGraph,
+    assert_trace_does_not_contain, assert_trace_match, register_data_deserializer, register_effect_deserializer,
+    simulation::SimulationBuilder, tm_clock, tm_clock_between, tm_external_effect, tm_input, tm_state,
+    trace_buffer::TraceBuffer,
+};
+
+#[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+struct ZeroWork;
+
+impl ExternalEffect for ZeroWork {
+    fn simulated_duration_dist(&self) -> DurationDist {
+        <Self as ExternalEffectAPI>::SIMULATED_DURATION
+    }
+
+    fn run(
+        self: Box<Self>,
+        _resources: Resources,
+    ) -> amaru_pure_stage::BoxFuture<'static, Box<dyn amaru_pure_stage::SendData>> {
+        Self::wrap_sync(())
+    }
+}
+
+impl ExternalEffectAPI for ZeroWork {
+    type Response = ();
+}
+
+#[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+struct ConstWork;
+
+impl ExternalEffect for ConstWork {
+    fn simulated_duration_dist(&self) -> DurationDist {
+        <Self as ExternalEffectAPI>::SIMULATED_DURATION
+    }
+
+    fn run(
+        self: Box<Self>,
+        _resources: Resources,
+    ) -> amaru_pure_stage::BoxFuture<'static, Box<dyn amaru_pure_stage::SendData>> {
+        Self::wrap_sync(())
+    }
+}
+
+impl ExternalEffectAPI for ConstWork {
+    type Response = ();
+    const SIMULATED_DURATION: DurationDist = DurationDist::Constant(Duration::from_secs(10));
+}
+
+#[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+struct UniformWork;
+
+impl ExternalEffect for UniformWork {
+    fn simulated_duration_dist(&self) -> DurationDist {
+        <Self as ExternalEffectAPI>::SIMULATED_DURATION
+    }
+
+    fn run(
+        self: Box<Self>,
+        _resources: Resources,
+    ) -> amaru_pure_stage::BoxFuture<'static, Box<dyn amaru_pure_stage::SendData>> {
+        Self::wrap_sync(())
+    }
+}
+
+impl ExternalEffectAPI for UniformWork {
+    type Response = ();
+    const SIMULATED_DURATION: DurationDist =
+        DurationDist::Uniform { min: Duration::from_secs(5), max: Duration::from_secs(15) };
+}
+
+#[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+struct ResolvedWork;
+
+impl ExternalEffect for ResolvedWork {
+    fn simulated_duration_dist(&self) -> DurationDist {
+        <Self as ExternalEffectAPI>::SIMULATED_DURATION
+    }
+
+    fn run(
+        self: Box<Self>,
+        _resources: Resources,
+    ) -> amaru_pure_stage::BoxFuture<'static, Box<dyn amaru_pure_stage::SendData>> {
+        Self::wrap_sync(())
+    }
+}
+
+impl ExternalEffectAPI for ResolvedWork {
+    type Response = ();
+    const SIMULATED_DURATION: DurationDist = DurationDist::UntilResolved;
+}
+
+fn run_once<E: ExternalEffectAPI<Response = ()> + Default>(
+    seed: u64,
+) -> (amaru_pure_stage::simulation::SimulationRunning, DeserializerGuards) {
+    let guards: DeserializerGuards = vec![
+        register_data_deserializer::<()>().boxed(),
+        register_data_deserializer::<u32>().boxed(),
+        register_effect_deserializer::<ZeroWork>().boxed(),
+        register_effect_deserializer::<ConstWork>().boxed(),
+        register_effect_deserializer::<UniformWork>().boxed(),
+        register_effect_deserializer::<ResolvedWork>().boxed(),
+    ];
+
+    let trace_buffer = TraceBuffer::new_shared(100, 1_000_000);
+    let mut network = SimulationBuilder::default().with_trace_buffer(trace_buffer).with_seed(seed);
+
+    let stage = network.stage("work", async |(), _msg: u32, eff| {
+        eff.external(E::default()).await;
+    });
+    let stage = network.wire_up(stage, ());
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mut running = network.run(rt.handle());
+
+    running.enqueue_msg(&stage, [1]);
+    running.run_until_blocked_incl_effects().assert_idle();
+    (running, guards)
+}
+
+#[test]
+fn dyn_external_effect_projects_type_constant() {
+    let zero: Box<dyn ExternalEffect> = Box::new(ZeroWork);
+    let constant: Box<dyn ExternalEffect> = Box::new(ConstWork);
+    let uniform: Box<dyn ExternalEffect> = Box::new(UniformWork);
+    let resolved: Box<dyn ExternalEffect> = Box::new(ResolvedWork);
+    assert_eq!(zero.simulated_duration_dist(), DurationDist::Zero);
+    assert_eq!(constant.simulated_duration_dist(), DurationDist::Constant(Duration::from_secs(10)));
+    assert_eq!(
+        uniform.simulated_duration_dist(),
+        DurationDist::Uniform { min: Duration::from_secs(5), max: Duration::from_secs(15) }
+    );
+    assert_eq!(resolved.simulated_duration_dist(), DurationDist::UntilResolved);
+}
+
+#[test]
+fn zero_does_not_advance_the_clock() {
+    let (running, _guards) = run_once::<ZeroWork>(1);
+    assert_trace_does_not_contain(
+        &running,
+        &[tm_clock(Duration::ZERO), tm_clock_between(Duration::ZERO, Duration::from_secs(1000))],
+    );
+    let (running, _guards) = run_once::<ZeroWork>(1);
+    assert_trace_match(
+        &running,
+        &[
+            tm_state("work-1", &()),
+            tm_input("work-1", &1u32),
+            tm_external_effect::<ZeroWork>("work-1"),
+            tm_state("work-1", &()),
+        ],
+    );
+}
+
+#[test]
+fn constant_advances_the_clock_by_exactly_delta() {
+    let (running, _guards) = run_once::<ConstWork>(1);
+    assert_trace_match(
+        &running,
+        &[
+            tm_state("work-1", &()),
+            tm_input("work-1", &1u32),
+            tm_external_effect::<ConstWork>("work-1"),
+            tm_clock(Duration::from_secs(10)),
+            tm_state("work-1", &()),
+        ],
+    );
+}
+
+#[test]
+fn uniform_advances_the_clock_inside_the_declared_range() {
+    let (running, _guards) = run_once::<UniformWork>(42);
+    assert_trace_match(
+        &running,
+        &[
+            tm_state("work-1", &()),
+            tm_input("work-1", &1u32),
+            tm_external_effect::<UniformWork>("work-1"),
+            tm_clock_between(Duration::from_secs(5), Duration::from_secs(15)),
+            tm_state("work-1", &()),
+        ],
+    );
+}
+
+#[test]
+fn uniform_clock_is_deterministic_for_a_seed() {
+    let (first, _g1) = run_once::<UniformWork>(7);
+    let (second, _g2) = run_once::<UniformWork>(7);
+    let clocks = |running: &amaru_pure_stage::simulation::SimulationRunning| {
+        running
+            .trace_buffer()
+            .lock()
+            .iter_entries()
+            .filter_map(|(_, e)| match e {
+                amaru_pure_stage::trace_buffer::TraceEntry::Clock(i) => Some(format!("{i}")),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(clocks(&first), clocks(&second));
+    assert!(!clocks(&first).is_empty());
+}
+
+#[test]
+fn sampled_delta_is_scheduled_when_the_effect_is_issued() {
+    let _guards: DeserializerGuards = vec![
+        register_data_deserializer::<()>().boxed(),
+        register_data_deserializer::<u32>().boxed(),
+        register_effect_deserializer::<ConstWork>().boxed(),
+    ];
+    let mut network = SimulationBuilder::default().with_seed(1);
+    let stage = network.stage("work", async |(), _msg: u32, eff| {
+        eff.external(ConstWork).await;
+    });
+    let stage = network.wire_up(stage, ());
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mut running = network.run(rt.handle());
+
+    running.enqueue_msg(&stage, [1]);
+    running.resume_receive(&stage).unwrap();
+    let _effect = running.effect();
+
+    // Wakeup exists before any result is provided — δ was sampled at issue time.
+    assert_eq!(running.next_wakeup().map(|t| t.sim_elapsed()), Some(Duration::from_secs(10)));
+    assert_eq!(running.now().sim_elapsed(), Duration::ZERO);
+
+    running.resume_external::<ConstWork>(stage.name(), ()).unwrap();
+    assert_eq!(running.now().sim_elapsed(), Duration::ZERO);
+    running.run_until_blocked().assert_idle();
+    assert_eq!(running.now().sim_elapsed(), Duration::from_secs(10));
+}
+
+#[test]
+fn until_resolved_does_not_schedule_a_wakeup() {
+    let _guards: DeserializerGuards = vec![
+        register_data_deserializer::<()>().boxed(),
+        register_data_deserializer::<u32>().boxed(),
+        register_effect_deserializer::<ResolvedWork>().boxed(),
+    ];
+    let mut network = SimulationBuilder::default().with_seed(1);
+    let stage = network.stage("work", async |(), _msg: u32, eff| {
+        eff.external(ResolvedWork).await;
+    });
+    let stage = network.wire_up(stage, ());
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mut running = network.run(rt.handle());
+
+    running.enqueue_msg(&stage, [1]);
+    running.resume_receive(&stage).unwrap();
+    let _effect = running.effect();
+
+    assert_eq!(running.next_wakeup(), None);
+    running.resume_external::<ResolvedWork>(stage.name(), ()).unwrap();
+    running.effect().assert_receive(&stage);
+    assert_eq!(running.now().sim_elapsed(), Duration::ZERO);
+}
+
+static COMPUTED_AT_DEADLINE: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+struct DeadlineWork;
+
+impl ExternalEffect for DeadlineWork {
+    fn simulated_duration_dist(&self) -> DurationDist {
+        DurationDist::Constant(Duration::from_secs(10))
+    }
+
+    fn run(
+        self: Box<Self>,
+        _resources: Resources,
+    ) -> amaru_pure_stage::BoxFuture<'static, Box<dyn amaru_pure_stage::SendData>> {
+        Box::pin(async {
+            COMPUTED_AT_DEADLINE.store(true, Ordering::SeqCst);
+            Box::new(()) as Box<dyn amaru_pure_stage::SendData>
+        })
+    }
+}
+
+impl ExternalEffectAPI for DeadlineWork {
+    type Response = ();
+    const SIMULATED_DURATION: DurationDist = DurationDist::Constant(Duration::from_secs(10));
+}
+
+#[test]
+fn sampled_deadline_forces_run_before_other_sim_steps() {
+    COMPUTED_AT_DEADLINE.store(false, Ordering::SeqCst);
+    let _guards: DeserializerGuards = vec![
+        register_data_deserializer::<()>().boxed(),
+        register_data_deserializer::<u32>().boxed(),
+        register_effect_deserializer::<DeadlineWork>().boxed(),
+    ];
+    let mut network = SimulationBuilder::default().with_seed(1);
+    let stage = network.stage("work", async |(), _msg: u32, eff| {
+        eff.external(DeadlineWork).await;
+    });
+    let stage = network.wire_up(stage, ());
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mut running = network.run(rt.handle());
+
+    running.enqueue_msg(&stage, [1]);
+    running.resume_receive(&stage).unwrap();
+    let effect = running.effect();
+    running.handle_effect(effect);
+
+    assert!(!COMPUTED_AT_DEADLINE.load(Ordering::SeqCst), "run() must not execute before the sampled deadline");
+    assert_eq!(running.next_wakeup().map(|t| t.sim_elapsed()), Some(Duration::from_secs(10)));
+
+    running.run_until_blocked().assert_idle();
+    assert!(COMPUTED_AT_DEADLINE.load(Ordering::SeqCst), "run() must be forced when the deadline fires");
+    assert_eq!(running.now().sim_elapsed(), Duration::from_secs(10));
+}
+
+#[test]
+fn until_resolved_leaves_no_clock_entry() {
+    let (running, _guards) = run_once::<ResolvedWork>(1);
+    assert_trace_does_not_contain(&running, &[tm_clock_between(Duration::ZERO, Duration::from_secs(1000))]);
+    let (running, _guards) = run_once::<ResolvedWork>(1);
+    assert_trace_match(
+        &running,
+        &[
+            tm_state("work-1", &()),
+            tm_input("work-1", &1u32),
+            tm_external_effect::<ResolvedWork>("work-1"),
+            tm_state("work-1", &()),
+        ],
+    );
+}

--- a/crates/amaru-pure-stage/tests/duration_dist.rs
+++ b/crates/amaru-pure-stage/tests/duration_dist.rs
@@ -1,4 +1,3 @@
-#![expect(clippy::unwrap_used, clippy::wildcard_enum_match_arm)]
 // Copyright 2026 PRAGMA
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#![expect(clippy::unwrap_used, clippy::wildcard_enum_match_arm)]
 
 //! Simulated duration of [`ExternalEffect`]: sampled `δ` is scheduled when the effect is
 //! issued; [`DurationDist::UntilResolved`] waits for the Future instead.

--- a/crates/amaru-pure-stage/tests/duration_dist.rs
+++ b/crates/amaru-pure-stage/tests/duration_dist.rs
@@ -32,85 +32,61 @@ use amaru_pure_stage::{
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 struct ZeroWork;
 
-impl ExternalEffect for ZeroWork {
-    fn simulated_duration_dist(&self) -> DurationDist {
-        <Self as ExternalEffectAPI>::SIMULATED_DURATION
-    }
+impl ExternalEffectAPI for ZeroWork {
+    type Response = ();
 
     fn run(
         self: Box<Self>,
         _resources: Resources,
     ) -> amaru_pure_stage::BoxFuture<'static, Box<dyn amaru_pure_stage::SendData>> {
-        Self::wrap_sync(())
+        self.wrap_sync(())
     }
-}
-
-impl ExternalEffectAPI for ZeroWork {
-    type Response = ();
 }
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 struct ConstWork;
 
-impl ExternalEffect for ConstWork {
-    fn simulated_duration_dist(&self) -> DurationDist {
-        <Self as ExternalEffectAPI>::SIMULATED_DURATION
-    }
+impl ExternalEffectAPI for ConstWork {
+    type Response = ();
+    const SIMULATED_DURATION: DurationDist = DurationDist::Constant(Duration::from_secs(10));
 
     fn run(
         self: Box<Self>,
         _resources: Resources,
     ) -> amaru_pure_stage::BoxFuture<'static, Box<dyn amaru_pure_stage::SendData>> {
-        Self::wrap_sync(())
+        self.wrap_sync(())
     }
-}
-
-impl ExternalEffectAPI for ConstWork {
-    type Response = ();
-    const SIMULATED_DURATION: DurationDist = DurationDist::Constant(Duration::from_secs(10));
 }
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 struct UniformWork;
 
-impl ExternalEffect for UniformWork {
-    fn simulated_duration_dist(&self) -> DurationDist {
-        <Self as ExternalEffectAPI>::SIMULATED_DURATION
-    }
+impl ExternalEffectAPI for UniformWork {
+    type Response = ();
+    const SIMULATED_DURATION: DurationDist =
+        DurationDist::Uniform { min: Duration::from_secs(5), max: Duration::from_secs(15) };
 
     fn run(
         self: Box<Self>,
         _resources: Resources,
     ) -> amaru_pure_stage::BoxFuture<'static, Box<dyn amaru_pure_stage::SendData>> {
-        Self::wrap_sync(())
+        self.wrap_sync(())
     }
-}
-
-impl ExternalEffectAPI for UniformWork {
-    type Response = ();
-    const SIMULATED_DURATION: DurationDist =
-        DurationDist::Uniform { min: Duration::from_secs(5), max: Duration::from_secs(15) };
 }
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 struct ResolvedWork;
 
-impl ExternalEffect for ResolvedWork {
-    fn simulated_duration_dist(&self) -> DurationDist {
-        <Self as ExternalEffectAPI>::SIMULATED_DURATION
-    }
+impl ExternalEffectAPI for ResolvedWork {
+    type Response = ();
+    const SIMULATED_DURATION: DurationDist = DurationDist::UntilResolved;
 
     fn run(
         self: Box<Self>,
         _resources: Resources,
     ) -> amaru_pure_stage::BoxFuture<'static, Box<dyn amaru_pure_stage::SendData>> {
-        Self::wrap_sync(())
+        self.wrap_sync(())
     }
-}
-
-impl ExternalEffectAPI for ResolvedWork {
-    type Response = ();
-    const SIMULATED_DURATION: DurationDist = DurationDist::UntilResolved;
 }
 
 fn run_once<E: ExternalEffectAPI<Response = ()> + Default>(
@@ -282,10 +258,9 @@ static COMPUTED_AT_DEADLINE: AtomicBool = AtomicBool::new(false);
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 struct DeadlineWork;
 
-impl ExternalEffect for DeadlineWork {
-    fn simulated_duration_dist(&self) -> DurationDist {
-        DurationDist::Constant(Duration::from_secs(10))
-    }
+impl ExternalEffectAPI for DeadlineWork {
+    type Response = ();
+    const SIMULATED_DURATION: DurationDist = DurationDist::Constant(Duration::from_secs(10));
 
     fn run(
         self: Box<Self>,
@@ -298,9 +273,32 @@ impl ExternalEffect for DeadlineWork {
     }
 }
 
-impl ExternalEffectAPI for DeadlineWork {
+#[cfg(debug_assertions)]
+#[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+struct MismatchedDuration;
+
+#[cfg(debug_assertions)]
+impl ExternalEffectAPI for MismatchedDuration {
     type Response = ();
-    const SIMULATED_DURATION: DurationDist = DurationDist::Constant(Duration::from_secs(10));
+    const SIMULATED_DURATION: DurationDist = DurationDist::UntilResolved;
+
+    fn simulated_duration_dist(&self) -> DurationDist {
+        DurationDist::ZERO
+    }
+
+    fn run(
+        self: Box<Self>,
+        _resources: Resources,
+    ) -> amaru_pure_stage::BoxFuture<'static, Box<dyn amaru_pure_stage::SendData>> {
+        self.wrap_sync(())
+    }
+}
+
+#[test]
+#[cfg(debug_assertions)]
+#[should_panic(expected = "must return ExternalEffectAPI::SIMULATED_DURATION")]
+fn wrap_rejects_duration_dist_mismatch() {
+    drop(ExternalEffectAPI::run(Box::new(MismatchedDuration), Resources::default()));
 }
 
 #[test]

--- a/crates/amaru-pure-stage/tests/functional.rs
+++ b/crates/amaru-pure-stage/tests/functional.rs
@@ -77,8 +77,8 @@ fn run_sim(graph: impl Fn(&mut SimulationBuilder)) -> Vec<E> {
     let mut network = SimulationBuilder::default().with_trace_buffer(trace_buffer.clone()).with_epoch_clock();
     graph(&mut network);
 
-    let mut sim = network.run();
-    sim.run_until_blocked_incl_effects(rt.handle()).assert_terminated("trigger");
+    let mut sim = network.run(rt.handle());
+    sim.run_until_blocked_incl_effects().assert_terminated("trigger");
 
     guard.defuse();
 

--- a/crates/amaru-pure-stage/tests/simulation.rs
+++ b/crates/amaru-pure-stage/tests/simulation.rs
@@ -33,6 +33,12 @@ use amaru_pure_stage::{
 use rand::{SeedableRng, rngs::StdRng};
 use tracing_subscriber::EnvFilter;
 
+#[expect(clippy::expect_used)]
+fn test_runtime() -> &'static tokio::runtime::Runtime {
+    static RT: std::sync::OnceLock<tokio::runtime::Runtime> = std::sync::OnceLock::new();
+    RT.get_or_init(|| tokio::runtime::Runtime::new().expect("tokio runtime"))
+}
+
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 struct State(u32, StageRef<u32>);
 
@@ -47,7 +53,7 @@ fn basic() {
     });
     let (output, mut rx) = network.output("output", 10);
     let basic = network.wire_up(basic, State(1u32, output.clone()));
-    let mut running = network.run();
+    let mut running = network.run(test_runtime().handle());
 
     // first check that the stages start out suspended on Receive
     running.try_effect().unwrap_err().assert_idle();
@@ -91,11 +97,10 @@ fn automatic() {
     }
 
     let (in_ref, mut rx, output) = basic(&mut network);
-    let mut running = network.run();
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mut running = network.run(test_runtime().handle());
 
     running.enqueue_msg(&in_ref, [1, 2, 3]);
-    running.run_until_blocked_incl_effects(rt.handle()).assert_idle();
+    running.run_until_blocked_incl_effects().assert_idle();
     assert_eq!(rx.drain().collect::<Vec<_>>(), vec![2, 4, 7]);
 
     let trace = trace_buffer.lock().hydrate_without_timestamps();
@@ -112,13 +117,13 @@ fn automatic() {
         "Input { stage: Name(\"output-2\"), input: SendDataValue { typetag: \"u32\", value: Integer(2) } }",
         "Resume { stage: Name(\"output-2\"), response: Unit }",
         "Suspend(External { at_stage: Name(\"output-2\"), effect: UnknownExternalEffect { value: SendDataValue { typetag: \"amaru_pure_stage::output::OutputEffect<u32>\", value: Map([(Text(\"name\"), Text(\"output-2\")), (Text(\"msg\"), Integer(2)), (Text(\"sender\"), Map([]))]) } } })",
+        "Resume { stage: Name(\"output-2\"), response: ExternalResponse(SendDataValue { typetag: \"()\", value: Array([]) }) }",
+        "State { stage: Name(\"output-2\"), state: SendDataValue { typetag: \"amaru_pure_stage::types::MpscSender<u32>\", value: Map([]) } }",
         "Resume { stage: Name(\"basic-1\"), response: Unit }",
         "State { stage: Name(\"basic-1\"), state: SendDataValue { typetag: \"simulation::State\", value: Array([Integer(2), Map([(Text(\"name\"), Text(\"output-2\"))])]) } }",
         "Input { stage: Name(\"basic-1\"), input: SendDataValue { typetag: \"u32\", value: Integer(2) } }",
         "Resume { stage: Name(\"basic-1\"), response: Unit }",
         "Suspend(Wait { at_stage: Name(\"basic-1\"), duration: 10s })",
-        "Resume { stage: Name(\"output-2\"), response: ExternalResponse(SendDataValue { typetag: \"()\", value: Array([]) }) }",
-        "State { stage: Name(\"output-2\"), state: SendDataValue { typetag: \"amaru_pure_stage::types::MpscSender<u32>\", value: Map([]) } }",
         "Clock(Instant(20s))",
         "Resume { stage: Name(\"basic-1\"), response: WaitResponse(Instant(20s)) }",
         "Suspend(Send { from: Name(\"basic-1\"), to: Name(\"output-2\"), msg: SendDataValue { typetag: \"u32\", value: Integer(4) } })",
@@ -170,11 +175,11 @@ fn breakpoint() {
     });
     let (output, mut rx) = network.output("output", 10);
     let basic = network.wire_up(basic, State(1u32, output.clone()));
-    let mut running = network.run();
+    let mut running = network.run(test_runtime().handle());
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     running.enqueue_msg(&basic, [1, 2, 3]);
-    let output2 = output.clone();
+    let output_for_assert = output.clone();
     running.breakpoint("send4", move |eff| {
         matches!(
             eff,
@@ -185,10 +190,17 @@ fn breakpoint() {
         )
     });
     running.run_until_blocked().assert_breakpoint("send4");
-    assert_eq!(&rt.block_on(running.await_external_effect()).unwrap(), output2.name());
+    // OutputEffect is Zero: run() is forced when issued. Depending on the eval
+    // strategy, the output stage's resume may already have been processed or still
+    // sit on the runnable queue.
     assert_eq!(rt.block_on(running.await_external_effect()), None);
-    running.effect().assert_receive(&output2);
-    running.try_effect().unwrap_err().assert_deadlock(["basic-1"]);
+    match running.try_effect() {
+        Ok(effect) => {
+            effect.assert_receive(&output_for_assert);
+            running.try_effect().unwrap_err().assert_deadlock(["basic-1"]);
+        }
+        Err(blocked) => blocked.assert_deadlock(["basic-1"]),
+    }
     assert_eq!(rx.drain().collect::<Vec<_>>(), vec![2]);
 }
 
@@ -210,8 +222,7 @@ fn overrides() {
     });
     let (output, mut rx) = network.output("output", 10);
     let basic = network.wire_up(basic, State(1u32, output.clone()));
-    let mut running = network.run();
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mut running = network.run(test_runtime().handle());
 
     let count = Arc::new(AtomicUsize::new(0));
     let count2 = count.clone();
@@ -224,7 +235,7 @@ fn overrides() {
             OverrideResult::no_match(eff)
         }
     });
-    running.run_until_blocked_incl_effects(rt.handle()).assert_idle();
+    running.run_until_blocked_incl_effects().assert_idle();
     assert_eq!(rx.drain().collect::<Vec<_>>(), vec![2, 7]);
     assert_eq!(count.load(Ordering::Relaxed), 1);
 
@@ -253,7 +264,7 @@ fn backpressure() {
     let sender = network.wire_up(sender, pressure.sender());
     let pressure = network.wire_up(pressure, 1u32);
 
-    let mut running = network.run();
+    let mut running = network.run(test_runtime().handle());
 
     running.enqueue_msg(&sender, [1]);
     running.breakpoint("pressure", {
@@ -305,7 +316,7 @@ fn schedule_delivered_despite_full_bulk_mailbox() {
         state
     });
     let stage = network.wire_up(stage, Vec::<u32>::new());
-    let mut running = network.run();
+    let mut running = network.run(test_runtime().handle());
 
     running.enqueue_msg(&stage, [0u32]);
     running.breakpoint("clock", {
@@ -351,7 +362,7 @@ fn schedule_cap_panics_at_limit_plus_one() {
         state
     });
     let stage = network.wire_up(stage, ());
-    let mut running = network.run();
+    let mut running = network.run(test_runtime().handle());
 
     running.enqueue_msg(&stage, [0u32]);
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -386,7 +397,7 @@ fn cancel_schedule_frees_priority_slot() {
         }
     });
     let stage = network.wire_up(stage, None);
-    let mut running = network.run();
+    let mut running = network.run(test_runtime().handle());
 
     running.enqueue_msg(&stage, [0u32]);
     // Stop at Sleeping so far-future schedules are not delivered yet.
@@ -414,7 +425,7 @@ fn clock() {
         State2::Full(msg, now, later)
     });
     let basic = network.wire_up(basic, State2::Empty);
-    let mut running = network.run();
+    let mut running = network.run(test_runtime().handle());
 
     running.enqueue_msg(&basic, [42]);
     let now = running.now();
@@ -437,7 +448,7 @@ fn clock_manual() {
         State2::Full(msg, now, later)
     });
     let stage = network.wire_up(stage, State2::Empty);
-    let mut running = network.run();
+    let mut running = network.run(test_runtime().handle());
 
     running.enqueue_msg(&stage, [42]);
     let now = running.now();
@@ -494,7 +505,7 @@ fn call() {
     let caller = network.wire_up(caller, State3(1u32, callee.sender()));
     let callee = network.wire_up(callee, ());
 
-    let mut sim = network.run();
+    let mut sim = network.run(test_runtime().handle());
 
     sim.enqueue_msg(&caller, [1]);
     sim.run_until_blocked().assert_idle();
@@ -533,7 +544,7 @@ fn call_external_sender_in_simulation() {
     let callee = network.wire_up(callee, ());
     let sender = network.input(callee.clone().without_state());
 
-    let mut sim = network.run();
+    let mut sim = network.run(test_runtime().handle());
     let call = rt.spawn(async move { sender.call::<u32>(|cr| Msg3(3, cr), Duration::from_secs(1)).await });
 
     rt.block_on(sim.await_external_input());
@@ -567,7 +578,7 @@ fn call_timeout_terminates_graph() {
     let caller = network.wire_up(caller, State3(0u32, callee.sender()));
     network.wire_up(callee, ());
 
-    let mut sim = network.run();
+    let mut sim = network.run(test_runtime().handle());
 
     sim.enqueue_msg(&caller, [1]);
     // Run until blocked, then assert termination flips true
@@ -626,9 +637,7 @@ fn create_stage_within_stage() {
 
     let (output, mut rx) = network.output("output", 10);
     let parent = network.wire_up(parent, ParentState { child_ref: None, output: output.clone() });
-    let mut running = network.run();
-
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let mut running = network.run(test_runtime().handle());
 
     // Initially, parent is waiting for Receive
     running.try_effect().unwrap_err().assert_idle();
@@ -668,8 +677,7 @@ fn create_stage_within_stage() {
     running.handle_effect(external_effect);
 
     running.effect().assert_receive(&child_ref);
-    running.try_effect().unwrap_err().assert_busy(["output-2"]).assert_external_effects(1);
-    assert_eq!(&rt.block_on(running.await_external_effect()).unwrap(), output.name());
+    // OutputEffect is Zero: run() is forced when the effect is issued.
     running.effect().assert_receive(&output);
 
     // Verify output received the message from the child stage
@@ -783,20 +791,15 @@ fn virtual_child_stages() {
     let (output, mut rx) = network.output("output", 10);
     let parent = network.wire_up(parent, ParentState { child_ref: None, output: output.clone() });
 
-    let mut running = network.run();
+    let mut running = network.run(test_runtime().handle());
     running.use_virtual_child_stages(true);
-
-    let rt = tokio::runtime::Runtime::new().unwrap();
 
     // Kick off the parent with a message that will trigger child creation + a send to the child.
     running.enqueue_msg(&parent, [42u32]);
     running.resume_receive(&parent).unwrap();
 
     // Run the simulation using the high-level automatic driver (the style used by consensus tests).
-    running.run_until_blocked_or_time_incl_effects(
-        Instant::at_offset(Duration::from_secs(1), Duration::ZERO),
-        rt.handle(),
-    );
+    running.run_until_blocked_or_time_incl_effects(Instant::at_offset(Duration::from_secs(1), Duration::ZERO));
 
     // Because the child was virtual, its logic never ran → nothing reached the output.
     assert!(rx.drain().collect::<Vec<_>>().is_empty(), "virtual child must not produce any output");

--- a/crates/amaru-pure-stage/tests/simulation.rs
+++ b/crates/amaru-pure-stage/tests/simulation.rs
@@ -794,11 +794,9 @@ fn virtual_child_stages() {
     let mut running = network.run(test_runtime().handle());
     running.use_virtual_child_stages(true);
 
-    // Kick off the parent with a message that will trigger child creation + a send to the child.
     running.enqueue_msg(&parent, [42u32]);
     running.resume_receive(&parent).unwrap();
 
-    // Run the simulation using the high-level automatic driver (the style used by consensus tests).
     running.run_until_blocked_or_time_incl_effects(Instant::at_offset(Duration::from_secs(1), Duration::ZERO));
 
     // Because the child was virtual, its logic never ran → nothing reached the output.

--- a/crates/amaru-sim/Cargo.toml
+++ b/crates/amaru-sim/Cargo.toml
@@ -27,6 +27,7 @@ rand_distr.workspace = true
 rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tokio.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
 

--- a/crates/amaru-sim/src/simulator/run_tests.rs
+++ b/crates/amaru-sim/src/simulator/run_tests.rs
@@ -105,7 +105,9 @@ fn run_test_nb(run_config: &RunConfig, test_run_dir: &Path, test_number: u32) ->
 pub fn run_test(run_config: &RunConfig, actions: &GeneratedActions) -> TestResult {
     let test = |actions: &GeneratedActions| {
         let mut rng = run_config.rng();
-        let mut nodes = create_nodes(&mut rng, node_configs(run_config, actions)).expect("failed to create nodes");
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let mut nodes =
+            create_nodes(&mut rng, node_configs(run_config, actions), rt.handle()).expect("failed to create nodes");
 
         nodes.run(&mut rng);
         check_chain_property(nodes, actions)


### PR DESCRIPTION
This is a foundational step towards building the much more powerful amaru-sim we aspire to
(EDR-011).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable simulated effect durations, including zero, fixed, random, and resolution-based timing.
  * Added deadline handling to force completion of effects that exceed their simulated duration.
  * Added trace matching for validating elapsed simulation time ranges.

* **Improvements**
  * Improved simulation timing, asynchronous effect handling, deterministic seeded behavior, and cleanup when stages finish.

* **Refactor**
  * Simplified simulation startup by providing the runtime once when creating a simulation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->