### PR TITLE
fix: switch to fork on the ledger only with a better tip

### DIFF
--- a/crates/amaru-consensus/src/stages/test_utils.rs
+++ b/crates/amaru-consensus/src/stages/test_utils.rs
@@ -17,6 +17,7 @@
 use std::{any::type_name, collections::BTreeSet, fmt, io, sync::Arc, time::Duration};
 
 use amaru_kernel::{Epoch, PREPROD_ERA_HISTORY, Slot};
+use amaru_observability::{CborConsoleEventFormat, console_field_formatter};
 use amaru_pure_stage::{
     DeserializerGuards, Effect, Instant, Name, Resources, SendData, StageGraph, TerminationReason,
     simulation::{SimulationBuilder, SimulationRunning},
@@ -285,9 +286,13 @@ where
     let writer = BufferWriter::new();
     let mut logs = writer.clone();
 
+    // Use the CBOR-aware console stack (EDR-033) so schema events render their typed fields
+    // as readable values instead of raw CBOR byte arrays.
     let sub = tracing_subscriber::fmt()
         .with_max_level(Level::DEBUG)
         .with_ansi(false)
+        .event_format(CborConsoleEventFormat::new().with_ansi(false))
+        .fmt_fields(console_field_formatter())
         .with_writer(move || writer.clone())
         .set_default();
     logs.set_guard(sub);

--- a/crates/amaru-consensus/src/stages/validate_block/mod.rs
+++ b/crates/amaru-consensus/src/stages/validate_block/mod.rs
@@ -204,6 +204,11 @@ pub async fn stage(
             // fetch_blocks streams the blocks of a new best candidate one by one, each with its own
             // tip. Only a tip that is strictly better than the current one (per the chain-selection
             // order) can be accepted as a candidate for a fork switch on the ledger.
+            //
+            // NOTE: the headers are loaded from the store on demand rather than kept in the stage
+            // state. This branch is neither on the sync hot path nor on the caught-up common path
+            // (both extend `current` and take the branch above), while a header held in the state
+            // would add ~1.5kB to every stage state snapshot serialized into the TraceBuffer.
             let store = Store::new(eff.clone());
             let message_header = store.load_header(&tip.hash()).await;
             let current_header = store.load_header(&state.current.hash()).await;

--- a/crates/amaru-consensus/src/stages/validate_block/mod.rs
+++ b/crates/amaru-consensus/src/stages/validate_block/mod.rs
@@ -16,14 +16,19 @@ use std::collections::BTreeMap;
 
 use amaru_kernel::{BlockHeight, HeaderHash, Point};
 use amaru_metrics::LedgerMetrics;
-use amaru_observability::{TraceContext, debug_span};
+use amaru_observability::{TraceContext, debug, debug_span};
 use amaru_ouroboros_traits::ForkSwitchOutcome;
+use amaru_protocols::store_effects::Store;
 use amaru_pure_stage::{Effects, OrTerminateWith, StageRef};
 use tracing::Instrument;
 
 use crate::{
     effects::{Ledger, LedgerOps, Metrics, MetricsOps},
-    stages::{adopt_chain::AdoptChainMsg, block_source::BlockSourceMsg, select_chain::SelectChainMsg},
+    stages::{
+        adopt_chain::AdoptChainMsg,
+        block_source::BlockSourceMsg,
+        select_chain::{SelectChainMsg, cmp_tip},
+    },
 };
 
 /// ValidateBlock stage: thin validation dispatcher + result router for the consensus pipeline.
@@ -40,6 +45,8 @@ use crate::{
 ///     `BlockSourceMsg::Validation { valid: true, point: msg.tip }`, and
 ///     `AdoptChainMsg::new(msg.tip, state.max_block_height)` to manager; update `state.current = msg.tip`.
 ///   - `Err`: log warn, send `...Result(msg.tip, false)` + `Validation { valid: false, ... }` (no adopt, no current update).
+/// - If `msg.tip` is not better than the current tip (using the [`cmp_tip`] function) the message is
+///   dropped.
 /// - Otherwise: ask the ledger to switch to the fork ending at `msg.tip` (`Ledger::switch_to_fork`,
 ///   a `SwitchToForkEffect`) and route its `ForkSwitchOutcome`:
 ///   - `Completed`: same signals as a successful extension.
@@ -194,6 +201,17 @@ pub async fn stage(
                 }
             }
         } else {
+            // fetch_blocks streams the blocks of a new best candidate one by one, each with its own
+            // tip. Only a tip that is strictly better than the current one (per the chain-selection
+            // order) can be accepted as a candidate for a fork switch on the ledger.
+            let store = Store::new(eff.clone());
+            let message_header = store.load_header(&tip.hash()).await;
+            let current_header = store.load_header(&state.current.hash()).await;
+            if cmp_tip(message_header.as_ref(), current_header.as_ref()) != std::cmp::Ordering::Greater {
+                debug!(consensus::block::SKIP, current = state.current, tip = tip);
+                return state;
+            }
+
             tracing::info!(parent = %msg.parent, current = %state.current, "switching the ledger to a new fork");
             let result = ledger
                 .switch_to_fork(&tip)

--- a/crates/amaru-consensus/src/stages/validate_block/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/validate_block/test_setup.rs
@@ -205,6 +205,10 @@ pub fn te_validate_block(at_stage: &str, point: Point) -> TraceEntry {
     TraceEntry::suspend(Effect::external(at_stage, Box::new(ValidateBlockEffect::new(&point))))
 }
 
+pub fn te_load_header(at_stage: &str, hash: HeaderHash) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(at_stage, Box::new(LoadHeaderEffect::new(hash))))
+}
+
 pub fn te_rollback_ledger(at_stage: &str, tip: &Point) -> TraceEntry {
     TraceEntry::suspend(Effect::external(at_stage, Box::new(SwitchToForkEffect::new(tip))))
 }

--- a/crates/amaru-consensus/src/stages/validate_block/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/validate_block/test_setup.rs
@@ -209,7 +209,7 @@ pub fn te_load_header(at_stage: &str, hash: HeaderHash) -> TraceEntry {
     TraceEntry::suspend(Effect::external(at_stage, Box::new(LoadHeaderEffect::new(hash))))
 }
 
-pub fn te_rollback_ledger(at_stage: &str, tip: &Point) -> TraceEntry {
+pub fn te_switch_to_fork(at_stage: &str, tip: &Point) -> TraceEntry {
     TraceEntry::suspend(Effect::external(at_stage, Box::new(SwitchToForkEffect::new(tip))))
 }
 

--- a/crates/amaru-consensus/src/stages/validate_block/tests.rs
+++ b/crates/amaru-consensus/src/stages/validate_block/tests.rs
@@ -22,8 +22,8 @@ use crate::stages::{
     select_chain::SelectChainMsg,
     test_utils::{te_input, te_state},
     validate_block::test_setup::{
-        assert_trace, setup, setup_many, te_rollback_ledger, te_send, te_terminate, te_terminated, te_validate_block,
-        test_prep, tm_record_metrics,
+        assert_trace, setup, setup_many, te_load_header, te_rollback_ledger, te_send, te_terminate, te_terminated,
+        te_validate_block, test_prep, tm_record_metrics,
     },
 };
 // if needed for Literal
@@ -86,19 +86,58 @@ fn test_parent_equals_current_validates_tip_only() {
 }
 
 #[test]
-fn test_parent_in_ledger_skips_roll_forward() {
+fn test_mock_rollback_fails_terminates() {
+    // The ledger is on the fork h2a (height 3).
+    // Switching back to the main chain tip h3 (height 4) fails at the rollback, which terminates the stage.
     let mut prep = test_prep();
     prep.set_current(prep.headers.h2a.point());
     prep.block_validator
-        .with_tip(prep.headers.h0.point())
         .with_contains(prep.headers.h1.point())
-        .with_contains(prep.headers.h2a.point());
+        .with_contains(prep.headers.h2a.point())
+        .with_rollback_fails(true);
     prep.store_headers(&prep.headers.all());
     prep.store_blocks(&prep.headers.all());
     prep.set_anchor(prep.headers.h0.hash());
 
-    let tip = prep.headers.h2.point();
-    let parent = prep.headers.h1.point();
+    let tip = prep.headers.h3.point();
+    let parent = prep.headers.h2.point();
+    let msg = ValidateBlockMsg::new(tip, parent, BlockHeight::from(0));
+
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    assert_trace(
+        &running,
+        &[
+            te_state("vb-1", &prep.state),
+            te_input("vb-1", &msg),
+            te_load_header("vb-1", tip.hash()),
+            te_load_header("vb-1", prep.headers.h2a.hash()),
+            te_rollback_ledger("vb-1", &tip),
+            te_terminate("vb-1"),
+            te_terminated("vb-1", TerminationReason::Voluntary),
+        ],
+    );
+    logs.assert_and_remove(Level::DEBUG, &["validating block"])
+        .assert_and_remove(Level::INFO, &["switching the ledger to a new fork"])
+        .assert_and_remove(Level::WARN, &["failed to switch to a new fork"])
+        .assert_and_remove(Level::INFO, &["terminated"])
+        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_completed_fork_switch_adopts_the_new_tip() {
+    // The ledger is on the fork h2a (height 3) and the main chain tip h3 (height 4) wins chain
+    // selection: the switch replays h2 and h3 from the store, completes, and h3 is adopted.
+    let mut prep = test_prep();
+    prep.set_current(prep.headers.h2a.point());
+    prep.store_headers(&prep.headers.all());
+    prep.store_blocks(&prep.headers.all());
+    prep.set_anchor(prep.headers.h0.hash());
+    prep.roll_forward_chain(prep.headers.h0.point());
+    prep.roll_forward_chain(prep.headers.h1.point());
+    prep.set_validity(prep.headers.h1.hash(), true);
+
+    let tip = prep.headers.h3.point();
+    let parent = prep.headers.h2.point();
     let msg = ValidateBlockMsg::new(tip, parent, BlockHeight::from(0));
 
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
@@ -118,14 +157,13 @@ fn test_parent_in_ledger_skips_roll_forward() {
 }
 
 #[test]
-fn test_mock_rollback_fails_terminates() {
+fn test_equal_height_fork_winning_the_tiebreak_is_switched_to() {
+    // A fork replacing the current chain at equal length is only adopted when its tip wins the
+    // chain-selection tiebreak. Here the ledger is on h2a (height 3) and h2 (height 3) wins:
+    // h2 and h2a share block number 3, so their VRF outputs tie and h2's higher op-cert
+    // sequence (1 vs 0) decides.
     let mut prep = test_prep();
     prep.set_current(prep.headers.h2a.point());
-    prep.block_validator
-        .with_tip(prep.headers.h0.point())
-        .with_contains(prep.headers.h1.point())
-        .with_contains(prep.headers.h2a.point())
-        .with_rollback_fails(true);
     prep.store_headers(&prep.headers.all());
     prep.store_blocks(&prep.headers.all());
     prep.set_anchor(prep.headers.h0.hash());
@@ -135,47 +173,11 @@ fn test_mock_rollback_fails_terminates() {
     let msg = ValidateBlockMsg::new(tip, parent, BlockHeight::from(0));
 
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
-    assert_trace(
-        &running,
-        &[
-            te_state("vb-1", &prep.state),
-            te_input("vb-1", &msg),
-            te_rollback_ledger("vb-1", &tip),
-            te_terminate("vb-1"),
-            te_terminated("vb-1", TerminationReason::Voluntary),
-        ],
-    );
-    logs.assert_and_remove(Level::DEBUG, &["validating block"])
-        .assert_and_remove(Level::INFO, &["switching the ledger to a new fork"])
-        .assert_and_remove(Level::WARN, &["failed to switch to a new fork"])
-        .assert_and_remove(Level::INFO, &["terminated"])
-        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
-}
-
-#[test]
-fn test_grand_parent_in_ledger() {
-    let mut prep = test_prep();
-    prep.set_current(prep.headers.h2a.point());
-    prep.block_validator
-        .with_tip(prep.headers.h0.point())
-        .with_contains(prep.headers.h1.point())
-        .with_contains(prep.headers.h2a.point());
-    prep.store_headers(&prep.headers.all());
-    prep.store_blocks(&prep.headers.all());
-    prep.set_anchor(prep.headers.h0.hash());
-    prep.roll_forward_chain(prep.headers.h0.point());
-    prep.roll_forward_chain(prep.headers.h1.point());
-    prep.set_validity(prep.headers.h1.hash(), true);
-
-    let tip = prep.headers.h3.point();
-    let parent = prep.headers.h2.point();
-    let msg = ValidateBlockMsg::new(tip, parent, BlockHeight::from(0));
-
-    let (running, _guards, mut logs) = setup(&prep, msg.clone());
     assert_trace_contains(
         &running,
         &[
             te_input("vb-1", &msg).into(),
+            te_rollback_ledger("vb-1", &tip).into(),
             te_send("vb-1", "select_chain", SelectChainMsg::BlockValidationResult(tip, true, BlockHeight::from(0)))
                 .into(),
             te_send("vb-1", "block_source", BlockSourceMsg::Validation { valid: true, point: tip }).into(),
@@ -246,6 +248,8 @@ fn test_rollback_fails_when_rollback_point_not_in_volatile_db() {
         &[
             te_state("vb-1", &prep.state),
             te_input("vb-1", &msg),
+            te_load_header("vb-1", tip.hash()),
+            te_load_header("vb-1", prep.headers.h2.hash()),
             te_rollback_ledger("vb-1", &tip),
             te_terminate("vb-1"),
             te_terminated("vb-1", TerminationReason::Voluntary),
@@ -324,8 +328,10 @@ fn test_validation_failure_sends_false() {
 
 #[test]
 fn test_partial_fork_switch_adopts_the_applied_prefix() {
+    // The ledger is on h2 (height 3) and switches to the fork h2a -> h3a (height 4): the switch
+    // stops at h2a because h3a fails to apply, and the applied prefix is adopted.
     let mut prep = test_prep();
-    prep.set_current(prep.headers.h1.point());
+    prep.set_current(prep.headers.h2.point());
     prep.block_validator.with_partial_switch(
         prep.headers.h3a.point(),
         prep.headers.h2a.point(),
@@ -374,8 +380,10 @@ fn test_partial_fork_switch_adopts_the_applied_prefix() {
 
 #[test]
 fn test_rolled_back_fork_switch_reports_the_failing_block() {
+    // The ledger is on h2 (height 3) and switches to the fork h2a -> h3a (height 4): the switch
+    // fails at its first block h2a, so the ledger restores its pre-switch state.
     let mut prep = test_prep();
-    prep.set_current(prep.headers.h1.point());
+    prep.set_current(prep.headers.h2.point());
     prep.block_validator.with_rolled_back_switch(prep.headers.h3a.point(), prep.headers.h2a.point());
     prep.store_headers(&prep.headers.all());
     prep.store_blocks(&prep.headers.all());
@@ -396,6 +404,8 @@ fn test_rolled_back_fork_switch_reports_the_failing_block() {
         &[
             te_state("vb-1", &prep.state),
             te_input("vb-1", &msg),
+            te_load_header("vb-1", tip.hash()),
+            te_load_header("vb-1", prep.headers.h2.hash()),
             te_rollback_ledger("vb-1", &tip),
             te_send("vb-1", "select_chain", SelectChainMsg::BlockValidationResult(failed, false, BlockHeight::from(0))),
             te_send("vb-1", "block_source", BlockSourceMsg::Validation { valid: false, point: failed }),
@@ -405,6 +415,42 @@ fn test_rolled_back_fork_switch_reports_the_failing_block() {
     logs.assert_and_remove(Level::DEBUG, &["validating block"])
         .assert_and_remove(Level::INFO, &["switching the ledger to a new fork"])
         .assert_and_remove(Level::WARN, &["failed to fork the ledger to a new tip"])
+        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_switch_to_a_fork_only_for_a_better_candidate() {
+    // We set-up the validate_block stage with a current tip of h3 (height 4).
+    // The stage receives a message from the fetch_blocks stage for block h2a. Since h2a is
+    // not a best candidate (it is not the longest chain), the stage must skip that message.
+    let mut prep = test_prep();
+    prep.set_current(prep.headers.h3.point());
+    prep.store_headers(&prep.headers.all());
+    prep.store_blocks(&prep.headers.all());
+    prep.set_anchor(prep.headers.h0.hash());
+    for h in &[&prep.headers.h0, &prep.headers.h1, &prep.headers.h2, &prep.headers.h3] {
+        prep.roll_forward_chain(h.point());
+        prep.set_validity(h.hash(), true);
+    }
+
+    let tip = prep.headers.h2a.point();
+    let parent = prep.headers.h1.point();
+    let msg = ValidateBlockMsg::new(tip, parent, BlockHeight::from(0));
+
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    assert_trace(
+        &running,
+        &[
+            te_state("vb-1", &prep.state),
+            te_input("vb-1", &msg),
+            te_load_header("vb-1", tip.hash()),
+            te_load_header("vb-1", prep.headers.h3.hash()),
+            // the message is dropped: no ledger effect, no downstream signal, no state change
+            te_state("vb-1", &prep.state),
+        ],
+    );
+    logs.assert_and_remove(Level::DEBUG, &["validating block"])
+        .assert_and_remove(Level::DEBUG, &["block.skip"])
         .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 

--- a/crates/amaru-consensus/src/stages/validate_block/tests.rs
+++ b/crates/amaru-consensus/src/stages/validate_block/tests.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 use amaru_kernel::{IsHeader, Point};
-use amaru_pure_stage::{TerminationReason, trace_match::assert_trace_contains};
+use amaru_pure_stage::{
+    TerminationReason,
+    trace_match::{assert_trace_contains, assert_trace_match},
+};
 use tracing::Level;
 
 use super::*;
@@ -22,14 +25,13 @@ use crate::stages::{
     select_chain::SelectChainMsg,
     test_utils::{te_input, te_state},
     validate_block::test_setup::{
-        assert_trace, setup, setup_many, te_load_header, te_rollback_ledger, te_send, te_terminate, te_terminated,
+        assert_trace, setup, setup_many, te_load_header, te_send, te_switch_to_fork, te_terminate, te_terminated,
         te_validate_block, test_prep, tm_record_metrics,
     },
 };
-// if needed for Literal
 
 #[test]
-fn test_genesis_block_skips_validation() {
+fn test_block_with_origin_parent_terminates() {
     let prep = test_prep();
     prep.store_headers(&prep.headers.main());
     prep.store_block(&prep.headers.h0);
@@ -54,7 +56,7 @@ fn test_genesis_block_skips_validation() {
 }
 
 #[test]
-fn test_parent_equals_current_validates_tip_only() {
+fn test_block_extending_the_current_tip_is_adopted() {
     let mut prep = test_prep();
     prep.set_current(prep.headers.h1.point());
     prep.store_headers(&prep.headers.main());
@@ -86,134 +88,75 @@ fn test_parent_equals_current_validates_tip_only() {
 }
 
 #[test]
-fn test_mock_rollback_fails_terminates() {
-    // The ledger is on the fork h2a (height 3).
-    // Switching back to the main chain tip h3 (height 4) fails at the rollback, which terminates the stage.
+fn test_invalid_block_condemns_in_flight_descendants() {
     let mut prep = test_prep();
-    prep.set_current(prep.headers.h2a.point());
-    prep.block_validator
-        .with_contains(prep.headers.h1.point())
-        .with_contains(prep.headers.h2a.point())
-        .with_rollback_fails(true);
+    prep.set_current(prep.headers.h1.point());
+    prep.block_validator.with_tip(prep.headers.h1.point()).with_validate_fails(prep.headers.h2a.point());
     prep.store_headers(&prep.headers.all());
     prep.store_blocks(&prep.headers.all());
     prep.set_anchor(prep.headers.h0.hash());
 
-    let tip = prep.headers.h3.point();
-    let parent = prep.headers.h2.point();
-    let msg = ValidateBlockMsg::new(tip, parent, BlockHeight::from(0));
+    let tip1 = prep.headers.h2a.point();
+    let msg1 = ValidateBlockMsg::new(tip1, prep.headers.h1.point(), BlockHeight::from(0));
+    let tip2 = prep.headers.h3a.point();
+    let msg2 = ValidateBlockMsg::new(tip2, prep.headers.h2a.point(), BlockHeight::from(0));
 
-    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    let after_first =
+        ValidateBlock { invalid_blocks: BTreeMap::from([(tip1.hash(), tip1.block_height())]), ..prep.state.clone() };
+    let after_second = ValidateBlock {
+        invalid_blocks: BTreeMap::from([(tip1.hash(), tip1.block_height()), (tip2.hash(), tip2.block_height())]),
+        ..prep.state.clone()
+    };
+
+    let (running, _guards, mut logs) = setup_many(&prep, vec![msg1.clone(), msg2.clone()]);
     assert_trace(
         &running,
         &[
             te_state("vb-1", &prep.state),
-            te_input("vb-1", &msg),
-            te_load_header("vb-1", tip.hash()),
-            te_load_header("vb-1", prep.headers.h2a.hash()),
-            te_rollback_ledger("vb-1", &tip),
-            te_terminate("vb-1"),
-            te_terminated("vb-1", TerminationReason::Voluntary),
+            te_input("vb-1", &msg1),
+            te_validate_block("vb-1", tip1),
+            te_send("vb-1", "select_chain", SelectChainMsg::BlockValidationResult(tip1, false, BlockHeight::from(0))),
+            te_send("vb-1", "block_source", BlockSourceMsg::Validation { valid: false, point: tip1 }),
+            te_state("vb-1", &after_first),
+            te_input("vb-1", &msg2),
+            // no ledger effect here: the parent is invalid
+            te_send("vb-1", "select_chain", SelectChainMsg::BlockValidationResult(tip2, false, BlockHeight::from(0))),
+            te_send("vb-1", "block_source", BlockSourceMsg::Validation { valid: false, point: tip2 }),
+            te_state("vb-1", &after_second),
         ],
     );
     logs.assert_and_remove(Level::DEBUG, &["validating block"])
-        .assert_and_remove(Level::INFO, &["switching the ledger to a new fork"])
-        .assert_and_remove(Level::WARN, &["failed to switch to a new fork"])
-        .assert_and_remove(Level::INFO, &["terminated"])
+        .assert_and_remove(Level::WARN, &["failed to advance the ledger to a new tip"])
+        .assert_and_remove(Level::WARN, &["refusing to validate the descendant of an invalid block"])
         .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 
 #[test]
-fn test_completed_fork_switch_adopts_the_new_tip() {
-    // The ledger is on the fork h2a (height 3) and the main chain tip h3 (height 4) wins chain
-    // selection: the switch replays h2 and h3 from the store, completes, and h3 is adopted.
+fn test_invalid_blocks_below_the_security_window_are_evicted() {
     let mut prep = test_prep();
-    prep.set_current(prep.headers.h2a.point());
-    prep.store_headers(&prep.headers.all());
-    prep.store_blocks(&prep.headers.all());
-    prep.set_anchor(prep.headers.h0.hash());
-    prep.roll_forward_chain(prep.headers.h0.point());
-    prep.roll_forward_chain(prep.headers.h1.point());
-    prep.set_validity(prep.headers.h1.hash(), true);
-
-    let tip = prep.headers.h3.point();
-    let parent = prep.headers.h2.point();
-    let msg = ValidateBlockMsg::new(tip, parent, BlockHeight::from(0));
-
-    let (running, _guards, mut logs) = setup(&prep, msg.clone());
-    assert_trace_contains(
-        &running,
-        &[
-            te_input("vb-1", &msg).into(),
-            te_send("vb-1", "select_chain", SelectChainMsg::BlockValidationResult(tip, true, BlockHeight::from(0)))
-                .into(),
-            te_send("vb-1", "block_source", BlockSourceMsg::Validation { valid: true, point: tip }).into(),
-            te_send("vb-1", "manager", AdoptChainMsg::new(tip, BlockHeight::from(0))).into(),
-        ],
-    );
-    logs.assert_and_remove(Level::DEBUG, &["validating block"])
-        .assert_and_remove(Level::INFO, &["switching the ledger to a new fork"])
-        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
-}
-
-#[test]
-fn test_equal_height_fork_winning_the_tiebreak_is_switched_to() {
-    // A fork replacing the current chain at equal length is only adopted when its tip wins the
-    // chain-selection tiebreak. Here the ledger is on h2a (height 3) and h2 (height 3) wins:
-    // h2 and h2a share block number 3, so their VRF outputs tie and h2's higher op-cert
-    // sequence (1 vs 0) decides.
-    let mut prep = test_prep();
-    prep.set_current(prep.headers.h2a.point());
-    prep.store_headers(&prep.headers.all());
-    prep.store_blocks(&prep.headers.all());
-    prep.set_anchor(prep.headers.h0.hash());
-
-    let tip = prep.headers.h2.point();
-    let parent = prep.headers.h1.point();
-    let msg = ValidateBlockMsg::new(tip, parent, BlockHeight::from(0));
-
-    let (running, _guards, mut logs) = setup(&prep, msg.clone());
-    assert_trace_contains(
-        &running,
-        &[
-            te_input("vb-1", &msg).into(),
-            te_rollback_ledger("vb-1", &tip).into(),
-            te_send("vb-1", "select_chain", SelectChainMsg::BlockValidationResult(tip, true, BlockHeight::from(0)))
-                .into(),
-            te_send("vb-1", "block_source", BlockSourceMsg::Validation { valid: true, point: tip }).into(),
-            te_send("vb-1", "manager", AdoptChainMsg::new(tip, BlockHeight::from(0))).into(),
-        ],
-    );
-    logs.assert_and_remove(Level::DEBUG, &["validating block"])
-        .assert_and_remove(Level::INFO, &["switching the ledger to a new fork"])
-        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
-}
-
-#[test]
-fn test_rollback_fails_when_ancestor_invalid() {
-    // this tests the case where a chain is built on an invalid block and the rest of the chain comes in from
-    // fetch_blocks while the invalidity travels to the select_chain stage
-    let mut prep = test_prep();
-    prep.set_current(prep.headers.h2.point());
+    prep.set_current(prep.headers.h1.point());
+    // With k = 2, an invalid block at height 1 falls out of the window once height 3 validates.
+    prep.state.consensus_security_param = 2;
+    let stale = (HeaderHash::from([9u8; 32]), BlockHeight::from(1));
+    let kept = (prep.headers.h2a.hash(), prep.headers.h2a.block_height());
+    prep.state.invalid_blocks = BTreeMap::from([stale, kept]);
     prep.store_headers(&prep.headers.main());
     prep.store_blocks(&prep.headers.main());
     prep.set_anchor(prep.headers.h0.hash());
-    prep.set_validity(prep.headers.h2.hash(), false);
 
-    let tip = prep.headers.h3.point();
-    let parent = prep.headers.h2.point();
-    let msg = ValidateBlockMsg::new(tip, parent, BlockHeight::from(0));
+    let tip = prep.headers.h2.point();
+    let msg = ValidateBlockMsg::new(tip, prep.headers.h1.point(), BlockHeight::from(0));
 
+    let expected = ValidateBlock {
+        current: tip,
+        invalid_blocks: BTreeMap::from([kept]),
+        consensus_security_param: 2,
+        ..prep.state.clone()
+    };
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
     assert_trace_contains(
         &running,
-        &[
-            te_input("vb-1", &msg).into(),
-            te_send("vb-1", "select_chain", SelectChainMsg::BlockValidationResult(tip, true, BlockHeight::from(0)))
-                .into(),
-            te_send("vb-1", "block_source", BlockSourceMsg::Validation { valid: true, point: tip }).into(),
-            te_send("vb-1", "manager", AdoptChainMsg::new(tip, BlockHeight::from(0))).into(),
-        ],
+        &[te_input("vb-1", &msg).into(), te_validate_block("vb-1", tip).into(), te_state("vb-1", &expected).into()],
     );
     logs.assert_and_remove(Level::DEBUG, &["validating block"]).assert_no_remaining_at([
         Level::INFO,
@@ -223,47 +166,7 @@ fn test_rollback_fails_when_ancestor_invalid() {
 }
 
 #[test]
-fn test_rollback_fails_when_rollback_point_not_in_volatile_db() {
-    // this tests the case where a rollback would travel into the immutable db: the ledger
-    // cannot switch to the fork and the stage terminates rather than adopting the chain
-    let mut prep = test_prep();
-    prep.set_current(prep.headers.h2.point());
-    prep.block_validator.with_rollback_fails(true);
-    prep.store_headers(&prep.headers.all());
-    prep.store_blocks(&prep.headers.all());
-    // normally, the anchor would be set to the tip of the chain, but that doesn’t happen
-    // at the same place and time, so we pessimistically place the anchor further in the past
-    prep.set_anchor(prep.headers.h0.hash());
-    prep.roll_forward_chain(prep.headers.h0.point());
-    prep.roll_forward_chain(prep.headers.h1.point());
-    prep.roll_forward_chain(prep.headers.h2.point());
-
-    let tip = prep.headers.h3a.point();
-    let parent = prep.headers.h2a.point();
-    let msg = ValidateBlockMsg::new(tip, parent, BlockHeight::new(0));
-
-    let (running, _guards, mut logs) = setup(&prep, msg.clone());
-    assert_trace(
-        &running,
-        &[
-            te_state("vb-1", &prep.state),
-            te_input("vb-1", &msg),
-            te_load_header("vb-1", tip.hash()),
-            te_load_header("vb-1", prep.headers.h2.hash()),
-            te_rollback_ledger("vb-1", &tip),
-            te_terminate("vb-1"),
-            te_terminated("vb-1", TerminationReason::Voluntary),
-        ],
-    );
-    logs.assert_and_remove(Level::DEBUG, &["validating block"])
-        .assert_and_remove(Level::INFO, &["switching the ledger to a new fork"])
-        .assert_and_remove(Level::WARN, &["failed to switch to a new fork"])
-        .assert_and_remove(Level::INFO, &["terminated"])
-        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
-}
-
-#[test]
-fn test_ledger_failure_terminates() {
+fn test_ledger_failure_during_validation_terminates() {
     // The mock validator returns an outer error for the tip, so or_terminate terminates the stage.
     let mut prep = test_prep();
     prep.set_current(prep.headers.h1.point());
@@ -294,35 +197,83 @@ fn test_ledger_failure_terminates() {
 }
 
 #[test]
-fn test_validation_failure_sends_false() {
-    // The mock validator returns a validation error for the tip, so the stage rejects the block.
+fn test_completed_fork_switch_adopts_the_new_tip() {
+    // The ledger is on the fork h2a (height 3) and the main chain tip h3 (height 4) wins chain
+    // selection: the switch replays h2 and h3 from the store, completes, and h3 is adopted.
     let mut prep = test_prep();
-    prep.set_current(prep.headers.h1.point());
-    prep.block_validator.with_tip(prep.headers.h1.point()).with_validate_fails(prep.headers.h2.point());
-    prep.store_headers(&prep.headers.main());
-    prep.store_blocks(&prep.headers.main());
+    prep.set_current(prep.headers.h2a.point());
+    prep.store_headers(&prep.headers.all());
+    prep.store_blocks(&prep.headers.all());
+    prep.set_anchor(prep.headers.h0.hash());
+    prep.roll_forward_chain(prep.headers.h0.point());
+    prep.roll_forward_chain(prep.headers.h1.point());
+    prep.set_validity(prep.headers.h1.hash(), true);
+
+    let tip = prep.headers.h3.point();
+    let parent = prep.headers.h2.point();
+    let msg = ValidateBlockMsg::new(tip, parent, BlockHeight::from(0));
+
+    let expected = ValidateBlock { current: tip, ..prep.state.clone() };
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    assert_trace_match(
+        &running,
+        &[
+            te_state("vb-1", &prep.state).into(),
+            te_input("vb-1", &msg).into(),
+            // deciding on the switch requires comparing the message tip's header with the current one
+            te_load_header("vb-1", tip.hash()).into(),
+            te_load_header("vb-1", prep.headers.h2a.hash()).into(),
+            te_switch_to_fork("vb-1", &tip).into(),
+            tm_record_metrics("vb-1"),
+            te_send("vb-1", "select_chain", SelectChainMsg::BlockValidationResult(tip, true, BlockHeight::from(0)))
+                .into(),
+            te_send("vb-1", "block_source", BlockSourceMsg::Validation { valid: true, point: tip }).into(),
+            te_send("vb-1", "manager", AdoptChainMsg::new(tip, BlockHeight::from(0))).into(),
+            te_state("vb-1", &expected).into(),
+        ],
+    );
+    logs.assert_and_remove(Level::DEBUG, &["validating block"])
+        .assert_and_remove(Level::INFO, &["switching the ledger to a new fork"])
+        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_equal_height_fork_winning_the_tiebreak_is_switched_to() {
+    // A fork replacing the current chain at equal length is only adopted when its tip wins the
+    // chain-selection tiebreak. Here the ledger is on h2a (height 3) and h2 (height 3) wins:
+    // h2 and h2a share block number 3, so their VRF outputs tie and h2's higher op-cert
+    // sequence (1 vs 0) decides.
+    let mut prep = test_prep();
+    prep.set_current(prep.headers.h2a.point());
+    prep.store_headers(&prep.headers.all());
+    prep.store_blocks(&prep.headers.all());
     prep.set_anchor(prep.headers.h0.hash());
 
     let tip = prep.headers.h2.point();
     let parent = prep.headers.h1.point();
     let msg = ValidateBlockMsg::new(tip, parent, BlockHeight::from(0));
 
-    let expected =
-        ValidateBlock { invalid_blocks: BTreeMap::from([(tip.hash(), tip.block_height())]), ..prep.state.clone() };
+    let expected = ValidateBlock { current: tip, ..prep.state.clone() };
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
-    assert_trace(
+    assert_trace_match(
         &running,
         &[
-            te_state("vb-1", &prep.state),
-            te_input("vb-1", &msg),
-            te_validate_block("vb-1", tip),
-            te_send("vb-1", "select_chain", SelectChainMsg::BlockValidationResult(tip, false, BlockHeight::from(0))),
-            te_send("vb-1", "block_source", BlockSourceMsg::Validation { valid: false, point: tip }),
-            te_state("vb-1", &expected),
+            te_state("vb-1", &prep.state).into(),
+            te_input("vb-1", &msg).into(),
+            // deciding on the switch requires comparing the message tip's header with the current one
+            te_load_header("vb-1", tip.hash()).into(),
+            te_load_header("vb-1", prep.headers.h2a.hash()).into(),
+            te_switch_to_fork("vb-1", &tip).into(),
+            tm_record_metrics("vb-1"),
+            te_send("vb-1", "select_chain", SelectChainMsg::BlockValidationResult(tip, true, BlockHeight::from(0)))
+                .into(),
+            te_send("vb-1", "block_source", BlockSourceMsg::Validation { valid: true, point: tip }).into(),
+            te_send("vb-1", "manager", AdoptChainMsg::new(tip, BlockHeight::from(0))).into(),
+            te_state("vb-1", &expected).into(),
         ],
     );
     logs.assert_and_remove(Level::DEBUG, &["validating block"])
-        .assert_and_remove(Level::WARN, &["failed to advance the ledger to a new tip"])
+        .assert_and_remove(Level::INFO, &["switching the ledger to a new fork"])
         .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 
@@ -356,7 +307,7 @@ fn test_partial_fork_switch_adopts_the_applied_prefix() {
         &running,
         &[
             te_input("vb-1", &msg).into(),
-            te_rollback_ledger("vb-1", &tip).into(),
+            te_switch_to_fork("vb-1", &tip).into(),
             tm_record_metrics("vb-1"),
             te_send(
                 "vb-1",
@@ -406,7 +357,7 @@ fn test_rolled_back_fork_switch_reports_the_failing_block() {
             te_input("vb-1", &msg),
             te_load_header("vb-1", tip.hash()),
             te_load_header("vb-1", prep.headers.h2.hash()),
-            te_rollback_ledger("vb-1", &tip),
+            te_switch_to_fork("vb-1", &tip),
             te_send("vb-1", "select_chain", SelectChainMsg::BlockValidationResult(failed, false, BlockHeight::from(0))),
             te_send("vb-1", "block_source", BlockSourceMsg::Validation { valid: false, point: failed }),
             te_state("vb-1", &expected),
@@ -455,113 +406,36 @@ fn test_switch_to_a_fork_only_for_a_better_candidate() {
 }
 
 #[test]
-fn test_invalid_block_condemns_in_flight_descendants() {
+fn test_ledger_failure_during_fork_switch_terminates() {
+    // The ledger is on the fork h2a (height 3).
+    // Switching back to the main chain tip h3 (height 4) fails at the rollback, which terminates the stage.
     let mut prep = test_prep();
-    prep.set_current(prep.headers.h1.point());
-    prep.block_validator.with_tip(prep.headers.h1.point()).with_validate_fails(prep.headers.h2a.point());
+    prep.set_current(prep.headers.h2a.point());
+    prep.block_validator.with_rollback_fails(true);
     prep.store_headers(&prep.headers.all());
     prep.store_blocks(&prep.headers.all());
     prep.set_anchor(prep.headers.h0.hash());
 
-    let tip1 = prep.headers.h2a.point();
-    let msg1 = ValidateBlockMsg::new(tip1, prep.headers.h1.point(), BlockHeight::from(0));
-    let tip2 = prep.headers.h3a.point();
-    let msg2 = ValidateBlockMsg::new(tip2, prep.headers.h2a.point(), BlockHeight::from(0));
+    let tip = prep.headers.h3.point();
+    let parent = prep.headers.h2.point();
+    let msg = ValidateBlockMsg::new(tip, parent, BlockHeight::from(0));
 
-    let after_first =
-        ValidateBlock { invalid_blocks: BTreeMap::from([(tip1.hash(), tip1.block_height())]), ..prep.state.clone() };
-    let after_second = ValidateBlock {
-        invalid_blocks: BTreeMap::from([(tip1.hash(), tip1.block_height()), (tip2.hash(), tip2.block_height())]),
-        ..prep.state.clone()
-    };
-
-    let (running, _guards, mut logs) = setup_many(&prep, vec![msg1.clone(), msg2.clone()]);
-    assert_trace(
-        &running,
-        &[
-            te_state("vb-1", &prep.state),
-            te_input("vb-1", &msg1),
-            te_validate_block("vb-1", tip1),
-            te_send("vb-1", "select_chain", SelectChainMsg::BlockValidationResult(tip1, false, BlockHeight::from(0))),
-            te_send("vb-1", "block_source", BlockSourceMsg::Validation { valid: false, point: tip1 }),
-            te_state("vb-1", &after_first),
-            te_input("vb-1", &msg2),
-            // no ledger effect here: the parent is invalid
-            te_send("vb-1", "select_chain", SelectChainMsg::BlockValidationResult(tip2, false, BlockHeight::from(0))),
-            te_send("vb-1", "block_source", BlockSourceMsg::Validation { valid: false, point: tip2 }),
-            te_state("vb-1", &after_second),
-        ],
-    );
-    logs.assert_and_remove(Level::DEBUG, &["validating block"])
-        .assert_and_remove(Level::WARN, &["failed to advance the ledger to a new tip"])
-        .assert_and_remove(Level::WARN, &["refusing to validate the descendant of an invalid block"])
-        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
-}
-
-#[test]
-fn test_descendant_of_invalid_block_is_refused_without_validation() {
-    let mut prep = test_prep();
-    prep.set_current(prep.headers.h1.point());
-    prep.state.invalid_blocks = BTreeMap::from([(prep.headers.h2a.hash(), prep.headers.h2a.block_height())]);
-    prep.store_headers(&prep.headers.all());
-    prep.store_blocks(&prep.headers.all());
-    prep.set_anchor(prep.headers.h0.hash());
-
-    let tip = prep.headers.h3a.point();
-    let msg = ValidateBlockMsg::new(tip, prep.headers.h2a.point(), BlockHeight::from(0));
-
-    let expected = ValidateBlock {
-        invalid_blocks: BTreeMap::from([
-            (prep.headers.h2a.hash(), prep.headers.h2a.block_height()),
-            (tip.hash(), tip.block_height()),
-        ]),
-        ..prep.state.clone()
-    };
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
     assert_trace(
         &running,
         &[
             te_state("vb-1", &prep.state),
             te_input("vb-1", &msg),
-            te_send("vb-1", "select_chain", SelectChainMsg::BlockValidationResult(tip, false, BlockHeight::from(0))),
-            te_send("vb-1", "block_source", BlockSourceMsg::Validation { valid: false, point: tip }),
-            te_state("vb-1", &expected),
+            te_load_header("vb-1", tip.hash()),
+            te_load_header("vb-1", prep.headers.h2a.hash()),
+            te_switch_to_fork("vb-1", &tip),
+            te_terminate("vb-1"),
+            te_terminated("vb-1", TerminationReason::Voluntary),
         ],
     );
-    logs.assert_and_remove(Level::WARN, &["refusing to validate the descendant of an invalid block"])
+    logs.assert_and_remove(Level::DEBUG, &["validating block"])
+        .assert_and_remove(Level::INFO, &["switching the ledger to a new fork"])
+        .assert_and_remove(Level::WARN, &["failed to switch to a new fork"])
+        .assert_and_remove(Level::INFO, &["terminated"])
         .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
-}
-
-#[test]
-fn test_invalid_blocks_below_the_security_window_are_evicted() {
-    let mut prep = test_prep();
-    prep.set_current(prep.headers.h1.point());
-    // With k = 2, a block invalid_blocks at height 1 falls out of the window once height 3 validates.
-    prep.state.consensus_security_param = 2;
-    let stale = (HeaderHash::from([9u8; 32]), BlockHeight::from(1));
-    let kept = (prep.headers.h2a.hash(), prep.headers.h2a.block_height());
-    prep.state.invalid_blocks = BTreeMap::from([stale, kept]);
-    prep.store_headers(&prep.headers.main());
-    prep.store_blocks(&prep.headers.main());
-    prep.set_anchor(prep.headers.h0.hash());
-
-    let tip = prep.headers.h2.point();
-    let msg = ValidateBlockMsg::new(tip, prep.headers.h1.point(), BlockHeight::from(0));
-
-    let expected = ValidateBlock {
-        current: tip,
-        invalid_blocks: BTreeMap::from([kept]),
-        consensus_security_param: 2,
-        ..prep.state.clone()
-    };
-    let (running, _guards, mut logs) = setup(&prep, msg.clone());
-    assert_trace_contains(
-        &running,
-        &[te_input("vb-1", &msg).into(), te_validate_block("vb-1", tip).into(), te_state("vb-1", &expected).into()],
-    );
-    logs.assert_and_remove(Level::DEBUG, &["validating block"]).assert_no_remaining_at([
-        Level::INFO,
-        Level::WARN,
-        Level::ERROR,
-    ]);
 }

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -213,6 +213,11 @@ define_schemas! {
                     required header_hash: amaru_kernel::HeaderHash
                     optional valid: bool
                 }
+                /// Skip a block validation when it is not better than the current ledger tip
+                public SKIP {
+                    required current: amaru_kernel::Point
+                    required tip: amaru_kernel::Point
+                }
                 /// Adopt a block as the next block in the best chain
                 ADOPT {
                     required tip: amaru_kernel::Point

--- a/crates/amaru-ouroboros-traits/src/validators/blocks/can_validate_blocks_mock.rs
+++ b/crates/amaru-ouroboros-traits/src/validators/blocks/can_validate_blocks_mock.rs
@@ -51,9 +51,9 @@ impl MockBlockValidatorInner {
     }
 
     /// Record a point as validated and make it the ledger tip.
-    fn apply(&mut self, point: Point) {
-        self.contains.insert(point);
-        self.tip = point;
+    fn apply(&mut self, tip: Point) {
+        self.contains.insert(tip);
+        self.tip = tip;
     }
 }
 
@@ -120,16 +120,16 @@ impl CanValidateBlocks for MockBlockValidator {
         &self,
         block: amaru_kernel::Block,
     ) -> Result<Result<LedgerMetrics, BlockValidationError>, BlockValidationError> {
-        let point = block.point();
+        let tip = block.point();
         let mut inner = self.inner.lock();
-        if inner.ledger_fails.contains(&point) {
+        if inner.ledger_fails.contains(&tip) {
             return Err(BlockValidationError::new(anyhow::anyhow!("mock ledger failed")));
         }
-        if inner.validate_fails.contains(&point) {
+        if inner.validate_fails.contains(&tip) {
             return Ok(Err(BlockValidationError::new(anyhow::anyhow!("mock validation failed"))));
         }
-        inner.contains.insert(point);
-        inner.tip = point;
+        inner.contains.insert(tip);
+        inner.tip = tip;
         Ok(Ok(Default::default()))
     }
 
@@ -141,6 +141,19 @@ impl CanValidateBlocks for MockBlockValidator {
         if inner.ledger_fails.contains(to) {
             return Err(BlockValidationError::new(anyhow::anyhow!("mock ledger failed")));
         }
+
+        // When the current tip height is known, enforce the same precondition as the real ledger:
+        // the fork must replace the current chain at equal height or extend it by exactly one block.
+        let current_height = inner.tip.block_height();
+        let new_height = to.block_height();
+        if new_height.as_u64() < current_height.as_u64() || new_height.as_u64() > current_height.as_u64() + 1 {
+            return Err(BlockValidationError::new(anyhow::anyhow!(
+                "cannot switch to a fork ending at height {} while the ledger tip is at height {}: the fork \
+                 must have the same height as the current chain or extend it by exactly one block",
+                new_height.as_u64(),
+                current_height.as_u64()
+            )));
+        };
 
         // A rolled back switch restores the pre-switch state: nothing to mutate.
         if let Some(failed) = inner.rolled_back_switches.get(to).copied() {

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -643,6 +643,21 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 </details>
 
+## target: `amaru::consensus::block`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `skip` | `TRACE` | public | Skip a block validation when it is not better than the current ledger tip | current, tip |  |
+
+<details><summary>span: `skip`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `current` | `string` | ✓ |
+| `tip` | `string` | ✓ |
+
+</details>
+
 ## target: `amaru::consensus::perf::fork`
 
 | name | level | public | description | required fields | optional fields |

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -1145,6 +1145,30 @@
       "description": "Finished uploading a snapshot archive",
       "public": true
     },
+    "amaru::consensus::block::SKIP": {
+      "type": "object",
+      "properties": {
+        "current": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Point"
+        },
+        "tip": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Point"
+        }
+      },
+      "required": [
+        "current",
+        "tip"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "skip",
+      "level": "TRACE",
+      "target": "amaru::consensus::block",
+      "description": "Skip a block validation when it is not better than the current ledger tip",
+      "public": true
+    },
     "amaru::consensus::perf::fork::SWITCH": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
This fix is an addition to #1190. That previous PR was assuming that the `fetch_blocks` stage was sending only the tip of a given branch to the `validate_block` stage. This made it safe to call `switch_to_fork` at the ledger level since the ledger only expects a fork that has the same length or one more block than the current chain.

The fix consists in comparing the current tip header to the incoming message header in the `validate_block` stage, using the same function that is used in the `select_chain` stage and only switch when the new tip is greater than the previous one.

During the test I also noticed that the output of of stage tests could contain raw CBOR for some fields and I fixed that too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented adoption of shorter or otherwise inferior forks, avoiding unnecessary ledger and downstream changes.
  - Added safeguards for invalid fork height transitions.

- **Observability**
  - Added trace events for skipped fork switches, including current and candidate chain tips.
  - Improved trace output with readable, typed event fields.

- **Tests**
  - Expanded coverage for fork switching, rollback failures, partial application, equal-height and longer-fork adoption, and rejected shorter forks.

- **Documentation**
  - Documented the new block-skip trace event and its required fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->