### PR TITLE
Fix Disjoint Inputs Check(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,6 @@ Other guiding principles:
 - **amaru-ledger**: do not re-encode locally submitted transactions to obtain their size.
 - **amaru-protocols**: preserve bytes of transactions flowing through the mempool.
 - **amaru-tui**: tweak block dissemination metrics headers (fetch → select, sync → fetch)
-
-### Fixed
-
 - **amaru-ledger**: Do not validate disjoint input sets in protocol version 11+. Similarly, do not allow non-disjoin input sets in PV3, regardless of protocol version.
 
 ## [v10.11.20260820](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260820)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ Other guiding principles:
 - **amaru-protocols**: preserve bytes of transactions flowing through the mempool.
 - **amaru-tui**: tweak block dissemination metrics headers (fetch → select, sync → fetch)
 
+### Fixed
+
+- **amaru-ledger**: Do not validate disjoint input sets in protocol version 11+. Similarly, do not allow non-disjoin input sets in PV3, regardless of protocol version.
+
 ## [v10.11.20260820](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260820)
 
 ### Added

--- a/crates/amaru-ledger/src/rules/transaction/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/fixture.rs
@@ -340,7 +340,8 @@ impl From<PhaseTwoError> for Predicate {
             | PhaseTwoError::ScriptContextStateError(_)
             | PhaseTwoError::ScriptDeserializationError(_)
             | PhaseTwoError::FlatDecodingError(_)
-            | PhaseTwoError::MissingCostModel(_) => unreachable!("no predicate mapping yet for {err}"),
+            | PhaseTwoError::MissingCostModel(_)
+            | PhaseTwoError::NonDisjointRefInputs { .. } => unreachable!("no predicate mapping yet for {err}"),
         }
     }
 }

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/inputs.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/inputs.rs
@@ -14,7 +14,7 @@
 
 use amaru_kernel::{
     Address, HasScriptHash, MemoizedDatum, ProtocolParameters, RedeemerTag, RequiredScript, Set, TransactionInput,
-    address::byron::AddressType, utils::string::display_collection,
+    address::byron::AddressType, protocol_version::PROTOCOL_VERSION_11, utils::string::display_collection,
 };
 use thiserror::Error;
 
@@ -53,7 +53,7 @@ where
 
     let mut intersection = Vec::new();
     let mut ref_scripts_size: u64 = 0;
-    let check_disjoint_reference_inputs = protocol_parameters.protocol_version.major() < 11;
+    let check_disjoint_reference_inputs = protocol_parameters.protocol_version < PROTOCOL_VERSION_11;
 
     if let Some(reference_inputs) = reference_inputs {
         for reference_input in reference_inputs {
@@ -122,7 +122,10 @@ where
         }
 
         if let Some((script_hash, script_size)) = script_ref {
-            if !reference_inputs.is_some_and(|reference_inputs| reference_inputs.contains(input)) {
+            // Sizes are summed over the union of inputs and reference inputs; an input present
+            // in both, allowed in pv11+, was already counted above.
+            let already_counted = reference_inputs.is_some_and(|reference_inputs| reference_inputs.contains(input));
+            if !already_counted {
                 ref_scripts_size += script_size;
             }
             context.acknowledge_script(script_hash, *input);

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/inputs.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/inputs.rs
@@ -53,11 +53,11 @@ where
 
     let mut intersection = Vec::new();
     let mut ref_scripts_size: u64 = 0;
+    let check_disjoint_reference_inputs = protocol_parameters.protocol_version.major() < 11;
 
     if let Some(reference_inputs) = reference_inputs {
         for reference_input in reference_inputs {
-            // Non-disjoint reference inputs
-            if inputs.contains(reference_input) {
+            if check_disjoint_reference_inputs && inputs.contains(reference_input) {
                 intersection.push(*reference_input);
                 continue;
             }
@@ -122,7 +122,9 @@ where
         }
 
         if let Some((script_hash, script_size)) = script_ref {
-            ref_scripts_size += script_size;
+            if !reference_inputs.is_some_and(|reference_inputs| reference_inputs.contains(input)) {
+                ref_scripts_size += script_size;
+            }
             context.acknowledge_script(script_hash, *input);
         }
 

--- a/crates/amaru-ledger/src/rules/transaction/phase_two/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_two/mod.rs
@@ -17,7 +17,8 @@ use std::{collections::BTreeMap, fmt, time::Instant};
 use amaru_kernel::{
     BorrowedScript, EraHistory, GlobalParameters, HasTransactionId, PlutusVersion, ProtocolParameters, RedeemerKey,
     TransactionBody, TransactionInput, TransactionPointer, TxInfo, TxInfoTranslationError, Utxos, WitnessSet, cbor,
-    to_cbor, utils::duration::elapsed_and_reset,
+    to_cbor,
+    utils::{duration::elapsed_and_reset, string::display_collection},
 };
 use amaru_observability::debug_span;
 use amaru_plutus::{
@@ -57,6 +58,11 @@ pub enum PhaseTwoError {
     ValidityStateError,
     #[error("missing cost models for version = {0:?}")]
     MissingCostModel(PlutusVersion),
+    #[error(
+        "inputs included in both reference inputs and spent inputs: intersection [{}]",
+        display_collection(.intersection),
+    )]
+    NonDisjointRefInputs { intersection: Vec<TransactionInput> },
 }
 
 #[derive(Debug)]
@@ -136,6 +142,14 @@ where
     )?;
 
     let scripts_to_execute = tx_info.to_script_contexts();
+    let non_disjoint_inputs = transaction_body
+        .reference_inputs
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .filter(|input| transaction_body.inputs.contains(input))
+        .copied()
+        .collect::<Vec<_>>();
 
     span.record(PHASE_TWO::FIELD_SCRIPT_CONTEXT_MICROS, elapsed_and_reset(&mut meter));
 
@@ -194,6 +208,10 @@ where
                     Ok::<_, PhaseTwoError>((program, plutus_version, args, cost_model))
                 }
                 BorrowedScript::PlutusV3(plutus_script) => {
+                    if !non_disjoint_inputs.is_empty() {
+                        return Err(PhaseTwoError::NonDisjointRefInputs { intersection: non_disjoint_inputs.clone() });
+                    }
+
                     let (program, plutus_version) =
                         decode_plutus_script(plutus_script, protocol_parameters.protocol_version, &arena)
                             .map_err(PhaseTwoError::from)?;

--- a/crates/amaru-ledger/src/rules/transaction/phase_two/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_two/mod.rs
@@ -142,14 +142,21 @@ where
     )?;
 
     let scripts_to_execute = tx_info.to_script_contexts();
-    let non_disjoint_inputs = transaction_body
-        .reference_inputs
-        .as_deref()
-        .unwrap_or_default()
-        .iter()
-        .filter(|input| transaction_body.inputs.contains(input))
-        .copied()
-        .collect::<Vec<_>>();
+
+    if scripts_to_execute.iter().any(|(_, _, script)| matches!(script, BorrowedScript::PlutusV3(_))) {
+        let non_disjoint_inputs = transaction_body
+            .reference_inputs
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .filter(|input| transaction_body.inputs.contains(input))
+            .copied()
+            .collect::<Vec<_>>();
+
+        if !non_disjoint_inputs.is_empty() {
+            return Err(PhaseTwoError::NonDisjointRefInputs { intersection: non_disjoint_inputs });
+        }
+    }
 
     span.record(PHASE_TWO::FIELD_SCRIPT_CONTEXT_MICROS, elapsed_and_reset(&mut meter));
 
@@ -208,10 +215,6 @@ where
                     Ok::<_, PhaseTwoError>((program, plutus_version, args, cost_model))
                 }
                 BorrowedScript::PlutusV3(plutus_script) => {
-                    if !non_disjoint_inputs.is_empty() {
-                        return Err(PhaseTwoError::NonDisjointRefInputs { intersection: non_disjoint_inputs.clone() });
-                    }
-
                     let (program, plutus_version) =
                         decode_plutus_script(plutus_script, protocol_parameters.protocol_version, &arena)
                             .map_err(PhaseTwoError::from)?;

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00247-pass-input-appears-as-both-spent-and-reference-v11.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00247-pass-input-appears-as-both-spent-and-reference-v11.json
@@ -1,0 +1,37 @@
+{
+  "title": "input appears as both spent and reference v11",
+  "description": "A protocol version 11 transaction includes the same input in both the spent inputs and the reference inputs.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json",
+    "$override": {
+      "version": {
+        "major": 11,
+        "minor": 0
+      }
+    }
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820827273a8722791f640b59ba20ba9340cb0398535b36e1957ed8e8dde693976d500",
+        "output": "bf00581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40ff"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a500d9010281825820827273a8722791f640b59ba20ba9340cb0398535b36e1957ed8e8dde693976d5000181bf00581d60a1c146c212acfe02048afbf8d2e5e9c806165934d9935c696f85c3dc011a00493e00ff021a00030d400f0012d9010281825820827273a8722791f640b59ba20ba9340cb0398535b36e1957ed8e8dde693976d500a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258400ff6be39c7b5de18a5c521e1658c73f600192efe2f186de55a51a1d5623a8bb7aa83e3beb4c821feae6d56f08afc22a594247ae0ccff4aa00bdd248322b60f0ff5f6",
+  "expected": "Pass"
+}


### PR DESCRIPTION
In pv11+, the reference inputs and the inputs do *not* need to be disjoint sets. That being said, script executions in PlutusV3 must have disjoint sets regardless of the protocol version.

This PR fixes that behavior, and adds a test for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transactions on protocol version 11 and later can reuse an input as both spent and referenced.
  * Reference-script sizes now count unique inputs correctly.
  * Telemetry metrics can be configured, with updated metric headers in the TUI.

* **Bug Fixes**
  * Overlapping inputs are rejected when Plutus V3 scripts are used.
  * Improved consensus and protocol logging.
  * Added chain-store hash validation and preserved transaction bytes.
  * Updated ledger validation and transaction scenario coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->