### PR TITLE
fix: amaru binary fails to create snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Other guiding principles:
 ### Fixed
 
 - **amaru-kernel**: decode transaction inputs as a set, rejecting duplicate inputs.
+- **amaru**: resolve `snapshot create` and `snapshot publish` default directories relative to the runtime executable instead of the build machine's source directory.
 - **amaru-tui**: calculate reported block and transaction throughput using the interval between system-metric samples.
 - **amaru-tui**: show the most recent `INFO` log messages.
 - **amaru-plutus**: encode `CostModels` as a map from language to cost model (#1219).

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -939,18 +939,6 @@ define_schemas! {
                 required description: String
                 optional cause: String
             }
-            cardano_node_config {
-                /// Use an existing cardano-node configuration
-                public USE {
-                    required config_dir: String
-                    required network: amaru_kernel::NetworkName
-                }
-                /// Download the official cardano-node configuration bundle
-                public DOWNLOAD {
-                    required config_dir: String
-                    required network: amaru_kernel::NetworkName
-                }
-            }
             chain_db {
                 /// Chain database already exists
                 public EXIST {

--- a/crates/amaru/src/bin/amaru/cmd/snapshot/create/config.rs
+++ b/crates/amaru/src/bin/amaru/cmd/snapshot/create/config.rs
@@ -18,11 +18,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use amaru_kernel::{NetworkName, utils::path::relative_path};
-use amaru_observability::info;
+use amaru_kernel::NetworkName;
 use serde::Deserialize;
 
-use super::repo_root;
 const OFFICIAL_CARDANO_NODE_CONFIG_BASE_URL: &str = "https://book.world.dev.cardano.org/environments";
 
 #[derive(Debug, Deserialize)]
@@ -76,19 +74,6 @@ pub(super) async fn resolve_config_dir(
         return Ok(config_dir);
     }
 
-    if let Some(config_dir) = bundled_config_dir(network) {
-        match validate_config_dir(&config_dir) {
-            Ok(()) => {
-                info!(cli::cardano_node_config::USE, config_dir = %relative_path(&config_dir)?.display(), network = %network);
-                return Ok(config_dir);
-            }
-            Err(_) => {
-                info!(cli::cardano_node_config::DOWNLOAD, config_dir = %relative_path(&config_dir)?.display(), network = %network);
-                return download_official_config_bundle(client, network, &config_dir).await;
-            }
-        }
-    }
-
     download_official_config_bundle(client, network, &cached_config_dir(work_dir, network)).await
 }
 
@@ -99,10 +84,6 @@ fn validate_explicit_config_dir_usage(network: NetworkName) -> Result<(), Box<dy
 
     Err(format!("--cardano-node-config-dir is only supported for custom testnet networks; omit it for {network}")
         .into())
-}
-
-fn bundled_config_dir(network: NetworkName) -> Option<PathBuf> {
-    matches!(network, NetworkName::Preprod).then(|| repo_root().join("cardano-node-config"))
 }
 
 fn cached_config_dir(work_dir: &Path, network: NetworkName) -> PathBuf {

--- a/crates/amaru/src/bin/amaru/cmd/snapshot/create/mod.rs
+++ b/crates/amaru/src/bin/amaru/cmd/snapshot/create/mod.rs
@@ -14,7 +14,7 @@
 
 use std::{
     fmt::{self, Display},
-    fs,
+    fs, io,
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
@@ -201,6 +201,12 @@ pub(super) fn default_snapshot_output_dir(network: NetworkName) -> PathBuf {
     repo_root().join(default_snapshots_dir(network))
 }
 
+fn create_directory(path: &Path, purpose: &str) -> io::Result<()> {
+    fs::create_dir_all(path).map_err(|err| {
+        io::Error::new(err.kind(), format!("failed to create {purpose} directory at {}: {err}", path.display()))
+    })
+}
+
 pub(crate) fn runnable(args: Args) -> Runnable {
     Runnable::exit_on_signal(RuntimeKind::Io, move || run(args))
 }
@@ -221,12 +227,13 @@ async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     let snapshot_output_dir = snapshot_dir.unwrap_or_else(|| default_snapshot_output_dir(network));
     let work_dir = dist_dir.join("work");
     let cardano_node_db = cardano_node_db.unwrap_or_else(|| work_dir.join("cardano-db"));
+    let immutable_dir = cardano_node_db.join("immutable");
     let ledger_snapshot_dir = cardano_node_db.join("ledger");
     let snapshots_str = utils::string::display_collection(&snapshot_points);
 
-    fs::create_dir_all(&snapshot_output_dir)?;
-    fs::create_dir_all(cardano_node_db.join("immutable"))?;
-    fs::create_dir_all(&ledger_snapshot_dir)?;
+    create_directory(&snapshot_output_dir, "snapshot output")?;
+    create_directory(&immutable_dir, "cardano-node immutable data")?;
+    create_directory(&ledger_snapshot_dir, "ledger snapshot")?;
 
     let config_dir = resolve_config_dir(&client, cardano_node_config_dir, network, &work_dir).await?;
 
@@ -272,7 +279,7 @@ async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         snapshots = @(!snapshots_str.is_empty()).then_some(snapshots_str),
     );
 
-    let from_chunk = first_missing_immutable_chunk(&cardano_node_db.join("immutable"))?;
+    let from_chunk = first_missing_immutable_chunk(&immutable_dir)?;
     let required_chunk = targets.last().and_then(|t| chunk_for_slot(network, t.slot.into()).ok()).unwrap_or(0);
 
     let progress_factory: Arc<dyn Fn(usize, &str) -> Box<dyn ProgressBar + Send + Sync> + Send + Sync> =

--- a/crates/amaru/src/bin/amaru/cmd/snapshot/create/mod.rs
+++ b/crates/amaru/src/bin/amaru/cmd/snapshot/create/mod.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::{
+    env,
     fmt::{self, Display},
     fs, io,
     path::{Path, PathBuf},
@@ -72,6 +73,8 @@ pub struct Args {
     epoch: Option<Epoch>,
 
     /// Distribution directory used for metadata, caches and temporary work files.
+    ///
+    /// Defaults to data/<NETWORK>/epoch-snapshots/ beside the `amaru` executable.
     #[arg(
         long = "dist-dir",
         value_name = amaru::value_names::DIRECTORY,
@@ -81,7 +84,7 @@ pub struct Args {
 
     /// Directory where snapshot archives and materialized snapshot directories are written.
     ///
-    /// Defaults to ./snapshots/<NETWORK>/ when unspecified.
+    /// Defaults to snapshots/<NETWORK>/ beside the `amaru` executable.
     #[arg(
         long,
         value_name = amaru::value_names::DIRECTORY,
@@ -92,8 +95,7 @@ pub struct Args {
     /// Directory containing the cardano-node config.json and genesis files.
     ///
     /// Only required for custom testnet networks. For mainnet, preprod and preview,
-    /// the config is downloaded automatically from the official source and cached
-    /// when no local bundled copy is available.
+    /// the config is downloaded automatically from the official source and cached.
     #[arg(
         long,
         value_name = amaru::value_names::DIRECTORY,
@@ -193,12 +195,24 @@ impl EpochTarget {
     }
 }
 
-fn default_dist_dir(network: NetworkName) -> PathBuf {
-    repo_root().join(format!("data/{}", network.to_string().to_lowercase())).join("epoch-snapshots")
+fn executable_dir() -> io::Result<PathBuf> {
+    let executable = env::current_exe()
+        .map_err(|err| io::Error::new(err.kind(), format!("failed to determine the amaru executable path: {err}")))?;
+
+    executable.parent().map(Path::to_path_buf).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("amaru executable path has no parent directory: {}", executable.display()),
+        )
+    })
 }
 
-pub(super) fn default_snapshot_output_dir(network: NetworkName) -> PathBuf {
-    repo_root().join(default_snapshots_dir(network))
+fn default_dist_dir(network: NetworkName) -> io::Result<PathBuf> {
+    Ok(executable_dir()?.join("data").join(network.to_string().to_lowercase()).join("epoch-snapshots"))
+}
+
+pub(super) fn default_snapshot_output_dir(network: NetworkName) -> io::Result<PathBuf> {
+    Ok(executable_dir()?.join(default_snapshots_dir(network)))
 }
 
 fn create_directory(path: &Path, purpose: &str) -> io::Result<()> {
@@ -223,8 +237,14 @@ async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     } = args;
 
     let client = reqwest::Client::new();
-    let dist_dir = dist_dir.unwrap_or_else(|| default_dist_dir(network));
-    let snapshot_output_dir = snapshot_dir.unwrap_or_else(|| default_snapshot_output_dir(network));
+    let dist_dir = match dist_dir {
+        Some(path) => path,
+        None => default_dist_dir(network)?,
+    };
+    let snapshot_output_dir = match snapshot_dir {
+        Some(path) => path,
+        None => default_snapshot_output_dir(network)?,
+    };
     let work_dir = dist_dir.join("work");
     let cardano_node_db = cardano_node_db.unwrap_or_else(|| work_dir.join("cardano-db"));
     let immutable_dir = cardano_node_db.join("immutable");
@@ -446,11 +466,6 @@ fn bootstrap_target_epochs(epoch: Epoch) -> Result<[Epoch; 3], Box<dyn std::erro
             .checked_add(Epoch::TWO)
             .ok_or_else(|| format!("bootstrap snapshot window overflows for epoch {epoch}"))?,
     ])
-}
-
-pub(super) fn repo_root() -> PathBuf {
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    manifest_dir.parent().and_then(Path::parent).unwrap_or(manifest_dir.as_path()).to_path_buf()
 }
 
 fn packaged_blocks_for_target(

--- a/crates/amaru/src/bin/amaru/cmd/snapshot/publish.rs
+++ b/crates/amaru/src/bin/amaru/cmd/snapshot/publish.rs
@@ -41,7 +41,7 @@ pub struct Args {
 
     /// Directory containing the local snapshot archives to publish.
     ///
-    /// Defaults to ./snapshots/<NETWORK>/ (same as `amaru snapshot create`).
+    /// Defaults to snapshots/<NETWORK>/ beside the `amaru` executable.
     #[arg(
         long,
         value_name = amaru::value_names::DIRECTORY,
@@ -96,7 +96,10 @@ async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     let aws_access_key_id = required_env(AWS_ACCESS_KEY_ID_ENV)?;
     let aws_secret_access_key = required_env(AWS_SECRET_ACCESS_KEY_ENV)?;
 
-    let snapshot_root = snapshot_dir.unwrap_or_else(|| default_snapshot_output_dir(network));
+    let snapshot_root = match snapshot_dir {
+        Some(path) => path,
+        None => default_snapshot_output_dir(network)?,
+    };
 
     let s3_config = S3Config { bucket: s3_bucket, endpoint: s3_endpoint, region: s3_region, public_url: s3_public_url };
     let s3 = S3Client::new_with_credentials(s3_config, &aws_access_key_id, &aws_secret_access_key);

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -359,31 +359,6 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 </details>
 
-## target: `amaru::cli::cardano_node_config`
-
-| name | level | public | description | required fields | optional fields |
-| --- | --- | --- | --- | --- | --- |
-| `download` | `TRACE` | public | Download the official cardano-node configuration bundle | config_dir, network |  |
-| `use` | `TRACE` | public | Use an existing cardano-node configuration | config_dir, network |  |
-
-<details><summary>span: `download`</summary>
-
-| field | type | required |
-| --- | --- | --- |
-| `config_dir` | `string` | ✓ |
-| `network` | `string` | ✓ |
-
-</details>
-
-<details><summary>span: `use`</summary>
-
-| field | type | required |
-| --- | --- | --- |
-| `config_dir` | `string` | ✓ |
-| `network` | `string` | ✓ |
-
-</details>
-
 ## target: `amaru::cli::chain_db`
 
 | name | level | public | description | required fields | optional fields |

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -559,52 +559,6 @@
       "description": "Process terminated with an error.",
       "public": true
     },
-    "amaru::cli::cardano_node_config::DOWNLOAD": {
-      "type": "object",
-      "properties": {
-        "config_dir": {
-          "type": "string"
-        },
-        "network": {
-          "type": "string",
-          "description": "Custom type: amaru_kernel::NetworkName"
-        }
-      },
-      "required": [
-        "config_dir",
-        "network"
-      ],
-      "optional": [],
-      "additionalProperties": false,
-      "name": "download",
-      "level": "TRACE",
-      "target": "amaru::cli::cardano_node_config",
-      "description": "Download the official cardano-node configuration bundle",
-      "public": true
-    },
-    "amaru::cli::cardano_node_config::USE": {
-      "type": "object",
-      "properties": {
-        "config_dir": {
-          "type": "string"
-        },
-        "network": {
-          "type": "string",
-          "description": "Custom type: amaru_kernel::NetworkName"
-        }
-      },
-      "required": [
-        "config_dir",
-        "network"
-      ],
-      "optional": [],
-      "additionalProperties": false,
-      "name": "use",
-      "level": "TRACE",
-      "target": "amaru::cli::cardano_node_config",
-      "description": "Use an existing cardano-node configuration",
-      "public": true
-    },
     "amaru::cli::chain_db::EXIST": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
Make sure amaru doesn't rely on build time constant. Improve error messages when directory can't be written to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot creation and publishing now resolve default directories relative to the running `amaru` executable.
  * Improved reporting when required directories cannot be accessed or created.
  * Snapshot commands automatically download configuration when no explicit directory is provided.

* **Documentation**
  * Updated command-line documentation to reflect the new default locations.
  * Removed outdated configuration download and usage trace documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->