### PR TITLE
Fix DRep valid_until when bootstrapping during dormant epochs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Other guiding principles:
 - **amaru-ledger**: prevent CC action of resigned members.
 - **amaru-ledger**: resolve and control CC member cold credentials following ratification or in-flight proposals.
 - **amaru-ledger**: disallow voters not relevant to the target proposals.
+- **amaru-ledger**: preserve dormant-epoch state during bootstrap and avoid extending the expiry of already-expired DReps.
 
 ## v10.11.20260813 _[unreleased; planned for 2026-08-13]_
 

--- a/crates/amaru-bootstrap/src/cardano_node/tvar.rs
+++ b/crates/amaru-bootstrap/src/cardano_node/tvar.rs
@@ -31,7 +31,6 @@ use amaru_kernel::{
 };
 use amaru_ledger::{
     bootstrap::import_initial_snapshot,
-    epoch_transition::GovernanceActivity,
     store::{self, Store, TransactionalContext},
 };
 use amaru_observability::info;
@@ -187,7 +186,7 @@ where
             transaction.save(
                 era_history,
                 &protocol_parameters,
-                GovernanceActivity::default(),
+                None,
                 point,
                 None,
                 store::Columns {

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -475,7 +475,7 @@ fn save_point(
     transaction.save(
         era_history,
         protocol_parameters,
-        governance_activity,
+        Some(governance_activity),
         point,
         None,
         Default::default(),
@@ -520,7 +520,7 @@ fn import_block_issuers(
                 era_history,
                 // TODO: Unused when storing block issuers; require API change.
                 &PREPROD_DEFAULT_PROTOCOL_PARAMETERS,
-                GovernanceActivity::default(),
+                None,
                 // NOTE: Synthetic keys for historical issuer counts
                 //
                 // These are not chain points. Each increment of `fake_slot` is a unique store key
@@ -587,7 +587,7 @@ fn import_dreps(
     transaction.save(
         era_history,
         protocol_parameters,
-        GovernanceActivity::default(),
+        None,
         point,
         None,
         store::Columns {
@@ -634,7 +634,7 @@ fn import_proposals(
     transaction.save(
         era_history,
         protocol_parameters,
-        GovernanceActivity::default(),
+        None,
         point,
         None,
         store::Columns {
@@ -767,7 +767,7 @@ fn import_stake_pools(
         era_history,
         // TODO: Unused when storing block issuers; require API change.
         protocol_parameters,
-        GovernanceActivity::default(),
+        None,
         point,
         None,
         store::Columns {
@@ -887,7 +887,7 @@ fn import_accounts(
         transaction.save(
             era_history,
             protocol_parameters,
-            GovernanceActivity::default(),
+            None,
             point,
             None,
             store::Columns {
@@ -913,7 +913,7 @@ fn import_accounts(
         transaction.save(
             era_history,
             protocol_parameters,
-            GovernanceActivity::default(),
+            None,
             point,
             None,
             Default::default(),
@@ -1017,7 +1017,7 @@ fn import_constitutional_committee(
     transaction.save(
         era_history,
         protocol_parameters,
-        GovernanceActivity::default(),
+        None,
         point,
         None,
         store::Columns {
@@ -1095,7 +1095,7 @@ fn import_votes(
     transaction.save(
         era_history,
         protocol_parameters,
-        GovernanceActivity::default(),
+        None,
         point,
         None,
         store::Columns {

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -355,11 +355,11 @@ impl<S: Store, HS: HistoricalStores + Send + Sync + 'static> State<S, HS> {
                         batch.save(
                             &self.era_history,
                             protocol_parameters,
-                            self.governance_activity_for(immutable_epoch).unwrap_or_else(|| unreachable! {
+                            Some(self.governance_activity_for(immutable_epoch).unwrap_or_else(|| unreachable! {
                                 "invariant violation: asking governance activity for an unreachable epoch; immutable epoch = {}; volatile epoch = {}",
                                 immutable_epoch,
                                 self.epoch(),
-                            }),
+                            })),
                             &stable_point,
                             Some(&stable_issuer),
                             add,

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -576,13 +576,16 @@ pub trait TransactionalContext<'a>: ReadStore {
 
     /// Add or remove entries to/from the store. The exact semantic of 'add' and 'remove' depends
     /// on the column type. All updates are atomatic and attached to the given `Point`.
+    ///
+    /// `governance_activity` is `None` for saves that carry no governance state (e.g. a raw UTxO
+    /// import): such saves leave the persisted dormant-epoch counter untouched.
     #[expect(clippy::too_many_arguments)]
     #[cfg(not(any(test, feature = "test-utils")))]
     fn save(
         &self,
         era_history: &EraHistory,
         protocol_parameters: &ProtocolParameters,
-        governance_activity: GovernanceActivity,
+        governance_activity: Option<GovernanceActivity>,
         point: &Point,
         issuer: Option<&pools::Key>,
         add: Columns<
@@ -612,7 +615,7 @@ pub trait TransactionalContext<'a>: ReadStore {
         &self,
         _era_history: &EraHistory,
         _protocol_parameters: &ProtocolParameters,
-        _governance_activity: GovernanceActivity,
+        _governance_activity: Option<GovernanceActivity>,
         point: &Point,
         _issuer: Option<&pools::Key>,
         _add: Columns<

--- a/crates/amaru-ledger/src/summary/governance.rs
+++ b/crates/amaru-ledger/src/summary/governance.rs
@@ -154,12 +154,17 @@ impl GovernanceSummary {
                     StakeCredential::ScriptHash(hash) => DRep::Script(hash),
                 };
 
+                // Dormant epochs extend a DRep's expiry only while it remains active; an already
+                // expired DRep keeps its raw expiry, matching the store's bake-in on reactivation.
+                let extended = valid_until + consecutive_dormant_epochs as u64;
+                let valid_until = if extended >= current_epoch { extended } else { valid_until };
+
                 Ok((
                     drep,
                     DRepState {
                         registered_at,
                         metadata: anchor,
-                        valid_until: Some(valid_until + consecutive_dormant_epochs as u64),
+                        valid_until: Some(valid_until),
                         // The actual stake is filled later when computing the stake distribution.
                         voting_stake: 0,
                     },

--- a/crates/amaru-node/src/tests/configuration.rs
+++ b/crates/amaru-node/src/tests/configuration.rs
@@ -290,7 +290,7 @@ impl NodeTestConfig {
             tx.save(
                 self.era_history(),
                 pp,
-                governance_activity,
+                Some(governance_activity),
                 &chain_anchor,
                 None,
                 Columns::empty(),

--- a/crates/amaru-stores/src/lib.rs
+++ b/crates/amaru-stores/src/lib.rs
@@ -186,7 +186,7 @@ pub mod tests {
             context.save(
                 &PREPROD_ERA_HISTORY,
                 &PREPROD_DEFAULT_PROTOCOL_PARAMETERS,
-                GovernanceActivity::default(),
+                Some(GovernanceActivity::default()),
                 &point,
                 Some(&slot_leader),
                 Columns {
@@ -326,7 +326,7 @@ pub mod tests {
         context.save(
             &PREPROD_ERA_HISTORY,
             &PREPROD_DEFAULT_PROTOCOL_PARAMETERS,
-            GovernanceActivity::default(),
+            Some(GovernanceActivity::default()),
             &point,
             None,
             Columns::empty(),
@@ -357,7 +357,7 @@ pub mod tests {
         context.save(
             &PREPROD_ERA_HISTORY,
             &PREPROD_DEFAULT_PROTOCOL_PARAMETERS,
-            GovernanceActivity::default(),
+            Some(GovernanceActivity::default()),
             &point,
             None,
             Columns::empty(),
@@ -387,7 +387,7 @@ pub mod tests {
         context.save(
             &PREPROD_ERA_HISTORY,
             &PREPROD_DEFAULT_PROTOCOL_PARAMETERS,
-            GovernanceActivity::default(),
+            Some(GovernanceActivity::default()),
             &point,
             None,
             Columns::empty(),
@@ -430,7 +430,7 @@ pub mod tests {
         context.save(
             &PREPROD_ERA_HISTORY,
             &PREPROD_DEFAULT_PROTOCOL_PARAMETERS,
-            GovernanceActivity::default(),
+            Some(GovernanceActivity::default()),
             &point,
             None,
             Columns::empty(),

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -781,7 +781,7 @@ impl TransactionalContext<'_> for RocksDBTransactionalContext<'_> {
         &self,
         era_history: &EraHistory,
         protocol_parameters: &ProtocolParameters,
-        mut governance_activity: GovernanceActivity,
+        governance_activity: Option<GovernanceActivity>,
         point: &Point,
         issuer: Option<&scolumns::pools::Key>,
         add: Columns<
@@ -824,7 +824,7 @@ impl TransactionalContext<'_> for RocksDBTransactionalContext<'_> {
                 }
 
                 let drep_validity = current_epoch + protocol_parameters.drep_expiry
-                    - governance_activity.consecutive_dormant_epochs as u64;
+                    - governance_activity.map_or(0, |ga| ga.consecutive_dormant_epochs) as u64;
 
                 utxo::add(&self.db, add.utxo)?;
                 pools::add(&self.db, add.pools)?;
@@ -847,26 +847,32 @@ impl TransactionalContext<'_> for RocksDBTransactionalContext<'_> {
                 accounts::remove(&self.db, remove.accounts, current_epoch)?;
                 dreps::remove(&self.db, remove.dreps)?;
 
-                // When a proposal is seen during a dormant period, we flush the current dormant
-                // epochs counter on each drep.
-                if governance_activity.consecutive_dormant_epochs > 0
-                    && proposals_count > 0
-                    && !self.host.incremental_save
-                {
-                    self.with_dreps(|iterator| {
-                        for (_, mut entry) in iterator {
-                            if let Some(row) = entry.borrow_mut() {
-                                let actual_expiry =
-                                    row.valid_until + governance_activity.consecutive_dormant_epochs as u64;
-                                if actual_expiry >= current_epoch {
-                                    row.valid_until = actual_expiry;
+                if let Some(mut governance_activity) = governance_activity {
+                    // When a proposal is seen during a dormant period, we flush the current dormant
+                    // epochs counter on each drep.
+                    let reactivating = governance_activity.consecutive_dormant_epochs > 0
+                        && proposals_count > 0
+                        && !self.host.incremental_save;
+                    if reactivating {
+                        self.with_dreps(|iterator| {
+                            for (_, mut entry) in iterator {
+                                if let Some(row) = entry.borrow_mut() {
+                                    let actual_expiry =
+                                        row.valid_until + governance_activity.consecutive_dormant_epochs as u64;
+                                    if actual_expiry >= current_epoch {
+                                        row.valid_until = actual_expiry;
+                                    }
                                 }
                             }
-                        }
-                    })?;
+                        })?;
 
-                    governance_activity.consecutive_dormant_epochs = 0;
-                    self.set_governance_activity(governance_activity)?;
+                        governance_activity.consecutive_dormant_epochs = 0;
+                    }
+
+                    // Bootstrap import bypasses the epoch-transition path that otherwise persists this counter.
+                    if reactivating || self.host.incremental_save {
+                        self.set_governance_activity(governance_activity)?;
+                    }
                 }
             }
         }

--- a/crates/amaru-stores/tests/bootstrap_dormant_epochs.rs
+++ b/crates/amaru-stores/tests/bootstrap_dormant_epochs.rs
@@ -1,0 +1,243 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Regression test for DRep expiry across a bootstrap taken during dormant governance.
+//!
+//! A node bootstrapped from a snapshot carries an imported `numDormantEpochs` counter. The
+//! effective expiry surfaced by [`GovernanceSummary`] is `stored valid_until +
+//! consecutive_dormant_epochs`, so the imported counter must survive the import.
+//!
+//! Bootstrap imports in two steps: an authoritative save (`save_point`) that carries the counter,
+//! then a governance-less UTxO import (`import_utxo_from_tvar`). This test reproduces that exact
+//! two-save sequence at the store -> `GovernanceSummary` boundary: the follow-up UTxO save must not
+//! clobber the counter recorded by the first. A single-save test cannot expose that; only the
+//! second save does.
+
+use amaru_kernel::{
+    BlockHeight, CertificatePointer, DRep, DRepRegistration, Hash, PREPROD_DEFAULT_PROTOCOL_PARAMETERS,
+    PREPROD_ERA_HISTORY, Point, Slot, StakeCredential, TransactionPointer,
+};
+use amaru_ledger::{
+    epoch_transition::GovernanceActivity,
+    state::volatile::Resettable,
+    store::{Columns, EpochTransitionProgress, ReadStore, Store, TransactionalContext},
+    summary::governance::GovernanceSummary,
+};
+use amaru_stores::rocksdb::{RocksDB, RocksDBHistoricalStores, RocksDbConfig};
+
+const DORMANT_EPOCHS: u32 = 19;
+
+#[test]
+fn bootstrap_preserves_dormant_epochs_across_utxo_import() {
+    let tmp_dir = tempfile::tempdir().expect("tempdir");
+    let cfg = RocksDbConfig::new(tmp_dir.path().into());
+
+    // A snapshot always sits at the last slot of an epoch; pick any preprod slot.
+    let slot = Slot::from(50_000_000u64);
+    let point = Point::Specific(slot, Hash::from([0u8; 32]), BlockHeight::from(1u64));
+    let epoch = PREPROD_ERA_HISTORY.slot_to_epoch(slot, slot).expect("slot_to_epoch");
+
+    let drep_hash = Hash::from([1u8; 28]);
+    let drep_key = StakeCredential::AddrKeyhash(drep_hash);
+    let registered_at = CertificatePointer {
+        transaction: TransactionPointer { slot: Slot::from(0), transaction_index: 0 },
+        certificate_index: 0,
+    };
+
+    let raw_valid_until = {
+        // `RocksDB::empty` is the bootstrap/import mode.
+        let store = RocksDB::empty(&cfg).expect("open empty store");
+
+        // 1. Authoritative import, as `save_point` performs it: a DRep together with the imported
+        //    dormant-epoch counter.
+        {
+            let context = store.create_transaction();
+            context
+                .save(
+                    &PREPROD_ERA_HISTORY,
+                    &PREPROD_DEFAULT_PROTOCOL_PARAMETERS,
+                    Some(GovernanceActivity { consecutive_dormant_epochs: DORMANT_EPOCHS }),
+                    &point,
+                    None,
+                    Columns {
+                        utxo: std::iter::empty(),
+                        pools: std::iter::empty(),
+                        accounts: std::iter::empty(),
+                        dreps: std::iter::once((
+                            drep_key,
+                            (
+                                Resettable::Unchanged,
+                                Some(DRepRegistration { deposit: 500_000_000, registered_at, valid_until: epoch }),
+                            ),
+                        )),
+                        cc_members: std::iter::empty(),
+                        proposals: std::iter::empty(),
+                        votes: std::iter::empty(),
+                    },
+                    Columns::empty(),
+                    std::iter::empty(),
+                )
+                .expect("import save");
+            context.commit().expect("commit");
+        }
+
+        // 2. Follow-up UTxO import, as `import_utxo_from_tvar` performs it: it carries no governance
+        //    state and passes a placeholder `GovernanceActivity::default()`, which must not clobber
+        //    the counter recorded above.
+        {
+            let context = store.create_transaction();
+            context
+                .save(
+                    &PREPROD_ERA_HISTORY,
+                    &PREPROD_DEFAULT_PROTOCOL_PARAMETERS,
+                    None,
+                    &point,
+                    None,
+                    Columns::empty(),
+                    Columns::empty(),
+                    std::iter::empty(),
+                )
+                .expect("utxo import save");
+            context.commit().expect("commit");
+        }
+
+        // The raw expiry actually persisted for the DRep (before the summary re-applies dormancy).
+        let raw_valid_until = store
+            .iter_dreps()
+            .expect("iter dreps")
+            .find(|(k, _)| k == &drep_key)
+            .map(|(_, row)| row.valid_until)
+            .expect("drep persisted");
+
+        store.next_snapshot(epoch).expect("snapshot");
+        store
+            .with_transaction(|batch| batch.try_epoch_transition(None, Some(EpochTransitionProgress::SnapshotTaken)))
+            .expect("epoch transition");
+
+        raw_valid_until
+    };
+
+    // Re-open the epoch snapshot and compute the governance summary the conformance test uses.
+    let snapshot = RocksDBHistoricalStores::for_epoch_with(&cfg, epoch).expect("open snapshot");
+    let summary = GovernanceSummary::new(&snapshot, &PREPROD_ERA_HISTORY).expect("governance summary");
+
+    let reported = summary.dreps.get(&DRep::Key(drep_hash)).expect("drep present in summary").valid_until;
+
+    assert_eq!(
+        reported,
+        Some(raw_valid_until + DORMANT_EPOCHS as u64),
+        "the imported dormant-epoch counter must survive the follow-up UTxO import and be re-applied \
+         to DRep expiry (raw valid_until={raw_valid_until:?}, dormant_epochs={DORMANT_EPOCHS})",
+    );
+}
+
+/// Dormant epochs pause the activity clock for DReps that are still active, but they must not revive
+/// a DRep that stays expired even after the extension. `GovernanceSummary` therefore extends a DRep's
+/// expiry by `consecutive_dormant_epochs` only when the result remains at/after the current epoch,
+/// matching the store's bake-in guard. Without that guard, an already-expired DRep is reported with
+/// an inflated expiry and diverges from the Haskell node.
+#[test]
+fn dormant_epochs_do_not_revive_expired_dreps() {
+    let tmp_dir = tempfile::tempdir().expect("tempdir");
+    let cfg = RocksDbConfig::new(tmp_dir.path().into());
+
+    let slot = Slot::from(50_000_000u64);
+    let point = Point::Specific(slot, Hash::from([0u8; 32]), BlockHeight::from(1u64));
+    let epoch = PREPROD_ERA_HISTORY.slot_to_epoch(slot, slot).expect("slot_to_epoch");
+
+    let registered_at = CertificatePointer {
+        transaction: TransactionPointer { slot: Slot::from(0), transaction_index: 0 },
+        certificate_index: 0,
+    };
+
+    // Active: raw expiry at the current epoch, so raw + dormant stays at/after it.
+    let active_hash = Hash::from([1u8; 28]);
+    let active_raw = epoch;
+    // Expired: raw expiry far enough in the past that even raw + dormant stays below the current epoch.
+    let expired_hash = Hash::from([2u8; 28]);
+    let expired_raw = epoch - (DORMANT_EPOCHS as u64 + 5);
+
+    {
+        let store = RocksDB::empty(&cfg).expect("open empty store");
+        {
+            let context = store.create_transaction();
+            context
+                .save(
+                    &PREPROD_ERA_HISTORY,
+                    &PREPROD_DEFAULT_PROTOCOL_PARAMETERS,
+                    Some(GovernanceActivity { consecutive_dormant_epochs: DORMANT_EPOCHS }),
+                    &point,
+                    None,
+                    Columns {
+                        utxo: std::iter::empty(),
+                        pools: std::iter::empty(),
+                        accounts: std::iter::empty(),
+                        dreps: [
+                            (
+                                StakeCredential::AddrKeyhash(active_hash),
+                                (
+                                    Resettable::Unchanged,
+                                    Some(DRepRegistration {
+                                        deposit: 500_000_000,
+                                        registered_at,
+                                        valid_until: active_raw,
+                                    }),
+                                ),
+                            ),
+                            (
+                                StakeCredential::AddrKeyhash(expired_hash),
+                                (
+                                    Resettable::Unchanged,
+                                    Some(DRepRegistration {
+                                        deposit: 500_000_000,
+                                        registered_at,
+                                        valid_until: expired_raw,
+                                    }),
+                                ),
+                            ),
+                        ]
+                        .into_iter(),
+                        cc_members: std::iter::empty(),
+                        proposals: std::iter::empty(),
+                        votes: std::iter::empty(),
+                    },
+                    Columns::empty(),
+                    std::iter::empty(),
+                )
+                .expect("import save");
+            context.commit().expect("commit");
+        }
+        store.next_snapshot(epoch).expect("snapshot");
+        store
+            .with_transaction(|batch| batch.try_epoch_transition(None, Some(EpochTransitionProgress::SnapshotTaken)))
+            .expect("epoch transition");
+    }
+
+    let snapshot = RocksDBHistoricalStores::for_epoch_with(&cfg, epoch).expect("open snapshot");
+    let summary = GovernanceSummary::new(&snapshot, &PREPROD_ERA_HISTORY).expect("governance summary");
+
+    // The active DRep is extended by the dormant epochs.
+    assert_eq!(
+        summary.dreps.get(&DRep::Key(active_hash)).expect("active drep in summary").valid_until,
+        Some(active_raw + DORMANT_EPOCHS as u64),
+        "an active DRep's expiry must be extended by the dormant epochs",
+    );
+
+    // The expired DRep is NOT revived: it keeps its raw expiry.
+    assert_eq!(
+        summary.dreps.get(&DRep::Key(expired_hash)).expect("expired drep in summary").valid_until,
+        Some(expired_raw),
+        "dormant epochs must not revive a DRep that stays expired even after the extension",
+    );
+}

--- a/crates/amaru-stores/tests/helpers.rs
+++ b/crates/amaru-stores/tests/helpers.rs
@@ -501,7 +501,7 @@ impl<'a> TransactionalContext<'a> for MockTransaction<'a> {
         &self,
         _era_history: &EraHistory,
         _protocol_parameters: &ProtocolParameters,
-        _governance_activity: GovernanceActivity,
+        _governance_activity: Option<GovernanceActivity>,
         point: &Point,
         _issuer: Option<&pools::Key>,
         _add: Columns<

--- a/crates/amaru-stores/tests/lib.rs
+++ b/crates/amaru-stores/tests/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod bootstrap_dormant_epochs;
 mod rollback;
 mod switch_to_fork;
 


### PR DESCRIPTION
Governance state keeps a `valid_until` for each DRep. After the
`valid_until` epoch, the DRep's voting power no longer counts towards
the quorum needed for governance actions to pass.

This gets updated when you register / re-register, update your DRep
certificate, and when casting a vote.

However, if there's no governance actions to vote on, this becomes quite
inconvenient. A user has to update their DRep certificate even if
nothing in their platform has changed.

At the end of each epoch with no live proposals, the ledger increments
this counter. Then, when a proposal is submitted, if the counter is
greater than 0, the counter gets added to each DRep's expiry (unless the
DRep would still be expired even after the extension), and the counter
reset to 0.

This counter lets the epoch boundary extend the effective expiry of each
DRep very cheaply, as opposed to having to iterate over every DRep each
epoch.

However, when a DRep takes some action that would refresh their expiry,
we can't just set their valid_until to current_epoch + drepActivity; the
dormant epochs accumulated before they acted would get double-counted.
So we subtract that counter from the valid_until, so that the next time
there's a proposal, they cancel out.

However, Amaru was guarding the reset and save by this condition:

```
    if governance_activity.consecutive_dormant_epochs > 0
        && proposals_count > 0
        && !self.host.incremental_save
```

This is because when we're importing from a snapshot, we end up calling
`save` on data from past epochs. The imported expiries already include
every flush that happened on-chain, so flushing again would double-count
them; the `!self.host.incremental_save` differentiates this case.

However, this also means that, during bootstrap, we would just skip
saving the governance metadata we were trying to save, and the counter
would always start at 0. This would only surface as a problem if you
bootstrapped during an epoch where this was non-zero, which is why we
never noticed it before.

`save` now takes an `Option<GovernanceActivity>`: an authoritative save
carries the counter and persists it (including in import mode), while
saves that carry no governance state pass `None` and leave the persisted
counter untouched. This matters because bootstrap saves repeatedly: we
were relying on `GovernanceActivity::default()` in many places where we
*don't* want to save governance data. That wasn't a problem while
persistence was gated on the proposal count, but once import-mode saves
persist the counter, those placeholder defaults would clobber it back
to 0. Outside import mode the persist condition reduces to the
pre-existing reactivation case, so normal operation is unchanged.

Separately, `GovernanceSummary` extended the expiry of already-expired
DReps when re-applying the counter. Dormant epochs now extend a DRep's
expiry only while the result stays at or after the current epoch,
mirroring the store's bake-in guard and the Haskell node's guarded
`updateDormantDRepExpiry`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed governance activity handling during bootstrap and block processing.
  - UTxO imports without governance data now preserve existing dormant-epoch state.
  - Improved DRep expiry calculations so dormant periods extend eligible active DReps without reviving already-expired DReps.
  - Preserved imported governance activity when saving bootstrap data.

- **Tests**
  - Added regression coverage for dormant governance epochs and DRep expiry behavior.

- **Documentation**
  - Updated the changelog with these governance and bootstrap fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->