### PR TITLE
log address_watch with ansi colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Other guiding principles:
 
 ### Changed
 
+- **amaru-node**: `Telemetry::install` / `install_local` take a `LogFormat` (`Plain`, `Ansi`, or `Json`) instead of a JSON boolean, so embedders can enable ANSI colour on the console sink (JSON remains exclusive with colour).
 - **amaru-bootstrap**: speed up node bootstrap by streaming state archives and account imports, decoding large snapshot maps incrementally, and avoiding unnecessary optimistic-transaction conflict tracking when importing fresh database batches.
 - **amaru-pure-stage**: `contramap` is now a method on `StageRef`. It no longer allocates a runtime name or adapter entry; the injection runs in the sending stage and traces record the transformed message sent to the original stage. `StageGraph::contramap` and `Effects::contramap` are removed. `Sender::send` now returns `SendError` instead of the original message (the payload cannot be recovered after a contramap injection). ([#762](https://github.com/pragma-org/amaru/issues/762))
 - **amaru-ledger**: group phase-one and phase-two traces under a single trace with multiple fields for each of the measurements.

--- a/crates/amaru-node/examples/address_watch.rs
+++ b/crates/amaru-node/examples/address_watch.rs
@@ -59,7 +59,7 @@ fn main() -> anyhow::Result<()> {
     let index = Arc::new(Mutex::new(AddressIndex::bootstrap(&args.ledger_dir, args.addresses.iter().cloned())?));
 
     {
-        let index = index.lock().expect("address index lock");
+        let mut index = index.lock().expect("address index lock");
         for report in index.reports_for_all() {
             println!("{report}");
         }
@@ -112,15 +112,34 @@ fn main() -> anyhow::Result<()> {
 // Address index
 // -------------------------------------------------------------------------------------------------
 
+const RESET: &str = "\x1b[0m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const BLUE: &str = "\x1b[34m";
+const YELLOW: &str = "\x1b[33m";
+const GREEN: &str = "\x1b[32m";
+const RED: &str = "\x1b[31m";
+
+fn ada(lovelace: u64) -> String {
+    format!("{}.{:06}₳", lovelace / 1_000_000, lovelace % 1_000_000)
+}
+
+fn signed_ada(delta: i64) -> String {
+    let abs = delta.unsigned_abs();
+    format!("{}{}.{:06}₳", if delta < 0 { "-" } else { "+" }, abs / 1_000_000, abs % 1_000_000)
+}
+
 /// UTxOs for one watched address.
 ///
 /// - `live`: currently unspent outputs (keyed by their out-ref).
 /// - `spent`: once-live outputs that were spent on the current tip path, kept so
 ///   undos can restore them when DiffSet only supplies the consumed input.
+/// - `last_reported_balance`: last printed live balance, for the signed Δ.
 #[derive(Debug, Default)]
 struct AddressPortfolio {
     live: HashMap<TransactionInput, Arc<MemoizedTransactionOutput>>,
     spent: HashMap<TransactionInput, Arc<MemoizedTransactionOutput>>,
+    last_reported_balance: Option<u64>,
 }
 
 impl AddressPortfolio {
@@ -128,25 +147,25 @@ impl AddressPortfolio {
         self.live.values().map(|output| output.lovelace()).sum()
     }
 
-    fn report(&self, address: &Address) -> String {
-        let mut lines = Vec::with_capacity(self.live.len() + 2);
-        lines.push(format!("\x1b[31mADDRESS_CHANGE\x1b[0m \x1b[33m{address}\x1b[0m"));
+    fn report(&mut self, address: &Address) -> String {
         let balance = self.balance();
-        let ada = balance / 1_000_000;
-        let lovelace = balance % 1_000_000;
-        lines.push(format!(
-            "  balance: \x1b[34m{}.{:06}₳\x1b[0m  utxos: \x1b[34m{}\x1b[0m",
-            ada,
-            lovelace,
-            self.live.len()
-        ));
-        // Stable print order for humans.
-        // let mut entries: Vec<_> = self.live.iter().collect();
-        // entries.sort_by_key(|(input, _)| *input);
-        // for (input, output) in entries {
-        //     lines.push(format!("    {input}: {:?}", output));
-        // }
-        lines.join("\n")
+        let delta = self.last_reported_balance.map(|prev| balance as i64 - prev as i64);
+        self.last_reported_balance = Some(balance);
+
+        let mut line = format!("  balance: {BLUE}{}{RESET}", ada(balance));
+        if let Some(delta) = delta {
+            let color = if delta < 0 {
+                RED
+            } else if delta > 0 {
+                GREEN
+            } else {
+                DIM
+            };
+            line.push_str(&format!("  {BOLD}{color}{}{RESET}", signed_ada(delta)));
+        }
+        line.push_str(&format!("  utxos: {}", self.live.len()));
+
+        format!("{YELLOW}ADDRESS_CHANGE{RESET} {DIM}{address}{RESET}\n{line}")
     }
 }
 
@@ -228,15 +247,15 @@ impl AddressIndex {
         changed
     }
 
-    fn report(&self, address: &Address) -> String {
+    fn report(&mut self, address: &Address) -> String {
         self.portfolios
-            .get(address)
+            .get_mut(address)
             .map(|p| p.report(address))
-            .unwrap_or_else(|| format!("ADDRESS_CHANGE {address}\n  (unknown address)"))
+            .unwrap_or_else(|| format!("{BOLD}ADDRESS_CHANGE{RESET} {DIM}{address}{RESET}\n  (unknown address)"))
     }
 
-    fn reports_for_all(&self) -> impl Iterator<Item = String> + '_ {
-        self.portfolios.iter().map(|(address, portfolio)| portfolio.report(address))
+    fn reports_for_all(&mut self) -> impl Iterator<Item = String> + '_ {
+        self.portfolios.iter_mut().map(|(address, portfolio)| portfolio.report(address))
     }
 
     // -- mutations ------------------------------------------------------------

--- a/crates/amaru-node/examples/address_watch.rs
+++ b/crates/amaru-node/examples/address_watch.rs
@@ -43,16 +43,15 @@ use std::{
 
 use amaru_kernel::{Address, HasLovelace, MemoizedTransactionOutput, NetworkName, TransactionInput};
 use amaru_ledger::store::ReadStore;
-use amaru_node::{LedgerBlockEvent, LedgerObservers, NodeBuilder, UtxoDiff, default_chain_dir, default_ledger_dir};
+use amaru_node::{
+    LedgerBlockEvent, LedgerObservers, LogFormat, NodeBuilder, Telemetry, UtxoDiff, default_chain_dir,
+    default_ledger_dir,
+};
 use amaru_stores::rocksdb::{ReadOnlyRocksDB, RocksDbConfig};
 use anyhow::Context;
-use tracing_subscriber::EnvFilter;
 
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
-        .with_writer(std::io::stderr)
-        .init();
+    Telemetry::install_local(LogFormat::Ansi)?;
 
     let args = Args::parse(env::args().skip(1))?;
     let rt = tokio::runtime::Builder::new_multi_thread().enable_all().thread_name("amaru-address-watch").build()?;
@@ -131,17 +130,22 @@ impl AddressPortfolio {
 
     fn report(&self, address: &Address) -> String {
         let mut lines = Vec::with_capacity(self.live.len() + 2);
-        lines.push(format!("ADDRESS_CHANGE {address}"));
+        lines.push(format!("\x1b[31mADDRESS_CHANGE\x1b[0m \x1b[33m{address}\x1b[0m"));
         let balance = self.balance();
         let ada = balance / 1_000_000;
         let lovelace = balance % 1_000_000;
-        lines.push(format!("  balance: {}.{:06} lovelace  utxos: {}", ada, lovelace, self.live.len()));
+        lines.push(format!(
+            "  balance: \x1b[34m{}.{:06}₳\x1b[0m  utxos: \x1b[34m{}\x1b[0m",
+            ada,
+            lovelace,
+            self.live.len()
+        ));
         // Stable print order for humans.
-        let mut entries: Vec<_> = self.live.iter().collect();
-        entries.sort_by_key(|(input, _)| *input);
-        for (input, output) in entries {
-            lines.push(format!("    {input}: {:?}", output));
-        }
+        // let mut entries: Vec<_> = self.live.iter().collect();
+        // entries.sort_by_key(|(input, _)| *input);
+        // for (input, output) in entries {
+        //     lines.push(format!("    {input}: {:?}", output));
+        // }
         lines.join("\n")
     }
 }

--- a/crates/amaru-node/examples/run_until.rs
+++ b/crates/amaru-node/examples/run_until.rs
@@ -34,7 +34,7 @@ use std::{
 
 use amaru_kernel::NetworkName;
 use amaru_node::{
-    LedgerObservers, MaxExtraLedgerSnapshots, NodeBuilder, Telemetry, default_chain_dir, default_ledger_dir,
+    LedgerObservers, LogFormat, MaxExtraLedgerSnapshots, NodeBuilder, Telemetry, default_chain_dir, default_ledger_dir,
 };
 
 fn main() -> anyhow::Result<()> {
@@ -45,7 +45,7 @@ fn main() -> anyhow::Result<()> {
     let done = Arc::new(AtomicBool::new(false));
     let reached = rt.block_on(async {
         // Install/shutdown are async so they run on this runtime (OTLP batch exporters attach to it).
-        let telemetry = Telemetry::install().await?;
+        let telemetry = Telemetry::install(LogFormat::Plain).await?;
 
         let done_flag = Arc::clone(&done);
 

--- a/crates/amaru-node/src/lib.rs
+++ b/crates/amaru-node/src/lib.rs
@@ -59,7 +59,7 @@ pub use stages::{
     config::{Config, LedgerConfig, MaxExtraLedgerSnapshots, StoreType},
 };
 pub use system_metrics::{BuildIdentity, track_system_metrics};
-pub use telemetry::Telemetry;
+pub use telemetry::{LogFormat, Telemetry};
 
 /// Default relative path for ledger storage for a known network.
 pub fn default_ledger_dir(network: NetworkName) -> String {

--- a/crates/amaru-node/src/telemetry.rs
+++ b/crates/amaru-node/src/telemetry.rs
@@ -21,10 +21,12 @@
 //! Console, JSON, and OTEL log/trace layers are the same CBOR-aware formatters
 //! as the product binary (`CborConsoleEventFormat`, `CborJsonEventFormat`,
 //! `CborTraceArrayLayer`, `CborOtelLogBridge`) so schema `record_bytes` fields
-//! decode to numbers and strings where the sink can hold them. The product
-//! stack in `amaru::observability` still adds TUI capture, a local metrics
-//! observer, ANSI colour, throttled OTEL filters, service instance id, dual
-//! `AMARU_LOG` / `AMARU_TRACE` filters, and delayed filter warnings.
+//! decode to numbers and strings where the sink can hold them. Local console
+//! colour is selected with [`LogFormat`] (`Plain` / `Ansi` / `Json` — JSON is
+//! exclusive with colour). The product stack in `amaru::observability` still
+//! adds TUI capture, a local metrics observer, throttled OTEL filters, service
+//! instance id, dual `AMARU_LOG` / `AMARU_TRACE` filters, and delayed filter
+//! warnings.
 //!
 //! [`Telemetry::install`] and [`Telemetry::shutdown`] are `async` so they must
 //! be driven on a Tokio runtime (`rt.block_on(...)` or `.await` inside an async
@@ -60,6 +62,32 @@ use crate::{
 const DEFAULT_SERVICE_NAME: &str = "amaru";
 const DEFAULT_AMARU_TRACE: &str = "info";
 
+/// How the local tracing subscriber writes events.
+///
+/// JSON is exclusive with console colour: [`Self::Json`] emits NDJSON on stdout,
+/// while [`Self::Plain`] and [`Self::Ansi`] write compact human-readable lines
+/// on stderr.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LogFormat {
+    /// Compact console on stderr, no ANSI colour.
+    #[default]
+    Plain,
+    /// Compact console on stderr with ANSI colour.
+    Ansi,
+    /// JSON log lines on stdout (trace-contract / machine consumers).
+    Json,
+}
+
+impl LogFormat {
+    fn is_json(self) -> bool {
+        matches!(self, Self::Json)
+    }
+
+    fn ansi(self) -> bool {
+        matches!(self, Self::Ansi)
+    }
+}
+
 /// Active telemetry pipeline for an embedder process.
 pub struct Telemetry {
     pub meter: Arc<Meter>,
@@ -73,8 +101,8 @@ impl Telemetry {
     /// Environment:
     /// - `AMARU_WITH_OPEN_TELEMETRY` — when truthy (`1`/`true`/`yes`/`on`), export
     ///   metrics, traces, and logs via OTLP (see `OTEL_EXPORTER_OTLP_ENDPOINT`).
-    /// - `AMARU_WITH_JSON_TRACES` — when truthy, emit JSON log lines on stdout
-    ///   (used by trace-contract checks).
+    /// - `AMARU_WITH_JSON_TRACES` — when truthy, forces [`LogFormat::Json`]
+    ///   regardless of `format` (used by trace-contract checks).
     /// - `AMARU_TRACE` — filter for Amaru event targets (default `info`).
     /// - `RUST_LOG` — optional extra filter for non-schema logging.
     /// - `OTEL_SERVICE_NAME` — resource service name (default `amaru`).
@@ -83,23 +111,27 @@ impl Telemetry {
     /// layer only and a default empty [`Meter`].
     ///
     /// Must be polled on a Tokio runtime (OTLP batch exporters spawn on it).
-    pub async fn install() -> anyhow::Result<Self> {
+    pub async fn install(format: LogFormat) -> anyhow::Result<Self> {
         let with_otlp = env_flag("AMARU_WITH_OPEN_TELEMETRY");
-        let with_json = env_flag("AMARU_WITH_JSON_TRACES");
+        let format = if env_flag("AMARU_WITH_JSON_TRACES") { LogFormat::Json } else { format };
 
         // Yield once so this future is clearly runtime-bound; batch exporters
         // also require a current runtime handle when constructed below.
         tokio::task::yield_now().await;
 
-        if with_otlp { Self::install_otlp(with_json) } else { Self::install_local(with_json) }
+        if with_otlp { Self::install_otlp(format) } else { Self::install_local(format) }
     }
 
-    fn install_local(with_json: bool) -> anyhow::Result<Self> {
-        init_fmt_subscriber(with_json)?;
+    /// Install a local fmt / JSON subscriber without OTLP export.
+    ///
+    /// [`LogFormat::Ansi`] colours stderr; [`LogFormat::Json`] is exclusive with
+    /// colour and writes NDJSON to stdout.
+    pub fn install_local(format: LogFormat) -> anyhow::Result<Self> {
+        init_fmt_subscriber(format)?;
         Ok(Self { meter: Arc::new(Meter::default()), system_metrics: None, teardown: None })
     }
 
-    fn install_otlp(with_json: bool) -> anyhow::Result<Self> {
+    fn install_otlp(format: LogFormat) -> anyhow::Result<Self> {
         let resource = build_resource();
         let service_name = resource
             .get(&opentelemetry::Key::from_static_str(SERVICE_NAME))
@@ -142,7 +174,7 @@ impl Telemetry {
         let log_bridge = CborOtelLogBridge::new(&logs_provider).with_filter(amaru_trace_filter()?);
 
         let fmt_filter = rust_log_filter();
-        if with_json {
+        if format.is_json() {
             tracing_subscriber::registry()
                 .with(otel_layer)
                 .with(CborTraceArrayLayer::new())
@@ -156,7 +188,7 @@ impl Telemetry {
                 .with(otel_layer)
                 .with(CborTraceArrayLayer::new())
                 .with(log_bridge)
-                .with(console_fmt_layer(std::io::stderr).with_filter(fmt_filter))
+                .with(console_fmt_layer(std::io::stderr, format.ansi()).with_filter(fmt_filter))
                 .try_init()
                 .context("init OTLP+fmt tracing subscriber")?;
         }
@@ -206,9 +238,9 @@ impl Drop for Telemetry {
     }
 }
 
-fn init_fmt_subscriber(with_json: bool) -> anyhow::Result<()> {
+fn init_fmt_subscriber(format: LogFormat) -> anyhow::Result<()> {
     let filter = rust_log_filter();
-    if with_json {
+    if format.is_json() {
         tracing_subscriber::registry()
             .with(CborJsonSpanLayer::new())
             .with(json_fmt_layer(std::io::stdout).with_filter(filter))
@@ -216,7 +248,7 @@ fn init_fmt_subscriber(with_json: bool) -> anyhow::Result<()> {
             .map_err(|e| anyhow!("init JSON tracing subscriber: {e}"))?;
     } else {
         tracing_subscriber::registry()
-            .with(console_fmt_layer(std::io::stderr).with_filter(filter))
+            .with(console_fmt_layer(std::io::stderr, format.ansi()).with_filter(filter))
             .try_init()
             .map_err(|e| anyhow!("init fmt tracing subscriber: {e}"))?;
     }
@@ -225,16 +257,16 @@ fn init_fmt_subscriber(with_json: bool) -> anyhow::Result<()> {
 
 /// Console sink used by [`Telemetry::install`]: decode CBOR `record_bytes` to
 /// native visit types and hide schema tags (EDR-033).
-fn console_fmt_layer<S, W>(writer: W) -> impl Layer<S>
+fn console_fmt_layer<S, W>(writer: W, ansi: bool) -> impl Layer<S>
 where
     S: Subscriber + for<'lookup> LookupSpan<'lookup>,
     W: for<'writer> MakeWriter<'writer> + Send + Sync + 'static,
 {
     tracing_subscriber::fmt::layer()
         .with_writer(writer)
-        .with_ansi(false)
+        .with_ansi(ansi)
         .fmt_fields(console_field_formatter())
-        .event_format(CborConsoleEventFormat::new().with_ansi(false))
+        .event_format(CborConsoleEventFormat::new().with_ansi(ansi))
 }
 
 /// JSON sink used by [`Telemetry::install`]: CBOR scalars become JSON numbers /
@@ -372,7 +404,7 @@ mod tests {
     #[test]
     fn console_stack_decodes_cbor_schema_fields_to_primitives() {
         let writer = CaptureWriter::default();
-        let subscriber = tracing_subscriber::registry().with(console_fmt_layer(writer.clone()));
+        let subscriber = tracing_subscriber::registry().with(console_fmt_layer(writer.clone(), false));
 
         tracing::subscriber::with_default(subscriber, emit_tip_adopt);
 
@@ -388,5 +420,18 @@ mod tests {
             !output.contains(&format!(r#"header_hash="\"{hash}\"""#)),
             "header_hash must not be diagnostic-quoted then Debug-quoted: {output}"
         );
+        assert!(!output.contains('\u{1b}'), "plain console must not emit ANSI: {output}");
+    }
+
+    #[test]
+    fn console_stack_emits_ansi_when_enabled() {
+        let writer = CaptureWriter::default();
+        let subscriber = tracing_subscriber::registry().with(console_fmt_layer(writer.clone(), true));
+
+        tracing::subscriber::with_default(subscriber, emit_tip_adopt);
+
+        let output = writer.contents();
+        assert!(output.contains('\u{1b}'), "ANSI console must emit SGR escapes: {output}");
+        assert!(output.contains(&SLOT.to_string()), "CBOR Slot must still print as a number: {output}");
     }
 }


### PR DESCRIPTION
disclaimer: I am not a designer, my color choices are terrible by definition


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable telemetry output formats: plain text, ANSI-colored logs, or JSON.
  * Added local telemetry support with ANSI-colored console output for improved readability.
  * JSON logging remains available for structured output and does not include color formatting.
* **Documentation**
  * Updated the unreleased changelog to document the new telemetry formatting options.
* **Examples**
  * Updated included examples to demonstrate plain and ANSI-colored telemetry output.
  * Improved address monitoring reports with colored output and signed balance changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->