### PR TITLE
Fix CC members preparations

### DIFF
--- a/crates/amaru-ledger/src/context/default/preparation.rs
+++ b/crates/amaru-ledger/src/context/default/preparation.rs
@@ -18,8 +18,8 @@ use std::{
 };
 
 use amaru_kernel::{
-    DRep, DRepRegistration, GovernanceAction, MemoizedTransactionOutput, PoolId, ProposalId, ProposalSlim,
-    ProposalsRoots, StakeCredential, TransactionInput, drep,
+    ConstitutionalCommitteeMemberStatus, DRep, DRepRegistration, GovernanceAction, MemoizedTransactionOutput, PoolId,
+    ProposalId, ProposalSlim, ProposalsRoots, StakeCredential, TransactionInput, drep,
 };
 use amaru_observability::debug_span;
 
@@ -399,37 +399,32 @@ fn resolve_committee<'block, 'volatile>(
         for (cold_credential, row) in db.iter_cc_members().map_err(ContextHydratationError::ResolveCommittee)? {
             let for_certificates = cold_credentials_in_certificates.contains(&cold_credential);
 
-            let for_votes = row
-                .status
-                .as_ref()
-                .and_then(|status| status.as_hot_credential())
-                .is_some_and(|hot| hot_credentials_in_votes.contains(hot));
+            let for_votes = |status: Option<&ConstitutionalCommitteeMemberStatus>| {
+                status.and_then(|st| st.as_hot_credential()).is_some_and(|hot| hot_credentials_in_votes.contains(hot))
+            };
 
-            if for_certificates || for_votes {
-                match volatile_cc_members.remove(&cold_credential) {
-                    Some(Existence::Unknown) | None => {
+            match volatile_cc_members.remove(&cold_credential) {
+                Some(Existence::Unknown) | None => {
+                    if for_certificates || for_votes(row.status.as_ref()) {
                         cc_members.insert(cold_credential, row);
                     }
+                }
 
-                    Some(Existence::Exists(Bind { left: status, right: valid_until, .. })) => {
+                Some(Existence::Exists(Bind { left: volatile_status, right: valid_until, .. })) => {
+                    let status = volatile_status.to_option(row.status.as_ref());
+                    if for_certificates || for_votes(status.as_ref()) {
                         cc_members.insert(
                             cold_credential,
-                            CCMember {
-                                status: status.to_option(row.status.as_ref()),
-                                valid_until: valid_until.to_option(row.valid_until.as_ref()),
-                            },
+                            CCMember { status, valid_until: valid_until.to_option(row.valid_until.as_ref()) },
                         );
                     }
+                }
 
-                    Some(Existence::Gone) => {
-                        if for_certificates {
-                            gone_but_requested.insert(cold_credential);
-                        }
+                Some(Existence::Gone) => {
+                    if for_certificates {
+                        gone_but_requested.insert(cold_credential);
                     }
                 }
-            } else {
-                // Discard this member entirely if it's not relevant to the context
-                volatile_cc_members.remove(&cold_credential);
             }
         }
 

--- a/crates/amaru-ledger/src/context/default/preparation.rs
+++ b/crates/amaru-ledger/src/context/default/preparation.rs
@@ -381,14 +381,14 @@ fn resolve_dreps<'volatile>(
 fn resolve_committee<'block, 'volatile>(
     volatile: &'volatile impl VolatileState<CCMembers<'volatile> = <VolatileDB as VolatileState>::CCMembers<'volatile>>,
     db: &impl ReadStore,
-    cold_credentials: BTreeSet<&'block StakeCredential>,
-    voters: BTreeSet<StakeCredential>,
+    cold_credentials_in_certificates: BTreeSet<&'block StakeCredential>,
+    hot_credentials_in_votes: BTreeSet<StakeCredential>,
 ) -> Result<BTreeMap<StakeCredential, CCMember>, ContextHydratationError> {
     debug_span!(ledger::validation_context::committee::HYDRATE).in_scope(|| {
         let mut cc_members = BTreeMap::new();
 
         // NOTE: No need to reach for the stable store if no context is needed.
-        if cold_credentials.is_empty() && voters.is_empty() {
+        if cold_credentials_in_certificates.is_empty() && hot_credentials_in_votes.is_empty() {
             return Ok(cc_members);
         }
 
@@ -397,12 +397,13 @@ fn resolve_committee<'block, 'volatile>(
         let mut gone_but_requested: BTreeSet<StakeCredential> = BTreeSet::new();
 
         for (cold_credential, row) in db.iter_cc_members().map_err(ContextHydratationError::ResolveCommittee)? {
-            let for_certificates = cold_credentials.contains(&cold_credential);
+            let for_certificates = cold_credentials_in_certificates.contains(&cold_credential);
+
             let for_votes = row
                 .status
                 .as_ref()
                 .and_then(|status| status.as_hot_credential())
-                .is_some_and(|hot| voters.contains(hot));
+                .is_some_and(|hot| hot_credentials_in_votes.contains(hot));
 
             if for_certificates || for_votes {
                 match volatile_cc_members.remove(&cold_credential) {
@@ -445,7 +446,7 @@ fn resolve_committee<'block, 'volatile>(
                 }
 
                 Existence::Gone | Existence::Unknown => {
-                    if cold_credentials.contains(cold_credential) {
+                    if cold_credentials_in_certificates.contains(cold_credential) {
                         gone_but_requested.insert(*cold_credential);
                     }
                 }
@@ -532,16 +533,17 @@ pub fn resolve_proposals(
 mod tests {
     #[cfg(test)]
     mod resolve_committee {
-        use std::{collections::BTreeMap, iter};
+        use std::collections::BTreeMap;
 
         use amaru_kernel::{
             ConstitutionalCommitteeMemberStatus, Epoch, GovernanceAction, Proposal, ProposalId, StakeCredential,
             any_proposal, any_proposal_id, any_rational_number, any_stake_credential, utils::tests::run_strategy,
         };
 
+        use super::super::resolve_committee;
         use crate::{
             context::CCMember,
-            state::volatile::{Bind, CommitteeMemberBind, Empty, Existence, VolatileState},
+            state::volatile::{Bind, CommitteeMemberBind, Empty, Existence, Resettable, VolatileState},
             store::{
                 ReadStore, StoreError,
                 columns::{cc_members, proposals},
@@ -549,7 +551,9 @@ mod tests {
         };
 
         struct Mock {
-            cc_members: Vec<(StakeCredential, Existence<Bind<ConstitutionalCommitteeMemberStatus, Epoch, Empty>>)>,
+            volatile_cc_members:
+                Vec<(StakeCredential, Existence<Bind<ConstitutionalCommitteeMemberStatus, Epoch, Empty>>)>,
+            stable_cc_members: Vec<(StakeCredential, Option<Epoch>, Option<ConstitutionalCommitteeMemberStatus>)>,
             proposals: Vec<Proposal>,
         }
 
@@ -564,7 +568,7 @@ mod tests {
             fn resolve_cc_members<'a>(&'a self) -> Self::CCMembers<'a> {
                 let mut map = BTreeMap::new();
 
-                for (k, v) in &self.cc_members {
+                for (k, v) in &self.volatile_cc_members {
                     map.insert(k, v.as_refs());
                 }
 
@@ -574,7 +578,9 @@ mod tests {
 
         impl ReadStore for Mock {
             fn iter_cc_members(&self) -> Result<impl Iterator<Item = (StakeCredential, cc_members::Row)>, StoreError> {
-                Ok(iter::empty())
+                Ok(self.stable_cc_members.iter().copied().map(|(cold_credential, valid_until, status)| {
+                    (cold_credential, cc_members::Row { valid_until, status })
+                }))
             }
 
             fn iter_proposals(&self) -> Result<impl Iterator<Item = (ProposalId, proposals::Row)>, StoreError> {
@@ -606,31 +612,74 @@ mod tests {
             let cold_credential: StakeCredential = run_strategy(any_stake_credential());
 
             let mock = Mock {
-                cc_members: vec![(cold_credential, Existence::Gone)],
+                volatile_cc_members: vec![(cold_credential, Existence::Gone)],
+                stable_cc_members: vec![(cold_credential, Some(Epoch::default()), None)],
                 proposals: vec![any_update_committee_proposal(cold_credential)],
             };
 
-            let committee =
-                super::super::resolve_committee(&mock, &mock, From::from([&cold_credential]), Default::default())
-                    .unwrap();
+            let context = resolve_committee(&mock, &mock, From::from([&cold_credential]), Default::default()).unwrap();
 
-            assert_eq!(committee.get(&cold_credential), Some(&CCMember::default()))
+            assert_eq!(context.get(&cold_credential), Some(&CCMember::default()))
         }
 
         #[test]
         fn recently_evicted_cc_members_still_in_proposals_are_not_resolved_for_votes() {
             let cold_credential: StakeCredential = run_strategy(any_stake_credential());
+            let hot_credential: StakeCredential = run_strategy(any_stake_credential());
 
             let mock = Mock {
-                cc_members: vec![(cold_credential, Existence::Gone)],
+                volatile_cc_members: vec![(cold_credential, Existence::Gone)],
+                stable_cc_members: vec![(cold_credential, Some(Epoch::default()), Some(hot_credential.into()))],
                 proposals: vec![any_update_committee_proposal(cold_credential)],
             };
 
-            let committee =
-                super::super::resolve_committee(&mock, &mock, Default::default(), From::from([cold_credential]))
-                    .unwrap();
+            let context = resolve_committee(&mock, &mock, Default::default(), From::from([hot_credential])).unwrap();
 
-            assert!(!committee.contains_key(&cold_credential))
+            assert!(context.is_empty())
+        }
+
+        #[test]
+        fn recent_volatile_hot_delegation_is_used_in_status_resolution_of_elected_member() {
+            let cold_credential: StakeCredential = run_strategy(any_stake_credential());
+            let hot_credential: StakeCredential = run_strategy(any_stake_credential());
+
+            let mock = Mock {
+                volatile_cc_members: vec![(
+                    cold_credential,
+                    Existence::Exists(Bind { left: Resettable::Set(hot_credential.into()), ..Bind::default() }),
+                )],
+                stable_cc_members: vec![(cold_credential, Some(Epoch::default()), None)],
+                proposals: vec![],
+            };
+
+            let context = resolve_committee(&mock, &mock, Default::default(), From::from([hot_credential])).unwrap();
+
+            assert_eq!(
+                context.get(&cold_credential),
+                Some(&CCMember { status: Some(hot_credential.into()), valid_until: Some(Epoch::default()) })
+            );
+        }
+
+        #[test]
+        fn unelected_cc_members_with_delegation_are_resolved_for_votes() {
+            let cold_credential: StakeCredential = run_strategy(any_stake_credential());
+            let hot_credential: StakeCredential = run_strategy(any_stake_credential());
+
+            let mock = Mock {
+                volatile_cc_members: vec![(
+                    cold_credential,
+                    Existence::Exists(Bind { left: Resettable::Set(hot_credential.into()), ..Bind::default() }),
+                )],
+                stable_cc_members: vec![],
+                proposals: vec![any_update_committee_proposal(cold_credential)],
+            };
+
+            let context = resolve_committee(&mock, &mock, Default::default(), From::from([hot_credential])).unwrap();
+
+            assert_eq!(
+                context.get(&cold_credential),
+                Some(&CCMember { status: Some(hot_credential.into()), valid_until: None })
+            );
         }
     }
 }

--- a/crates/amaru-ledger/src/context/default/preparation.rs
+++ b/crates/amaru-ledger/src/context/default/preparation.rs
@@ -465,11 +465,12 @@ fn resolve_committee<'block, 'volatile>(
         // reachable through the stable store.
         if !gone_but_requested.is_empty() {
             for (_, row) in db.iter_proposals().map_err(ContextHydratationError::ResolveCommittee)? {
-                if let GovernanceAction::UpdateCommittee(_, _, added, _) = row.proposal.gov_action
-                    && let Some((cold_credential, _)) =
-                        added.into_iter().find(|(candidate, _)| gone_but_requested.contains(candidate))
-                {
-                    cc_members.entry(cold_credential).or_default();
+                if let GovernanceAction::UpdateCommittee(_, _, added, _) = row.proposal.gov_action {
+                    for (cold_credential, _) in
+                        added.into_iter().filter(|(candidate, _)| gone_but_requested.contains(candidate))
+                    {
+                        cc_members.entry(cold_credential).or_default();
+                    }
                 }
             }
         }
@@ -592,10 +593,20 @@ mod tests {
         }
 
         pub fn any_update_committee_proposal(cold_credential: StakeCredential) -> Proposal {
+            any_update_committee_proposal_with_members(vec![cold_credential])
+        }
+
+        pub fn any_update_committee_proposal_with_members(cold_credentials: Vec<StakeCredential>) -> Proposal {
             let gov_action = GovernanceAction::UpdateCommittee(
                 Default::default(),
                 Default::default(),
-                TryFrom::try_from(vec![(cold_credential, Default::default())]).unwrap(),
+                TryFrom::try_from(
+                    cold_credentials
+                        .into_iter()
+                        .map(|cold_credential| (cold_credential, Default::default()))
+                        .collect::<Vec<_>>(),
+                )
+                .unwrap(),
                 run_strategy(any_rational_number()),
             );
 
@@ -675,6 +686,38 @@ mod tests {
                 context.get(&cold_credential),
                 Some(&CCMember { status: Some(hot_credential.into()), valid_until: None })
             );
+        }
+
+        #[test]
+        fn all_recently_evicted_cc_members_still_proposal_are_resolved_for_certificates() {
+            let first_cold_credential: StakeCredential = run_strategy(any_stake_credential());
+            let second_cold_credential: StakeCredential = run_strategy(any_stake_credential());
+
+            let mock = Mock {
+                volatile_cc_members: vec![
+                    (first_cold_credential, Existence::Gone),
+                    (second_cold_credential, Existence::Gone),
+                ],
+                stable_cc_members: vec![
+                    (first_cold_credential, Some(Epoch::default()), None),
+                    (second_cold_credential, Some(Epoch::default()), None),
+                ],
+                proposals: vec![any_update_committee_proposal_with_members(vec![
+                    first_cold_credential,
+                    second_cold_credential,
+                ])],
+            };
+
+            let context = resolve_committee(
+                &mock,
+                &mock,
+                From::from([&first_cold_credential, &second_cold_credential]),
+                Default::default(),
+            )
+            .unwrap();
+
+            assert_eq!(context.get(&first_cold_credential), Some(&CCMember::default()));
+            assert_eq!(context.get(&second_cold_credential), Some(&CCMember::default()));
         }
     }
 }

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -527,11 +527,6 @@ impl<S: Store, HS: HistoricalStores + Send + Sync + 'static> State<S, HS> {
         let is_previous_epoch_stable =
             self.era_history.slot_in_epoch(tip, tip).unwrap_or_default() >= self.global_parameters().stability_window();
 
-        // FIXME: Asynchronous rewards calculation
-        //
-        // compute rewards in a thread, or in a non-blocking manner to carry on with other
-        // tasks while rewards are being computed; they only need to be available at the epoch
-        // boundary.
         if self.volatile.rewards_not_ready()
             && self.rewards_join_handle.is_none()
             && Some(self.most_recent_snapshot()) == current_epoch.checked_sub(Epoch::ONE)


### PR DESCRIPTION
Two fixes; the first one was causing a sync issue on Mainnet epoch 602 due to the preparation step failing to correctly resolve the volatile hot delegation of a newly added member.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved committee membership resolution for certificates and votes.
  * Recent hot-credential delegations and newly added members are now recognized during vote processing.
  * Improved handling of inactive committee members in certificate processing.
  * Multi-member committee updates now correctly include all matching additions.
  * Expanded coverage for committee filtering, delegations, unelected members, and proposal updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->