### PR TITLE
fix(amaru-ledger): reduce peak allocation during stake distribution calculation

### DIFF
--- a/crates/amaru-kernel/src/data_structures/sorted_pairs.rs
+++ b/crates/amaru-kernel/src/data_structures/sorted_pairs.rs
@@ -44,29 +44,6 @@ impl<K: Ord, V> SortedPairs<K, V> {
         self
     }
 
-    /// Concatenate two pairs together.
-    ///
-    /// Panics if the first key of the right-hand side is not strictly after the last key of the
-    /// left-hand side.
-    pub fn append(mut self, mut rhs: Self) -> Self
-    where
-        K: fmt::Debug,
-    {
-        if let Some((lhs_last, _)) = self.0.last()
-            && let Some((rhs_first, _)) = rhs.0.first()
-        {
-            assert!(
-                rhs_first > lhs_last,
-                "invariant violation (SortedPairs.append): rhs' first element ({:?}) is not after lhs' last element ({:?})",
-                rhs_first,
-                lhs_last,
-            );
-        }
-
-        self.0.append(&mut rhs.0);
-        self
-    }
-
     /// Returns true if the pairs contains a value for the specified key.
     ///
     /// The key may be any borrowed form of the pairs’ key type, but the ordering on the borrowed form must match the ordering on the key type.
@@ -146,6 +123,8 @@ impl<K: Ord, V> SortedPairs<K, V> {
 
     /// Add a new key/value pair after existing keys.
     ///
+    /// # Panics
+    ///
     /// Panics if the key is not strictly after the last inserted one.
     pub fn push(&mut self, k: K, v: V)
     where
@@ -157,7 +136,6 @@ impl<K: Ord, V> SortedPairs<K, V> {
                 "invariant violation (SortedPairs.push): pushed element ({k:?}) is not after last element ({last:?})",
             );
         }
-
         self.0.push((k, v));
     }
 
@@ -182,11 +160,42 @@ impl<K: Ord, V> SortedPairs<K, V> {
     }
 }
 
+impl<K: Ord, V> From<Vec<(K, V)>> for SortedPairs<K, V> {
+    fn from(mut vec: Vec<(K, V)>) -> Self {
+        vec.sort_unstable_by(|(lhs, _), (rhs, _)| lhs.cmp(rhs));
+        Self(vec)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use proptest::{collection::btree_map, prelude::*};
 
     use crate::SortedPairs;
+
+    #[test]
+    fn from_vec() {
+        #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+        enum Foo {
+            A(usize),
+            B(usize),
+        }
+
+        let mut vec = Vec::with_capacity(4);
+        vec.push((Foo::B(0), ()));
+        vec.push((Foo::B(1), ()));
+        vec.push((Foo::A(2), ()));
+        vec.push((Foo::A(3), ()));
+
+        assert_eq!(
+            SortedPairs::from(vec),
+            SortedPairs::with_capacity(4)
+                .and_push(Foo::A(2), ())
+                .and_push(Foo::A(3), ())
+                .and_push(Foo::B(0), ())
+                .and_push(Foo::B(1), ())
+        )
+    }
 
     proptest! {
         #[test]

--- a/crates/amaru-ledger/src/summary/stake_distribution.rs
+++ b/crates/amaru-ledger/src/summary/stake_distribution.rs
@@ -149,9 +149,7 @@ impl StakeSummary {
             })
             .collect::<BTreeMap<PoolId, PoolState>>();
 
-        let capacities = Capacity::get_or_init(db);
-        let mut key_accounts = SortedPairs::with_capacity(capacities.keys);
-        let mut script_accounts = SortedPairs::with_capacity(capacities.scripts);
+        let mut accounts = Vec::with_capacity(Capacity::get_or_init(db));
 
         for (credential, row) in db.iter_accounts()? {
             let state = AccountState {
@@ -169,27 +167,25 @@ impl StakeSummary {
                     }
                 }),
             };
-            // NOTE: discrepancy between Ord and serialised ordering
-            //
-            // Weirdly enough, the variants of a StakeCredential comes with the script hash first,
-            // and then the key hash. However, they are serialised the other away around (key
-            // variant comes with tag index 0, whereas script is 1).
-            //
-            // RocksDB yields data in ascending order of the serialised key. So if we want to keep
-            // the ordering here, we have to accumulate them separately, and then concatenate the
-            // two arrays.
-            match credential {
-                StakeCredential::AddrKeyhash(..) => &mut key_accounts,
-                StakeCredential::ScriptHash(..) => &mut script_accounts,
-            }
-            .push(credential, state)
+
+            accounts.push((credential, state));
         }
 
-        Capacity::update(key_accounts.len(), script_accounts.len());
-
-        let mut accounts = script_accounts.append(key_accounts);
+        // NOTE: discrepancy between Ord and serialised ordering
+        //
+        // Weirdly enough, the variants of a StakeCredential comes with the script hash first,
+        // and then the key hash. However, they are serialised the other away around (key
+        // variant comes with tag index 0, whereas script is 1).
+        //
+        // RocksDB yields data in ascending order of the serialised key; so we append them in
+        // db-order, and turn them into a sorted vector afterwards by sorting in-place.
+        //
+        // This trick allows to allocate only a single vector with minimal overhead.
+        let mut accounts = SortedPairs::from(accounts);
 
         let accounts_len = accounts.len();
+        Capacity::update(accounts_len);
+
         let total_work = network.estimated_utxo_size().saturating_add(accounts_len.saturating_mul(2)).max(1);
         let progress_after_accounts = (accounts_len as f64 / total_work as f64).clamp(0.0, 1.0);
         notify(progress_after_accounts);
@@ -358,49 +354,34 @@ impl serde::Serialize for StakeSummary {
     }
 }
 
-/// A type to inform of the ideal capacity for scripts and keys accounts in rewards.
+/// A type to inform of the ideal capacity for accounts in rewards.
 #[derive(Debug, Default, Clone, Copy)]
-struct Capacity<T> {
-    keys: T,
-    scripts: T,
-}
+struct Capacity<T>(T);
 
 static CAPACITY: OnceLock<Capacity<AtomicUsize>> = OnceLock::new();
 
 impl Capacity<usize> {
     /// Record updated lengths as hints for the next query
-    fn update(keys: usize, scripts: usize) {
+    fn update(len: usize) {
         if let Some(capacity) = OnceLock::get(&CAPACITY) {
-            capacity.keys.store(keys, atomic::Ordering::Relaxed);
-            capacity.scripts.store(scripts, atomic::Ordering::Relaxed);
+            capacity.0.store(len, atomic::Ordering::Relaxed);
         }
     }
 
-    /// Get the value of the current capacities, or resolve it once from the database.
+    /// Get the value of the current capacity, or resolve it once from the database.
     #[expect(clippy::panic)]
-    fn get_or_init(db: &impl Snapshot) -> Self {
+    fn get_or_init(db: &impl Snapshot) -> usize {
         let base_capacity = CAPACITY.get_or_init(|| {
-            let mut keys = 0;
-            let mut scripts = 0;
-
-            for (credential, _) in
-                db.iter_accounts().unwrap_or_else(|e| panic!("unable to initialize accounts capacities: {e}"))
-            {
-                match credential {
-                    StakeCredential::AddrKeyhash(..) => keys += 1,
-                    StakeCredential::ScriptHash(..) => scripts += 1,
-                }
-            }
-
-            Capacity { keys: AtomicUsize::new(keys), scripts: AtomicUsize::new(scripts) }
+            Capacity(AtomicUsize::new(
+                db.iter_accounts().unwrap_or_else(|e| panic!("unable to initialize accounts capacities: {e}")).count(),
+            ))
         });
 
-        let keys = base_capacity.keys.load(atomic::Ordering::Relaxed);
-        let scripts = base_capacity.scripts.load(atomic::Ordering::Relaxed);
+        let len = base_capacity.0.load(atomic::Ordering::Relaxed);
 
         // We always return a little more than what's needed to cope with new accounts
         // registrations and with unclaimed rewards.
-        Capacity { keys: keys + keys / 10, scripts: scripts + scripts / 10 }
+        len + len / 10
     }
 }
 

--- a/crates/amaru/tests/summary.rs
+++ b/crates/amaru/tests/summary.rs
@@ -107,7 +107,8 @@ fn compare_stake_distribution_with_haskell_node(
 }
 
 #[test]
-// NOTE: To see the output of this test, pass `--no-capture` to the test runner.
+#[ignore]
+// NOTE: To see the output of this test, pass `--ignored` and `--no-capture` to the test runner.
 fn measure_new_snapshot_summary_memory() -> Result<(), Box<dyn std::error::Error>> {
     let network = env::var(env_vars::NETWORK)
         .ok()


### PR DESCRIPTION


  Elements are already *mostly* ordered and we can rotate vectors in
  place and reduce unnecessary allocations.

  ## Before

  ```
  =============== STAKE SUMMARY MEMORY USAGE REPORT ===============
  network              mainnet
  summary              rss=407MiB     alloc=160MiB   peak=333MiB
  ```

  ## After

  ```
  =============== STAKE SUMMARY MEMORY USAGE REPORT ===============
  network              mainnet
  summary              rss=264MiB     alloc=160MiB   peak=160MiB
  ```

No-changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved account data handling with consistent ordering across credential types.
  * Added support for normalizing collections into key order during processing.
  * Simplified account capacity tracking and improved resource estimation with additional headroom.

* **Bug Fixes**
  * Improved capacity calculations when loading account data.

* **Tests**
  * Updated a memory measurement test to run only when explicitly requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->