### PR TITLE
fix(amaru-bootstrap): resolve recently unregistered accounts from previous rocksdb snapshots.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Other guiding principles:
 - **amaru-node**: `Telemetry` (used by `run_until`) now uses the product CBOR-aware tracing layers so structured log properties decode to numbers and strings instead of diagnostic byte strings.
 - **amaru**: more homogenous traces fields representations across peers, connection id and hashes.
 - **amaru**: detect local snapshots for bootstrap when they exists.
+- **amaru**: resolution of recently unregistered accounts during bootstrap, later triggering a "rewards discrepancy" invariant.
 
 ## v10.11.20260813 _[unreleased; planned for 2026-08-13]_
 

--- a/crates/amaru-bootstrap/src/bootstrap/mod.rs
+++ b/crates/amaru-bootstrap/src/bootstrap/mod.rs
@@ -26,11 +26,11 @@ use amaru_kernel::{
     RawBlock, Slot, StakeCredential, extract_block_header_cbor, from_cbor, num::CheckedSub,
     utils::string::display_collection,
 };
-use amaru_ledger::store::{EpochTransitionProgress, Store, TransactionalContext};
+use amaru_ledger::store::{EpochTransitionProgress, ReadStore, Store, TransactionalContext};
 use amaru_observability::{error, info};
 use amaru_ouroboros::{BaseReadChainStore, ChainStore, Nonces, OpcertSequenceNumbers, WriteChainStore};
-use amaru_progress_bar::TerminalProgressBar;
-use amaru_stores::rocksdb::{RocksDB, RocksDbConfig, consensus::RocksDBStore};
+use amaru_progress_bar::{ProgressBar, TerminalProgressBar};
+use amaru_stores::rocksdb::{ReadOnlyRocksDB, RocksDB, RocksDbConfig, consensus::RocksDBStore};
 use anyhow::anyhow;
 use pallas_network::{facades::PeerClient, miniprotocols::chainsync::NextResponse};
 use serde::{Deserialize, Serialize};
@@ -458,10 +458,7 @@ pub async fn bootstrap(
     let third_snapshot_path = resolve_snapshot_path(&snapshots_dir, third_snapshot)
         .ok_or_else(|| BootstrapError::MissingSnapshot(snapshot_archive_path(&snapshots_dir, third_snapshot)))?;
 
-    let mut recently_unregistered_accounts = BTreeSet::new();
-
-    import_snapshot(network, global_parameters, &first_snapshot_path, &ledger_dir, &mut recently_unregistered_accounts)
-        .await?;
+    import_snapshot(network, global_parameters, &first_snapshot_path, &ledger_dir).await?;
 
     // Extract nonces for the second snapshot tip as well: packaged bootstrap headers must enter
     // the chain store already carrying nonces so that "nonces present ⇔ header validated" holds
@@ -472,7 +469,6 @@ pub async fn bootstrap(
         &second_snapshot_path,
         &ledger_dir,
         Some(snapshot_hash(first_snapshot)?),
-        &mut recently_unregistered_accounts,
     )
     .await?;
 
@@ -482,7 +478,6 @@ pub async fn bootstrap(
         &third_snapshot_path,
         &ledger_dir,
         Some(snapshot_hash(second_snapshot)?),
-        &mut recently_unregistered_accounts,
     )
     .await?;
 
@@ -662,9 +657,8 @@ pub async fn import_snapshots(
     ledger_dir: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     info!(bootstrap::snapshots::IMPORT, count = snapshots.len());
-    let mut recently_unregistered_accounts: BTreeSet<StakeCredential> = BTreeSet::new();
     for snapshot in snapshots {
-        import_snapshot(network, global_parameters, snapshot, ledger_dir, &mut recently_unregistered_accounts).await?;
+        import_snapshot(network, global_parameters, snapshot, ledger_dir).await?;
     }
     Ok(())
 }
@@ -685,17 +679,8 @@ async fn import_snapshot(
     global_parameters: &GlobalParameters,
     snapshot: &Path,
     ledger_dir: &Path,
-    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    import_snapshot_with_optional_nonces(
-        network,
-        global_parameters,
-        snapshot,
-        ledger_dir,
-        None,
-        recently_unregistered_accounts,
-    )
-    .await?;
+    import_snapshot_with_optional_nonces(network, global_parameters, snapshot, ledger_dir, None).await?;
     Ok(())
 }
 
@@ -705,18 +690,9 @@ async fn import_snapshot_with_optional_nonces(
     snapshot: &Path,
     ledger_dir: &Path,
     nonce_tail: Option<HeaderHash>,
-    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
 ) -> Result<ImportedSnapshot, Box<dyn std::error::Error>> {
     if snapshot.is_file() && has_snapshot_archive_extension(snapshot) {
-        return import_node_snapshot_archive(
-            network,
-            global_parameters,
-            snapshot,
-            ledger_dir,
-            nonce_tail,
-            recently_unregistered_accounts,
-        )
-        .await;
+        return import_node_snapshot_archive(network, global_parameters, snapshot, ledger_dir, nonce_tail).await;
     }
 
     Err(Box::new(ImportError::UnsupportedSnapshotPath(snapshot.to_path_buf())))
@@ -728,19 +704,9 @@ async fn import_node_snapshot_archive(
     snapshot_archive: &Path,
     ledger_dir: &Path,
     nonce_tail: Option<HeaderHash>,
-    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
 ) -> Result<ImportedSnapshot, Box<dyn std::error::Error>> {
     info!(bootstrap::snapshot::IMPORT_ARCHIVE, path = %snapshot_archive.display());
-
-    import_node_snapshot_source(
-        network,
-        global_parameters,
-        snapshot_archive,
-        ledger_dir,
-        nonce_tail,
-        recently_unregistered_accounts,
-    )
-    .await
+    import_node_snapshot_source(network, global_parameters, snapshot_archive, ledger_dir, nonce_tail).await
 }
 
 #[expect(clippy::unwrap_used)]
@@ -750,21 +716,34 @@ async fn import_node_snapshot_source(
     archive_path: &Path,
     ledger_dir: &Path,
     nonce_tail: Option<HeaderHash>,
-    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
 ) -> Result<ImportedSnapshot, Box<dyn std::error::Error>> {
     fs::create_dir_all(ledger_dir)?;
 
-    if fs::exists(ledger_dir.join("live"))? {
+    let previous_accounts = if fs::exists(ledger_dir.join("live"))? {
+        let progress = TerminalProgressBar::new(0_u64, "{spinner:.green} Loading previous accounts");
+
+        let live = ReadOnlyRocksDB::new(&RocksDbConfig::new(ledger_dir.to_path_buf()))?;
+        let previous_accounts = live
+            .iter_accounts()?
+            .map(|(credential, _)| credential)
+            .chain(live.iter_recently_unregistered_accounts()?)
+            .collect();
+
         fs::remove_dir_all(ledger_dir.join("live"))?;
-    }
+
+        progress.clear();
+
+        previous_accounts
+    } else {
+        BTreeSet::new()
+    };
 
     let db = RocksDB::empty(&RocksDbConfig::new(ledger_dir.to_path_buf()))?;
     let global_parameters = global_parameters.clone();
     let archive_path = archive_path.to_path_buf();
     let builder = std::thread::Builder::new().stack_size(10_000_000);
-    let mut accounts = recently_unregistered_accounts.clone();
 
-    let (db, epoch, chain_state, accounts) = builder
+    let (db, epoch, chain_state) = builder
         .spawn(move || {
             import_node_snapshot_archive_data(
                 &archive_path,
@@ -772,16 +751,14 @@ async fn import_node_snapshot_source(
                 network,
                 &global_parameters,
                 nonce_tail,
-                &mut accounts,
+                previous_accounts,
             )
             .map_err(|e| e.to_string())
-            .map(|(epoch, _point, chain_state)| (db, epoch, chain_state, accounts))
+            .map(|(epoch, _point, chain_state)| (db, epoch, chain_state))
         })
         .unwrap()
         .join()
         .unwrap()?;
-
-    *recently_unregistered_accounts = accounts;
 
     db.next_snapshot(epoch)?;
 
@@ -796,11 +773,13 @@ fn import_node_snapshot_archive_data(
     network: NetworkName,
     global_parameters: &GlobalParameters,
     nonce_tail: Option<HeaderHash>,
-    accounts: &mut BTreeSet<StakeCredential>,
+    previous_accounts: BTreeSet<StakeCredential>,
 ) -> Result<(Epoch, Point, Option<ChainState>), Box<dyn Error>> {
     let archive_file = fs::File::open(archive_path)?;
     let mut archive = Archive::new(ZstdDecoder::new(archive_file)?);
+
     let mut imported_state = None;
+    let mut previous_accounts: Option<BTreeSet<StakeCredential>> = Some(previous_accounts);
 
     for entry in archive.entries()? {
         let mut entry = entry?;
@@ -813,7 +792,9 @@ fn import_node_snapshot_archive_data(
                 network,
                 global_parameters,
                 nonce_tail,
-                accounts,
+                previous_accounts.take().ok_or_else(|| -> Box<dyn Error> {
+                    format!("multiple {SNAPSHOT_STATE_FILE_NAME} in archive {}?", archive_path.display()).into()
+                })?,
                 |size, template| TerminalProgressBar::new(size as u64, template).boxed(),
             )?);
         } else if snapshot_archive_entry_matches(&path, Path::new(SNAPSHOT_UTXO_FILE_NAME)) {

--- a/crates/amaru-bootstrap/src/cardano_node/tvar.rs
+++ b/crates/amaru-bootstrap/src/cardano_node/tvar.rs
@@ -47,7 +47,7 @@ pub fn import_snapshot_from_tvar<S, F, State, Utxo>(
     network: NetworkName,
     global_parameters: &GlobalParameters,
     nonce_tail: Option<HeaderHash>,
-    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
+    previous_accounts: BTreeSet<StakeCredential>,
     with_progress: F,
 ) -> Result<(Epoch, Point, Option<ChainState>), Box<dyn std::error::Error>>
 where
@@ -62,7 +62,7 @@ where
         network,
         global_parameters,
         nonce_tail,
-        recently_unregistered_accounts,
+        previous_accounts,
         with_progress,
     )?;
 
@@ -77,7 +77,7 @@ pub(crate) fn import_state_from_tvar<S, F, State>(
     network: NetworkName,
     global_parameters: &GlobalParameters,
     nonce_tail: Option<HeaderHash>,
-    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
+    previous_accounts: BTreeSet<StakeCredential>,
     with_progress: F,
 ) -> Result<(Epoch, Point, EraHistory, Option<ChainState>), Box<dyn std::error::Error>>
 where
@@ -94,7 +94,7 @@ where
     let epoch = import_initial_snapshot_with_decoder(
         db,
         &mut decoder,
-        recently_unregistered_accounts,
+        previous_accounts,
         &point,
         &parsed_snapshot.era_history,
         network,

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -15,7 +15,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     io::Read,
-    iter, mem,
+    iter,
     rc::Rc,
     sync::LazyLock,
 };
@@ -129,8 +129,12 @@ struct InitialSnapshot {
     delta_fees: i64,
 }
 
+/// Accounts present in the map with no deposit which we pre-filled with the protocol parameters'
+/// deposit. They are stashed away when importing accounts because we only know about the protocol
+/// parameters later on.
 struct ImportedAccounts {
-    credentials: Vec<StakeCredential>,
+    account_len: usize,
+    recently_unregistered_accounts: BTreeSet<StakeCredential>,
     awaiting_default_deposit: Vec<(StakeCredential, NodeAccount)>,
 }
 
@@ -150,38 +154,6 @@ fn save_bootstrap_account_batches(
         db.save_bootstrap_accounts(batch.into_iter())?;
         on_batch(size);
     }
-}
-
-fn decode_mark_snapshot(
-    decoder: &mut LazyDecoder<'_>,
-    registered_accounts: Vec<StakeCredential>,
-    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
-) -> Result<usize, Box<dyn std::error::Error>> {
-    decoder.begin_array()?;
-
-    let len = decoder.stream_map(
-        |d| {
-            let credential = d.decode()?;
-            d.skip()?;
-            Ok(credential)
-        },
-        |_| 0_usize,
-        |total_len, credentials| {
-            *total_len += credentials.len();
-
-            for credential in credentials {
-                if registered_accounts.binary_search(&credential).is_err() {
-                    recently_unregistered_accounts.insert(credential);
-                }
-            }
-
-            Ok(())
-        },
-    )?;
-
-    decoder.skip()?;
-
-    Ok(len)
 }
 
 fn skip_stake_snapshot_lazy(decoder: &mut LazyDecoder<'_>) -> Result<(), Box<dyn std::error::Error>> {
@@ -234,7 +206,7 @@ fn import_accounts(
     db: &impl Store,
     point: &Point,
     network: NetworkName,
-    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
+    mut recently_unregistered_accounts: BTreeSet<StakeCredential>,
     with_progress: &impl Fn(usize, &str) -> Box<dyn ProgressBar>,
 ) -> Result<ImportedAccounts, Box<dyn std::error::Error>> {
     if db.iter_accounts()?.next().is_some() {
@@ -243,7 +215,7 @@ fn import_accounts(
 
     decoder.begin_array()?;
 
-    let (progress, credentials, awaiting_default_deposit) = decoder.stream_map(
+    let (progress, size, awaiting_default_deposit) = decoder.stream_map(
         |d| Ok((d.decode::<StakeCredential>()?, d.decode::<NodeAccount>()?)),
         |length| {
             let estimated_size = length.map(|size| size as usize).unwrap_or(match network {
@@ -257,16 +229,20 @@ fn import_accounts(
                     estimated_size,
                     "{spinner:.green} Importing accounts {bar:40.green} [{pos:>7}/{len:7}] ({eta} remaining)",
                 ),
-                Vec::with_capacity(estimated_size),
+                0,
                 Vec::new(),
             )
         },
-        |(progress, credentials, awaiting_default_deposit), entries| {
+        |(progress, size, awaiting_default_deposit), entries| {
             progress.tick(entries.len());
-            credentials.extend(entries.iter().map(|(credential, _)| *credential));
 
-            let (awaiting, ready): (Vec<_>, Vec<_>) =
-                entries.into_iter().partition(|(_, account)| account.deposit == 0);
+            *size += entries.len();
+
+            let (awaiting, ready): (Vec<_>, Vec<_>) = entries.into_iter().partition(|(credential, account)| {
+                recently_unregistered_accounts.remove(credential);
+                account.deposit == 0
+            });
+
             awaiting_default_deposit.extend(awaiting);
 
             let ready = ready.into_iter().map(|(credential, account)| (credential, account.into_row(point, None)));
@@ -277,16 +253,42 @@ fn import_accounts(
 
     progress.clear();
 
-    info!(bootstrap::accounts::IMPORT, size = credentials.len());
+    info!(bootstrap::accounts::IMPORT, size = size);
 
-    with_progress(0, "{spinner:.green} Retaining recently unregistred accounts");
+    Ok(ImportedAccounts { awaiting_default_deposit, recently_unregistered_accounts, account_len: size })
+}
 
-    // Prune the recently unregistered set from account we saw, which indicates they have re-registered.
+fn import_recently_unregistered_accounts(
+    db: &impl Store,
+    point: &Point,
+    era_history: &EraHistory,
+    protocol_parameters: &ProtocolParameters,
+    recently_unregistered_accounts: BTreeSet<StakeCredential>,
+) -> Result<(), Box<dyn std::error::Error>> {
     if !recently_unregistered_accounts.is_empty() {
-        recently_unregistered_accounts.retain(|credential| credentials.binary_search(credential).is_err());
+        db.with_transaction(|transaction| {
+            transaction.save(
+                era_history,
+                protocol_parameters,
+                None,
+                point,
+                None,
+                Default::default(),
+                store::Columns {
+                    utxo: iter::empty(),
+                    pools: iter::empty(),
+                    accounts: recently_unregistered_accounts.into_iter(),
+                    dreps: iter::empty(),
+                    cc_members: iter::empty(),
+                    proposals: iter::empty(),
+                    votes: iter::empty(),
+                },
+                iter::empty(),
+            )
+        })?;
     }
 
-    Ok(ImportedAccounts { credentials, awaiting_default_deposit })
+    Ok(())
 }
 
 fn import_default_account_deposits(
@@ -294,21 +296,19 @@ fn import_default_account_deposits(
     point: &Point,
     default_deposit: Lovelace,
     with_progress: &impl Fn(usize, &str) -> Box<dyn ProgressBar>,
-    accounts: &mut ImportedAccounts,
+    mut accounts: Vec<(StakeCredential, NodeAccount)>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    if accounts.awaiting_default_deposit.is_empty() {
+    if accounts.is_empty() {
         return Ok(());
     }
 
     let progress = with_progress(
-        accounts.awaiting_default_deposit.len(),
+        accounts.len(),
         "{spinner:.green} Adjusting default account deposits {bar:40.green} [{pos:>7}/{len:7}] ({eta} remaining)",
     );
 
-    let awaiting = accounts
-        .awaiting_default_deposit
-        .drain(..)
-        .map(|(credential, account)| (credential, account.into_row(point, Some(default_deposit))));
+    let awaiting =
+        accounts.drain(..).map(|(credential, account)| (credential, account.into_row(point, Some(default_deposit))));
 
     save_bootstrap_account_batches(db, awaiting, |size| progress.tick(size))?;
 
@@ -322,13 +322,15 @@ fn import_default_account_deposits(
 ///
 /// Account rows are persisted in bounded batches while decoding; all other snapshot state stays
 /// in memory until the payload has been validated.
+#[expect(clippy::too_many_arguments)]
 fn decode_initial_snapshot(
     decoder: &mut LazyDecoder<'_>,
     db: &impl Store,
-    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
+    previous_accounts: BTreeSet<StakeCredential>,
     point: &Point,
     expected_epoch: Epoch,
     network: NetworkName,
+    era_history: &EraHistory,
     with_progress: &impl Fn(usize, &str) -> Box<dyn ProgressBar>,
 ) -> Result<InitialSnapshot, Box<dyn std::error::Error>> {
     let epoch: Epoch = decoder.with_decoder(|d| decode_initial_snapshot_prefix(d, expected_epoch))?;
@@ -368,8 +370,9 @@ fn decode_initial_snapshot(
     })?;
     pool_state_progress.clear();
 
-    let mut accounts = import_accounts(decoder, db, point, network, recently_unregistered_accounts, with_progress)
-        .map_err(|err| format!("decode accounts: {err}"))?;
+    let ImportedAccounts { recently_unregistered_accounts, awaiting_default_deposit, account_len } =
+        import_accounts(decoder, db, point, network, previous_accounts, with_progress)
+            .map_err(|err| format!("decode accounts: {err}"))?;
 
     let remaining_state_progress = with_progress(0, "{spinner:.green} Reading remaining ledger state");
 
@@ -418,7 +421,7 @@ fn decode_initial_snapshot(
         point,
         protocol_parameters.stake_credential_deposit,
         with_progress,
-        &mut accounts,
+        awaiting_default_deposit,
     )?;
 
     let (pools, pools_updates, pools_retirements) =
@@ -457,11 +460,9 @@ fn decode_initial_snapshot(
 
     // Epoch State / Snapshots
     decoder.begin_array()?;
-    let rewards_size =
-        decode_mark_snapshot(decoder, mem::take(&mut accounts.credentials), recently_unregistered_accounts)?;
+    skip_stake_snapshot_lazy(decoder)?; // Epoch State / Snapshots / Mark
     skip_stake_snapshot_lazy(decoder)?; // Epoch State / Snapshots / Set
     skip_stake_snapshot_lazy(decoder)?; // Epoch State / Snapshots / Go
-    remaining_state_progress.clear();
     decoder.skip()?; // Epoch State / Snapshots / Fee
     decoder.skip()?; // Epoch State / NonMyopic
 
@@ -486,10 +487,12 @@ fn decode_initial_snapshot(
         })
         .map_err(|err| format!("decode rewards update: {err}"))?;
 
+    remaining_state_progress.clear();
+
     let (delta_treasury, delta_reserves, unclaimed_rewards, delta_fees) = if is_complete {
         let delta_treasury: i64 = decoder.decode()?;
         let delta_reserves: i64 = decoder.decode()?;
-        let unclaimed_rewards = import_rewards(decoder, db, rewards_size, with_progress)?;
+        let unclaimed_rewards = import_rewards(decoder, db, account_len, with_progress)?;
         let delta_fees: i64 = decoder.decode()?;
         decoder.skip()?;
         (delta_treasury, delta_reserves, unclaimed_rewards, delta_fees)
@@ -500,6 +503,14 @@ fn decode_initial_snapshot(
 
     decoder.skip()?; // Pool distribution
     decoder.skip()?; // Stashed AVVM addresses
+
+    import_recently_unregistered_accounts(
+        db,
+        point,
+        era_history,
+        &protocol_parameters,
+        recently_unregistered_accounts,
+    )?;
 
     Ok(InitialSnapshot {
         epoch,
@@ -533,7 +544,7 @@ fn decode_initial_snapshot(
 pub fn import_initial_snapshot(
     db: &impl Store,
     reader: &mut dyn Read,
-    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
+    previous_accounts: BTreeSet<StakeCredential>,
     point: &Point,
     era_history: &EraHistory,
     network: NetworkName,
@@ -543,7 +554,7 @@ pub fn import_initial_snapshot(
     import_initial_snapshot_with_decoder(
         db,
         &mut decoder,
-        recently_unregistered_accounts,
+        previous_accounts,
         point,
         era_history,
         network,
@@ -557,7 +568,7 @@ pub fn import_initial_snapshot(
 pub fn import_initial_snapshot_with_decoder(
     db: &impl Store,
     decoder: &mut LazyDecoder<'_>,
-    recently_unregistered_accounts: &mut BTreeSet<StakeCredential>,
+    previous_accounts: BTreeSet<StakeCredential>,
     point: &Point,
     era_history: &EraHistory,
     network: NetworkName,
@@ -593,10 +604,11 @@ pub fn import_initial_snapshot_with_decoder(
     } = decode_initial_snapshot(
         decoder,
         db,
-        recently_unregistered_accounts,
+        previous_accounts,
         point,
         expected_epoch,
         network,
+        era_history,
         &with_progress,
     )?;
 
@@ -614,14 +626,6 @@ pub fn import_initial_snapshot_with_decoder(
     import_recently_pruned_proposals(db, era_history, epoch, &proposals_roots, enacted_proposals, expired_proposals)?;
 
     import_votes(db, point, era_history, &protocol_parameters, proposals)?;
-
-    import_recently_unregistered_accounts(
-        db,
-        point,
-        era_history,
-        &protocol_parameters,
-        recently_unregistered_accounts,
-    )?;
 
     import_pots(
         db,
@@ -996,39 +1000,6 @@ fn import_pots(db: &impl Store, pots: Pots) -> Result<(), Box<dyn std::error::Er
     transaction.commit()?;
     let Pots { treasury, reserves, fees, donations } = pots;
     info!(bootstrap::pots::IMPORT, treasury, reserves, fees, donations);
-    Ok(())
-}
-
-fn import_recently_unregistered_accounts(
-    db: &impl Store,
-    point: &Point,
-    era_history: &EraHistory,
-    protocol_parameters: &ProtocolParameters,
-    recently_unregistered_accounts: &BTreeSet<StakeCredential>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    if !recently_unregistered_accounts.is_empty() {
-        db.with_transaction(|transaction| {
-            transaction.save(
-                era_history,
-                protocol_parameters,
-                None,
-                point,
-                None,
-                Default::default(),
-                store::Columns {
-                    utxo: iter::empty(),
-                    pools: iter::empty(),
-                    accounts: recently_unregistered_accounts.iter().cloned(),
-                    dreps: iter::empty(),
-                    cc_members: iter::empty(),
-                    proposals: iter::empty(),
-                    votes: iter::empty(),
-                },
-                iter::empty(),
-            )
-        })?;
-    }
-
     Ok(())
 }
 

--- a/crates/amaru-ledger/src/store/epoch_transition.rs
+++ b/crates/amaru-ledger/src/store/epoch_transition.rs
@@ -21,7 +21,7 @@ use amaru_kernel::{
     AsHash, ConstitutionalCommitteeStatus, ConstitutionalCommitteeUpdate, Hash, Lovelace, PoolId, ProposalId,
     ProtocolParameters, RatificationStatus, RationalNumber, StakeCredential, StakeCredentialKind, size::SCRIPT,
 };
-use amaru_observability::{debug, debug_span};
+use amaru_observability::{debug, debug_span, error};
 use num::BigUint;
 use tracing::Span;
 
@@ -48,7 +48,6 @@ pub fn pay_rewards<'store>(
 
             for (credential, mut row) in iterator {
                 let rewards = effective_rewards.reward_of(&credential);
-
                 if rewards > 0 {
                     // The condition avoids the mutable borrow when not needed,
                     // which will incur a db operation.
@@ -56,6 +55,12 @@ pub fn pay_rewards<'store>(
                         accounts_paid += 1;
                         rewards_paid += rewards;
                         account.rewards += rewards;
+                    } else {
+                        error!(
+                            stores::ledger::overlay::account::GONE,
+                            rewards = rewards,
+                            account = credential,
+                        );
                     }
                 }
             }

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -1142,6 +1142,13 @@ define_schemas! {
                         /// Reserves depletion from incentives; always negative.
                         optional reserves_delta: i64
                     }
+                    account {
+                        /// An account supposed to receive rewards is gone
+                        GONE {
+                            required rewards: amaru_kernel::Lovelace
+                            required account: amaru_kernel::StakeCredential
+                        }
+                    }
                     /// Pruned proposals at an epoch boundary, recorded to facilitate future stake
                     /// distribution calculations.
                     public RECORD_PRUNED_PROPOSALS {}


### PR DESCRIPTION
The Mark snapshot from the Haskell's epoch state is no good, it does not contain accounts which did not receive rewards but that may receive some in the following epoch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bootstrap handling for recently unregistered and re-registered accounts.
  * Prevented duplicate transaction inputs and incomplete state entries during snapshot restoration.
  * Ensured snapshot directories resolve relative to the executable.
  * Preserved reward information and detected discrepancies when accounts are no longer present.
  * Added safeguards for missing nonce data during bootstrap.
* **Observability**
  * Added reporting for rewards associated with accounts that are no longer stored.
* **Documentation**
  * Added changelog entries covering bootstrap, snapshot, and reward consistency improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->