### PR TITLE
fix(amaru-protocols): preserve bytes of transactions flowing through the mempool.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Other guiding principles:
 - **workflows**: executable permissions are now correctly preserved in the release workflow.
 - **amaru-ledger**: Correctly calculate an output's minimum lovelace value.
 - **amaru-ledger**: do not re-encode locally submitted transactions to obtain their size.
+- **amaru-protocols**: preserve bytes of transactions flowing through the mempool.
 
 ## [v10.11.20260820](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260820)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ dependencies = [
  "minicbor",
  "num",
  "num-bigint",
+ "proptest",
  "serde",
  "tracing",
 ]

--- a/crates/amaru-consensus/src/stages/mempool/stage.rs
+++ b/crates/amaru-consensus/src/stages/mempool/stage.rs
@@ -14,7 +14,7 @@
 
 use std::time::Instant;
 
-use amaru_kernel::{Point, Transaction};
+use amaru_kernel::{Point, Transaction, cbor::WithOriginalBytes};
 use amaru_ouroboros::{MempoolMsg, MempoolSeqNo, TxInsertResult, TxOrigin, TxRejectReason};
 use amaru_protocols::{mempool_effects::MemoryPool, store_effects::Store};
 use amaru_pure_stage::{Effects, StageRef};
@@ -112,7 +112,7 @@ pub async fn stage(state: MempoolStageState, msg: MempoolMsg, eff: Effects<Mempo
 async fn validate_and_insert(
     ledger: &Ledger,
     memory_pool: &MemoryPool,
-    tx: Transaction,
+    tx: WithOriginalBytes<Transaction>,
     origin: &TxOrigin,
 ) -> TxInsertResult {
     match ledger.validate_tx(&tx).await {

--- a/crates/amaru-consensus/src/stages/mempool/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/mempool/test_setup.rs
@@ -14,7 +14,8 @@
 
 use amaru_kernel::{
     Hash, PREPROD_ERA_HISTORY, PREPROD_GLOBAL_PARAMETERS, Transaction, TransactionBody, TransactionInput, WitnessSet,
-    cbor::WithSize, size::TRANSACTION_BODY,
+    cbor::{WithOriginalBytes, WithSize},
+    size::TRANSACTION_BODY,
 };
 use amaru_metrics::{MetricsEvent, mempool::MempoolMetrics};
 use amaru_ouroboros::{MempoolMsg, ResourceMempool, TxInsertResult, TxOrigin};
@@ -48,7 +49,7 @@ pub struct TestPrep {
 
 #[derive(serde::Serialize)]
 struct InsertEffectPayload {
-    tx: Transaction,
+    tx: WithOriginalBytes<Transaction>,
     tx_origin: TxOrigin,
 }
 
@@ -102,7 +103,7 @@ pub fn te_validate_tx(at_stage: &str, tx: &Transaction) -> TraceEntry {
     TraceEntry::suspend(Effect::external(at_stage, Box::new(ValidateTxEffect::new(tx))))
 }
 
-pub fn te_insert(at_stage: &str, tx: &Transaction, tx_origin: TxOrigin) -> TraceEntry {
+pub fn te_insert(at_stage: &str, tx: &WithOriginalBytes<Transaction>, tx_origin: TxOrigin) -> TraceEntry {
     let payload = InsertEffectPayload { tx: tx.clone(), tx_origin };
     let value = SendDataValue::from_json("payload", &payload).cast::<SendDataValue>().unwrap().value;
     let effect: Box<dyn ExternalEffect> = Box::new(UnknownExternalEffect::new(SendDataValue {
@@ -132,7 +133,7 @@ pub fn te_record_metrics(at_stage: &str, metrics: MempoolMetrics) -> TraceEntry 
     ))
 }
 
-pub fn create_transaction(input_index: usize) -> Transaction {
+pub fn create_transaction(input_index: usize) -> WithOriginalBytes<Transaction> {
     let tx_input = TransactionInput { transaction_id: Hash::new([1; TRANSACTION_BODY]), index: input_index as u64 };
     let body = TransactionBody::new([tx_input], [], 0);
     Transaction {
@@ -141,4 +142,5 @@ pub fn create_transaction(input_index: usize) -> Transaction {
         is_expected_valid: true,
         auxiliary_data: None,
     }
+    .into()
 }

--- a/crates/amaru-consensus/src/stages/mempool/tests.rs
+++ b/crates/amaru-consensus/src/stages/mempool/tests.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use amaru_kernel::{Transaction, to_cbor};
+use amaru_kernel::{Transaction, cbor::WithOriginalBytes, to_cbor};
 use amaru_mempool::InMemoryMempool;
 use amaru_metrics::mempool::{MempoolMetricEvent, MempoolMetrics, TxInsertionOrigin, TxInsertionResult};
 use amaru_ouroboros::{
@@ -80,7 +80,7 @@ fn new_tip_invalidates_transactions_against_current_ledger_state() {
     let tx_0 = create_transaction(0);
     let tx_1 = create_transaction(1);
     let tx_2 = create_transaction(2);
-    let mempool = Arc::new(InMemoryMempool::<Transaction>::default());
+    let mempool = Arc::new(InMemoryMempool::<WithOriginalBytes<Transaction>>::default());
     mempool.insert(tx_0.clone(), TxOrigin::Local);
     mempool.insert(tx_1.clone(), TxOrigin::Local);
     mempool.insert(tx_2.clone(), TxOrigin::Local);
@@ -111,14 +111,15 @@ fn new_tip_reports_transactions_included_in_the_adopted_block() {
 
     // The mempool holds the transaction carried by the adopted block (identified by its body
     // alone) and an unrelated one, both invalidated by the new tip.
-    let included_tx = Transaction {
+    let included_tx: WithOriginalBytes<Transaction> = Transaction {
         body: block.transaction_bodies[0].clone(),
         witnesses: Default::default(),
         is_expected_valid: true,
         auxiliary_data: None,
-    };
+    }
+    .into();
     let evicted_tx = create_transaction(0);
-    let mempool = Arc::new(InMemoryMempool::<Transaction>::default());
+    let mempool = Arc::new(InMemoryMempool::<WithOriginalBytes<Transaction>>::default());
     mempool.insert(included_tx.clone(), TxOrigin::Local);
     mempool.insert(evicted_tx.clone(), TxOrigin::Local);
 
@@ -150,7 +151,7 @@ pub fn make_insert_batch_example() -> TestPrep {
     TestPrep {
         msg: MempoolMsg::InsertBatch { txs, origin: TxOrigin::Local, caller },
         rt: crate::stages::test_utils::test_runtime(),
-        mempool: Arc::new(InMemoryMempool::<Transaction>::default()),
+        mempool: Arc::new(InMemoryMempool::<WithOriginalBytes<Transaction>>::default()),
         validator: Arc::new(reject_tx_1),
         chain_store: Arc::new(InMemoryChainStore::default()),
     }
@@ -173,7 +174,7 @@ fn insertion_metric(state: MempoolState, result: TxInsertionResult) -> MempoolMe
     }
 }
 
-fn expected_results(txs: &[Transaction]) -> Vec<TxInsertResult> {
+fn expected_results(txs: &[WithOriginalBytes<Transaction>]) -> Vec<TxInsertResult> {
     vec![
         TxInsertResult::accepted(txs[0].tx_id(), MempoolSeqNo(1)),
         TxInsertResult::rejected(

--- a/crates/amaru-kernel/src/lib.rs
+++ b/crates/amaru-kernel/src/lib.rs
@@ -50,10 +50,11 @@ pub use data_structures::{
 
 pub mod cbor {
     pub use amaru_minicbor_extra::{
-        TAG_MAP_259, TAG_SET_258, WithSize, allow_tag, check_tagged_array_length, collect_array_item_bytes,
-        collect_map_value_bytes, count_bytes, decode_break, decode_bytes, decode_string, encode_variable_length_map,
-        expect_tag, from_cbor, from_cbor_no_leftovers, from_cbor_no_leftovers_with, heterogeneous_array,
-        heterogeneous_map, heterogeneous_map_with, lazy, missing_field, tee, to_cbor, to_cbor_with, unexpected_field,
+        TAG_MAP_259, TAG_SET_258, WithOriginalBytes, WithSize, allow_tag, check_tagged_array_length,
+        collect_array_item_bytes, collect_map_value_bytes, count_bytes, decode_break, decode_bytes, decode_string,
+        encode_variable_length_map, expect_tag, from_cbor, from_cbor_no_leftovers, from_cbor_no_leftovers_with,
+        heterogeneous_array, heterogeneous_map, heterogeneous_map_with, lazy, missing_field, tee, to_cbor,
+        to_cbor_with, unexpected_field,
     };
     pub use minicbor::{
         CborLen, Decode, Decoder, Encode, Encoder, bytes,

--- a/crates/amaru-kernel/src/traits/has_transaction_id.rs
+++ b/crates/amaru-kernel/src/traits/has_transaction_id.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{Transaction, TransactionBody, TransactionId};
+use std::ops::Deref;
+
+use crate::{Transaction, TransactionBody, TransactionId, cbor::WithOriginalBytes};
 
 pub trait HasTransactionId {
     fn tx_id(&self) -> TransactionId;
@@ -21,6 +23,12 @@ pub trait HasTransactionId {
 impl HasTransactionId for Transaction {
     fn tx_id(&self) -> TransactionId {
         self.tx_id()
+    }
+}
+
+impl<T: HasTransactionId> HasTransactionId for WithOriginalBytes<T> {
+    fn tx_id(&self) -> TransactionId {
+        self.deref().tx_id()
     }
 }
 

--- a/crates/amaru-minicbor-extra/Cargo.toml
+++ b/crates/amaru-minicbor-extra/Cargo.toml
@@ -28,6 +28,7 @@ tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 hex.workspace = true
+proptest.workspace = true
 
 [target.'cfg(all(not(target_family="wasm"), not(target_arch="riscv32")))'.dependencies]
 amaru-deps.workspace = true

--- a/crates/amaru-minicbor-extra/src/decode.rs
+++ b/crates/amaru-minicbor-extra/src/decode.rs
@@ -28,6 +28,9 @@ pub mod lazy;
 mod with_size;
 pub use with_size::*;
 
+mod with_original_bytes;
+pub use with_original_bytes::*;
+
 /// Decode an arbitrary-precision integer, accepting both CBOR native integers and the tagged
 /// bignum forms (tag 2 for positive, tag 3 for negative).
 pub fn decode_bigint(d: &mut cbor::Decoder<'_>) -> Result<BigInt, decode::Error> {

--- a/crates/amaru-minicbor-extra/src/decode/with_original_bytes.rs
+++ b/crates/amaru-minicbor-extra/src/decode/with_original_bytes.rs
@@ -1,0 +1,132 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Deref;
+
+use crate::{cbor, tee, to_cbor};
+
+/// Decode an element and retain its original bytes.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, serde::Deserialize, serde::Serialize)]
+pub struct WithOriginalBytes<A> {
+    value: A,
+    bytes: Vec<u8>,
+}
+
+impl<A: Default + cbor::encode::Encode<()>> Default for WithOriginalBytes<A> {
+    fn default() -> Self {
+        Self::new(A::default())
+    }
+}
+
+impl<A> WithOriginalBytes<A> {
+    /// Returns `true` if the len is null.
+    pub fn new(value: A) -> Self
+    where
+        A: cbor::encode::Encode<()>,
+    {
+        Self { bytes: to_cbor(&value), value }
+    }
+
+    /// Returns `true` if the len is null.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the original serialised length for this element.
+    pub fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    /// Consume the `WithOriginalBytes` wrapper to get back the element.
+    pub fn into_inner(self) -> A {
+        self.value
+    }
+}
+
+impl<A: cbor::encode::Encode<()>> From<A> for WithOriginalBytes<A> {
+    fn from(value: A) -> Self {
+        Self::new(value)
+    }
+}
+
+impl<A> Deref for WithOriginalBytes<A> {
+    type Target = A;
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<'d, A: cbor::decode::Decode<'d, C>, C> cbor::decode::Decode<'d, C> for WithOriginalBytes<A> {
+    fn decode(d: &mut cbor::Decoder<'d>, ctx: &mut C) -> Result<Self, cbor::decode::Error> {
+        let (value, bytes) = tee(d, |d| d.decode_with(ctx))?;
+        Ok(WithOriginalBytes { bytes: bytes.to_vec(), value })
+    }
+}
+
+impl<A: cbor::encode::Encode<C>, C> cbor::encode::Encode<C> for WithOriginalBytes<A> {
+    fn encode<W: cbor::encode::Write>(
+        &self,
+        e: &mut cbor::Encoder<W>,
+        _ctx: &mut C,
+    ) -> Result<(), cbor::encode::Error<W::Error>> {
+        e.writer_mut().write_all(&self.bytes).map_err(cbor::encode::Error::write)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::WithOriginalBytes;
+    use crate::{from_cbor_no_leftovers, to_cbor};
+
+    #[test]
+    fn preserves_original_cbor_encoding() {
+        // 1 fits in the CBOR header byte, so re-encoding would shrink these two bytes to one.
+        let original = [0x18, 0x01];
+        let value: WithOriginalBytes<u64> = from_cbor_no_leftovers(&original).expect("decode original CBOR");
+        assert_eq!(*value, 1);
+        assert_eq!(to_cbor(&value), original);
+    }
+
+    proptest! {
+        #[test]
+        fn preserves_fixed_width_integer_encodings(n in any::<u64>()) {
+            for original in fixed_width_encodings(n) {
+                let value: WithOriginalBytes<u64> =
+                    from_cbor_no_leftovers(&original).expect("decode fixed-width CBOR");
+                prop_assert_eq!(*value, n);
+                prop_assert_eq!(to_cbor(&value), original);
+            }
+        }
+    }
+
+    /// Every fixed-width CBOR encoding of `n`, widest first. All but the last one are wider than
+    /// necessary, so an implementation that re-encodes instead of replaying the original bytes
+    /// produces something shorter.
+    fn fixed_width_encodings(n: u64) -> Vec<Vec<u8>> {
+        let mut encodings = vec![[&[0x1b][..], &n.to_be_bytes()[..]].concat()];
+        if let Ok(n) = u32::try_from(n) {
+            encodings.push([&[0x1a][..], &n.to_be_bytes()[..]].concat());
+        }
+        if let Ok(n) = u16::try_from(n) {
+            encodings.push([&[0x19][..], &n.to_be_bytes()[..]].concat());
+        }
+        if let Ok(n) = u8::try_from(n) {
+            encodings.push([&[0x18][..], &n.to_be_bytes()[..]].concat());
+        }
+        encodings
+    }
+}

--- a/crates/amaru-node/src/submit_api.rs
+++ b/crates/amaru-node/src/submit_api.rs
@@ -14,7 +14,7 @@
 
 use std::net::SocketAddr;
 
-use amaru_kernel::Transaction;
+use amaru_kernel::{Transaction, cbor::WithOriginalBytes};
 use amaru_ouroboros::{MempoolMsg, TxInsertResult, TxOrigin, TxRejectReason};
 use amaru_protocols::tx_submission::DEFAULT_MEMPOOL_INSERT_TIMEOUT;
 use amaru_pure_stage::{CallError, Sender};
@@ -74,7 +74,7 @@ async fn submit_tx(State(mempool_sender): State<SubmitApiState>, headers: Header
         return text_response(StatusCode::UNSUPPORTED_MEDIA_TYPE, "Content-Type must be application/cbor");
     }
 
-    let tx: Transaction = match minicbor::decode(&body) {
+    let tx: WithOriginalBytes<Transaction> = match minicbor::decode(&body) {
         Ok(tx) => tx,
         Err(e) => {
             return text_response(StatusCode::BAD_REQUEST, format!("Invalid CBOR transaction: {e}"));
@@ -129,7 +129,7 @@ mod tests {
         effects::{ResourceBlockValidation, ResourceEraHistory, ResourceTxValidation},
         stages::mempool::MempoolStageState,
     };
-    use amaru_kernel::{RawBlock, Transaction, to_cbor};
+    use amaru_kernel::{RawBlock, Transaction, cbor::WithOriginalBytes, to_cbor};
     use amaru_mempool::{InMemoryMempool, MempoolConfig};
     use amaru_ouroboros::{MempoolMsg, ResourceMempool};
     use amaru_ouroboros_traits::{
@@ -187,6 +187,28 @@ mod tests {
         Ok(())
     }
 
+    /// The bytes a client submits must reach the mempool untouched, so that what we later relay is
+    /// byte-identical to what was submitted rather than to our own re-encoding of it.
+    #[tokio::test]
+    async fn test_submission_preserves_original_transaction_bytes() -> anyhow::Result<()> {
+        let mempool: Arc<dyn TxSubmissionMempool<WithOriginalBytes<Transaction>>> =
+            Arc::new(InMemoryMempool::<WithOriginalBytes<Transaction>>::default());
+        let (addr, _shutdown) = start_test_server_with_mempool(mempool.clone()).await?;
+
+        let tx = create_transaction(0);
+        let expected_tx_id = tx.tx_id();
+        let body = non_canonical_transaction_cbor(&tx);
+
+        let resp = submit_tx(addr, body.clone()).await?;
+        assert_eq!(resp.status(), 202);
+        assert_eq!(resp.headers()[CONTENT_TYPE], "application/json");
+        assert_eq!(resp.text().await?, format!("\"{expected_tx_id}\""));
+
+        let stored = mempool.get_tx(&expected_tx_id).expect("the submitted transaction in the mempool");
+        assert_eq!(to_cbor(&stored), body);
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_invalid_cbor() -> anyhow::Result<()> {
         let (addr, _shutdown) = start_test_server().await?;
@@ -221,8 +243,10 @@ mod tests {
         let second = create_transaction(1);
 
         let max_bytes = to_cbor(&first).len() as u64;
-        let mempool: Arc<dyn TxSubmissionMempool<Transaction>> =
-            Arc::new(InMemoryMempool::<Transaction>::new(MempoolConfig::default().with_max_bytes(max_bytes)));
+        let mempool: Arc<dyn TxSubmissionMempool<WithOriginalBytes<Transaction>>> =
+            Arc::new(InMemoryMempool::<WithOriginalBytes<Transaction>>::new(
+                MempoolConfig::default().with_max_bytes(max_bytes),
+            ));
         let (addr, _shutdown) = start_test_server_with_mempool(mempool).await?;
 
         let resp = submit_tx(addr, amaru_kernel::to_cbor(&first)).await?;
@@ -236,7 +260,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_validation_failure() -> anyhow::Result<()> {
-        let mempool: Arc<dyn amaru_ouroboros_traits::TxSubmissionMempool<Transaction>> =
+        let mempool: Arc<dyn amaru_ouroboros_traits::TxSubmissionMempool<WithOriginalBytes<Transaction>>> =
             Arc::new(InMemoryMempool::new(Default::default()));
         let (addr, _shutdown) =
             start_test_server_with_mempool_and_validator(mempool, Arc::new(reject_transactions)).await?;
@@ -251,7 +275,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_mempool_unavailable() -> anyhow::Result<()> {
-        let mempool: Arc<dyn TxSubmissionMempool<Transaction>> = Arc::new(InMemoryMempool::<Transaction>::default());
+        let mempool: Arc<dyn TxSubmissionMempool<WithOriginalBytes<Transaction>>> =
+            Arc::new(InMemoryMempool::<WithOriginalBytes<Transaction>>::default());
         let (sender, running) = make_mempool_sender_and_running(mempool, Arc::new(MockCanValidateTxs));
         running.abort();
 
@@ -299,19 +324,28 @@ mod tests {
 
     // HELPERS
 
+    /// Re-encode a transaction's outer array header with a redundant one-byte length: still valid
+    /// CBOR, but no longer byte-identical to what our encoder produces.
+    fn non_canonical_transaction_cbor(tx: &WithOriginalBytes<Transaction>) -> Vec<u8> {
+        let canonical = to_cbor(tx);
+        assert_eq!(canonical[0], 0x84, "expected a definite-length array of 4 elements");
+        [&[0x98, 0x04][..], &canonical[1..]].concat()
+    }
+
     async fn start_test_server() -> anyhow::Result<(SocketAddr, CancellationToken)> {
-        let mempool: Arc<dyn TxSubmissionMempool<Transaction>> = Arc::new(InMemoryMempool::<Transaction>::default());
+        let mempool: Arc<dyn TxSubmissionMempool<WithOriginalBytes<Transaction>>> =
+            Arc::new(InMemoryMempool::<WithOriginalBytes<Transaction>>::default());
         start_test_server_with_mempool(mempool).await
     }
 
     async fn start_test_server_with_mempool(
-        mempool: Arc<dyn TxSubmissionMempool<Transaction>>,
+        mempool: Arc<dyn TxSubmissionMempool<WithOriginalBytes<Transaction>>>,
     ) -> anyhow::Result<(SocketAddr, CancellationToken)> {
         start_test_server_with_mempool_and_validator(mempool, Arc::new(MockCanValidateTxs)).await
     }
 
     async fn start_test_server_with_mempool_and_validator(
-        mempool: Arc<dyn TxSubmissionMempool<Transaction>>,
+        mempool: Arc<dyn TxSubmissionMempool<WithOriginalBytes<Transaction>>>,
         validator: ResourceTxValidation,
     ) -> anyhow::Result<(SocketAddr, CancellationToken)> {
         let sender = make_mempool_sender(mempool, validator);
@@ -322,14 +356,14 @@ mod tests {
     }
 
     fn make_mempool_sender(
-        mempool: Arc<dyn TxSubmissionMempool<Transaction>>,
+        mempool: Arc<dyn TxSubmissionMempool<WithOriginalBytes<Transaction>>>,
         validator: ResourceTxValidation,
     ) -> Sender<MempoolMsg> {
         make_mempool_sender_and_running(mempool, validator).0
     }
 
     fn make_mempool_sender_and_running(
-        mempool: Arc<dyn TxSubmissionMempool<Transaction>>,
+        mempool: Arc<dyn TxSubmissionMempool<WithOriginalBytes<Transaction>>>,
         validator: ResourceTxValidation,
     ) -> (Sender<MempoolMsg>, TokioRunning) {
         use amaru_consensus::stages::mempool;

--- a/crates/amaru-node/src/tests/configuration.rs
+++ b/crates/amaru-node/src/tests/configuration.rs
@@ -21,6 +21,7 @@ use std::{
 use amaru_kernel::{
     Anchor, Constitution, Epoch, EraHistory, Header, IsHeader, MaxString128, NetworkName, Peer, Point,
     ProtocolParameters, Transaction, TransactionId, cardano::network_block::make_encoded_block,
+    cbor::WithOriginalBytes,
 };
 use amaru_ledger::{
     epoch_transition::GovernanceActivity,
@@ -54,7 +55,7 @@ use crate::{
 #[derive(Clone)]
 pub struct NodeTestConfig {
     pub chain_store: Arc<InMemoryChainStore>,
-    pub mempool: Arc<InMemoryMempool<Transaction>>,
+    pub mempool: Arc<InMemoryMempool<WithOriginalBytes<Transaction>>>,
     pub connections: ConnectionsResource,
     pub chain_length: usize,
     pub upstream_peers: Vec<Peer>,
@@ -165,7 +166,7 @@ impl NodeTestConfig {
         self
     }
 
-    pub fn with_mempool(mut self, mempool: Arc<InMemoryMempool<Transaction>>) -> Self {
+    pub fn with_mempool(mut self, mempool: Arc<InMemoryMempool<WithOriginalBytes<Transaction>>>) -> Self {
         self.mempool = mempool;
         self
     }

--- a/crates/amaru-node/src/tests/test_data.rs
+++ b/crates/amaru-node/src/tests/test_data.rs
@@ -15,15 +15,20 @@
 use std::sync::Arc;
 
 use amaru_kernel::{
-    Hash, Transaction, TransactionBody, TransactionInput, WitnessSet, cbor::WithSize, size::TRANSACTION_BODY,
+    Hash, Transaction, TransactionBody, TransactionInput, WitnessSet,
+    cbor::{WithOriginalBytes, WithSize},
+    size::TRANSACTION_BODY,
 };
 use amaru_ouroboros::{Mempool, TxInsertResult, TxOrigin};
 
-pub fn create_transactions(number: usize) -> Vec<Transaction> {
+pub fn create_transactions(number: usize) -> Vec<WithOriginalBytes<Transaction>> {
     (0..number).map(create_transaction).collect()
 }
 
-pub fn create_transactions_in_mempool(mempool: Arc<dyn Mempool<Transaction>>, number: usize) -> Vec<Transaction> {
+pub fn create_transactions_in_mempool(
+    mempool: Arc<dyn Mempool<WithOriginalBytes<Transaction>>>,
+    number: usize,
+) -> Vec<WithOriginalBytes<Transaction>> {
     let mut txs = vec![];
     for i in 0..number {
         let tx = create_transaction(i);
@@ -35,7 +40,7 @@ pub fn create_transactions_in_mempool(mempool: Arc<dyn Mempool<Transaction>>, nu
 }
 
 /// Create a transaction with a unique input based on the given id.
-pub fn create_transaction(id: usize) -> Transaction {
+pub fn create_transaction(id: usize) -> WithOriginalBytes<Transaction> {
     let tx_input = TransactionInput { transaction_id: Hash::new([1; TRANSACTION_BODY]), index: id as u64 };
 
     let body = TransactionBody::new([tx_input], [], 0);
@@ -46,4 +51,5 @@ pub fn create_transaction(id: usize) -> Transaction {
         is_expected_valid: true,
         auxiliary_data: None,
     }
+    .into()
 }

--- a/crates/amaru-ouroboros-traits/src/mempool/mempool_traits.rs
+++ b/crates/amaru-ouroboros-traits/src/mempool/mempool_traits.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use amaru_kernel::TransactionId;
+use amaru_kernel::{TransactionId, cbor::WithOriginalBytes};
 
 use crate::mempool::{MempoolSeqNo, MempoolState, TxInsertResult, TxOrigin};
 
@@ -40,7 +40,7 @@ pub trait Mempool<Tx: Send + Sync + 'static>: TxSubmissionMempool<Tx> + Send + S
         Self: Sized;
 }
 
-pub type ResourceMempool<Tx> = Arc<dyn TxSubmissionMempool<Tx>>;
+pub type ResourceMempool<Tx> = Arc<dyn TxSubmissionMempool<WithOriginalBytes<Tx>>>;
 
 pub trait TxSubmissionMempool<Tx: Send + Sync + 'static>: Send + Sync {
     /// Insert a transaction into the mempool, specifying its origin.

--- a/crates/amaru-ouroboros/src/mempool.rs
+++ b/crates/amaru-ouroboros/src/mempool.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{Point, Transaction, TransactionId};
+use amaru_kernel::{Point, Transaction, TransactionId, cbor::WithOriginalBytes};
 use amaru_ouroboros_traits::{MempoolSeqNo, TxInsertResult, TxOrigin, TxRejectReason};
 use amaru_pure_stage::StageRef;
 
@@ -35,8 +35,8 @@ use amaru_pure_stage::StageRef;
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum MempoolMsg {
     WaitForAtLeast { seq_no: MempoolSeqNo, caller: StageRef<()> },
-    Insert { tx: Box<Transaction>, origin: TxOrigin, caller: StageRef<TxInsertResult> },
-    InsertBatch { txs: Vec<Transaction>, origin: TxOrigin, caller: StageRef<Vec<TxInsertResult>> },
+    Insert { tx: Box<WithOriginalBytes<Transaction>>, origin: TxOrigin, caller: StageRef<TxInsertResult> },
+    InsertBatch { txs: Vec<WithOriginalBytes<Transaction>>, origin: TxOrigin, caller: StageRef<Vec<TxInsertResult>> },
     NewTip(Point),
     SubscribeCapacity { caller: StageRef<()> },
 }

--- a/crates/amaru-protocols/src/mempool_effects.rs
+++ b/crates/amaru-protocols/src/mempool_effects.rs
@@ -14,7 +14,7 @@
 
 use std::fmt::Debug;
 
-use amaru_kernel::{Transaction, TransactionId};
+use amaru_kernel::{Transaction, TransactionId, cbor::WithOriginalBytes};
 use amaru_ouroboros::ResourceMempool;
 use amaru_ouroboros_traits::{MempoolSeqNo, MempoolState, TxInsertResult, TxOrigin, TxSubmissionMempool};
 use amaru_pure_stage::{BoxFuture, Effects, ExternalEffectAPI, Resources, SendData, Void};
@@ -32,16 +32,16 @@ pub struct MemoryPool {
 }
 
 pub trait AsyncMempool: Send + Sync {
-    fn insert(&self, tx: Transaction, tx_origin: TxOrigin) -> BoxFuture<'_, TxInsertResult>;
-    fn get_tx(&self, tx_id: TransactionId) -> BoxFuture<'_, Option<Transaction>>;
+    fn insert(&self, tx: WithOriginalBytes<Transaction>, tx_origin: TxOrigin) -> BoxFuture<'_, TxInsertResult>;
+    fn get_tx(&self, tx_id: TransactionId) -> BoxFuture<'_, Option<WithOriginalBytes<Transaction>>>;
     fn contains(&self, tx_id: &TransactionId) -> BoxFuture<'_, bool>;
     fn tx_ids_since(
         &self,
         from_seq: MempoolSeqNo,
         limit: u16,
     ) -> BoxFuture<'_, Vec<(TransactionId, u32, MempoolSeqNo)>>;
-    fn get_txs_for_ids(&self, ids: &[TransactionId]) -> BoxFuture<'_, Vec<Transaction>>;
-    fn mempool_txs(&self) -> BoxFuture<'_, Vec<Transaction>>;
+    fn get_txs_for_ids(&self, ids: &[TransactionId]) -> BoxFuture<'_, Vec<WithOriginalBytes<Transaction>>>;
+    fn mempool_txs(&self) -> BoxFuture<'_, Vec<WithOriginalBytes<Transaction>>>;
     fn remove_txs(&self, ids: &[TransactionId]) -> BoxFuture<'_, ()>;
     fn last_seq_no(&self) -> BoxFuture<'_, MempoolSeqNo>;
     fn is_near_capacity(&self, additional_bytes: u64) -> BoxFuture<'_, bool>;
@@ -57,11 +57,15 @@ impl MemoryPool {
         self.effects.external(effect)
     }
 
-    pub fn insert(&self, tx: Transaction, tx_origin: TxOrigin) -> BoxFuture<'static, TxInsertResult> {
+    pub fn insert(
+        &self,
+        tx: WithOriginalBytes<Transaction>,
+        tx_origin: TxOrigin,
+    ) -> BoxFuture<'static, TxInsertResult> {
         self.external(Insert::new(tx, tx_origin))
     }
 
-    pub fn get_tx(&self, tx_id: &TransactionId) -> BoxFuture<'static, Option<Transaction>> {
+    pub fn get_tx(&self, tx_id: &TransactionId) -> BoxFuture<'static, Option<WithOriginalBytes<Transaction>>> {
         self.external(GetTx::new(*tx_id))
     }
 
@@ -77,11 +81,11 @@ impl MemoryPool {
         self.external(TxIdsSince::new(from_seq, limit))
     }
 
-    pub fn get_txs_for_ids(&self, ids: &[TransactionId]) -> BoxFuture<'static, Vec<Transaction>> {
+    pub fn get_txs_for_ids(&self, ids: &[TransactionId]) -> BoxFuture<'static, Vec<WithOriginalBytes<Transaction>>> {
         self.external(GetTxsForIds::new(ids))
     }
 
-    pub fn mempool_txs(&self) -> BoxFuture<'static, Vec<Transaction>> {
+    pub fn mempool_txs(&self) -> BoxFuture<'static, Vec<WithOriginalBytes<Transaction>>> {
         self.external(MempoolTxs)
     }
 
@@ -107,11 +111,11 @@ impl MemoryPool {
 }
 
 impl AsyncMempool for MemoryPool {
-    fn insert(&self, tx: Transaction, tx_origin: TxOrigin) -> BoxFuture<'_, TxInsertResult> {
+    fn insert(&self, tx: WithOriginalBytes<Transaction>, tx_origin: TxOrigin) -> BoxFuture<'_, TxInsertResult> {
         MemoryPool::insert(self, tx, tx_origin)
     }
 
-    fn get_tx(&self, tx_id: TransactionId) -> BoxFuture<'_, Option<Transaction>> {
+    fn get_tx(&self, tx_id: TransactionId) -> BoxFuture<'_, Option<WithOriginalBytes<Transaction>>> {
         MemoryPool::get_tx(self, &tx_id)
     }
 
@@ -127,11 +131,11 @@ impl AsyncMempool for MemoryPool {
         MemoryPool::tx_ids_since(self, from_seq, limit)
     }
 
-    fn get_txs_for_ids(&self, ids: &[TransactionId]) -> BoxFuture<'_, Vec<Transaction>> {
+    fn get_txs_for_ids(&self, ids: &[TransactionId]) -> BoxFuture<'_, Vec<WithOriginalBytes<Transaction>>> {
         MemoryPool::get_txs_for_ids(self, ids)
     }
 
-    fn mempool_txs(&self) -> BoxFuture<'_, Vec<Transaction>> {
+    fn mempool_txs(&self) -> BoxFuture<'_, Vec<WithOriginalBytes<Transaction>>> {
         MemoryPool::mempool_txs(self)
     }
 
@@ -152,12 +156,12 @@ impl AsyncMempool for MemoryPool {
     }
 }
 
-impl<T: TxSubmissionMempool<Transaction> + ?Sized> AsyncMempool for T {
-    fn insert(&self, tx: Transaction, tx_origin: TxOrigin) -> BoxFuture<'_, TxInsertResult> {
+impl<T: TxSubmissionMempool<WithOriginalBytes<Transaction>> + ?Sized> AsyncMempool for T {
+    fn insert(&self, tx: WithOriginalBytes<Transaction>, tx_origin: TxOrigin) -> BoxFuture<'_, TxInsertResult> {
         Box::pin(async move { TxSubmissionMempool::insert(self, tx, tx_origin) })
     }
 
-    fn get_tx(&self, tx_id: TransactionId) -> BoxFuture<'_, Option<Transaction>> {
+    fn get_tx(&self, tx_id: TransactionId) -> BoxFuture<'_, Option<WithOriginalBytes<Transaction>>> {
         Box::pin(async move { TxSubmissionMempool::get_tx(self, &tx_id) })
     }
 
@@ -174,12 +178,12 @@ impl<T: TxSubmissionMempool<Transaction> + ?Sized> AsyncMempool for T {
         Box::pin(async move { TxSubmissionMempool::tx_ids_since(self, from_seq, limit) })
     }
 
-    fn get_txs_for_ids(&self, ids: &[TransactionId]) -> BoxFuture<'_, Vec<Transaction>> {
+    fn get_txs_for_ids(&self, ids: &[TransactionId]) -> BoxFuture<'_, Vec<WithOriginalBytes<Transaction>>> {
         let tx_ids = ids.to_vec();
         Box::pin(async move { TxSubmissionMempool::get_txs_for_ids(self, &tx_ids) })
     }
 
-    fn mempool_txs(&self) -> BoxFuture<'_, Vec<Transaction>> {
+    fn mempool_txs(&self) -> BoxFuture<'_, Vec<WithOriginalBytes<Transaction>>> {
         Box::pin(async move { TxSubmissionMempool::mempool_txs(self) })
     }
 
@@ -205,12 +209,12 @@ impl<T: TxSubmissionMempool<Transaction> + ?Sized> AsyncMempool for T {
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 struct Insert {
-    tx: Transaction,
+    tx: WithOriginalBytes<Transaction>,
     tx_origin: TxOrigin,
 }
 
 impl Insert {
-    pub fn new(tx: Transaction, tx_origin: TxOrigin) -> Self {
+    pub fn new(tx: WithOriginalBytes<Transaction>, tx_origin: TxOrigin) -> Self {
         Self { tx, tx_origin }
     }
 }
@@ -239,7 +243,7 @@ impl GetTx {
 }
 
 impl ExternalEffectAPI for GetTx {
-    type Response = Option<Transaction>;
+    type Response = Option<WithOriginalBytes<Transaction>>;
 
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
@@ -309,7 +313,7 @@ impl GetTxsForIds {
 }
 
 impl ExternalEffectAPI for GetTxsForIds {
-    type Response = Vec<Transaction>;
+    type Response = Vec<WithOriginalBytes<Transaction>>;
 
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
@@ -324,7 +328,7 @@ impl ExternalEffectAPI for GetTxsForIds {
 struct MempoolTxs;
 
 impl ExternalEffectAPI for MempoolTxs {
-    type Response = Vec<Transaction>;
+    type Response = Vec<WithOriginalBytes<Transaction>>;
 
     #[expect(clippy::expect_used)]
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
@@ -407,12 +411,15 @@ impl ExternalEffectAPI for State {
 
 #[cfg(test)]
 mod tests {
-    use amaru_kernel::{Transaction, TransactionBody, TransactionId, WitnessSet, cbor::WithSize};
+    use amaru_kernel::{
+        Transaction, TransactionBody, TransactionId, WitnessSet,
+        cbor::{WithOriginalBytes, WithSize},
+    };
     use amaru_ouroboros_traits::{MempoolSeqNo, MempoolState, TxInsertResult, TxOrigin, TxSubmissionMempool};
 
     #[allow(dead_code)]
     pub struct ConstantMempool {
-        tx: Transaction,
+        tx: WithOriginalBytes<Transaction>,
     }
 
     impl ConstantMempool {
@@ -420,17 +427,17 @@ mod tests {
         pub fn new() -> Self {
             let body = TransactionBody::new([], [], 0);
             let witnesses = WithSize::<WitnessSet>::default().with_size(1);
-            let tx: Transaction = Transaction { body, witnesses, is_expected_valid: true, auxiliary_data: None };
+            let tx = Transaction { body, witnesses, is_expected_valid: true, auxiliary_data: None }.into();
             Self { tx }
         }
     }
 
-    impl TxSubmissionMempool<Transaction> for ConstantMempool {
-        fn insert(&self, tx: Transaction, _tx_origin: TxOrigin) -> TxInsertResult {
+    impl TxSubmissionMempool<WithOriginalBytes<Transaction>> for ConstantMempool {
+        fn insert(&self, tx: WithOriginalBytes<Transaction>, _tx_origin: TxOrigin) -> TxInsertResult {
             TxInsertResult::accepted(tx.tx_id(), MempoolSeqNo(1))
         }
 
-        fn get_tx(&self, _tx_id: &TransactionId) -> Option<Transaction> {
+        fn get_tx(&self, _tx_id: &TransactionId) -> Option<WithOriginalBytes<Transaction>> {
             Some(self.tx.clone())
         }
 
@@ -438,11 +445,11 @@ mod tests {
             vec![(self.tx.tx_id(), 100, MempoolSeqNo(1))]
         }
 
-        fn get_txs_for_ids(&self, _ids: &[TransactionId]) -> Vec<Transaction> {
+        fn get_txs_for_ids(&self, _ids: &[TransactionId]) -> Vec<WithOriginalBytes<Transaction>> {
             vec![self.tx.clone()]
         }
 
-        fn mempool_txs(&self) -> Vec<Transaction> {
+        fn mempool_txs(&self) -> Vec<WithOriginalBytes<Transaction>> {
             vec![self.tx.clone()]
         }
 

--- a/crates/amaru-protocols/src/tests/configuration.rs
+++ b/crates/amaru-protocols/src/tests/configuration.rs
@@ -16,7 +16,7 @@ use std::{net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 
 use amaru_kernel::{
     HeaderHash, IsHeader, PREPROD_ERA_HISTORY, Transaction, TransactionId, any_headers_chain_with_root,
-    cardano::network_block::make_network_block, make_header, utils::tests::run_strategy,
+    cardano::network_block::make_network_block, cbor::WithOriginalBytes, make_header, utils::tests::run_strategy,
 };
 use amaru_mempool::InMemoryMempool;
 use amaru_ouroboros_traits::{ChainStore, in_memory_chain_store::InMemoryChainStore};
@@ -31,7 +31,7 @@ use crate::tx_submission::{create_transactions, create_transactions_in_mempool};
 #[derive(Clone)]
 pub(super) struct Configuration {
     pub(super) chain_store: Arc<InMemoryChainStore>,
-    pub(super) mempool: Arc<InMemoryMempool<Transaction>>,
+    pub(super) mempool: Arc<InMemoryMempool<WithOriginalBytes<Transaction>>>,
     pub(super) addr: SocketAddr,
     pub(super) reconnect_delay: Duration,
     pub(super) processing_wait: Option<Duration>,

--- a/crates/amaru-protocols/src/tests/setup.rs
+++ b/crates/amaru-protocols/src/tests/setup.rs
@@ -22,7 +22,7 @@ use std::{
     time::Duration,
 };
 
-use amaru_kernel::{NonEmptyBytes, Peer, Transaction};
+use amaru_kernel::{NonEmptyBytes, Peer, Transaction, cbor::WithOriginalBytes};
 use amaru_network::connection::TokioConnections;
 use amaru_ouroboros_traits::{
     BaseReadChainStore, CanValidateBlocks, CanValidateTxs, ConnectionId, ConnectionProvider, ConnectionsResource,
@@ -59,7 +59,7 @@ pub(super) type ResourceTxValidation = Arc<dyn CanValidateTxs + Send + Sync>;
 /// In particular set up an in-memory chain store with different chain lengths for the initiator and responder.
 pub(super) fn set_resources(
     chain_store: Arc<InMemoryChainStore>,
-    mempool: Arc<dyn Mempool<Transaction>>,
+    mempool: Arc<dyn Mempool<WithOriginalBytes<Transaction>>>,
     network: &mut TokioBuilder,
     connections: TokioConnections,
 ) -> anyhow::Result<()> {
@@ -69,7 +69,7 @@ pub(super) fn set_resources(
 /// Add resources for each role with a custom connection provider.
 pub(super) fn set_resources_with_connections(
     chain_store: Arc<InMemoryChainStore>,
-    mempool: Arc<dyn Mempool<Transaction>>,
+    mempool: Arc<dyn Mempool<WithOriginalBytes<Transaction>>>,
     network: &mut TokioBuilder,
     connections: ConnectionsResource,
 ) -> anyhow::Result<()> {

--- a/crates/amaru-protocols/src/tx_submission/initiator.rs
+++ b/crates/amaru-protocols/src/tx_submission/initiator.rs
@@ -54,7 +54,9 @@ use std::{
 };
 
 use ProtocolError::*;
-use amaru_kernel::{EraHistory, Peer, Transaction, TransactionId, utils::string::display_collection};
+use amaru_kernel::{
+    EraHistory, Peer, Transaction, TransactionId, cbor::WithOriginalBytes, utils::string::display_collection,
+};
 use amaru_observability::{debug, debug_span};
 use amaru_ouroboros::{MempoolMsg, MempoolSeqNo};
 use amaru_pure_stage::{DeserializerGuards, Effects, StageRef, Void};
@@ -309,7 +311,7 @@ impl TxSubmissionInitiator {
     }
 
     /// Wrap each transaction with the current era tag for outgoing wire messages.
-    fn tag_txs(&self, items: Vec<Transaction>) -> Vec<EraTaggedTx> {
+    fn tag_txs(&self, items: Vec<WithOriginalBytes<Transaction>>) -> Vec<EraTaggedTx> {
         let era = self.era_history.current_era_tag();
         items.into_iter().map(|tx| EraTaggedTx { era, tx }).collect()
     }
@@ -978,7 +980,7 @@ mod tests {
         Ok(action)
     }
 
-    fn reply_tx_ids(txs: &[Transaction], ids: &[usize]) -> InitiatorAction {
+    fn reply_tx_ids(txs: &[WithOriginalBytes<Transaction>], ids: &[usize]) -> InitiatorAction {
         let era = test_era();
         let pairs: Vec<(EraTaggedTxId, u32)> = ids
             .iter()
@@ -987,7 +989,7 @@ mod tests {
         InitiatorAction::SendReplyTxIds(pairs)
     }
 
-    fn reply_txs(txs: &[Transaction], ids: &[usize]) -> InitiatorAction {
+    fn reply_txs(txs: &[WithOriginalBytes<Transaction>], ids: &[usize]) -> InitiatorAction {
         let era = test_era();
         let payload: Vec<EraTaggedTx> = ids.iter().map(|id| EraTaggedTx { era, tx: txs[*id].clone() }).collect();
         InitiatorAction::SendReplyTxs(payload)
@@ -997,11 +999,11 @@ mod tests {
         InitiatorResult::RequestTxIds { ack, req, blocking }
     }
 
-    fn new_mempool() -> Arc<InMemoryMempool<Transaction>> {
+    fn new_mempool() -> Arc<InMemoryMempool<WithOriginalBytes<Transaction>>> {
         Arc::new(InMemoryMempool::default())
     }
 
-    fn request_txs(txs: &[Transaction], ids: &[usize]) -> InitiatorResult {
+    fn request_txs(txs: &[WithOriginalBytes<Transaction>], ids: &[usize]) -> InitiatorResult {
         InitiatorResult::RequestTxs(ids.iter().map(|id| txs[*id].tx_id()).collect())
     }
 

--- a/crates/amaru-protocols/src/tx_submission/messages.rs
+++ b/crates/amaru-protocols/src/tx_submission/messages.rs
@@ -15,7 +15,8 @@
 use std::fmt::Display;
 
 use amaru_kernel::{
-    EraName, NonEmptyBytes, Transaction, TransactionId, cbor, to_cbor, utils::string::display_collection,
+    EraName, NonEmptyBytes, Transaction, TransactionId, cbor, cbor::WithOriginalBytes, from_cbor_no_leftovers_with,
+    to_cbor, utils::string::display_collection,
 };
 
 use crate::tx_submission::Blocking;
@@ -33,7 +34,7 @@ pub struct EraTaggedTxId {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct EraTaggedTx {
     pub era: EraName,
-    pub tx: Transaction,
+    pub tx: WithOriginalBytes<Transaction>,
 }
 
 /// Messages for the txsubmission mini-protocol.
@@ -226,14 +227,14 @@ impl cbor::Encode<()> for EraTaggedTx {
         e: &mut cbor::Encoder<W>,
         _ctx: &mut (),
     ) -> Result<(), cbor::encode::Error<W::Error>> {
-        let bytes = encode_tx(&self.tx).map_err(|_| cbor::encode::Error::message("failed to encode transaction"))?;
+        let bytes = to_cbor(&self.tx);
         e.array(2)?.u16(self.era.header_variant() as u16)?.tag(cbor::IanaTag::Cbor)?.bytes(&bytes)?;
         Ok(())
     }
 }
 
 impl<'b> cbor::Decode<'b, ()> for EraTaggedTx {
-    fn decode(d: &mut cbor::Decoder<'b>, _ctx: &mut ()) -> Result<Self, cbor::decode::Error> {
+    fn decode(d: &mut cbor::Decoder<'b>, ctx: &mut ()) -> Result<Self, cbor::decode::Error> {
         let era = decode_era_tag(d)?;
         let tag = d.tag()?;
         if tag != cbor::IanaTag::Cbor.tag() {
@@ -246,17 +247,9 @@ impl<'b> cbor::Decode<'b, ()> for EraTaggedTx {
         // Conformance: the Haskell node unwraps CBOR-in-CBOR with cborg's `decodeBytes`,
         // which rejects indefinite-length byte strings, so we reject them too.
         #[allow(clippy::disallowed_methods)]
-        let tx = decode_tx(d.bytes()?)?;
+        let tx = from_cbor_no_leftovers_with(d.bytes()?, ctx)?;
         Ok(EraTaggedTx { era, tx })
     }
-}
-
-/// Encode the inner transaction body: `[body, witnesses, is_valid, auxiliary_data]`.
-fn encode_tx(tx: &Transaction) -> Result<Vec<u8>, cbor::encode::Error<std::convert::Infallible>> {
-    let mut bytes = Vec::new();
-    let mut e = cbor::Encoder::new(&mut bytes);
-    e.array(4)?.encode(&tx.body)?.encode(&tx.witnesses)?.bool(tx.is_expected_valid)?.encode(&tx.auxiliary_data)?;
-    Ok(bytes)
 }
 
 /// Decode the `[era_index, _]` prefix and return the era. Leaves the decoder positioned at the
@@ -273,25 +266,6 @@ fn decode_era_tag(d: &mut cbor::Decoder<'_>) -> Result<EraName, cbor::decode::Er
     } else {
         Ok(era_name)
     }
-}
-
-/// Decode the inner transaction body produced by [`encode_tx`], asserting that
-/// no trailing bytes follow the four-element array.
-fn decode_tx(bytes: &[u8]) -> Result<Transaction, cbor::decode::Error> {
-    let mut d = cbor::Decoder::new(bytes);
-    let len = d.array()?;
-    cbor::check_tagged_array_length(0, len, 4)?;
-    let body = d.decode()?;
-    let witnesses = d.decode()?;
-    let is_expected_valid = d.bool()?;
-    let auxiliary_data = d.decode()?;
-    if !d.datatype().is_err_and(|e| e.is_end_of_input()) {
-        return Err(cbor::decode::Error::message(format!(
-            "leftovers bytes after txsubmission transaction at position {}",
-            d.position()
-        )));
-    }
-    Ok(Transaction { body, witnesses, is_expected_valid, auxiliary_data })
 }
 
 /// Decode a CBOR array — definite or indefinite-length — of items implementing `Decode`.
@@ -450,6 +424,26 @@ mod tests {
         assert_eq!(d.position(), encoded.len()); // outer message fully consumed
     }
 
+    /// A relayed transaction must go back on the wire byte-identical to how it arrived, instead of
+    /// being replaced by our own re-encoding of it.
+    #[test]
+    fn reply_txs_preserves_original_transaction_bytes() {
+        let tx_bytes = non_canonical_transaction_cbor(&create_transaction(0));
+
+        let mut encoded = Vec::new();
+        let mut e = cbor::Encoder::new(&mut encoded);
+        e.array(2).unwrap().u16(3).unwrap();
+        e.begin_array().unwrap();
+        e.array(2).unwrap().u16(EraName::Conway.header_variant() as u16).unwrap();
+        e.tag(cbor::IanaTag::Cbor).unwrap().bytes(&tx_bytes).unwrap();
+        e.end().unwrap();
+
+        let message: Message = from_cbor_no_leftovers_with(&encoded, &mut ()).expect("decode a reply_txs message");
+        let Message::ReplyTxs(txs) = &message else { panic!("expected a reply_txs message, got {message:?}") };
+        assert_eq!(to_cbor(&txs[0].tx), tx_bytes);
+        assert_eq!(to_cbor(&message), encoded);
+    }
+
     #[test]
     fn reply_tx_ids_decoding() {
         let ids = vec![(EraTaggedTxId { era: EraName::Conway, id: TransactionId::new(Hash::new([1u8; 32])) }, 42)];
@@ -550,6 +544,14 @@ mod tests {
     }
 
     // HELPERS
+
+    /// Re-encode a transaction's outer array header with a redundant one-byte length: still valid
+    /// CBOR, but no longer byte-identical to what our encoder produces.
+    fn non_canonical_transaction_cbor(tx: &WithOriginalBytes<Transaction>) -> Vec<u8> {
+        let canonical = to_cbor(tx);
+        assert_eq!(canonical[0], 0x84, "expected a definite-length array of 4 elements");
+        [&[0x98, 0x04][..], &canonical[1..]].concat()
+    }
 
     prop_compose! {
         pub fn any_tx_id()(

--- a/crates/amaru-protocols/src/tx_submission/responder.rs
+++ b/crates/amaru-protocols/src/tx_submission/responder.rs
@@ -21,7 +21,7 @@ use std::{
 
 use ProtocolError::*;
 use TerminationCause::*;
-use amaru_kernel::{EraHistory, Peer, Transaction, TransactionId, to_cbor};
+use amaru_kernel::{EraHistory, Peer, Transaction, TransactionId, cbor::WithOriginalBytes, to_cbor};
 use amaru_observability::{debug, debug_span};
 use amaru_ouroboros::{MempoolInsertResult, MempoolMsg, MempoolSeqNo, TxInsertResult, TxOrigin, TxRejectReason};
 use amaru_pure_stage::{DeserializerGuards, Effects, StageRef, Void};
@@ -207,7 +207,7 @@ pub enum FetchOutcome {
 pub enum ResponderResult {
     Init,
     ReplyTxIds(Vec<(TransactionId, u32)>),
-    ReplyTxs(Vec<Transaction>),
+    ReplyTxs(Vec<WithOriginalBytes<Transaction>>),
     Done,
 }
 
@@ -488,12 +488,12 @@ impl TxSubmissionResponder {
     /// Hard errors (mempool stage unavailable or timed out) terminate the connection.
     async fn insert_txs(
         &mut self,
-        txs: Vec<Transaction>,
+        txs: Vec<WithOriginalBytes<Transaction>>,
         eff: &Effects<Inputs<ResponderLocalIn>>,
     ) -> anyhow::Result<Option<ResponderAction>> {
         debug!(protocols::tx_submission::responder::REPLY_TXS_RECEIVED, peer = self.peer, count = txs.len());
         // De-duplicate transactions by tx_id.
-        let txs: Vec<Transaction> =
+        let txs: Vec<WithOriginalBytes<Transaction>> =
             txs.into_iter().map(|tx| (tx.tx_id(), tx)).collect::<BTreeMap<_, _>>().into_values().collect();
 
         if let Some(action) = self.validate_received_txs(&txs)? {
@@ -541,7 +541,7 @@ impl TxSubmissionResponder {
     /// body's tx_id won't be Inflight in `tx_states`, and then a `TxNotRequested` error is returned.
     ///
     /// Note that duplicate bodies are allowed in the in the batch (`insert_txs` have de-duplicated them).
-    fn validate_received_txs(&self, txs: &[Transaction]) -> anyhow::Result<Option<ResponderAction>> {
+    fn validate_received_txs(&self, txs: &[WithOriginalBytes<Transaction>]) -> anyhow::Result<Option<ResponderAction>> {
         let not_requested: Vec<TransactionId> = txs
             .iter()
             .map(|tx| tx.tx_id())
@@ -771,12 +771,12 @@ pub enum TxSubmissionMsg {
         caller: StageRef<()>,
     },
     Insert {
-        tx: Box<Transaction>,
+        tx: Box<WithOriginalBytes<Transaction>>,
         origin: TxOrigin,
         caller: StageRef<Result<TxInsertResult, MempoolInsertResult>>,
     },
     InsertBatch {
-        txs: Vec<Transaction>,
+        txs: Vec<WithOriginalBytes<Transaction>>,
         origin: TxOrigin,
         caller: StageRef<Result<Vec<TxInsertResult>, MempoolInsertResult>>,
     },
@@ -1155,7 +1155,7 @@ mod tests {
 
     /// Build a `(TransactionId, advertised_size)` list for the given transactions, with sizes computed
     /// from the actual CBOR encoding (so the byte-budget logic in `txs_to_request` is realistic).
-    fn advertised(txs: &[Transaction], indexes: &[usize]) -> Vec<(TransactionId, u32)> {
+    fn advertised(txs: &[WithOriginalBytes<Transaction>], indexes: &[usize]) -> Vec<(TransactionId, u32)> {
         indexes.iter().map(|i| (txs[*i].tx_id(), to_cbor(&txs[*i]).len() as u32)).collect()
     }
 
@@ -1234,7 +1234,7 @@ mod tests {
                     }
                 }
                 ResponderResult::ReplyTxs(txs) => {
-                    let txs: Vec<Transaction> =
+                    let txs: Vec<WithOriginalBytes<Transaction>> =
                         txs.into_iter().map(|tx| (tx.tx_id(), tx)).collect::<BTreeMap<_, _>>().into_values().collect();
                     if let Some(action) = responder.validate_received_txs(&txs)? {
                         Some(action)
@@ -1270,11 +1270,11 @@ mod tests {
         ResponderResult::Done
     }
 
-    fn reply_tx_ids(txs: &[Transaction], ids: &[usize]) -> ResponderResult {
+    fn reply_tx_ids(txs: &[WithOriginalBytes<Transaction>], ids: &[usize]) -> ResponderResult {
         ResponderResult::ReplyTxIds(ids.iter().map(|id| (txs[*id].tx_id(), to_cbor(&txs[*id]).len() as u32)).collect())
     }
 
-    fn reply_txs(txs: &[Transaction], ids: &[usize]) -> ResponderResult {
+    fn reply_txs(txs: &[WithOriginalBytes<Transaction>], ids: &[usize]) -> ResponderResult {
         ResponderResult::ReplyTxs(ids.iter().map(|id| txs[*id].clone()).collect())
     }
 
@@ -1282,7 +1282,7 @@ mod tests {
         ResponderAction::SendRequestTxIds { ack, req, blocking }
     }
 
-    fn request_txs(txs: &[Transaction], ids: &[usize]) -> ResponderAction {
+    fn request_txs(txs: &[WithOriginalBytes<Transaction>], ids: &[usize]) -> ResponderAction {
         let era = test_era();
         let payload: Vec<EraTaggedTxId> = ids.iter().map(|id| EraTaggedTxId { era, id: txs[*id].tx_id() }).collect();
         ResponderAction::SendRequestTxs(payload)
@@ -1304,7 +1304,7 @@ mod tests {
             results.into_iter().map(|result| (*result.tx_id(), result)).collect();
         Arc::new(
             OverridingMempool::builder(Arc::new(InMemoryMempool::default()))
-                .with_insert(move |_inner, tx: Transaction, _origin| {
+                .with_insert(move |_inner, tx: WithOriginalBytes<Transaction>, _origin| {
                     let tx_id = tx.tx_id();
                     by_id.remove(&tx_id).expect("missing insert result for mock mempool test")
                 })

--- a/crates/amaru-protocols/src/tx_submission/tests/test_data.rs
+++ b/crates/amaru-protocols/src/tx_submission/tests/test_data.rs
@@ -13,15 +13,20 @@
 // limitations under the License.
 
 use amaru_kernel::{
-    Hash, Transaction, TransactionBody, TransactionInput, WitnessSet, cbor::WithSize, size::TRANSACTION_BODY,
+    Hash, Transaction, TransactionBody, TransactionInput, WitnessSet,
+    cbor::{WithOriginalBytes, WithSize},
+    size::TRANSACTION_BODY,
 };
 use amaru_ouroboros_traits::{Mempool, TxOrigin};
 
-pub fn create_transactions(number: u64) -> Vec<Transaction> {
+pub fn create_transactions(number: u64) -> Vec<WithOriginalBytes<Transaction>> {
     (0..number).map(create_transaction).collect()
 }
 
-pub fn create_transactions_in_mempool(mempool: &dyn Mempool<Transaction>, number: u64) -> Vec<Transaction> {
+pub fn create_transactions_in_mempool(
+    mempool: &dyn Mempool<WithOriginalBytes<Transaction>>,
+    number: u64,
+) -> Vec<WithOriginalBytes<Transaction>> {
     let mut txs = vec![];
     for i in 0..number {
         let tx = create_transaction(i);
@@ -32,7 +37,7 @@ pub fn create_transactions_in_mempool(mempool: &dyn Mempool<Transaction>, number
 }
 
 /// Create a transaction with a unique input based on the given id.
-pub fn create_transaction(id: u64) -> Transaction {
+pub fn create_transaction(id: u64) -> WithOriginalBytes<Transaction> {
     let tx_input = TransactionInput { transaction_id: Hash::new([1; TRANSACTION_BODY]), index: id };
 
     let body = TransactionBody::new([tx_input], [], 0);
@@ -43,4 +48,5 @@ pub fn create_transaction(id: u64) -> Transaction {
         is_expected_valid: true,
         auxiliary_data: None,
     }
+    .into()
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the exact original transaction bytes as transactions move through submission, relay, validation, and the mempool.
  * Ensured non-canonical transaction encodings are relayed byte-for-byte without being rewritten.
  * Maintained transaction identification and validation behavior while retaining the original encoded representation.
* **Tests**
  * Added coverage verifying preservation of non-canonical transaction bytes during mempool and relay flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->