### PR TITLE
Prune irrelevant votes when removing their corresponding proposals

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,7 @@
 **/*.cbor linguist-generated=true linguist-vendored
 **/*.stderr eol=lf
 data/**/*.json linguist-generated=true linguist-vendored
-crates/amaru-kernel/tests/data/cbor.decode/**/* linguist-generated=true linguist-vendored --diff
+crates/amaru-kernel/tests/data/cbor.decode/**/* linguist-generated=true linguist-vendored -diff
 crates/amaru-ledger/tests/data/rules-conformance/**/* linguist-generated=true linguist-vendored
 crates/amaru-ledger/tests/data/**/*.cbor linguist-generated=true linguist-vendored
 CHANGELOG.md merge=union

--- a/.github/workflows/ci-build-and-test.yml
+++ b/.github/workflows/ci-build-and-test.yml
@@ -163,6 +163,6 @@ jobs:
           echo ""
           echo "If schemas changed, also run:"
           echo ""
-          echo "  cargo run --bin amaru -- dump-traces-schema 2> docs/traces-schema.json"
+          echo "  cargo run --bin amaru -- dev traces dump 1> docs/traces-schema.json"
           echo ""
           echo "Then commit the updated files."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Other guiding principles:
 - **amaru-ledger**: resolve and control CC member cold credentials following ratification or in-flight proposals.
 - **amaru-ledger**: disallow voters not relevant to the target proposals.
 - **amaru**: use definite decoding for Conway bytes
+- **amaru-stores**: prune obsolete votes when removing expired/ratified/evicted proposals.
 
 ## v10.11.20260813 _[unreleased; planned for 2026-08-13]_
 

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ serve-traces-doc: generate-traces-doc ## &build Regenerate traces docs and serve
 	@python3 -m http.server $(TRACES_PORT) --directory docs
 
 validate-trace-schemas: ## &test Validate generated trace schemas against docs/traces-schema.json
-	@cargo run --quiet --profile $(BUILD_PROFILE) --bin amaru -- dump-traces-schema 2> /tmp/schemas-current.json
+	@cargo run --quiet --profile $(BUILD_PROFILE) --bin amaru -- dev traces dump 1> /tmp/schemas-current.json
 	@./scripts/unused-schemas
 	@set -eu; \
 	jq -S 'walk(if type == "object" then del(.private) else . end)' docs/traces-schema.json > /tmp/expected.json; \

--- a/crates/amaru-kernel/src/cardano/ballot_id.rs
+++ b/crates/amaru-kernel/src/cardano/ballot_id.rs
@@ -20,6 +20,19 @@ pub struct BallotId {
     pub voter: Voter,
 }
 
+impl BallotId {
+    /// Returns the CBOR prefix resulting from encoding this ballot with a given proposal id but an
+    /// unknown voter.
+    pub fn encode_prefix<W: cbor::encode::Write>(
+        proposal: &ProposalId,
+        e: &mut cbor::Encoder<W>,
+    ) -> Result<(), cbor::encode::Error<W::Error>> {
+        e.array(2)?;
+        e.encode(proposal)?;
+        Ok(())
+    }
+}
+
 impl<C: cbor::HasProtocolVersion> cbor::encode::Encode<C> for BallotId {
     fn encode<W: cbor::encode::Write>(
         &self,

--- a/crates/amaru-ledger/src/context/default/preparation.rs
+++ b/crates/amaru-ledger/src/context/default/preparation.rs
@@ -689,7 +689,7 @@ mod tests {
         }
 
         #[test]
-        fn all_recently_evicted_cc_members_still_proposal_are_resolved_for_certificates() {
+        fn all_recently_evicted_cc_members_still_in_proposals_are_resolved_for_certificates() {
             let first_cold_credential: StakeCredential = run_strategy(any_stake_credential());
             let second_cold_credential: StakeCredential = run_strategy(any_stake_credential());
 
@@ -718,6 +718,25 @@ mod tests {
 
             assert_eq!(context.get(&first_cold_credential), Some(&CCMember::default()));
             assert_eq!(context.get(&second_cold_credential), Some(&CCMember::default()));
+        }
+
+        #[test]
+        fn stable_hot_delegation_is_resolved_for_votes_without_volatile_entry() {
+            let cold_credential: StakeCredential = run_strategy(any_stake_credential());
+            let hot_credential: StakeCredential = run_strategy(any_stake_credential());
+
+            let mock = Mock {
+                volatile_cc_members: vec![],
+                stable_cc_members: vec![(cold_credential, Some(Epoch::default()), Some(hot_credential.into()))],
+                proposals: vec![],
+            };
+
+            let context = resolve_committee(&mock, &mock, Default::default(), From::from([hot_credential])).unwrap();
+
+            assert_eq!(
+                context.get(&cold_credential),
+                Some(&CCMember { status: Some(hot_credential.into()), valid_until: Some(Epoch::default()) })
+            );
         }
     }
 }

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -724,11 +724,11 @@ pub trait TransactionalContext<'a>: ReadStore {
     /// Remove a list of proposals from the database. This is done when enacting proposals that
     /// cause other proposals to become obsolete.
     #[cfg(not(any(test, feature = "test-utils")))]
-    fn remove_proposals<'iter>(&self, proposals: impl Iterator<Item = &'iter ProposalId>) -> Result<()>;
+    fn remove_proposals<T>(&self, proposals: &BTreeMap<ProposalId, T>) -> Result<()>;
 
     #[cfg(any(test, feature = "test-utils"))]
-    fn remove_proposals<'iter>(&self, proposals: impl Iterator<Item = &'iter ProposalId>) -> Result<()> {
-        unimplemented!("TransactionalContext.remove_proposals({:?})", proposals.collect::<Vec<_>>());
+    fn remove_proposals<T>(&self, proposals: &BTreeMap<ProposalId, T>) -> Result<()> {
+        unimplemented!("TransactionalContext.remove_proposals({:?})", proposals.keys().collect::<Vec<_>>());
     }
 
     /// Prune all recently unregistered accounts from the database that are no longer required to
@@ -800,15 +800,6 @@ pub trait TransactionalContext<'a>: ReadStore {
     #[cfg(any(test, feature = "test-utils"))]
     fn with_dreps(&self, _with: impl FnMut(dreps::Iter<'_, '_>)) -> Result<()> {
         unimplemented!("TransactionalContext.with_dreps()");
-    }
-
-    /// Provide an access to iterate over dreps, similar to 'with_pools'.
-    #[cfg(not(any(test, feature = "test-utils")))]
-    fn with_proposals(&self, with: impl FnMut(proposals::Iter<'_, '_>)) -> Result<()>;
-
-    #[cfg(any(test, feature = "test-utils"))]
-    fn with_proposals(&self, _with: impl FnMut(proposals::Iter<'_, '_>)) -> Result<()> {
-        unimplemented!("TransactionalContext.with_proposals()");
     }
 
     /// Provide an access to iterate over cc members, similar to 'with_pools'.

--- a/crates/amaru-ledger/src/store/epoch_transition.rs
+++ b/crates/amaru-ledger/src/store/epoch_transition.rs
@@ -259,7 +259,7 @@ pub fn apply_governance_updates<'store>(
             db.set_governance_activity(governance_activity)?;
         }
 
-        db.remove_proposals(updates.pruned_proposals.keys())?;
+        db.remove_proposals(&updates.pruned_proposals)?;
 
         Ok((updates.protocol_parameters.clone(), governance_activity, guardrail_script))
     })

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -1280,6 +1280,8 @@ define_schemas! {
                 votes {
                     /// Record governance votes
                     public ADD {}
+                    /// Remove now-obsolete governance votes
+                    public PRUNE {}
                 }
                 slots {
                     /// Point-read a slot/block-issuer entry

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -1281,7 +1281,7 @@ define_schemas! {
                     /// Record governance votes
                     public ADD {}
                     /// Remove now-obsolete governance votes
-                    public PRUNE {}
+                    public REMOVE {}
                 }
                 slots {
                     /// Point-read a slot/block-issuer entry

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/proposals.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/proposals.rs
@@ -15,7 +15,7 @@
 use std::collections::BTreeMap;
 
 pub use amaru_ledger::store::{
-    StoreError,
+    StoreError, TransactionalContext,
     columns::{
         proposals::{Key, Row, Value},
         unsafe_decode,
@@ -24,7 +24,10 @@ pub use amaru_ledger::store::{
 use amaru_observability::trace_span;
 use rocksdb::{DBPinnableSlice, Transaction};
 
-use crate::rocksdb::common::{PREFIX_LEN, as_key, as_value};
+use crate::rocksdb::{
+    common::{PREFIX_LEN, as_key, as_value},
+    votes,
+};
 
 /// Name prefixed used for storing Proposals entries. UTF-8 encoding for "prop"
 pub const PREFIX: [u8; PREFIX_LEN] = *b"prop";
@@ -55,9 +58,11 @@ pub fn add<DB>(db: &Transaction<'_, DB>, rows: impl Iterator<Item = (Key, Value)
     })
 }
 
-/// Remove an expired or enacted proposal.
+/// Remove an expired or enacted proposal and the votes that pertains to it.
 pub fn remove<DB, V>(db: &Transaction<'_, DB>, proposals: &BTreeMap<Key, V>) -> Result<(), StoreError> {
     trace_span!(stores::ledger::proposals::REMOVE).in_scope(|| {
+        votes::prune(db, |ballot_id| proposals.contains_key(&ballot_id.proposal))?;
+
         for key in proposals.keys() {
             db.delete(as_key(&PREFIX, key)).map_err(|err| StoreError::Internal(err.into()))?;
         }

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/proposals.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/proposals.rs
@@ -15,7 +15,7 @@
 use std::collections::BTreeMap;
 
 pub use amaru_ledger::store::{
-    StoreError, TransactionalContext,
+    StoreError,
     columns::{
         proposals::{Key, Row, Value},
         unsafe_decode,
@@ -69,4 +69,104 @@ pub fn remove<DB, V>(db: &Transaction<'_, DB>, proposals: &BTreeMap<Key, V>) -> 
 
         Ok(())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use amaru_kernel::{Ballot, BallotId, ProposalId, Voter, any_ballot, any_proposal, any_proposal_id, any_voter};
+    use amaru_ledger::store::{ReadStore, Store};
+    use proptest::{
+        collection::{btree_map, btree_set},
+        prelude::*,
+    };
+    use tempfile::TempDir;
+
+    use crate::rocksdb::{RocksDB, RocksDbConfig, StoreError, proposals, votes};
+
+    prop_compose! {
+        fn any_proposal_row()(proposal in any_proposal()) -> proposals::Row {
+            proposals::Row {
+                proposed_in: Default::default(),
+                valid_until: Default::default(),
+                proposal,
+            }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn remove(
+            proposals in btree_map(any_proposal_id(), any_proposal_row(), 2..=3),
+            votes in btree_map(any_voter(), any_ballot(), 100),
+            indices_to_remove in btree_set(any::<usize>(), 0..=3),
+        ) {
+            let tmp = TempDir::new().expect("failed to create temp dir");
+            let db = RocksDB::empty(&RocksDbConfig::new(tmp.path().into())).unwrap();
+
+            fixture_proposals_and_votes(&db, proposals.clone().into_iter(), votes.into_iter());
+
+            let (removed, kept): (BTreeMap<ProposalId, ()>, BTreeSet<ProposalId>) = proposals.keys().enumerate().fold(
+                Default::default(),
+                |(mut removed, mut kept), (ix, proposal_id)| {
+                    if indices_to_remove.contains(&ix) {
+                        removed.insert(*proposal_id, ());
+                    } else {
+                        kept.insert(*proposal_id);
+                    }
+
+                    (removed, kept)
+                }
+            );
+
+            // Remove proposals and associated votes
+            db.with_transaction(|ctx| proposals::remove(&ctx.db, &removed)).unwrap();
+
+            // No votes to that proposal should remain
+            for (ballot_id, _) in db.iter_votes()? {
+                prop_assert!(kept.contains(&ballot_id.proposal));
+                prop_assert!(!removed.contains_key(&ballot_id.proposal));
+            }
+
+            // Proposals should have been pruned or left untouched.
+            db.with_transaction(|ctx| {
+                for (proposal_id, proposal) in proposals {
+                    prop_assert_eq!(
+                        proposals::get(|key| ctx.db.get_pinned(key), &proposal_id).unwrap(),
+                        if removed.contains_key(&proposal_id) {
+                            None
+                        } else {
+                            Some(proposal)
+                        }
+                    );
+                }
+
+                Ok(())
+            }).unwrap();
+        }
+    }
+
+    fn fixture_proposals_and_votes(
+        db: &RocksDB,
+        proposals: impl Iterator<Item = (ProposalId, proposals::Row)>,
+        votes: impl Iterator<Item = (Voter, Ballot)>,
+    ) {
+        db.with_transaction(|ctx| {
+            let proposals = proposals.collect::<Vec<_>>();
+
+            votes::add(
+                &ctx.db,
+                votes.enumerate().map(|(ix, (voter, ballot))| {
+                    let ballot_id = BallotId { voter, proposal: proposals[ix % proposals.len()].0 };
+                    (ballot_id, ballot)
+                }),
+            )?;
+
+            proposals::add(&ctx.db, proposals.into_iter())?;
+
+            Ok::<_, StoreError>(())
+        })
+        .unwrap();
+    }
 }

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/proposals.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/proposals.rs
@@ -61,9 +61,8 @@ pub fn add<DB>(db: &Transaction<'_, DB>, rows: impl Iterator<Item = (Key, Value)
 /// Remove an expired or enacted proposal and the votes that pertains to it.
 pub fn remove<DB, V>(db: &Transaction<'_, DB>, proposals: &BTreeMap<Key, V>) -> Result<(), StoreError> {
     trace_span!(stores::ledger::proposals::REMOVE).in_scope(|| {
-        votes::prune(db, |ballot_id| proposals.contains_key(&ballot_id.proposal))?;
-
         for key in proposals.keys() {
+            votes::iter_by_proposal(db, key)?.try_for_each(|vote| votes::remove(db, vote))?;
             db.delete(as_key(&PREFIX, key)).map_err(|err| StoreError::Internal(err.into()))?;
         }
 
@@ -73,7 +72,10 @@ pub fn remove<DB, V>(db: &Transaction<'_, DB>, proposals: &BTreeMap<Key, V>) -> 
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, BTreeSet};
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        sync::LazyLock,
+    };
 
     use amaru_kernel::{Ballot, BallotId, ProposalId, Voter, any_ballot, any_proposal, any_proposal_id, any_voter};
     use amaru_ledger::store::{ReadStore, Store};
@@ -84,6 +86,13 @@ mod tests {
     use tempfile::TempDir;
 
     use crate::rocksdb::{RocksDB, RocksDbConfig, StoreError, proposals, votes};
+
+    // Re-using the database connection for property tests considerably speed things up. One must
+    // `.clear()` the database at the start of each test, though.
+    static DB: LazyLock<RocksDB> = LazyLock::new(|| {
+        let tmp = TempDir::new().expect("failed to create temp dir");
+        RocksDB::empty(&RocksDbConfig::new(tmp.path().into())).unwrap()
+    });
 
     prop_compose! {
         fn any_proposal_row()(proposal in any_proposal()) -> proposals::Row {
@@ -100,12 +109,15 @@ mod tests {
         fn remove(
             proposals in btree_map(any_proposal_id(), any_proposal_row(), 2..=3),
             votes in btree_map(any_voter(), any_ballot(), 100),
-            indices_to_remove in btree_set(any::<usize>(), 0..=3),
+            indices_to_remove in btree_set(any::<usize>(), 1..=3),
         ) {
-            let tmp = TempDir::new().expect("failed to create temp dir");
-            let db = RocksDB::empty(&RocksDbConfig::new(tmp.path().into())).unwrap();
+            DB.clear().unwrap();
 
-            fixture_proposals_and_votes(&db, proposals.clone().into_iter(), votes.into_iter());
+            prop_assume!(DB.iter_votes()?.collect::<Vec<_>>().is_empty());
+
+            let indices_to_remove: BTreeSet<usize> = indices_to_remove.into_iter().map(|ix| ix % proposals.len()).collect();
+
+            let mut votes_count_before = fixture_proposals_and_votes(&DB, proposals.clone().into_iter(), votes.into_iter());
 
             let (removed, kept): (BTreeMap<ProposalId, ()>, BTreeSet<ProposalId>) = proposals.keys().enumerate().fold(
                 Default::default(),
@@ -120,17 +132,26 @@ mod tests {
                 }
             );
 
+            prop_assume!(!removed.is_empty());
+
             // Remove proposals and associated votes
-            db.with_transaction(|ctx| proposals::remove(&ctx.db, &removed)).unwrap();
+            DB.with_transaction(|ctx| proposals::remove(&ctx.db, &removed)).unwrap();
+
+            let mut votes_count_after = BTreeMap::new();
 
             // No votes to that proposal should remain
-            for (ballot_id, _) in db.iter_votes()? {
-                prop_assert!(kept.contains(&ballot_id.proposal));
-                prop_assert!(!removed.contains_key(&ballot_id.proposal));
+            for (ballot_id, _) in DB.iter_votes()? {
+                votes_count_after.entry(ballot_id.proposal).and_modify(|n| *n += 1).or_insert(1);
+                prop_assert!(kept.contains(&ballot_id.proposal), "{ballot_id:?} => {kept:?}");
+                prop_assert!(!removed.contains_key(&ballot_id.proposal), "{ballot_id:?} => {removed:?}");
             }
 
+            // Ensures that no other votes are deleted;
+            votes_count_before.retain(|k, _| !removed.contains_key(k));
+            prop_assert_eq!(votes_count_before, votes_count_after);
+
             // Proposals should have been pruned or left untouched.
-            db.with_transaction(|ctx| {
+            DB.with_transaction(|ctx| {
                 for (proposal_id, proposal) in proposals {
                     prop_assert_eq!(
                         proposals::get(|key| ctx.db.get_pinned(key), &proposal_id).unwrap(),
@@ -147,18 +168,23 @@ mod tests {
         }
     }
 
+    // Prepare the store with some votes, returning a map of the number of votes for each proposal.
     fn fixture_proposals_and_votes(
         db: &RocksDB,
         proposals: impl Iterator<Item = (ProposalId, proposals::Row)>,
         votes: impl Iterator<Item = (Voter, Ballot)>,
-    ) {
+    ) -> BTreeMap<ProposalId, usize> {
+        let mut count = BTreeMap::new();
+
         db.with_transaction(|ctx| {
             let proposals = proposals.collect::<Vec<_>>();
 
             votes::add(
                 &ctx.db,
                 votes.enumerate().map(|(ix, (voter, ballot))| {
-                    let ballot_id = BallotId { voter, proposal: proposals[ix % proposals.len()].0 };
+                    let proposal = proposals[ix % proposals.len()].0;
+                    count.entry(proposal).and_modify(|n| *n += 1).or_insert(1);
+                    let ballot_id = BallotId { voter, proposal };
                     (ballot_id, ballot)
                 }),
             )?;
@@ -168,5 +194,7 @@ mod tests {
             Ok::<_, StoreError>(())
         })
         .unwrap();
+
+        count
     }
 }

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/proposals.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/proposals.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
+
 pub use amaru_ledger::store::{
     StoreError,
     columns::{
@@ -54,9 +56,9 @@ pub fn add<DB>(db: &Transaction<'_, DB>, rows: impl Iterator<Item = (Key, Value)
 }
 
 /// Remove an expired or enacted proposal.
-pub fn remove<'iter, DB>(db: &Transaction<'_, DB>, rows: impl Iterator<Item = &'iter Key>) -> Result<(), StoreError> {
+pub fn remove<DB, V>(db: &Transaction<'_, DB>, proposals: &BTreeMap<Key, V>) -> Result<(), StoreError> {
     trace_span!(stores::ledger::proposals::REMOVE).in_scope(|| {
-        for key in rows {
+        for key in proposals.keys() {
             db.delete(as_key(&PREFIX, key)).map_err(|err| StoreError::Internal(err.into()))?;
         }
 

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/votes.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/votes.rs
@@ -22,7 +22,10 @@ pub use amaru_ledger::store::{
 use amaru_observability::trace_span;
 use rocksdb::Transaction;
 
-use crate::rocksdb::common::{PREFIX_LEN, as_key, as_value};
+use crate::rocksdb::{
+    common::{PREFIX_LEN, as_key, as_value},
+    iter,
+};
 
 /// Name prefixed used for storing Proposals entries. UTF-8 encoding for "vote"
 pub const PREFIX: [u8; PREFIX_LEN] = [0x76, 0x6f, 0x74, 0x65];
@@ -53,5 +56,17 @@ pub fn add<DB>(
         }
 
         Ok(voting_dreps)
+    })
+}
+
+pub fn prune<DB>(db: &Transaction<'_, DB>, should_prune: impl Fn(&Key) -> bool) -> Result<(), StoreError> {
+    trace_span!(stores::ledger::votes::PRUNE).in_scope(|| {
+        for (ballot_id, _) in iter::<Key, Value, _, _>(|mode, opts| db.iterator_opt(mode, opts), PREFIX)? {
+            if should_prune(&ballot_id) {
+                db.delete(as_key(&PREFIX, &ballot_id)).map_err(|err| StoreError::Internal(err.into()))?;
+            }
+        }
+
+        Ok(())
     })
 }

--- a/crates/amaru-stores/src/rocksdb/ledger/columns/votes.rs
+++ b/crates/amaru-stores/src/rocksdb/ledger/columns/votes.rs
@@ -14,7 +14,7 @@
 
 use std::collections::BTreeSet;
 
-use amaru_kernel::{StakeCredential, Voter};
+use amaru_kernel::{BallotId, ProposalId, StakeCredential, Voter, cbor};
 pub use amaru_ledger::store::{
     StoreError,
     columns::votes::{Key, Row, Value},
@@ -24,7 +24,7 @@ use rocksdb::Transaction;
 
 use crate::rocksdb::{
     common::{PREFIX_LEN, as_key, as_value},
-    iter,
+    from_store, iter_raw, prefix_successor,
 };
 
 /// Name prefixed used for storing Proposals entries. UTF-8 encoding for "vote"
@@ -59,14 +59,38 @@ pub fn add<DB>(
     })
 }
 
-pub fn prune<DB>(db: &Transaction<'_, DB>, should_prune: impl Fn(&Key) -> bool) -> Result<(), StoreError> {
-    trace_span!(stores::ledger::votes::PRUNE).in_scope(|| {
-        for (ballot_id, _) in iter::<Key, Value, _, _>(|mode, opts| db.iterator_opt(mode, opts), PREFIX)? {
-            if should_prune(&ballot_id) {
-                db.delete(as_key(&PREFIX, &ballot_id)).map_err(|err| StoreError::Internal(err.into()))?;
-            }
-        }
+#[expect(clippy::expect_used)]
+pub fn iter_by_proposal<DB>(
+    db: &Transaction<'_, DB>,
+    proposal: &ProposalId,
+) -> Result<impl Iterator<Item = Key>, StoreError> {
+    let mut prefix = Vec::new();
+    prefix.extend_from_slice(&PREFIX);
+    BallotId::encode_prefix(proposal, &mut cbor::encode::Encoder::new(&mut prefix))
+        .unwrap_or_else(|_| unreachable!("encoding to a mutable Vec cannot fail"));
 
-        Ok(())
-    })
+    let lo = prefix.clone();
+    let hi = prefix_successor(&prefix[..]).expect("successor always exists here");
+
+    iter_raw(
+        |mode, mut opts| {
+            // NOTE: RocksDB iterator and prefixes
+            //
+            // We configure a prefix size of PREFIX_LEN at start; which means that unless we provide
+            // an explicit range here; RocksDB will match only based on the first PREFIX_LEN bytes
+            // of our prefix and as a consequence, will yield entry we precisely don't want to
+            // match!
+            //
+            // By setting an explicit prefix range, we avoid this headache.
+            opts.set_iterate_range(lo..hi);
+            db.iterator_opt(mode, opts)
+        },
+        prefix,
+        |key, _| from_store(&key[PREFIX_LEN..]),
+    )
+}
+
+pub fn remove<DB>(db: &Transaction<'_, DB>, key: Key) -> Result<(), StoreError> {
+    trace_span!(stores::ledger::votes::REMOVE)
+        .in_scope(|| db.delete(as_key(&PREFIX, &key)).map_err(|err| StoreError::Internal(err.into())))
 }

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -221,6 +221,17 @@ impl RocksDB {
             .map_err(|err| map_rocksdb_open_error(&live_dir, err))
     }
 
+    /// Remove all entries from the store; mostly useful for testing.
+    pub fn clear(&self) -> Result<(), StoreError> {
+        self.with_transaction(|ctx| {
+            for (key, _) in self.db.iterator(rocksdb::IteratorMode::Start).flatten() {
+                ctx.db.delete(key).map_err(|err| StoreError::Internal(err.into()))?;
+            }
+
+            Ok(())
+        })
+    }
+
     /// Use `chain_store` to recover the block height of the ledger `@tip` [`NetworkPoint`].
     pub fn set_chain_store(&self, chain_store: Arc<dyn BaseReadChainStore>) {
         *self.chain_store.lock() = Some(chain_store);
@@ -495,9 +506,10 @@ macro_rules! impl_ReadStore_body {
             }
 
             fn iter_stake_distribution(&self) -> Result<impl Iterator<Item = StakeEntry>, StoreError> {
-                iter_value::<scolumns::utxo::Key, StakeEntry, _, _>(
+                iter_raw::<_, _, StakeEntry>(
                     |mode, opts| self.db.iterator_opt(mode, opts),
                     utxo::PREFIX,
+                    |_, value| from_store(value),
                 )
             }
 
@@ -986,80 +998,63 @@ where
         .map_err(StoreError::Undecodable)
 }
 
+fn new_raw_iterator<'db, DB, F>(db_iter_opt: F, prefix: &[u8]) -> rocksdb::DBRawIteratorWithThreadMode<'db, DB>
+where
+    DB: DBAccess,
+    F: FnOnce(IteratorMode<'_>, ReadOptions) -> DBIteratorWithThreadMode<'db, DB>,
+{
+    let mut opts = ReadOptions::default();
+    opts.set_prefix_same_as_start(true);
+    (db_iter_opt)(IteratorMode::From(prefix, Direction::Forward), opts).into()
+}
+
 #[expect(clippy::panic)]
+fn from_store<T>(bytes: &[u8]) -> T
+where
+    T: for<'d> cbor::Decode<'d, ()>,
+{
+    cbor::decode(bytes).unwrap_or_else(|e| {
+        panic!("unable to decode {} as <{}>: {e:?}", hex::encode(bytes), std::any::type_name::<T>(),)
+    })
+}
+
 pub fn iter<'a, 'b, K, V, DB, F>(
     db_iter_opt: F,
     prefix: [u8; PREFIX_LEN],
 ) -> Result<impl Iterator<Item = (K, V)> + 'a, StoreError>
 where
     DB: 'a + 'b + DBAccess,
-    F: Fn(IteratorMode<'_>, ReadOptions) -> DBIteratorWithThreadMode<'b, DB> + 'a,
+    F: FnOnce(IteratorMode<'_>, ReadOptions) -> DBIteratorWithThreadMode<'b, DB> + 'a,
     'b: 'a,
     K: for<'d> cbor::Decode<'d, ()> + 'a,
     V: for<'d> cbor::Decode<'d, ()> + 'a,
 {
-    let mut opts = ReadOptions::default();
-    opts.set_prefix_same_as_start(true);
-    let mut it: rocksdb::DBRawIteratorWithThreadMode<'_, _> =
-        (db_iter_opt)(IteratorMode::From(prefix.as_ref(), Direction::Forward), opts).into();
-    Ok(std::iter::from_fn(move || {
-        if let Some((key, value)) = it.item() {
-            let k = cbor::decode(&key[PREFIX_LEN..]).unwrap_or_else(|e| {
-                panic!(
-                    "unable to decode key {}::<{}> for type {}: {e:?}",
-                    hex::encode(key),
-                    std::any::type_name::<K>(),
-                    std::any::type_name::<V>()
-                )
-            });
-            let v = cbor::decode(value).unwrap_or_else(|e| {
-                panic!(
-                    "unable to decode value {}::<{}> for key {}::<{}>: {e:?}",
-                    hex::encode(value),
-                    std::any::type_name::<V>(),
-                    hex::encode(key),
-                    std::any::type_name::<K>(),
-                )
-            });
-            it.next();
-            Some((k, v))
-        } else {
-            None
-        }
-    }))
+    iter_raw(db_iter_opt, prefix, |key, value| {
+        let k = from_store::<K>(&key[PREFIX_LEN..]);
+        let v = from_store::<V>(value);
+        (k, v)
+    })
 }
 
-#[expect(clippy::panic)]
-pub fn iter_value<'a, 'b, K, V, DB, F>(
+#[inline]
+pub fn iter_raw<'db, DB, F, T>(
     db_iter_opt: F,
-    prefix: [u8; PREFIX_LEN],
-) -> Result<impl Iterator<Item = V> + 'a, StoreError>
+    prefix: impl AsRef<[u8]>,
+    to_item: impl Fn(&[u8], &[u8]) -> T,
+) -> Result<impl Iterator<Item = T>, StoreError>
 where
-    DB: 'a + 'b + DBAccess,
-    F: Fn(IteratorMode<'_>, ReadOptions) -> DBIteratorWithThreadMode<'b, DB> + 'a,
-    'b: 'a,
-    V: for<'d> cbor::Decode<'d, ()> + 'a,
+    DB: DBAccess + 'db,
+    F: FnOnce(IteratorMode<'_>, ReadOptions) -> DBIteratorWithThreadMode<'db, DB>,
 {
-    let mut opts = ReadOptions::default();
-    opts.set_prefix_same_as_start(true);
-    let mut it: rocksdb::DBRawIteratorWithThreadMode<'_, _> =
-        (db_iter_opt)(IteratorMode::From(prefix.as_ref(), Direction::Forward), opts).into();
+    let mut iterator = new_raw_iterator(db_iter_opt, prefix.as_ref());
     Ok(std::iter::from_fn(move || {
-        if let Some((key, value)) = it.item() {
-            let v = cbor::decode(value).unwrap_or_else(|e| {
-                panic!(
-                    "unable to decode value {}::<{}> for key {}::<{}>: {e:?}",
-                    hex::encode(value),
-                    std::any::type_name::<V>(),
-                    hex::encode(key),
-                    std::any::type_name::<K>(),
-                )
-            });
-            it.next();
-            Some(v)
-        } else {
-            None
+        if let Some((key, value)) = iterator.item() {
+            let item = to_item(key, value);
+            iterator.next();
+            return Some(item);
         }
+
+        None
     }))
 }
 
@@ -1108,6 +1103,21 @@ fn with_prefix_iterator<
         );
         Ok(())
     })
+}
+
+/// Look for the successor of a prefix, to construct upper-bound of seek ranges. Returns `None` if
+/// the prefix is already all `0xff`.
+pub fn prefix_successor(prefix: &[u8]) -> Option<Vec<u8>> {
+    let mut next = prefix.to_vec();
+
+    while let Some(byte) = next.pop() {
+        if byte != 0xff {
+            next.push(byte + 1);
+            return Some(next);
+        }
+    }
+
+    None
 }
 
 // Tests

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -765,11 +765,8 @@ impl TransactionalContext<'_> for RocksDBTransactionalContext<'_> {
 
     /// Remove a list of proposals from the database. This is done when enacting proposals that
     /// cause other proposals to become obsolete.
-    fn remove_proposals<'iter>(
-        &self,
-        proposals: impl IntoIterator<Item = &'iter ProposalId>,
-    ) -> Result<(), StoreError> {
-        proposals::remove(&self.db, proposals.into_iter())
+    fn remove_proposals<T>(&self, proposals: &BTreeMap<ProposalId, T>) -> Result<(), StoreError> {
+        proposals::remove(&self.db, proposals)
     }
 
     /// Prune recently unregistered accounts from the database that are no longer required.
@@ -912,10 +909,6 @@ impl TransactionalContext<'_> for RocksDBTransactionalContext<'_> {
 
     fn with_dreps(&self, with: impl FnMut(scolumns::dreps::Iter<'_, '_>)) -> Result<(), StoreError> {
         with_prefix_iterator(&self.db, dreps::PREFIX, "dreps", with)
-    }
-
-    fn with_proposals(&self, with: impl FnMut(scolumns::proposals::Iter<'_, '_>)) -> Result<(), StoreError> {
-        with_prefix_iterator(&self.db, proposals::PREFIX, "proposals", with)
     }
 
     fn with_cc_members(&self, with: impl FnMut(scolumns::cc_members::Iter<'_, '_>)) -> Result<(), StoreError> {

--- a/crates/amaru-stores/tests/helpers.rs
+++ b/crates/amaru-stores/tests/helpers.rs
@@ -23,7 +23,7 @@ use std::{
 use amaru_kernel::{
     Anchor, Block, BlockHeight, CertificatePointer, Constitution, ConstitutionalCommitteeStatus, Epoch, EraHistory,
     GlobalParameters, Hash, Header, HeaderHash, MaxString128, NetworkName, PREPROD_DEFAULT_PROTOCOL_PARAMETERS,
-    PREPROD_ERA_HISTORY, PREPROD_GLOBAL_PARAMETERS, Point, Pots, ProposalsRoots, ProtocolParameters, Slot,
+    PREPROD_ERA_HISTORY, PREPROD_GLOBAL_PARAMETERS, Point, Pots, ProposalId, ProposalsRoots, ProtocolParameters, Slot,
     cardano::network_block::make_block, cbor, make_header, to_cbor,
 };
 use amaru_ledger::{
@@ -457,18 +457,11 @@ impl<'a> TransactionalContext<'a> for MockTransaction<'a> {
         Ok(())
     }
 
-    fn with_proposals(&self, _with: impl FnMut(proposals::Iter<'_, '_>)) -> amaru_ledger::store::Result<()> {
-        Ok(())
-    }
-
     fn with_cc_members(&self, _with: impl FnMut(cc_members::Iter<'_, '_>)) -> amaru_ledger::store::Result<()> {
         Ok(())
     }
 
-    fn remove_proposals<'iter>(
-        &self,
-        _proposals: impl Iterator<Item = &'iter amaru_kernel::ProposalId>,
-    ) -> amaru_ledger::store::Result<()> {
+    fn remove_proposals<T>(&self, _proposals: &BTreeMap<ProposalId, T>) -> amaru_ledger::store::Result<()> {
         Ok(())
     }
 

--- a/crates/amaru/src/bin/amaru/cmd/dev/traces/dump.rs
+++ b/crates/amaru/src/bin/amaru/cmd/dev/traces/dump.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeMap, env};
+use std::{collections::BTreeMap, env, io};
 
 use amaru::lifecycle::{Runnable, RuntimeKind};
 use amaru_observability::{aliases, registry::SchemaEntry};
@@ -34,10 +34,13 @@ pub(crate) fn runnable(args: Args) -> Runnable {
 async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     let aliases = aliases::load_workspace_type_aliases_from(&env::current_dir()?)?;
     let output = generate_traces_json_schema(&SchemaEntry::all(), &aliases);
-    let json_string =
-        if args.compact { serde_json::to_string(&output)? } else { serde_json::to_string_pretty(&output)? };
 
-    eprintln!("{}", json_string);
+    if args.compact {
+        serde_json::to_writer(io::stdout(), &output)
+    } else {
+        serde_json::to_writer_pretty(io::stdout(), &output)
+    }?;
+
     Ok(())
 }
 

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -2147,6 +2147,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
 | `add` | `TRACE` | public | Record governance votes |  |  |
+| `prune` | `TRACE` | public | Remove now-obsolete governance votes |  |  |
 
 ## Updating This Documentation
 

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -2147,7 +2147,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
 | `add` | `TRACE` | public | Record governance votes |  |  |
-| `prune` | `TRACE` | public | Remove now-obsolete governance votes |  |  |
+| `remove` | `TRACE` | public | Remove now-obsolete governance votes |  |  |
 
 ## Updating This Documentation
 

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -4638,6 +4638,18 @@
       "target": "amaru::stores::ledger::votes",
       "description": "Record governance votes",
       "public": true
+    },
+    "amaru::stores::ledger::votes::PRUNE": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "prune",
+      "level": "TRACE",
+      "target": "amaru::stores::ledger::votes",
+      "description": "Remove now-obsolete governance votes",
+      "public": true
     }
   }
 }

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -4639,13 +4639,13 @@
       "description": "Record governance votes",
       "public": true
     },
-    "amaru::stores::ledger::votes::PRUNE": {
+    "amaru::stores::ledger::votes::REMOVE": {
       "type": "object",
       "properties": {},
       "required": [],
       "optional": [],
       "additionalProperties": false,
-      "name": "prune",
+      "name": "remove",
       "level": "TRACE",
       "target": "amaru::stores::ledger::votes",
       "description": "Remove now-obsolete governance votes",

--- a/scripts/generate-traces-doc
+++ b/scripts/generate-traces-doc
@@ -16,7 +16,7 @@ SCHEMAS_FILE="${DOCS_DIR}/traces-schema.json"
 trap "rm -f ${SCHEMAS_JSON}" EXIT
 
 # Ensure the amaru binary is up to date
-cargo run --quiet --profile $BUILD_PROFILE --locked --bin amaru -- dump-traces-schema 2> "${SCHEMAS_JSON}" || {
+cargo run --quiet --profile $BUILD_PROFILE --locked --bin amaru -- dev traces dump 1> "${SCHEMAS_JSON}" || {
   echo "Error generating schemas:" >&2
   cat "${SCHEMAS_JSON}" >&2
   exit 1

--- a/scripts/unused-schemas
+++ b/scripts/unused-schemas
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Find schema constants (from dump-traces-schema JSON) never referenced in debug_span! calls.
+# Find schema constants never referenced in debug_span! calls.
 #
 # Private schemas (public: false) are included in the registry so they appear here too.
 
@@ -8,7 +8,7 @@ set -euo pipefail
 BUILD_PROFILE="${BUILD_PROFILE:-test}"
 
 # Get all schema paths from the compiled registry (both public and private)
-all_paths=$(cargo run --quiet --profile $BUILD_PROFILE dump-traces-schema 2>&1 | jq -r '.definitions | keys[]' | sort)
+all_paths=$(cargo run --quiet --profile $BUILD_PROFILE dev traces dump | jq -r '.definitions | keys[]' | sort)
 
 total=$(echo "$all_paths" | wc -l | tr -d ' ')
 unused=0


### PR DESCRIPTION
This wasn't causing any kind of logic / behavioral issue, but we would just keep all votes in the ledger state including those of expired proposals. This is not only wasted storage, but would also make the epoch transition a bit slower every epoch as we would always be iterating over all the votes since the dawn of time. 

Note that PR is also fixing the `dev traces dump` command to dump the JSON schema on `stdout` instead of `stderr`; I bumped into this locally while running the command through cargo run and getting `jq` to choke on the non-JSON outputs from Cargo... 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Obsolete governance votes are now removed when expired, ratified, or evicted proposals are pruned.
  * Stable committee delegation is correctly resolved when no volatile committee entry exists.
  * Proposal and vote cleanup behavior is now more consistent and reliable.

* **Observability**
  * Added tracing for governance vote pruning.

* **Maintenance**
  * Updated trace-schema generation commands and documentation.
  * Improved trace output generation and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->