### PR TITLE
feat: focus on the info tab when the tui starts up

### DIFF
--- a/crates/amaru-tui/src/model.rs
+++ b/crates/amaru-tui/src/model.rs
@@ -116,7 +116,7 @@ impl Model {
             peer_pane_mode: PaneMode::Normal,
             proposal_pane_mode: PaneMode::Normal,
             scroll_focus: ScrollFocus::Logs,
-            level_filter: LevelFilter::Debug,
+            level_filter: LevelFilter::Info,
             target_filter: TargetFilter::All,
             catching_up: true,
             log_scroll: 0,


### PR DESCRIPTION
Skip-Changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default logging level to Info, reducing verbose debug messages in the terminal interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->