### PR TITLE
fix: normalize types around conn_id / peer + ensure various simple types are traced as strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Other guiding principles:
 - **amaru-stores**: prune obsolete votes when removing expired/ratified/evicted proposals.
 - **amaru**: missing epoch stake distribution snapshots for mainnet, and fixed stake distribution management Makefile.
 - **amaru-node**: `Telemetry` (used by `run_until`) now uses the product CBOR-aware tracing layers so structured log properties decode to numbers and strings instead of diagnostic byte strings.
+- **amaru**: more homogenous traces fields representations across peers, connection id and hashes.
 
 ## v10.11.20260813 _[unreleased; planned for 2026-08-13]_
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,7 @@ dependencies = [
 name = "amaru-observability"
 version = "0.1.2"
 dependencies = [
+ "amaru-kernel",
  "amaru-observability-macros",
  "cbor-data",
  "cbor4ii",

--- a/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/mod.rs
@@ -400,7 +400,7 @@ impl FetchBlocks {
 
         // check that body belongs to header
         if block.header.body().block_body_hash != block.body_hash() {
-            let span = debug_span!(consensus::block::MISMATCHED_HASH, peer = peer.clone(), header_hash = point.hash());
+            let span = debug_span!(consensus::block::MISMATCHED_HASH, peer = &peer, header_hash = point.hash());
             eff.send(&self.peer_selection, PeerSelectionMsg::Adversarial(peer, (&span).into())).await;
             tracing::warn!(expected = %block.header.body().block_body_hash, actual = %block.body_hash(), "block body hash mismatch");
             return;

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -543,7 +543,7 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
         }
         PeerSelectionMsg::Adversarial(peer, trace_context) => {
             tracing::debug!(%peer, "peer_selection.adversarial");
-            let span = debug_span!(parent_context: trace_context, consensus::peer::BAN, peer = peer.clone());
+            let span = debug_span!(parent_context: trace_context, consensus::peer::BAN, peer = &peer);
             state.ban_peer(peer, &eff).instrument(span).await;
         }
         PeerSelectionMsg::CheckCooldowns => {
@@ -651,7 +651,7 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
             {
                 let span = debug_span!(
                     amaru::protocols::peer_selection::peer::DISCONNECTED,
-                    peer = peer.clone(),
+                    peer = &peer,
                     conn_id = conn_id.as_u64(),
                     direction = ConnectionDirection::Outbound,
                 )

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -22,7 +22,7 @@ use amaru_kernel::{
     BlockHeight, Epoch, EraHistory, EraName, Header, IsHeader, ORIGIN_HASH, Peer, Point, Slot, from_cbor_no_leftovers,
     num::CheckedSub,
 };
-use amaru_observability::{TraceContext, debug, debug_record, debug_span, error};
+use amaru_observability::{TraceContext, debug, debug_record, debug_span, error, info_span};
 use amaru_ouroboros::ConnectionId;
 use amaru_ouroboros_traits::Nonces;
 use amaru_protocols::{
@@ -641,7 +641,7 @@ impl TrackPeers {
                 }
                 error!(
                     consensus::perf::header::LIFECYCLE,
-                    peer = peer.clone(),
+                    peer = peer,
                     header_hash = header.hash(),
                     error = %error,
                     outcome = HeaderLifecycleOutcome::InvalidHeader.as_str()
@@ -674,7 +674,7 @@ impl TrackPeers {
                 .await;
                 debug!(
                     consensus::perf::header::LIFECYCLE,
-                    peer = peer.clone(),
+                    peer = peer,
                     header_hash = current.hash(),
                     outcome = HeaderLifecycleOutcome::DuplicateHeader.as_str()
                 );
@@ -689,7 +689,7 @@ impl TrackPeers {
                         let error = ConsensusError::StoreHeaderFailed(header.hash(), e);
                         error!(
                             consensus::perf::header::LIFECYCLE,
-                            peer = peer.clone(),
+                            peer = peer,
                             header_hash = current.hash(),
                             error = %error,
                             outcome = HeaderLifecycleOutcome::StoreHeaderError.as_str()
@@ -765,8 +765,7 @@ impl TrackPeers {
                 self.clear_availability_if_gone(&peer, &eff).await;
             }
             RollForward(header_content, tip) => {
-                let peer_clone = peer.clone();
-                let span = debug_span!(root, consensus::roll_forward::PROCESS, tip = tip, peer = peer_clone,);
+                let span = debug_span!(root, consensus::roll_forward::PROCESS, tip = tip, peer = &peer);
                 let trace_context: TraceContext = (&span).into();
                 async {
                     tracing::trace!(%peer, variant = header_content.variant.as_str(), highest = %tip, "roll forward");
@@ -779,7 +778,7 @@ impl TrackPeers {
                             self.purge_connection(conn_id);
                             error!(
                                 consensus::perf::header::LIFECYCLE,
-                                peer = peer.clone(),
+                                peer = peer,
                                 error = %error,
                                 outcome = HeaderLifecycleOutcome::UndecodableHeader.as_str()
                             );
@@ -860,16 +859,8 @@ impl TrackPeers {
                     .await
             }
             RollBackward(current, tip) => {
-                tracing::info!(%peer, %current, highest = %tip, "roll backward");
-                let peer_clone = peer.clone();
-                let span = debug_span!(
-                    root,
-                    consensus::rollback::PROCESS,
-                    current = %current,
-                    peer = %peer_clone,
-                    tip = %tip,
-                    header_hash = tip.hash(),
-                );
+                let span =
+                    info_span!(root, consensus::roll_backward::PROCESS, current = current, peer = &peer, tip = tip);
                 let trace_context: TraceContext = (&span).into();
                 async {
                     eff.send(&handler, chainsync::InitiatorMessage::RequestNext).await;

--- a/crates/amaru-consensus/src/stages/track_peers/tests.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/tests.rs
@@ -911,11 +911,7 @@ fn test_roll_backward_updates_peer() {
             te_state("tp-1", &expected).into(),
         ],
     );
-    logs.assert_and_remove(Level::INFO, &["roll backward"]).assert_no_remaining_at([
-        Level::INFO,
-        Level::WARN,
-        Level::ERROR,
-    ]);
+    logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 
 #[test]
@@ -947,7 +943,6 @@ fn test_roll_backward_unknown_peer_removes_peer() {
         ],
     );
     logs.assert_and_remove(Level::ERROR, &["chain_sync.roll_backward.failed", "Unknown peer"])
-        .assert_and_remove(Level::INFO, &["roll backward"])
         .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 
@@ -980,7 +975,6 @@ fn test_roll_backward_unknown_point_removes_peer() {
         ],
     );
     logs.assert_and_remove(Level::ERROR, &["chain_sync.roll_backward.failed", "Unknown point"])
-        .assert_and_remove(Level::INFO, &["roll backward"])
         .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 

--- a/crates/amaru-observability/Cargo.toml
+++ b/crates/amaru-observability/Cargo.toml
@@ -30,6 +30,7 @@ tracing-subscriber.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+amaru-kernel.workspace = true
 opentelemetry_sdk = { workspace = true, features = ["logs", "testing", "trace"] }
 
 [lints]

--- a/crates/amaru-observability/macros/src/define_schemas.rs
+++ b/crates/amaru-observability/macros/src/define_schemas.rs
@@ -94,10 +94,35 @@ impl SchemaField {
             "i64" | "i32" | "i16" | "i8" | "isize" => FieldTransportKind::I64,
             "u64" | "u32" | "u16" | "u8" | "usize" => FieldTransportKind::U64,
             "f64" | "f32" => FieldTransportKind::F64,
-            "String" => FieldTransportKind::Str,
+            ty if is_as_ref_str_transport(ty) => FieldTransportKind::Str,
+            ty if is_display_str_transport(ty) => FieldTransportKind::DisplayStr,
             _ => FieldTransportKind::Cbor,
         }
     }
+}
+
+fn is_as_ref_str_transport(ty: &str) -> bool {
+    matches!(ty, "String" | "amaru_kernel::Peer")
+}
+
+fn is_display_str_transport(ty: &str) -> bool {
+    matches!(
+        ty,
+        "amaru_kernel::Address"
+            | "amaru_kernel::BallotId"
+            | "amaru_kernel::HeaderHash"
+            | "amaru_kernel::Network"
+            | "amaru_kernel::NetworkName"
+            | "amaru_kernel::Nonce"
+            | "amaru_kernel::PoolId"
+            | "amaru_kernel::ProposalId"
+            | "amaru_kernel::RedeemerTag"
+            | "amaru_kernel::Relay"
+            | "amaru_kernel::Tip"
+            | "amaru_kernel::TransactionId"
+            | "amaru_kernel::Vote"
+            | "amaru_kernel::Voter"
+    ) || ty.starts_with("amaru_kernel::Hash<")
 }
 
 /// Wire representation for a schema field value.
@@ -108,6 +133,7 @@ enum FieldTransportKind {
     U64,
     F64,
     Str,
+    DisplayStr,
     /// Serialized with cbor4ii and recorded via `record_bytes`.
     Cbor,
 }
@@ -923,6 +949,10 @@ fn as_str_value_path(_config: &GenerationConfig) -> proc_macro2::TokenStream {
     quote! { ::amaru_observability::field::as_str_value }
 }
 
+fn display_string_value_path(_config: &GenerationConfig) -> proc_macro2::TokenStream {
+    quote! { ::amaru_observability::field::display_string_value }
+}
+
 fn serialize_trait_path(_config: &GenerationConfig) -> proc_macro2::TokenStream {
     // Always use the absolute path: `$crate` inside `#[macro_export]` helpers is easy to
     // mis-resolve when those helpers are invoked via `::amaru_observability::…!`.
@@ -939,6 +969,7 @@ fn generate_record_macro(schema: &Schema, config: &GenerationConfig) -> proc_mac
     let macro_export = config.macro_export_attr();
     let encode_cbor = encode_cbor_path(config);
     let as_str_value = as_str_value_path(config);
+    let display_string_value = display_string_value_path(config);
     let serialize_trait = serialize_trait_path(config);
 
     let all_fields: Vec<_> = schema.required_fields.iter().chain(schema.optional_fields.iter()).collect();
@@ -954,6 +985,17 @@ fn generate_record_macro(schema: &Schema, config: &GenerationConfig) -> proc_mac
                         __amaru_assert_type($expr);
                     }};
                 },
+                FieldTransportKind::DisplayStr => {
+                    let field_type = &field.ty;
+                    quote! {
+                        (#field_name, $expr:expr, validate_value) => {{
+                            let __amaru_assert_type = |_: &#field_type| {};
+                            let __amaru_assert_display = |_: &dyn ::std::fmt::Display| {};
+                            __amaru_assert_type($expr);
+                            __amaru_assert_display($expr);
+                        }};
+                    }
+                }
                 FieldTransportKind::Bool
                 | FieldTransportKind::I64
                 | FieldTransportKind::U64
@@ -1025,6 +1067,15 @@ fn generate_record_macro(schema: &Schema, config: &GenerationConfig) -> proc_mac
                         #as_str_value($expr)
                     }};
                 },
+                FieldTransportKind::DisplayStr => {
+                    let field_type = &field.ty;
+                    quote! {
+                        (#field_name, $expr:expr, format_typed) => {{
+                            let __amaru_v: &#field_type = $expr;
+                            #display_string_value(__amaru_v)
+                        }};
+                    }
+                }
                 FieldTransportKind::Cbor => {
                     let field_type = &field.ty;
                     quote! {

--- a/crates/amaru-observability/macros/src/traces.rs
+++ b/crates/amaru-observability/macros/src/traces.rs
@@ -234,10 +234,27 @@ pub fn expand_trace_record(input: TokenStream) -> TokenStream {
         parse::{Parse, ParseStream},
     };
 
+    enum TraceRecordFormatter {
+        /// Bare `field = expr`: type-driven transport (primitive or CBOR).
+        Typed,
+        /// Explicit `field = %expr`: Display-rendered.
+        Display,
+        /// Explicit `field = ?expr`: Debug-rendered.
+        Debug,
+        /// Explicit `field = @expr`: ready-made `tracing::Value`.
+        Value,
+    }
+
+    struct TraceRecordField {
+        name: syn::Ident,
+        value: syn::Expr,
+        formatter: TraceRecordFormatter,
+    }
+
     struct TraceRecordArgs {
         level: Option<syn::Ident>,
         schema_path: syn::Path,
-        field_assignments: Vec<(syn::Ident, syn::Expr)>,
+        fields: Vec<TraceRecordField>,
     }
 
     impl Parse for TraceRecordArgs {
@@ -267,9 +284,9 @@ pub fn expand_trace_record(input: TokenStream) -> TokenStream {
             };
 
             let schema_path: syn::Path = input.parse()?;
-            let mut field_assignments = Vec::new();
+            let mut fields = Vec::new();
 
-            // Parse comma-separated field = value pairs
+            // Parse comma-separated fields
             while input.peek(Token![,]) {
                 input.parse::<Token![,]>()?; // consume comma
 
@@ -277,14 +294,57 @@ pub fn expand_trace_record(input: TokenStream) -> TokenStream {
                     break;
                 }
 
-                let field_name: syn::Ident = input.parse()?;
-                input.parse::<Token![=]>()?;
-                let value_expr: syn::Expr = input.parse()?;
+                // Shorthands: `%ident`, `?ident` and `@ident` name the field after the variable.
+                if input.peek(Token![%]) || input.peek(Token![?]) || input.peek(Token![@]) {
+                    let formatter = if input.peek(Token![%]) {
+                        input.parse::<Token![%]>()?;
+                        TraceRecordFormatter::Display
+                    } else if input.peek(Token![?]) {
+                        input.parse::<Token![?]>()?;
+                        TraceRecordFormatter::Debug
+                    } else {
+                        input.parse::<Token![@]>()?;
+                        TraceRecordFormatter::Value
+                    };
+                    let name: syn::Ident = input.parse()?;
+                    let value = syn::parse_quote!(#name);
+                    fields.push(TraceRecordField { name, value, formatter });
+                    continue;
+                }
 
-                field_assignments.push((field_name, value_expr));
+                let name: syn::Ident = input.parse()?;
+
+                // Bare `ident` records the variable under its own name.
+                if !input.peek(Token![=]) {
+                    let value = syn::parse_quote!(#name);
+                    fields.push(TraceRecordField { name, value, formatter: TraceRecordFormatter::Typed });
+                    continue;
+                }
+
+                input.parse::<Token![=]>()?;
+
+                let formatter = if input.peek(Token![%]) {
+                    input.parse::<Token![%]>()?;
+                    TraceRecordFormatter::Display
+                } else if input.peek(Token![?]) {
+                    input.parse::<Token![?]>()?;
+                    TraceRecordFormatter::Debug
+                } else if input.peek(Token![@]) {
+                    input.parse::<Token![@]>()?;
+                    TraceRecordFormatter::Value
+                } else {
+                    TraceRecordFormatter::Typed
+                };
+                let value: syn::Expr = input.parse()?;
+
+                fields.push(TraceRecordField { name, value, formatter });
             }
 
-            Ok(TraceRecordArgs { level, schema_path, field_assignments })
+            if !input.is_empty() {
+                return Err(input.error("unexpected tokens after field assignments"));
+            }
+
+            Ok(TraceRecordArgs { level, schema_path, fields })
         }
     }
 
@@ -293,7 +353,7 @@ pub fn expand_trace_record(input: TokenStream) -> TokenStream {
         Err(err) => return err.to_compile_error().into(),
     };
 
-    if args.field_assignments.is_empty() {
+    if args.fields.is_empty() {
         return syn::Error::new_spanned(
             &args.schema_path,
             "trace_record! requires at least one field assignment: trace_record!(SCHEMA_CONST, field = value, ...)",
@@ -314,17 +374,61 @@ pub fn expand_trace_record(input: TokenStream) -> TokenStream {
     let mut span_records = Vec::new();
     let mut event_fields = Vec::new();
 
-    for (index, (field_name, value_expr)) in args.field_assignments.iter().enumerate() {
+    for (index, field) in args.fields.iter().enumerate() {
+        let field_name = &field.name;
         let field_name_str = field_name.to_string();
         let field_name_literal = syn::LitStr::new(&field_name_str, proc_macro2::Span::call_site());
         let value_ident = make_ident(&format!("__amaru_record_value_{index}"));
         let formatted_ident = make_ident(&format!("__amaru_record_formatted_{index}"));
-        let format_call =
-            meta.macro_call_expr(&record_macro_ident, quote! { #field_name_str, #value_ident, format_typed });
-        field_prep.push(quote! {
-            let #value_ident = &(#value_expr);
-            let #formatted_ident = #format_call;
-        });
+
+        match field.formatter {
+            TraceRecordFormatter::Typed => {
+                let format_call =
+                    meta.macro_call_expr(&record_macro_ident, quote! { #field_name_str, #value_ident, format_typed });
+                let value_expr = &field.value;
+                field_prep.push(quote! {
+                    let #value_ident = &(#value_expr);
+                    let #formatted_ident = #format_call;
+                });
+            }
+            TraceRecordFormatter::Display => {
+                let value_expr = &field.value;
+                let validate_call = meta.macro_call_stmt(
+                    &record_macro_ident,
+                    quote! { #field_name_str, #value_ident, validate_event_display },
+                );
+                field_prep.push(quote! {
+                    let #value_ident = &(#value_expr);
+                    #validate_call
+                    let #formatted_ident = tracing::field::display(#value_ident);
+                });
+            }
+            TraceRecordFormatter::Debug => {
+                let value_expr = &field.value;
+                let validate_call = meta.macro_call_stmt(
+                    &record_macro_ident,
+                    quote! { #field_name_str, #value_ident, validate_event_debug },
+                );
+                field_prep.push(quote! {
+                    let #value_ident = &(#value_expr);
+                    #validate_call
+                    let #formatted_ident = tracing::field::debug(#value_ident);
+                });
+            }
+            TraceRecordFormatter::Value => {
+                let value_expr = &field.value;
+                let validate_call = meta.macro_call_stmt(
+                    &record_macro_ident,
+                    quote! { #field_name_str, #value_ident, validate_event_value },
+                );
+                field_prep.push(quote! {
+                    let #value_ident = &(#value_expr);
+                    #validate_call
+                    let #formatted_ident = #value_ident;
+                });
+            }
+        }
+
         span_records.push(quote! {
             tracing::Span::current().record(#field_name_literal, &#formatted_ident);
         });
@@ -758,15 +862,13 @@ pub fn expand_trace_span(input: TokenStream) -> TokenStream {
 
                 // Check for tracing format specifiers (%, ?, or expressions)
                 let (validation_expr, formatter) = if input.peek(Token![%]) {
-                    // Format specifier %field
                     input.parse::<Token![%]>()?;
-                    let field_ref: syn::Ident = input.parse()?;
-                    (quote! { #field_ref }, TraceSpanFormatter::Display)
+                    let value_expr: syn::Expr = input.parse()?;
+                    (quote! { #value_expr }, TraceSpanFormatter::Display)
                 } else if input.peek(Token![?]) {
-                    // Format specifier ?field
                     input.parse::<Token![?]>()?;
-                    let field_ref: syn::Ident = input.parse()?;
-                    (quote! { #field_ref }, TraceSpanFormatter::Debug)
+                    let value_expr: syn::Expr = input.parse()?;
+                    (quote! { #value_expr }, TraceSpanFormatter::Debug)
                 } else {
                     // Regular expression: typed primitive or CBOR
                     let value_expr: syn::Expr = input.parse()?;

--- a/crates/amaru-observability/macros/tests/instrument_target.rs
+++ b/crates/amaru-observability/macros/tests/instrument_target.rs
@@ -249,10 +249,22 @@ fn roll_forward(peer: String) {
     let _guard = _span.enter();
 }
 
+fn roll_forward_with_display_expressions(peer: String) {
+    let _span = trace_span!(crate::amaru::consensus::roll_forward::PROCESS, peer = %peer.clone());
+    let _guard = _span.enter();
+}
+
 fn root_roll_forward(peer: String) {
     let _outer = tracing::debug_span!("outer");
     let _outer_guard = _outer.enter();
     let _span = trace_span!(root, crate::amaru::consensus::roll_forward::PROCESS, peer = &peer);
+    let _guard = _span.enter();
+}
+
+fn root_roll_forward_with_display_expression(peer: String) {
+    let _outer = tracing::debug_span!("outer");
+    let _outer_guard = _outer.enter();
+    let _span = trace_span!(root, crate::amaru::consensus::roll_forward::PROCESS, peer = %&peer);
     let _guard = _span.enter();
 }
 
@@ -491,6 +503,8 @@ mod test {
 
         tracing::subscriber::with_default(subscriber, || {
             distinct_formatting(DistinctFormatting, DistinctFormatting);
+            roll_forward_with_display_expressions("peer-a".to_string());
+            root_roll_forward_with_display_expression("peer-b".to_string());
         });
 
         let recorded = values.lock().unwrap();

--- a/crates/amaru-observability/macros/tests/validation.rs
+++ b/crates/amaru-observability/macros/tests/validation.rs
@@ -305,12 +305,27 @@ mod trace_record_tests {
         trace_record!(crate::ledger::state::RESOLVE_INPUTS, resolved_from_context = 100_u64);
     }
 
+    fn augment_with_formatters(
+        _resolved_from_context: impl std::fmt::Display,
+        _resolved_from_volatile: impl std::fmt::Debug,
+        _resolved_from_db: impl tracing::field::Value,
+    ) {
+        trace_record!(
+            INFO,
+            crate::ledger::state::RESOLVE_INPUTS,
+            resolved_from_context = %_resolved_from_context,
+            resolved_from_volatile = ?_resolved_from_volatile,
+            resolved_from_db = @_resolved_from_db
+        );
+    }
+
     #[test]
     fn test_trace_record() {
         augment_with_optional(10);
         augment_with_multiple(10, 20);
         augment_with_extra(10, "extra");
         augment_with_expression();
+        augment_with_formatters(10, vec![20], 30_u64);
     }
 }
 

--- a/crates/amaru-observability/src/field.rs
+++ b/crates/amaru-observability/src/field.rs
@@ -26,6 +26,8 @@
 //!
 //! Downstream layers owned by this crate decode those bytes for human/JSON/OTEL presentation.
 
+use std::fmt::Display;
+
 use cbor_data::Cbor;
 use opentelemetry::{Array, Key, StringValue, Value as TraceValue, logs::AnyValue};
 use serde::Serialize;
@@ -65,6 +67,13 @@ pub fn encode_cbor<T: Serialize>(value: &T) -> Box<[u8]> {
 #[inline]
 pub fn as_str_value<T: AsRef<str> + ?Sized>(value: &T) -> &str {
     value.as_ref()
+}
+
+/// Render `value` as an owned string for field types that are best transported as text via
+/// their [`Display`] implementation.
+#[inline]
+pub fn display_string_value<T: Display + ?Sized>(value: &T) -> String {
+    value.to_string()
 }
 
 /// Format CBOR bytes using cbor-data's diagnostic notation (RFC 8610 style).

--- a/crates/amaru-observability/src/lib.rs
+++ b/crates/amaru-observability/src/lib.rs
@@ -33,7 +33,7 @@ mod trace_context;
 pub use amaru_observability_macros::{define_schemas, trace_event as __trace_event, trace_record, trace_span};
 pub use field::{
     DecodedField, TAG_FIELD_PREFIX, as_str_value, cbor_to_any_value, cbor_to_decoded_field, cbor_to_trace_value,
-    encode_cbor, is_tag_field_name,
+    display_string_value, encode_cbor, is_tag_field_name,
 };
 pub use json_format::{CborJsonEventFormat, CborJsonFields, CborJsonSpanLayer, SpanJsonFields};
 pub use layers::{

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -170,14 +170,13 @@ define_schemas! {
                     optional header_hash: amaru_kernel::HeaderHash
                 }
             }
-            rollback {
+            roll_backward {
                 tags: cpu
                 /// Received a header to rollback
                 PROCESS {
                     required current: amaru_kernel::Point
                     required tip: amaru_kernel::Point
                     required peer: amaru_kernel::Peer
-                    required header_hash: amaru_kernel::HeaderHash
                 }
             }
             header {
@@ -201,7 +200,6 @@ define_schemas! {
                 /// Forward to a downstream peer
                 FORWARD {
                     required tip: amaru_kernel::Point
-                    required header_hash: amaru_kernel::HeaderHash
                     required peer: amaru_kernel::Peer
                 }
             }
@@ -870,7 +868,7 @@ define_schemas! {
             peer {
                 /// Failed to connect to a peer while bootstrapping
                 public FAILED_TO_CONNECT {
-                    required peer: String
+                    required peer: amaru_kernel::Peer
                     required reason: String
                 }
             }
@@ -1389,7 +1387,7 @@ define_schemas! {
                     /// Handle connection stage messages
                     PROCESS {
                         required message_type: String
-                        required conn_id: String
+                        required conn_id: u64
                         required peer: amaru_kernel::Peer
                         required role: String
                     }
@@ -1414,7 +1412,7 @@ define_schemas! {
                     /// An inbound connection was accepted from a peer
                     public ACCEPTED {
                         required peer: amaru_kernel::Peer
-                        required conn_id: String
+                        required conn_id: u64
                     }
                     /// A peer was removed from the manager
                     public REMOVE {
@@ -1423,7 +1421,7 @@ define_schemas! {
                     /// A peer connection has died
                     public CONNECTION_DIED {
                         required peer: amaru_kernel::Peer
-                        required conn_id: String
+                        required conn_id: u64
                         required role: String
                     }
                 }
@@ -1543,7 +1541,7 @@ define_schemas! {
                     /// Measured round-trip time for a keepalive exchange on an established peer connection.
                     public ROUND_TRIP {
                         required peer: amaru_kernel::Peer
-                        required conn_id: String
+                        required conn_id: u64
                         required round_trip_micros: u64
                     }
                 }
@@ -1572,8 +1570,8 @@ define_schemas! {
                 initiator {
                     /// Handle peer-sharing initiator stage messages
                     PEER_SHARING_INITIATOR_STAGE {
-                        required peer: String
-                        required conn_id: String
+                        required peer: amaru_kernel::Peer
+                        required conn_id: u64
                     }
                     /// Handle peer-sharing initiator protocol messages
                     PEER_SHARING_INITIATOR_PROTOCOL {

--- a/crates/amaru-observability/tests/display_transport.rs
+++ b/crates/amaru-observability/tests/display_transport.rs
@@ -1,0 +1,50 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use amaru_kernel::{Epoch, Hash, Peer, Slot};
+use amaru_observability::{FieldValue, TelemetryCaptureLayer, amaru, info};
+use tracing_subscriber::prelude::*;
+
+#[test]
+fn peer_and_hash_schema_fields_are_emitted_as_plain_strings() {
+    let (tx, rx) = std::sync::mpsc::sync_channel(4);
+    let subscriber = tracing_subscriber::registry().with(TelemetryCaptureLayer::new(tx));
+
+    let peer = Peer::new("1.2.3.4:3001");
+    let header_hash = Hash::<32>::from([0xabu8; 32]);
+
+    tracing::subscriber::with_default(subscriber, || {
+        info!(amaru::protocols::manager::peer::ADD, peer = peer.clone());
+        info!(
+            amaru::ledger::tip::UPDATE,
+            slot = Slot::from(42),
+            header_hash = header_hash,
+            block_height = 99_u64,
+            tx_count = 3_usize,
+            epoch = Epoch::from(1),
+            slot_in_epoch = Slot::from(42),
+            density = 0.5_f64,
+            current_kes_period = 7_u64,
+            remaining_kes_periods = 20_u64
+        );
+    });
+
+    let records: Vec<_> = rx.try_iter().collect();
+    let peer_record =
+        records.iter().find(|record| record.name == amaru::protocols::manager::peer::ADD::NAME).expect("peer event");
+    let tip_record = records.iter().find(|record| record.name == amaru::ledger::tip::UPDATE::NAME).expect("tip event");
+
+    assert_eq!(peer_record.fields.get("peer"), Some(&FieldValue::Str(peer.to_string())));
+    assert_eq!(tip_record.fields.get("header_hash"), Some(&FieldValue::Str(header_hash.to_string())));
+}

--- a/crates/amaru-protocols/src/chainsync/responder.rs
+++ b/crates/amaru-protocols/src/chainsync/responder.rs
@@ -82,8 +82,7 @@ impl StageState<ResponderState, Responder> for ChainSyncResponder {
                     parent_context: trace_context,
                     consensus::header::FORWARD,
                     tip = tip,
-                    header_hash = tip.hash(),
-                    peer = self.peer.clone()
+                    peer = &self.peer,
                 );
                 self.upstream = tip;
                 let action = next_header(*proto, &mut self.pointer, &Store::new(eff.clone()), self.upstream)

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -171,9 +171,8 @@ pub async fn stage(
     eff: Effects<ConnectionMessage>,
 ) -> Connection {
     let message_type = msg.message_type().to_string();
-    let conn_id = params.conn_id.to_string();
+    let Params { conn_id, role, .. } = params;
     let peer = params.peer.clone();
-    let role = format!("{:?}", params.role);
 
     async move {
         let state = match (state, msg) {
@@ -181,7 +180,7 @@ pub async fn stage(
                 return teardown(state, &params, &eff).await;
             }
             (state, ConnectionMessage::ChildDied(child)) => {
-                tracing::info!(?child, peer = %params.peer, conn_id = %params.conn_id, "connection child died");
+                tracing::info!(?child, peer = %params.peer, conn_id = conn_id.as_u64(), "connection child died");
                 return teardown(state, &params, &eff).await;
             }
             (State::Initial, ConnectionMessage::Initialize) => do_initialize(&params, eff).await,
@@ -235,9 +234,9 @@ pub async fn stage(
     .instrument(debug_span!(
         protocols::connection::message::PROCESS,
         message_type = message_type,
-        conn_id = conn_id,
+        conn_id = conn_id.as_u64(),
         peer = peer,
-        role = role
+        role = %role,
     ))
     .await
 }

--- a/crates/amaru-protocols/src/keepalive/initiator.rs
+++ b/crates/amaru-protocols/src/keepalive/initiator.rs
@@ -108,8 +108,8 @@ impl StageState<State, Initiator> for KeepAliveInitiator {
                 let round_trip_micros = received_at.saturating_since(sent_at).as_micros() as u64;
                 debug!(
                     protocols::keepalive::peer::ROUND_TRIP,
-                    peer = self.peer.clone(),
-                    conn_id = self.conn_id.to_string(),
+                    peer = &self.peer,
+                    conn_id = self.conn_id.as_u64(),
                     round_trip_micros = round_trip_micros
                 );
             }

--- a/crates/amaru-protocols/src/manager/mod.rs
+++ b/crates/amaru-protocols/src/manager/mod.rs
@@ -673,7 +673,7 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
                 manager.add_peer(peer, &eff).instrument(span).await;
             }
             ManagerMessage::Accepted(peer, conn_id) => {
-                let span = debug_span!(protocols::manager::peer::ACCEPTED, peer = &peer, conn_id = conn_id.to_string());
+                let span = debug_span!(protocols::manager::peer::ACCEPTED, peer = &peer, conn_id = conn_id.as_u64());
                 manager.accepted(peer, conn_id, &eff).instrument(span).await;
             }
             ManagerMessage::RemovePeer(peer) => {
@@ -692,8 +692,8 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
                 let span = debug_span!(
                     protocols::manager::peer::CONNECTION_DIED,
                     peer = &peer,
-                    conn_id = conn_id.to_string(),
-                    role = role.to_string()
+                    conn_id = conn_id.as_u64(),
+                    role = %role,
                 );
                 manager.connection_died(peer, conn_id, role, &eff).instrument(span).await;
             }

--- a/crates/amaru-protocols/src/peer_sharing/initiator.rs
+++ b/crates/amaru-protocols/src/peer_sharing/initiator.rs
@@ -159,8 +159,8 @@ impl StageState<State, Initiator> for PeerSharingInitiator {
     ) -> anyhow::Result<(Option<InitiatorAction>, Self)> {
         let span = debug_span!(
             protocols::peer_sharing::initiator::PEER_SHARING_INITIATOR_STAGE,
-            peer = self.peer.to_string(),
-            conn_id = self.conn_id.to_string(),
+            peer = &self.peer,
+            conn_id = self.conn_id.as_u64()
         );
         async move {
             match input {

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -1642,7 +1642,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | field | type | required |
 | --- | --- | --- |
 | `peer` | `string` | ✓ |
-| `conn_id` | `string` | ✓ |
+| `conn_id` | `integer` | ✓ |
 | `round_trip_micros` | `integer` | ✓ |
 
 </details>
@@ -1676,7 +1676,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | field | type | required |
 | --- | --- | --- |
 | `peer` | `string` | ✓ |
-| `conn_id` | `string` | ✓ |
+| `conn_id` | `integer` | ✓ |
 
 </details>
 
@@ -1701,7 +1701,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | field | type | required |
 | --- | --- | --- |
 | `peer` | `string` | ✓ |
-| `conn_id` | `string` | ✓ |
+| `conn_id` | `integer` | ✓ |
 | `role` | `string` | ✓ |
 
 </details>

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -268,7 +268,8 @@
       "type": "object",
       "properties": {
         "peer": {
-          "type": "string"
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Peer"
         },
         "reason": {
           "type": "string"
@@ -3477,7 +3478,7 @@
           "description": "Custom type: amaru_kernel::Peer"
         },
         "conn_id": {
-          "type": "string"
+          "type": "integer"
         },
         "round_trip_micros": {
           "type": "integer"
@@ -3522,7 +3523,7 @@
           "description": "Custom type: amaru_kernel::Peer"
         },
         "conn_id": {
-          "type": "string"
+          "type": "integer"
         }
       },
       "required": [
@@ -3583,7 +3584,7 @@
           "description": "Custom type: amaru_kernel::Peer"
         },
         "conn_id": {
-          "type": "string"
+          "type": "integer"
         },
         "role": {
           "type": "string"


### PR DESCRIPTION
This commit also introduce better parsing for the tracing macros, so that %,@,? and full expressions can be used for span and event fields.

I noticed this when looking at the TUI now showing peer's as `{ "address": "foo.bar:1234" }` instead of just the address. I started replacing some field instanciation with `peer = %peer` and figured it would be a bit too brittle, and that it's better to treat the type directly. 

@etorreborre I purposely didn't touch any of the non-schema-based traces to minimize conflicts since I believe you've been looking into transforming them into new schema-based ones?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized trace fields for peers, connection IDs, hashes, and other displayed values.
  * Reported connection identifiers as numeric values for clearer trace analysis.
  * Added support for display, debug, and preformatted trace values.
  * Simplified consensus rollback tracing and removed redundant header-hash fields.

* **Documentation**
  * Updated trace documentation and schemas to reflect revised field types and names.

* **Bug Fixes**
  * Corrected trace output so peer and hash values are consistently represented as readable strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->