### PR TITLE
Fix the Min UTxO Value Calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Other guiding principles:
 
 ## v10.11.20260827 _[unreleased; planned for 2026-08-27]_
 
+### Fixed
+
+- **amaru-ledger**: Correctly calculate an output's minimum lovelace value.
+
 ## [v10.11.20260820](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260820)
 
 ### Added

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/outputs/inherent_value.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/outputs/inherent_value.rs
@@ -16,12 +16,17 @@ use amaru_kernel::{HasLovelace, MemoizedTransactionOutput, ProtocolParameters, c
 
 use super::InvalidOutput;
 
+/// Constant charged on top of the serialized output size, approximating the in-memory overhead
+/// of the corresponding transaction input and UTxO map entry.
+const UTXO_ENTRY_OVERHEAD: u64 = 160;
+
 pub fn execute(
     protocol_parameters: &ProtocolParameters,
     output: &MemoizedTransactionOutput,
 ) -> Result<(), InvalidOutput> {
     // This conversion is safe with no loss of information
-    let minimum_value = output.original_size() as u64 * protocol_parameters.lovelace_per_utxo_byte;
+    let minimum_value =
+        (UTXO_ENTRY_OVERHEAD + output.original_size() as u64) * protocol_parameters.lovelace_per_utxo_byte;
     let given_value = output.lovelace();
 
     if given_value < minimum_value {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00254-fail-output-one-lovelace-below-the-minimum.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00254-fail-output-one-lovelace-below-the-minimum.json
@@ -1,0 +1,27 @@
+{
+  "title": "output one lovelace below the minimum",
+  "description": "A simple transfer producing one 39-byte output holding 857,689 lovelace, one below the minimum at the default 4,310-lovelace-per-byte coefficient.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "82582019a4645f9b82992ca33be19011a1e0b9f0a66d56ab4317cd349d9689f0ab968b00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00102399"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a400d901028182582019a4645f9b82992ca33be19011a1e0b9f0a66d56ab4317cd349d9689f0ab968b000181a200581d60c3f9920656fdbfe2842e2c5671e0a2b0c1c84c497d42879de5376d7b011a000d1659021a00030d400f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840c92d4c6eb3abe7f755b9831cccf049f09f133611945b74a793871d52f22ec055f7139108d78d583e8b6dde49f0ffe1eba6e2761322b316c5ea75a8e540a47c08f5f6",
+  "expected": {
+    "predicate": "BabbageOutputTooSmallUTxO"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00255-pass-output-holding-exactly-the-minimum-lovelace.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00255-pass-output-holding-exactly-the-minimum-lovelace.json
@@ -1,0 +1,25 @@
+{
+  "title": "output holding exactly the minimum lovelace",
+  "description": "A simple transfer producing one 39-byte output holding 857,690 lovelace, the exact minimum at the default 4,310-lovelace-per-byte coefficient.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820b308d3cd60d01a5531eadaddc1e0667eff9907b88038ca87503eff343b18f30b00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a0010239a"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a400d9010281825820b308d3cd60d01a5531eadaddc1e0667eff9907b88038ca87503eff343b18f30b000181a200581d60c3f9920656fdbfe2842e2c5671e0a2b0c1c84c497d42879de5376d7b011a000d165a021a00030d400f00a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258401b20b93436485eb654e038a67a9c757f44a66fbeb6f2b8477376c9f52c6cd910561f5b20487238a43c4f925fee72903685bcb23713a5d9532cd4b2f667b0b309f5f6",
+  "expected": "Pass"
+}


### PR DESCRIPTION
Our min UTxO value calculation was incorrectly missing the constant of `160` that is added to the size of the UTxO. This was not caught anywhere since fixture 49 set `coins_per_utxo_byte` to 100 billion.

This PR fixes the problem, and adds tests around the boundary. It's worth noting, that if the value of `coins_per_utxo_byte` changes, the tests will have to change as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected minimum lovelace calculation for ledger outputs by accounting for the fixed UTxO entry overhead.
  * Outputs containing exactly the required minimum lovelace are now accepted.
  * Outputs one lovelace below the minimum are correctly rejected.

* **Tests**
  * Added coverage for both boundary cases to verify minimum-value output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->