### PR TITLE
feat: log the eviction reason for evicted mempool transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Other guiding principles:
 ### Added
 
 - **amaru-pure-stage**: simulate how long an `ExternalEffect` occupies time (`DurationDist`: zero, constant, uniform, or until the effect future resolves). Sampled durations are scheduled when the effect is issued; `SimulationBuilder::run` now takes a Tokio `Handle` so a still-pending `run()` can be forced at that deadline. ([#1224](https://github.com/pragma-org/amaru/pull/1224))
+- **amaru-consensus**: log the transaction ids evicted from the mempool when a block is adopted, and specify if those transactions were included in a block (#1243).
 
 ### Changed
 

--- a/crates/amaru-consensus/src/stages/mempool/stage.rs
+++ b/crates/amaru-consensus/src/stages/mempool/stage.rs
@@ -16,7 +16,7 @@ use std::time::Instant;
 
 use amaru_kernel::{Point, Transaction};
 use amaru_ouroboros::{MempoolMsg, MempoolSeqNo, TxInsertResult, TxOrigin, TxRejectReason};
-use amaru_protocols::mempool_effects::MemoryPool;
+use amaru_protocols::{mempool_effects::MemoryPool, store_effects::Store};
 use amaru_pure_stage::{Effects, StageRef};
 
 use crate::{
@@ -73,14 +73,8 @@ pub async fn stage(state: MempoolStageState, msg: MempoolMsg, eff: Effects<Mempo
 
             let result = validate_and_insert(&ledger, &memory_pool, tx, &origin).await;
             record_insert(memory_pool.state().await, &metrics_ops, &origin, &result).await;
-            match result {
-                TxInsertResult::Accepted { seq_no, .. } => {
-                    tracing::info!(%tx_id, %seq_no, %origin, "transaction accepted into mempool");
-                    notify_ready_waiters(&mut state, &eff, seq_no).await;
-                }
-                TxInsertResult::Rejected { tx_id, ref reason } => {
-                    tracing::info!(%tx_id, %reason, "transaction rejected by mempool");
-                }
+            if let TxInsertResult::Accepted { seq_no, .. } = result {
+                notify_ready_waiters(&mut state, &eff, seq_no).await;
             }
             eff.send(&caller, result).await;
         }
@@ -91,22 +85,17 @@ pub async fn stage(state: MempoolStageState, msg: MempoolMsg, eff: Effects<Mempo
                 emit_tx_received(&tx_id, &origin);
                 let result = validate_and_insert(&ledger, &memory_pool, tx, &origin).await;
                 record_insert(memory_pool.state().await, &metrics_ops, &origin, &result).await;
-                match result {
-                    TxInsertResult::Accepted { seq_no, .. } => {
-                        tracing::info!(%tx_id, %seq_no, %origin, "transaction accepted into mempool");
-                        notify_ready_waiters(&mut state, &eff, seq_no).await;
-                    }
-                    TxInsertResult::Rejected { tx_id, ref reason } => {
-                        tracing::info!(%tx_id, %reason, "transaction rejected by mempool");
-                    }
+                if let TxInsertResult::Accepted { seq_no, .. } = result {
+                    notify_ready_waiters(&mut state, &eff, seq_no).await;
                 }
                 results.push(result);
             }
             eff.send(&caller, results).await;
         }
         MempoolMsg::NewTip(tip) => {
+            let store = Store::new(eff.clone());
             let outcome = apply_new_tip(&ledger, &memory_pool, tip).await;
-            record_revalidation(memory_pool.state().await, &metrics_ops, &outcome).await;
+            record_revalidation(memory_pool.state().await, &metrics_ops, &store, tip, &outcome).await;
             if !outcome.evicted_tx_ids.is_empty() {
                 notify_capacity_waiters(&mut state, &eff).await;
             }
@@ -120,7 +109,6 @@ pub async fn stage(state: MempoolStageState, msg: MempoolMsg, eff: Effects<Mempo
 
 /// Validate a transaction against the current ledger state
 /// and insert it into the mempool if it is valid.
-///
 async fn validate_and_insert(
     ledger: &Ledger,
     memory_pool: &MemoryPool,

--- a/crates/amaru-consensus/src/stages/mempool/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/mempool/test_setup.rs
@@ -43,6 +43,7 @@ pub struct TestPrep {
     pub rt: Runtime,
     pub mempool: ResourceMempool<Transaction>,
     pub validator: ResourceTxValidation,
+    pub chain_store: amaru_protocols::store_effects::ResourceHeaderStore,
 }
 
 #[derive(serde::Serialize)]
@@ -85,6 +86,7 @@ pub fn setup(prep: &TestPrep) -> (SimulationRunning, DeserializerGuards, Logs) {
     network.resources().put::<ResourceBlockValidation>(std::sync::Arc::new(MockBlockValidator::default()));
     network.resources().put::<ResourceMempool<Transaction>>(prep.mempool.clone());
     network.resources().put::<ResourceTxValidation>(prep.validator.clone());
+    network.resources().put::<amaru_protocols::store_effects::ResourceHeaderStore>(prep.chain_store.clone());
 
     let mempool = network.stage("mempool", stage);
     let mempool = network.wire_up(mempool, MempoolStageState::default());

--- a/crates/amaru-consensus/src/stages/mempool/tests.rs
+++ b/crates/amaru-consensus/src/stages/mempool/tests.rs
@@ -20,7 +20,7 @@ use amaru_metrics::mempool::{MempoolMetricEvent, MempoolMetrics, TxInsertionOrig
 use amaru_ouroboros::{
     MempoolMsg, MempoolSeqNo, MempoolState, TransactionValidationError, TxInsertResult, TxOrigin, TxRejectReason,
 };
-use amaru_ouroboros_traits::TxSubmissionMempool;
+use amaru_ouroboros_traits::{TxSubmissionMempool, in_memory_chain_store::InMemoryChainStore};
 use amaru_pure_stage::StageRef;
 use tracing::Level;
 
@@ -68,9 +68,9 @@ fn insert_batch_returns_one_result_per_transaction() {
         ],
     );
 
-    logs.assert_and_remove(Level::INFO, &["transaction accepted into mempool"])
-        .assert_and_remove(Level::INFO, &["transaction rejected by mempool", "transaction rejected for testing"])
-        .assert_and_remove(Level::INFO, &["transaction rejected by mempool", "Transaction is a duplicate"])
+    logs.assert_and_remove(Level::INFO, &["transaction.accepted"])
+        .assert_and_remove(Level::INFO, &["transaction.rejected", "invalid", "transaction rejected for testing"])
+        .assert_and_remove(Level::INFO, &["transaction.rejected", "duplicate"])
         .assert_and_remove(Level::DEBUG, &["state.update", "tx_count=1", "size_bytes=51"])
         .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
@@ -89,13 +89,56 @@ fn new_tip_invalidates_transactions_against_current_ledger_state() {
         rt: crate::stages::test_utils::test_runtime(),
         mempool: mempool.clone(),
         validator: Arc::new(reject_tx_1),
+        chain_store: Arc::new(InMemoryChainStore::default()),
     };
 
     let (_running, _guards, mut logs) = setup(&prep);
 
     assert_eq!(mempool.mempool_txs(), vec![tx_0, tx_2]);
+    logs.assert_and_remove(Level::INFO, &["transaction.evicted", "evicted_after_new_tip"]);
     logs.assert_and_remove(Level::DEBUG, &["state.update", "tx_count=2", "size_bytes=102"]);
     logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn new_tip_reports_transactions_included_in_the_adopted_block() {
+    use amaru_kernel::{IsHeader, cardano::network_block::make_encoded_block, cbor, make_header};
+    use amaru_ouroboros_traits::{WriteChainStore, in_memory_chain_store::InMemoryChainStore};
+
+    let header = make_header(1, 1, None);
+    let raw = make_encoded_block(&header, &amaru_kernel::EraHistory::default());
+    let (_, block): (u16, amaru_kernel::Block) = cbor::decode(&raw).unwrap();
+
+    // The mempool holds the transaction carried by the adopted block (identified by its body
+    // alone) and an unrelated one, both invalidated by the new tip.
+    let included_tx = Transaction {
+        body: block.transaction_bodies[0].clone(),
+        witnesses: Default::default(),
+        is_expected_valid: true,
+        auxiliary_data: None,
+    };
+    let evicted_tx = create_transaction(0);
+    let mempool = Arc::new(InMemoryMempool::<Transaction>::default());
+    mempool.insert(included_tx.clone(), TxOrigin::Local);
+    mempool.insert(evicted_tx.clone(), TxOrigin::Local);
+
+    let chain_store = Arc::new(InMemoryChainStore::default());
+    chain_store.store_block(&header.hash(), &raw).unwrap();
+
+    let prep = TestPrep {
+        msg: MempoolMsg::NewTip(amaru_kernel::Point::Specific(1.into(), header.hash(), 1.into())),
+        rt: crate::stages::test_utils::test_runtime(),
+        mempool: mempool.clone(),
+        validator: Arc::new(|_: &Transaction| Err(anyhow::anyhow!("invalid after tip").into())),
+        chain_store,
+    };
+
+    let (_running, _guards, mut logs) = setup(&prep);
+
+    assert!(mempool.mempool_txs().is_empty());
+    logs.assert_and_remove(Level::INFO, &["transaction.evicted", "included_in_adopted_block"])
+        .assert_and_remove(Level::INFO, &["transaction.evicted", "evicted_after_new_tip"])
+        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
 }
 
 pub fn make_insert_batch_example() -> TestPrep {
@@ -109,6 +152,7 @@ pub fn make_insert_batch_example() -> TestPrep {
         rt: crate::stages::test_utils::test_runtime(),
         mempool: Arc::new(InMemoryMempool::<Transaction>::default()),
         validator: Arc::new(reject_tx_1),
+        chain_store: Arc::new(InMemoryChainStore::default()),
     }
 }
 

--- a/crates/amaru-consensus/src/stages/mempool/traces.rs
+++ b/crates/amaru-consensus/src/stages/mempool/traces.rs
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{Slot, TransactionId};
+use std::collections::BTreeSet;
+
+use amaru_kernel::{Block, Point, Slot, TransactionId, cbor};
 use amaru_metrics::mempool::{
     MempoolMetricEvent, MempoolMetrics, TxEvictedReason, TxInsertionOrigin, TxInsertionResult,
 };
-use amaru_observability::{debug, debug_record, trace_record};
+use amaru_observability::{debug, debug_record, info};
 use amaru_ouroboros::MempoolMsg;
 use amaru_ouroboros_traits::{MempoolState, TxInsertResult, TxOrigin, TxRejectReason};
+use amaru_protocols::store_effects::Store;
 
 use crate::effects::{Metrics, MetricsOps};
 
@@ -52,19 +55,14 @@ pub(super) async fn record_insert(
 ) {
     match result {
         TxInsertResult::Accepted { tx_id, seq_no } => {
-            trace_record!(
-                mempool::transaction::ACCEPTED,
-                id = tx_id,
-                seq_no = seq_no.0,
-                origin = tx_origin_label(origin)
-            );
+            info!(mempool::transaction::ACCEPTED, id = tx_id, seq_no = seq_no.0, origin = tx_origin_label(origin));
         }
         TxInsertResult::Rejected { tx_id, reason } => {
             let reason_label = reject_reason_label(reason);
             match reason {
                 TxRejectReason::Invalid(err) => {
                     let validation_error = err.to_string();
-                    trace_record!(
+                    info!(
                         mempool::transaction::REJECTED,
                         id = tx_id,
                         reason = reason_label,
@@ -72,7 +70,7 @@ pub(super) async fn record_insert(
                     );
                 }
                 TxRejectReason::Duplicate | TxRejectReason::MempoolFull => {
-                    trace_record!(mempool::transaction::REJECTED, id = tx_id, reason = reason_label);
+                    info!(mempool::transaction::REJECTED, id = tx_id, reason = reason_label);
                 }
             }
         }
@@ -93,14 +91,25 @@ pub(super) async fn record_insert(
 pub(super) async fn record_revalidation(
     mempool_state: MempoolState,
     metrics: &Metrics<'_, MempoolMsg>,
+    store: &Store,
+    tip: Point,
     outcome: &RevalidationOutcome,
 ) {
     let evicted_count = outcome.evicted_tx_ids.len() as u64;
 
-    for tx_id in &outcome.evicted_tx_ids {
-        trace_record!(mempool::transaction::EVICTED, id = tx_id, reason = "invalid_after_tip".to_string());
-    }
     if evicted_count > 0 {
+        // An evicted transaction either made it into the adopted block, or a conflicting
+        // transaction spent its inputs.
+        let included = adopted_block_tx_ids(store, &tip).await;
+
+        for tx_id in &outcome.evicted_tx_ids {
+            if included.contains(tx_id) {
+                info!(mempool::transaction::EVICTED, id = tx_id, tip = tip, reason = "included_in_adopted_block");
+            } else {
+                info!(mempool::transaction::EVICTED, id = tx_id, tip = tip, reason = "evicted_after_new_tip");
+            }
+        }
+
         emit_metrics(
             mempool_state,
             metrics,
@@ -109,18 +118,35 @@ pub(super) async fn record_revalidation(
         .await;
     }
 
-    trace_record!(
-        mempool::transaction::REVALIDATION_DETAIL,
-        tip_slot = outcome.tip_slot,
-        total_before = outcome.total_before,
-        evicted_count = evicted_count,
-        duration_micros = outcome.duration_micros
-    );
+    if evicted_count > 0 || outcome.total_before > 0 {
+        debug!(
+            mempool::transaction::REVALIDATION_DETAIL,
+            tip_slot = outcome.tip_slot,
+            total_before = outcome.total_before,
+            evicted_count = evicted_count,
+            duration_micros = outcome.duration_micros
+        );
+    }
 
     emit_metrics(mempool_state, metrics, MempoolMetricEvent::Revalidated { duration_micros: outcome.duration_micros })
         .await;
     if should_emit_state_after_revalidation(outcome) {
         emit_state(mempool_state);
+    }
+}
+
+/// The ids of the transactions carried by the newly adopted block.
+/// This shouldn't put too much load on the store, since the block should be in the store already
+/// and "warm" from having been recently validated. If this becomes a concern we can also
+/// pass the validated tx ids from the `validate_block` stage to this stage.
+async fn adopted_block_tx_ids(store: &Store, tip: &Point) -> BTreeSet<TransactionId> {
+    let raw = match store.load_block(&tip.hash()).await {
+        Ok(Some(raw)) => raw,
+        _ => return BTreeSet::new(),
+    };
+    match cbor::decode::<(u16, Block)>(&raw) {
+        Ok((_, block)) => block.transaction_bodies.iter().map(|tx| TransactionId::new(tx.id())).collect(),
+        Err(_) => BTreeSet::new(),
     }
 }
 

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -1363,10 +1363,10 @@ define_schemas! {
                     required reason: String
                     optional validation_error: String
                 }
-                /// Transaction removed from the mempool. Reason ∈ {invalid_after_tip}.
-                /// TODO: split the reason into invalid after tip + present in applied block
+                /// Transaction removed from the mempool. Reason ∈ {included_in_adopted_block, evicted_after_new_tip}.
                 public EVICTED {
                     required id: amaru_kernel::TransactionId
+                    required tip: amaru_kernel::Point
                     required reason: String
                 }
                 /// Detail trace carrying upstream peer attribution for a received tx.

--- a/crates/amaru-ouroboros-traits/src/mempool/values.rs
+++ b/crates/amaru-ouroboros-traits/src/mempool/values.rs
@@ -109,6 +109,6 @@ impl Display for TransactionValidationError {
 
 impl From<anyhow::Error> for TransactionValidationError {
     fn from(error: anyhow::Error) -> Self {
-        TransactionValidationError(error.to_string())
+        TransactionValidationError(format!("{error:#}"))
     }
 }

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -1537,7 +1537,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
 | `accepted` | `TRACE` | public | Transaction validated and inserted into the mempool. | id, seq_no, origin |  |
-| `evicted` | `TRACE` | public | Transaction removed from the mempool. Reason ∈ {invalid_after_tip}. TODO: split the reason into invalid after tip + present in applied block | id, reason |  |
+| `evicted` | `TRACE` | public | Transaction removed from the mempool. Reason ∈ {included_in_adopted_block, evicted_after_new_tip}. | id, tip, reason |  |
 | `received` | `TRACE` | public | Transaction received by the mempool stage, before validation. | id, origin |  |
 | `rejected` | `TRACE` | public | Transaction rejected at insertion. Reason ∈ {invalid, duplicate, mempool_full}. | id, reason | validation_error |
 
@@ -1556,6 +1556,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | field | type | required |
 | --- | --- | --- |
 | `id` | `string` | ✓ |
+| `tip` | `string` | ✓ |
 | `reason` | `string` | ✓ |
 
 </details>

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -3304,12 +3304,17 @@
           "type": "string",
           "description": "Custom type: amaru_kernel::TransactionId"
         },
+        "tip": {
+          "type": "string",
+          "description": "Custom type: amaru_kernel::Point"
+        },
         "reason": {
           "type": "string"
         }
       },
       "required": [
         "id",
+        "tip",
         "reason"
       ],
       "optional": [],
@@ -3317,7 +3322,7 @@
       "name": "evicted",
       "level": "TRACE",
       "target": "amaru::mempool::transaction",
-      "description": "Transaction removed from the mempool. Reason ∈ {invalid_after_tip}. TODO: split the reason into invalid after tip + present in applied block",
+      "description": "Transaction removed from the mempool. Reason ∈ {included_in_adopted_block, evicted_after_new_tip}.",
       "public": true
     },
     "amaru::mempool::transaction::RECEIVED": {


### PR DESCRIPTION
This PR adds log events when transactions are evicted to the mempool. Those events are useful to understand if a transaction was evicted because it was part of the last applied block or if it became invalid for another reason.

This is also useful for demoing the txsubmission protocol.