### PR TITLE
Don't fail when snapshots directory doesn't exist

### DIFF
--- a/crates/amaru-bootstrap/src/bootstrap/mod.rs
+++ b/crates/amaru-bootstrap/src/bootstrap/mod.rs
@@ -141,12 +141,24 @@ async fn bootstrap_snapshots(
         try_push(&mut snapshots, s3_snap.point.to_string(), s3_snap.key.to_string())?;
     }
 
-    for dir_entry in snapshots_dir.read_dir()? {
-        let path = dir_entry?.path();
-        let filename = path.file_name().unwrap_or_default().to_str().unwrap_or_default();
-        if let Some(prefix) = filename.strip_suffix(Snapshot::ARCHIVE_SUFFIX) {
-            try_push(&mut snapshots, prefix.to_string(), format!("{network}/{prefix}{}", Snapshot::ARCHIVE_SUFFIX))?;
+    match snapshots_dir.read_dir() {
+        Ok(entries) => {
+            for dir_entry in entries {
+                let path = dir_entry?.path();
+                let filename = path.file_name().unwrap_or_default().to_str().unwrap_or_default();
+                if let Some(prefix) = filename.strip_suffix(Snapshot::ARCHIVE_SUFFIX) {
+                    try_push(
+                        &mut snapshots,
+                        prefix.to_string(),
+                        format!("{network}/{prefix}{}", Snapshot::ARCHIVE_SUFFIX),
+                    )?;
+                }
+            }
         }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            // If there is no directory already created, we should not fail
+        }
+        Err(err) => return Err(err.into()),
     }
 
     snapshots.sort_unstable_by_key(|snapshot| snapshot.epoch);


### PR DESCRIPTION
If you run bootstrap without a pre-existing snapshots directory, it will fail. It shouldn't, since the process will download snapshots. This PR means we ignore a `NotFound` error, restoring the expected behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot handling when the local snapshots directory is missing.
  * Other directory access errors continue to be reported normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->