### PR TITLE
Fix committee acknowledgment to NOT modify the final/resulting state 

### DIFF
--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -1018,7 +1018,7 @@ fn import_constitutional_committee(
         }
     };
 
-    transaction.update_constitutional_committee(&cc, BTreeMap::new(), BTreeSet::new())?;
+    transaction.update_constitutional_committee(&cc, &BTreeMap::new(), &BTreeSet::new())?;
 
     transaction.save(
         era_history,

--- a/crates/amaru-ledger/src/context/default/validation.rs
+++ b/crates/amaru-ledger/src/context/default/validation.rs
@@ -394,10 +394,7 @@ impl ProposalsSlice for DefaultValidationContext {
         if let GovernanceAction::UpdateCommittee(_, _, added, _) = &state.proposal.gov_action {
             for (cold_credential, _) in added.iter() {
                 if !matches!(self.state.committee.get(cold_credential), Existence::Exists(..)) {
-                    self.state
-                        .committee
-                        .bind_left(*cold_credential, None)
-                        .unwrap_or_else(|_| unreachable!("committee members are never 'unregistered'"));
+                    self.committee.entry(*cold_credential).or_default();
                 }
             }
         }
@@ -490,10 +487,14 @@ impl BalanceSlice for DefaultValidationContext {
 
 #[cfg(test)]
 mod tests {
-    use amaru_kernel::{Slot, TransactionPointer};
+    use amaru_kernel::{
+        Proposal, Slot, TransactionPointer, any_proposal, any_proposal_id, any_rational_number, any_stake_credential,
+        utils::tests::run_strategy,
+    };
     use test_case::test_case;
 
     use super::*;
+    use crate::{context::ProposalState, state::volatile::DiffBind};
 
     fn cred(tag: u8) -> StakeCredential {
         StakeCredential::AddrKeyhash(Hash::new([tag; 28]))
@@ -686,5 +687,36 @@ mod tests {
             CommitteeSlice::lookup_by_hot_credential(&ctx, &cred(9)).collect::<BTreeSet<_>>(),
             BTreeSet::from([first, second])
         );
+    }
+
+    #[test]
+    fn proposal_acknowledgement_does_not_modify_committee_state() {
+        let proposal_id = run_strategy(any_proposal_id());
+
+        let cold_credential = run_strategy(any_stake_credential());
+
+        let committee_update_adding_members = ProposalState {
+            proposed_in: Default::default(),
+            valid_until: Default::default(),
+            proposal: Proposal {
+                gov_action: GovernanceAction::UpdateCommittee(
+                    None,
+                    Default::default(),
+                    vec![(cold_credential, Default::default())].try_into().unwrap(),
+                    run_strategy(any_rational_number()),
+                ),
+                ..run_strategy(any_proposal())
+            },
+        };
+
+        let mut ctx = DefaultValidationContext::default();
+
+        ctx.acknowledge(proposal_id, committee_update_adding_members);
+
+        // Member is reachable
+        assert!(CommitteeSlice::lookup_by_cold_credential(&ctx, &cold_credential,).is_some());
+
+        // But no state-change is yield
+        assert_eq!(VolatileFragment::from(ctx).committee, DiffBind::default())
     }
 }

--- a/crates/amaru-ledger/src/state/volatile/bind.rs
+++ b/crates/amaru-ledger/src/state/volatile/bind.rs
@@ -15,7 +15,7 @@
 use crate::state::volatile::Resettable;
 
 /// An empty struct to indicate unused left or right delegations in a `Bind`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Empty;
 
 /// A structure that captures:

--- a/crates/amaru-ledger/src/store.rs
+++ b/crates/amaru-ledger/src/store.rs
@@ -665,16 +665,16 @@ pub trait TransactionalContext<'a>: ReadStore {
     fn update_constitutional_committee(
         &self,
         status: &ConstitutionalCommitteeStatus,
-        added: BTreeMap<StakeCredential, Epoch>,
-        removed: BTreeSet<StakeCredential>,
+        added: &BTreeMap<StakeCredential, Epoch>,
+        removed: &BTreeSet<StakeCredential>,
     ) -> Result<()>;
 
     #[cfg(any(test, feature = "test-utils"))]
     fn update_constitutional_committee(
         &self,
         status: &ConstitutionalCommitteeStatus,
-        added: BTreeMap<StakeCredential, Epoch>,
-        removed: BTreeSet<StakeCredential>,
+        added: &BTreeMap<StakeCredential, Epoch>,
+        removed: &BTreeSet<StakeCredential>,
     ) -> Result<()> {
         unimplemented!("TransactionalContext.update_constitutional_committee({status:?}, {added:?}, {removed:?})");
     }

--- a/crates/amaru-ledger/src/store/epoch_transition.rs
+++ b/crates/amaru-ledger/src/store/epoch_transition.rs
@@ -279,8 +279,8 @@ pub fn update_constitutional_committee<'store>(
             Some(ConstitutionalCommitteeUpdate::NoConfidence) => {
                 db.update_constitutional_committee(
                     &ConstitutionalCommitteeStatus::NoConfidence,
-                    BTreeMap::new(),
-                    BTreeSet::new(),
+                    &BTreeMap::new(),
+                    &BTreeSet::new(),
                 )?;
 
                 // NOTE: CC members and no-confidence mode
@@ -312,7 +312,7 @@ pub fn update_constitutional_committee<'store>(
 
                 // The committee is a handful of members, so cloning the added/removed sets to hand
                 // owned values to the store is negligible and lets the caller borrow the update.
-                db.update_constitutional_committee(&committee_status, added.clone(), removed.clone())?;
+                db.update_constitutional_committee(&committee_status, added, removed)?;
             }
 
             None => {}

--- a/crates/amaru-stores/src/lib.rs
+++ b/crates/amaru-stores/src/lib.rs
@@ -469,8 +469,8 @@ pub mod tests {
         let context = store.create_transaction();
         context.update_constitutional_committee(
             &committee,
-            BTreeMap::from([(fixture.cc_member_key, term)]),
-            BTreeSet::new(),
+            &BTreeMap::from([(fixture.cc_member_key, term)]),
+            &BTreeSet::new(),
         )?;
         context.commit()?;
 
@@ -483,8 +483,8 @@ pub mod tests {
         let context = store.create_transaction();
         context.update_constitutional_committee(
             &committee,
-            BTreeMap::new(),
-            BTreeSet::from([fixture.cc_member_key]),
+            &BTreeMap::new(),
+            &BTreeSet::from([fixture.cc_member_key]),
         )?;
         context.commit()?;
 

--- a/crates/amaru-stores/src/rocksdb/mod.rs
+++ b/crates/amaru-stores/src/rocksdb/mod.rs
@@ -731,20 +731,20 @@ impl TransactionalContext<'_> for RocksDBTransactionalContext<'_> {
     fn update_constitutional_committee(
         &self,
         status: &ConstitutionalCommitteeStatus,
-        added: BTreeMap<StakeCredential, Epoch>,
-        removed: BTreeSet<StakeCredential>,
+        added: &BTreeMap<StakeCredential, Epoch>,
+        removed: &BTreeSet<StakeCredential>,
     ) -> Result<(), StoreError> {
         self.db.put(KEY_CONSTITUTIONAL_COMMITTEE, as_value(status)).map_err(|err| StoreError::Internal(err.into()))?;
 
         cc_members::upsert(
             &self.db,
-            removed.into_iter().map(|cold_credential| (cold_credential, (Resettable::Unchanged, Resettable::Reset))),
+            removed.iter().map(|cold_credential| (*cold_credential, (Resettable::Unchanged, Resettable::Reset))),
         )?;
 
         cc_members::upsert(
             &self.db,
-            added.into_iter().map(|(cold_credential, valid_until)| {
-                (cold_credential, (Resettable::Unchanged, Resettable::Set(valid_until)))
+            added.iter().map(|(cold_credential, valid_until)| {
+                (*cold_credential, (Resettable::Unchanged, Resettable::Set(*valid_until)))
             }),
         )?;
 

--- a/crates/amaru-stores/tests/helpers.rs
+++ b/crates/amaru-stores/tests/helpers.rs
@@ -141,8 +141,8 @@ pub fn make_state_in_epoch_with_snapshots_and_store(
             tx.set_protocol_parameters(&PREPROD_DEFAULT_PROTOCOL_PARAMETERS)?;
             tx.update_constitutional_committee(
                 &ConstitutionalCommitteeStatus::NoConfidence,
-                BTreeMap::new(),
-                BTreeSet::new(),
+                &BTreeMap::new(),
+                &BTreeSet::new(),
             )
         })
         .expect("seeding the store succeeds");
@@ -472,8 +472,8 @@ impl<'a> TransactionalContext<'a> for MockTransaction<'a> {
     fn update_constitutional_committee(
         &self,
         _status: &ConstitutionalCommitteeStatus,
-        _added: BTreeMap<amaru_kernel::StakeCredential, Epoch>,
-        _removed: BTreeSet<amaru_kernel::StakeCredential>,
+        _added: &BTreeMap<amaru_kernel::StakeCredential, Epoch>,
+        _removed: &BTreeSet<amaru_kernel::StakeCredential>,
     ) -> amaru_ledger::store::Result<()> {
         Ok(())
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected constitutional committee updates so newly acknowledged members are available at the start of the block.
  - Prevented unnecessary empty volatile committee entries during committee updates.
  - Improved handling of committee membership additions and removals while preserving existing committee state.

- **Tests**
  - Added regression coverage verifying newly introduced committee members can be found correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->