### PR TITLE
chore: publish a few new recent epoch-stake-distribution snapshots for mainnet + fix Makefile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Other guiding principles:
 - **amaru-ledger**: preserve dormant-epoch state during bootstrap and avoid extending the expiry of already-expired DReps.
 - **amaru-ledger**: reject votes cast on governance actions that have expired. ([#1143][], [#926][])
 - **amaru-stores**: prune obsolete votes when removing expired/ratified/evicted proposals.
+- **amaru**: missing epoch stake distribution snapshots for mainnet, and fixed stake distribution management Makefile.
 
 ## v10.11.20260813 _[unreleased; planned for 2026-08-13]_
 

--- a/crates/amaru/tests/conformance/stake-distributions/Makefile
+++ b/crates/amaru/tests/conformance/stake-distributions/Makefile
@@ -31,6 +31,11 @@ check-network-dir:
 		exit 1; \
 	}
 
+check-aws-env:
+	@test -n "$(ENDPOINT)" || { echo "Missing ENDPOINT"; exit 1; }
+	@test -n "$(AWS_ACCESS_KEY_ID)" || { echo "Missing AWS_ACCESS_KEY_ID"; exit 1; }
+	@test -n "$(AWS_SECRET_ACCESS_KEY)" || { echo "Missing AWS_SECRET_ACCESS_KEY"; exit 1; }
+
 zst: check-network-dir ## Compress individual .json files using zstd compression
 	@set -- *.json; \
 	if [ ! -e "$$1" ]; then \

--- a/crates/amaru/tests/conformance/stake-distributions/haskell-node-extractor/package.json
+++ b/crates/amaru/tests/conformance/stake-distributions/haskell-node-extractor/package.json
@@ -3,8 +3,8 @@
     "stakeDistributions": {
       "startFrom": {
         "mainnet": {
-          "slot": 193276767,
-          "id": "a2d99f003c7bc316d0e3c95abe1529fa2180cf0f835875cdf9b5b636e64e0e2d"
+          "slot": 195436790,
+          "id": "7ea0fe8109eef4c2b93263d5387b860ce5dcfa954c345470dec6c5648c58f7d6"
         },
         "preprod": {
           "slot": 128390395,

--- a/crates/amaru/tests/conformance/stake-distributions/mainnet/MANIFEST
+++ b/crates/amaru/tests/conformance/stake-distributions/mainnet/MANIFEST
@@ -104,3 +104,9 @@ epoch_639.json.zst
 epoch_640.json.zst
 epoch_641.json.zst
 epoch_642.json.zst
+epoch_643.json.zst
+epoch_644.json.zst
+epoch_645.json.zst
+epoch_646.json.zst
+epoch_647.json.zst
+epoch_648.json.zst


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added missing mainnet stake-distribution snapshots for epochs 643–648.
  - Updated the mainnet stake-distribution starting point.

- **Chores**
  - Added validation to ensure required AWS configuration is provided before running stake-distribution checks.
  - Corrected stake-distribution management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->