### PR TITLE
Avoid Double Decoding Scripts & Fix Witness Checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Other guiding principles:
 - **amaru-tui**: tweak block dissemination metrics headers (fetch → select, sync → fetch)
 - **amaru-ledger**: Do not validate disjoint input sets in protocol version 11+. Similarly, do not allow non-disjoin input sets in PV3, regardless of protocol version.
 - **amaru-kernel**: decode reward accounts as a network tag plus stake credential, rejecting malformed reward accounts at deserialization.
+- **amaru-ledger**: do not allow the same script to exist in both the witness set and in a reference input
 
 ## [v10.11.20260820](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260820)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,6 @@ Other guiding principles:
 - **amaru-observability**: field rendering is declared on the schema (`%` Display, `?` Debug, otherwise `Serialize + JsonSchema`). Call sites no longer take `%` / `?`; `@` remains for `tracing::Value` passthrough. `amaru dev traces dump` emits the JSON-sink schema of each field. `Point` traces encode as `[slot, hash, height]` with a CBOR byte-string hash ([#1263](https://github.com/pragma-org/amaru/issues/1263)).
 - **amaru-kernel**: `Hash` (and newtypes / `FixedBytes`) serialize as CBOR byte strings on the tracing path; JSON serde still uses hex. JSON/console/TUI/OTEL span sinks render those bytes as hex; OTEL logs keep byte strings.
 - **amaru**: use the `amaru-observability` crate with all other amaru crates so that all tracing events have a schema (#1266).
-
-### Changed
 - **amaru-ledger**: restructured script validations and sped up phase-one validation by up to ~11.5%
 
 ### Fixed
@@ -66,6 +64,7 @@ Other guiding principles:
 - **amaru-tui**: tweak block dissemination metrics headers (fetch → select, sync → fetch)
 - **amaru-ledger**: Do not validate disjoint input sets in protocol version 11+. Similarly, do not allow non-disjoin input sets in PV3, regardless of protocol version.
 - **amaru-kernel**: decode reward accounts as a network tag plus stake credential, rejecting malformed reward accounts at deserialization.
+- **amaru-ledger**: Do not validate disjoint input sets in protocol version 11+. Similarly, do not allow non-disjoint input sets in PV3, regardless of protocol version.
 - **amaru-ledger**: do not allow the same script to exist in both the witness set and in a reference input
 
 ## [v10.11.20260820](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260820)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ Other guiding principles:
 - **amaru-kernel**: `Hash` (and newtypes / `FixedBytes`) serialize as CBOR byte strings on the tracing path; JSON serde still uses hex. JSON/console/TUI/OTEL span sinks render those bytes as hex; OTEL logs keep byte strings.
 - **amaru**: use the `amaru-observability` crate with all other amaru crates so that all tracing events have a schema (#1266).
 
+### Changed
+- **amaru-ledger**: restructured script validations and sped up phase-one validation by up to ~11.5%
+
 ### Fixed
 
 - **amaru-protocols**: cancel the tx-submission responder's inflight-fetch timeout as soon as the peer replies, so bursty inbound traffic cannot fill the priority mailbox and panic ([#1270](https://github.com/pragma-org/amaru/issues/1270)).
@@ -57,7 +60,7 @@ Other guiding principles:
 - **amaru-stores**: abort on chain-store header and block loads whose content does not hash to the requested key (including the block body hash), including diagnostic scans ([#1261](https://github.com/pragma-org/amaru/issues/1261)).
 - **amaru-ledger**: drop the block-body-hash rule; the chain store now enforces it on load ([#1261](https://github.com/pragma-org/amaru/issues/1261)).
 - **workflows**: executable permissions are now correctly preserved in the release workflow.
-- **amaru-ledger**: Correctly calculate an output's minimum lovelace value.
+- **amaru-ledger**: correctly calculate an output's minimum lovelace value.
 - **amaru-ledger**: do not re-encode locally submitted transactions to obtain their size.
 - **amaru-protocols**: preserve bytes of transactions flowing through the mempool.
 - **amaru-tui**: tweak block dissemination metrics headers (fetch → select, sync → fetch)

--- a/crates/amaru-ledger/src/rules/block.rs
+++ b/crates/amaru-ledger/src/rules/block.rs
@@ -29,7 +29,11 @@ use thiserror::Error;
 use crate::{
     context::ValidationContext,
     epoch_transition::GovernanceActivity,
-    rules::transaction::{self, phase_one::PhaseOneError, phase_two::PhaseTwoError},
+    rules::transaction::{
+        self,
+        phase_one::PhaseOneError,
+        phase_two::{ScriptEvaluationError, TagMismatch},
+    },
 };
 
 pub mod body_size;
@@ -38,12 +42,25 @@ pub mod header_size;
 pub mod header_version;
 pub mod ref_scripts_size;
 
+/// The single point deciding which validation phase a failure belongs to: phase one rejects the
+/// transaction outright, phase two is a disagreement between the claimed and actual script results.
 #[derive(Debug, Error)]
 pub enum TransactionInvalid {
     #[error("transaction failed phase one validation: {0}")]
-    PhaseOneError(#[from] PhaseOneError),
+    PhaseOne(#[from] PhaseOneError),
     #[error("transaction failed phase two validation: {0}")]
-    PhaseTwoError(#[from] PhaseTwoError),
+    PhaseTwo(TagMismatch),
+}
+
+impl From<ScriptEvaluationError> for TransactionInvalid {
+    fn from(err: ScriptEvaluationError) -> Self {
+        match err {
+            ScriptEvaluationError::Preparation(err) => {
+                TransactionInvalid::PhaseOne(PhaseOneError::ScriptPreparation(err))
+            }
+            ScriptEvaluationError::ValidationTagMismatch(err) => TransactionInvalid::PhaseTwo(err),
+        }
+    }
 }
 #[derive(Debug)]
 pub enum InvalidBlockDetails {

--- a/crates/amaru-ledger/src/rules/transaction/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/fixture.rs
@@ -37,7 +37,7 @@ use crate::{
                 outputs::{InvalidOutput, InvalidOutputs},
                 proposals::InvalidProposals,
             },
-            phase_two::PhaseTwoError,
+            phase_two::{PhaseTwoError, PreparationError, TagMismatch},
         },
     },
 };
@@ -273,6 +273,7 @@ pub(super) enum Predicate {
     InvalidPrevGovActionId,
     InvalidWitnessesUTXOW,
     MalformedReferenceScripts,
+    MalformedScriptWitnesses,
     MaxTxSizeUTxO,
     MissingTxBodyMetadataHash,
     MissingTxMetadata,
@@ -318,23 +319,25 @@ impl From<TransactionInvalid> for Predicate {
 impl From<PhaseTwoError> for Predicate {
     fn from(err: PhaseTwoError) -> Self {
         match err {
-            // Reaching the caller means `is_valid` was true, since a failing script is what an
-            // invalid transaction is expected to exhibit.
-            PhaseTwoError::UplcMachineError(_) => {
+            PhaseTwoError::ValidationTagMismatch(TagMismatch::FailedUnexpectedly(_)) => {
                 Predicate::ValidationTagMismatch { description: TagMismatchDescription::FailedUnexpectedly }
             }
-            PhaseTwoError::ValidityStateError => {
+            PhaseTwoError::ValidationTagMismatch(TagMismatch::PassedUnexpectedly) => {
                 Predicate::ValidationTagMismatch { description: TagMismatchDescription::PassedUnexpectedly }
+            }
+            PhaseTwoError::Preparation(PreparationError::MalformedScriptWitness(_)) => {
+                Predicate::MalformedScriptWitnesses
             }
             // The Haskell ledger reports these as 'CollectErrors' rather than a tag mismatch: they
             // are raised while assembling the script arguments, before any script runs.
-            PhaseTwoError::MissingInput(_)
-            | PhaseTwoError::TransactionTranslationError(_)
-            | PhaseTwoError::ScriptContextStateError(_)
-            | PhaseTwoError::ScriptDeserializationError(_)
-            | PhaseTwoError::FlatDecodingError(_)
-            | PhaseTwoError::MissingCostModel(_)
-            | PhaseTwoError::NonDisjointRefInputs { .. } => unreachable!("no predicate mapping yet for {err}"),
+            PhaseTwoError::Preparation(
+                PreparationError::MissingInput(_)
+                | PreparationError::TransactionTranslation(_)
+                | PreparationError::ScriptContextState(_)
+                | PreparationError::ScriptDeserialization(_)
+                | PreparationError::MissingCostModel(_)
+                | PreparationError::NonDisjointRefInputs { .. },
+            ) => unreachable!("no predicate mapping yet for {err}"),
         }
     }
 }

--- a/crates/amaru-ledger/src/rules/transaction/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/fixture.rs
@@ -37,7 +37,7 @@ use crate::{
                 outputs::{InvalidOutput, InvalidOutputs},
                 proposals::InvalidProposals,
             },
-            phase_two::{PhaseTwoError, PreparationError, TagMismatch},
+            phase_two::{PreparationError, TagMismatch},
         },
     },
 };
@@ -311,34 +311,13 @@ pub(super) enum Predicate {
 impl From<TransactionInvalid> for Predicate {
     fn from(err: TransactionInvalid) -> Self {
         match err {
-            TransactionInvalid::PhaseOneError(err) => Predicate::from(err),
-            TransactionInvalid::PhaseTwoError(err) => Predicate::from(err),
-        }
-    }
-}
-
-impl From<PhaseTwoError> for Predicate {
-    fn from(err: PhaseTwoError) -> Self {
-        match err {
-            PhaseTwoError::ValidationTagMismatch(TagMismatch::FailedUnexpectedly(_)) => {
+            TransactionInvalid::PhaseOne(err) => Predicate::from(err),
+            TransactionInvalid::PhaseTwo(TagMismatch::FailedUnexpectedly(_)) => {
                 Predicate::ValidationTagMismatch { description: TagMismatchDescription::FailedUnexpectedly }
             }
-            PhaseTwoError::ValidationTagMismatch(TagMismatch::PassedUnexpectedly) => {
+            TransactionInvalid::PhaseTwo(TagMismatch::PassedUnexpectedly) => {
                 Predicate::ValidationTagMismatch { description: TagMismatchDescription::PassedUnexpectedly }
             }
-            PhaseTwoError::Preparation(PreparationError::MalformedScriptWitness(_)) => {
-                Predicate::MalformedScriptWitnesses
-            }
-            // The Haskell ledger reports these as 'CollectErrors' rather than a tag mismatch: they
-            // are raised while assembling the script arguments, before any script runs.
-            PhaseTwoError::Preparation(
-                PreparationError::MissingInput(_)
-                | PreparationError::TransactionTranslation(_)
-                | PreparationError::ScriptContextState(_)
-                | PreparationError::ScriptDeserialization(_)
-                | PreparationError::MissingCostModel(_)
-                | PreparationError::NonDisjointRefInputs { .. },
-            ) => unreachable!("no predicate mapping yet for {err}"),
         }
     }
 }
@@ -421,6 +400,17 @@ impl From<PhaseOneError> for Predicate {
             PhaseOneError::Scripts(InvalidScripts::ExtraneousScriptWitnesses(_)) => {
                 Predicate::ExtraneousScriptWitnessesUTXOW
             }
+            PhaseOneError::ScriptPreparation(PreparationError::MalformedScriptWitness(_)) => {
+                Predicate::MalformedScriptWitnesses
+            }
+            PhaseOneError::ScriptPreparation(
+                PreparationError::MissingInput(_)
+                | PreparationError::TransactionTranslation(_)
+                | PreparationError::ScriptContextState(_)
+                | PreparationError::ScriptDeserialization(_)
+                | PreparationError::MissingCostModel(_)
+                | PreparationError::NonDisjointRefInputs { .. },
+            ) => unreachable!("no predicate mapping yet for {err}"),
             PhaseOneError::Certificates(InvalidCertificates::StakeCredentialInvalidPoolDelegation(ref e)) => match e {
                 DelegateError::UnknownSource(_) => Predicate::StakeCredentialInvalidPoolDelegation,
                 DelegateError::UnknownTarget(_) => Predicate::DelegateeStakePoolNotRegistered,

--- a/crates/amaru-ledger/src/rules/transaction/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/fixture.rs
@@ -31,9 +31,9 @@ use crate::{
         block::TransactionInvalid,
         transaction::{
             phase_one::{
-                InvalidCertificates, InvalidCollateral, InvalidFees, InvalidInputs, InvalidTransactionMetadata,
-                InvalidValidityInterval, InvalidVerificationKeyWitness, InvalidVotingProcedures, InvalidWithdrawals,
-                PhaseOneError,
+                InvalidCertificates, InvalidCollateral, InvalidFees, InvalidInputs, InvalidScripts,
+                InvalidTransactionMetadata, InvalidValidityInterval, InvalidVerificationKeyWitness,
+                InvalidVotingProcedures, InvalidWithdrawals, PhaseOneError,
                 outputs::{InvalidOutput, InvalidOutputs},
                 proposals::InvalidProposals,
             },
@@ -262,6 +262,7 @@ pub(super) enum Predicate {
     ConwayTxRefScriptsSizeTooBig,
     ConwayWdrlNotDelegatedToDRep,
     DisallowedVoters,
+    ExtraneousScriptWitnessesUTXOW,
     FeeTooSmallUTxO,
     GovActionsDoNotExist,
     IncorrectDepositDELEG,
@@ -417,6 +418,9 @@ impl From<PhaseOneError> for Predicate {
                 Predicate::VotingOnExpiredGovAction
             }
             PhaseOneError::ValueNotPreserved(_) => Predicate::ValueNotConservedUTxO,
+            PhaseOneError::Scripts(InvalidScripts::ExtraneousScriptWitnesses(_)) => {
+                Predicate::ExtraneousScriptWitnessesUTXOW
+            }
             PhaseOneError::Certificates(InvalidCertificates::StakeCredentialInvalidPoolDelegation(ref e)) => match e {
                 DelegateError::UnknownSource(_) => Predicate::StakeCredentialInvalidPoolDelegation,
                 DelegateError::UnknownTarget(_) => Predicate::DelegateeStakePoolNotRegistered,

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/metadata.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/metadata.rs
@@ -14,10 +14,11 @@
 
 use amaru_kernel::{AuxiliaryData, Bytes, Hash, ProtocolVersion, TransactionBody};
 use amaru_plutus::arena_pool::ArenaPool;
-use amaru_uplc::{arena::Arena, flat::FlatDecodeError};
+use amaru_uplc::{
+    arena::Arena,
+    flat::{FlatDecodeError, decode_plutus_script},
+};
 use thiserror::Error;
-
-use crate::rules::transaction::phase_one::scripts::validate_plutus_script;
 
 #[derive(Error, Debug)]
 pub enum InvalidTransactionMetadata {
@@ -64,8 +65,8 @@ fn validate_auxiliary_data_scripts(
     protocol_version: ProtocolVersion,
     arena: &Arena,
 ) -> Result<(), FlatDecodeError> {
-    data.plutus_v1_scripts().iter().try_for_each(|s| validate_plutus_script(s, protocol_version, arena))?;
-    data.plutus_v2_scripts().iter().try_for_each(|s| validate_plutus_script(s, protocol_version, arena))?;
-    data.plutus_v3_scripts().iter().try_for_each(|s| validate_plutus_script(s, protocol_version, arena))?;
+    data.plutus_v1_scripts().iter().try_for_each(|s| decode_plutus_script(s, protocol_version, arena).map(|_| ()))?;
+    data.plutus_v2_scripts().iter().try_for_each(|s| decode_plutus_script(s, protocol_version, arena).map(|_| ()))?;
+    data.plutus_v3_scripts().iter().try_for_each(|s| decode_plutus_script(s, protocol_version, arena).map(|_| ()))?;
     Ok(())
 }

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/metadata.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/metadata.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use amaru_kernel::{AuxiliaryData, Bytes, Hash, PlutusVersion, ProtocolVersion, TransactionBody};
+use amaru_kernel::{AuxiliaryData, Bytes, Hash, ProtocolVersion, TransactionBody};
+use amaru_plutus::arena_pool::ArenaPool;
 use amaru_uplc::{arena::Arena, flat::FlatDecodeError};
 use thiserror::Error;
 
@@ -36,6 +37,7 @@ pub enum InvalidTransactionMetadata {
 }
 
 pub fn execute(
+    arena_pool: &ArenaPool,
     transaction: &TransactionBody,
     auxiliary_data: Option<&AuxiliaryData>,
     protocol_version: ProtocolVersion,
@@ -50,9 +52,8 @@ pub fn execute(
                 return Err(InvalidTransactionMetadata::ConflictingMetadataHash { supplied, expected });
             }
 
-            // TODO: we should not be allocating a new arena here, instead using a shared pool, such as the one we use for phase 2 validation.
-            let mut arena = Arena::new();
-            validate_auxiliary_data_scripts(data, protocol_version, &mut arena)?;
+            let arena = arena_pool.acquire();
+            validate_auxiliary_data_scripts(data, protocol_version, &arena)?;
             Ok(())
         }
     }
@@ -61,16 +62,10 @@ pub fn execute(
 fn validate_auxiliary_data_scripts(
     data: &AuxiliaryData,
     protocol_version: ProtocolVersion,
-    arena: &mut Arena,
+    arena: &Arena,
 ) -> Result<(), FlatDecodeError> {
-    data.plutus_v1_scripts()
-        .iter()
-        .try_for_each(|s| validate_plutus_script(s, PlutusVersion::V1, protocol_version, arena))?;
-    data.plutus_v2_scripts()
-        .iter()
-        .try_for_each(|s| validate_plutus_script(s, PlutusVersion::V2, protocol_version, arena))?;
-    data.plutus_v3_scripts()
-        .iter()
-        .try_for_each(|s| validate_plutus_script(s, PlutusVersion::V3, protocol_version, arena))?;
+    data.plutus_v1_scripts().iter().try_for_each(|s| validate_plutus_script(s, protocol_version, arena))?;
+    data.plutus_v2_scripts().iter().try_for_each(|s| validate_plutus_script(s, protocol_version, arena))?;
+    data.plutus_v3_scripts().iter().try_for_each(|s| validate_plutus_script(s, protocol_version, arena))?;
     Ok(())
 }

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
@@ -160,7 +160,7 @@ where
     )?;
     span.record(PHASE_ONE::FIELD_VALIDITY_INTERVAL_MICROS, elapsed_and_reset(&mut meter));
 
-    metadata::execute(&transaction_body, transaction_auxiliary_data, protocol_parameters.protocol_version)?;
+    metadata::execute(arena_pool, &transaction_body, transaction_auxiliary_data, protocol_parameters.protocol_version)?;
     span.record(PHASE_ONE::FIELD_METADATA_MICROS, elapsed_and_reset(&mut meter));
 
     let ref_scripts_size = inputs::execute(
@@ -211,6 +211,7 @@ where
 
     outputs::execute(
         context,
+        arena_pool,
         protocol_parameters,
         network,
         mem::take(&mut transaction_body.collateral_return).map(|x| vec![*x]).unwrap_or_default(),
@@ -233,6 +234,7 @@ where
 
     outputs::execute(
         context,
+        arena_pool,
         protocol_parameters,
         network,
         mem::take(&mut transaction_body.outputs),
@@ -324,7 +326,6 @@ where
 
     scripts::execute(
         context,
-        arena_pool,
         transaction_witness_set,
         transaction_body.validity_interval(),
         protocol_parameters,

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/mod.rs
@@ -24,8 +24,9 @@ use amaru_plutus::arena_pool::ArenaPool;
 use thiserror::Error;
 
 use crate::{
-    context::ValidationContext, epoch_transition::GovernanceActivity,
-    rules::transaction::phase_one::outputs::SupplementalDatumPolicy,
+    context::ValidationContext,
+    epoch_transition::GovernanceActivity,
+    rules::transaction::{phase_one::outputs::SupplementalDatumPolicy, phase_two::PreparationError},
 };
 
 pub mod certificates;
@@ -89,6 +90,9 @@ pub enum PhaseOneError {
 
     #[error("invalid transaction scripts: {0}")]
     Scripts(#[from] InvalidScripts),
+
+    #[error("script preparation failed: {0}")]
+    ScriptPreparation(PreparationError),
 
     #[error("invalid collateral: {0}")]
     Collateral(#[from] InvalidCollateral),

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/outputs.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/outputs.rs
@@ -17,12 +17,12 @@ use amaru_kernel::{
     ProtocolParameters, ProtocolVersion, TransactionInput, Value, size::SCRIPT, utils::string::display_collection,
 };
 use amaru_plutus::arena_pool::ArenaPool;
-use amaru_uplc::arena::Arena;
+use amaru_uplc::{arena::Arena, flat::decode_plutus_script};
 use thiserror::Error;
 
 use crate::{
     context::{BalanceSlice, UtxoSlice, WitnessSlice},
-    rules::{WithPosition, transaction::phase_one::scripts::validate_plutus_script},
+    rules::WithPosition,
 };
 
 mod inherent_value;
@@ -138,9 +138,9 @@ fn validate_reference_script(
     arena: &Arena,
 ) -> Result<(), InvalidOutput> {
     let result = match script {
-        MemoizedScript::PlutusV1Script(s) => validate_plutus_script(s, protocol_version, arena),
-        MemoizedScript::PlutusV2Script(s) => validate_plutus_script(s, protocol_version, arena),
-        MemoizedScript::PlutusV3Script(s) => validate_plutus_script(s, protocol_version, arena),
+        MemoizedScript::PlutusV1Script(s) => decode_plutus_script(s, protocol_version, arena).map(|_| ()),
+        MemoizedScript::PlutusV2Script(s) => decode_plutus_script(s, protocol_version, arena).map(|_| ()),
+        MemoizedScript::PlutusV3Script(s) => decode_plutus_script(s, protocol_version, arena).map(|_| ()),
         MemoizedScript::NativeScript(_) => return Ok(()),
     };
     result.map_err(|_| InvalidOutput::MalformedReferenceScript(script.script_hash()))

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/outputs.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/outputs.rs
@@ -14,9 +14,9 @@
 
 use amaru_kernel::{
     Address, HasScriptHash, Hash, Lovelace, MemoizedDatum, MemoizedScript, MemoizedTransactionOutput, Network,
-    PlutusVersion, ProtocolParameters, ProtocolVersion, TransactionInput, Value, size::SCRIPT,
-    utils::string::display_collection,
+    ProtocolParameters, ProtocolVersion, TransactionInput, Value, size::SCRIPT, utils::string::display_collection,
 };
+use amaru_plutus::arena_pool::ArenaPool;
 use amaru_uplc::arena::Arena;
 use thiserror::Error;
 
@@ -64,6 +64,7 @@ pub enum SupplementalDatumPolicy {
 
 pub fn execute<C>(
     context: &mut C,
+    arena_pool: &ArenaPool,
     protocol_parameters: &ProtocolParameters,
     network: Network,
     outputs: Vec<MemoizedTransactionOutput>,
@@ -74,8 +75,7 @@ where
     C: WitnessSlice + UtxoSlice + BalanceSlice,
 {
     let mut invalid_outputs = Vec::new();
-    // TODO: we should not be allocating a new arena here, instead using a shared pool, such as the one we use for phase 2 validation.
-    let mut arena = Arena::new();
+    let arena = arena_pool.acquire();
 
     for (position, output) in outputs.into_iter().enumerate() {
         inherent_value::execute(protocol_parameters, &output)
@@ -94,7 +94,7 @@ where
         }
 
         if let Some(script) = output.script.as_ref() {
-            validate_reference_script(script, protocol_parameters.protocol_version, &mut arena)
+            validate_reference_script(script, protocol_parameters.protocol_version, &arena)
                 .unwrap_or_else(|element| invalid_outputs.push(WithPosition { position, element }));
         }
 
@@ -135,12 +135,12 @@ fn validate_network(output: &MemoizedTransactionOutput, expected: Network) -> Re
 fn validate_reference_script(
     script: &MemoizedScript,
     protocol_version: ProtocolVersion,
-    arena: &mut Arena,
+    arena: &Arena,
 ) -> Result<(), InvalidOutput> {
     let result = match script {
-        MemoizedScript::PlutusV1Script(s) => validate_plutus_script(s, PlutusVersion::V1, protocol_version, arena),
-        MemoizedScript::PlutusV2Script(s) => validate_plutus_script(s, PlutusVersion::V2, protocol_version, arena),
-        MemoizedScript::PlutusV3Script(s) => validate_plutus_script(s, PlutusVersion::V3, protocol_version, arena),
+        MemoizedScript::PlutusV1Script(s) => validate_plutus_script(s, protocol_version, arena),
+        MemoizedScript::PlutusV2Script(s) => validate_plutus_script(s, protocol_version, arena),
+        MemoizedScript::PlutusV3Script(s) => validate_plutus_script(s, protocol_version, arena),
         MemoizedScript::NativeScript(_) => return Ok(()),
     };
     result.map_err(|_| InvalidOutput::MalformedReferenceScript(script.script_hash()))

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/scripts.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/scripts.rs
@@ -25,7 +25,6 @@ use amaru_kernel::{
     size::{DATUM, SCRIPT},
     utils::string::display_collection,
 };
-use amaru_plutus::arena_pool::ArenaPool;
 use amaru_uplc::{
     arena::Arena,
     flat::{FlatDecodeError, decode_plutus_script},
@@ -134,9 +133,6 @@ pub enum InvalidScripts {
     )]
     MissingRedeemers(Vec<RedeemerKey>),
 
-    #[error("malformed script witnesses: [{}]", display_collection(.0))]
-    MalformedScriptWitnesses(BTreeSet<Hash<SCRIPT>>),
-
     #[error("transaction execution units exceeded: provided {provided:?}, max {max:?}")]
     TooManyExUnits { provided: ExUnits, max: ExUnits },
 
@@ -148,15 +144,11 @@ pub enum InvalidScripts {
         format_expected_integrity(.expected.as_deref())
     )]
     ScriptIntegrityHashMismatch { supplied: Option<Hash<32>>, expected: Option<Box<ScriptIntegrityData>> },
-
-    #[error("no cost model in protocol parameters for language used by transaction: {0:?}")]
-    MissingCostModel(PlutusVersion),
 }
 
 // TODO: Split this whole function into smaller functions to make it more graspable.
 pub fn execute<C>(
     context: &mut C,
-    arena_pool: &ArenaPool,
     witness_set: &WitnessSet,
     validity_interval: ValidityInterval,
     protocol_parameters: &ProtocolParameters,
@@ -172,13 +164,7 @@ where
     let required_script_hashes: BTreeSet<&Hash<SCRIPT>> =
         required_scripts.iter().map(|RequiredScript { hash, .. }| hash).collect();
 
-    let provided_scripts = collect_provided_scripts(
-        context,
-        arena_pool,
-        &required_script_hashes,
-        witness_set,
-        protocol_parameters.protocol_version,
-    )?;
+    let provided_scripts = collect_provided_scripts(context, &required_script_hashes, witness_set);
 
     super::native_scripts::execute(&provided_scripts, &required_script_hashes, witness_set, validity_interval)?;
 
@@ -213,17 +199,6 @@ where
 
     if !extra_redeemers.is_empty() {
         return Err(InvalidScripts::ExtraneousRedeemers(extra_redeemers));
-    }
-
-    for lang in &languages {
-        let has_cost_model = match lang {
-            PlutusVersion::V1 => protocol_parameters.cost_models.plutus_v1.is_some(),
-            PlutusVersion::V2 => protocol_parameters.cost_models.plutus_v2.is_some(),
-            PlutusVersion::V3 => protocol_parameters.cost_models.plutus_v3.is_some(),
-        };
-        if !has_cost_model {
-            return Err(InvalidScripts::MissingCostModel(*lang));
-        }
     }
 
     // NOTE: Two conformance tests ("PlutusV3 Initialization/Updating CostModels ...") fail this
@@ -351,26 +326,21 @@ fn datum_hashes(witness_set: &WitnessSet) -> BTreeSet<Hash<DATUM>> {
 /// - Scripts from collateral return
 fn collect_provided_scripts<'a, C>(
     context: &'a mut C,
-    arena_pool: &ArenaPool,
     required: &BTreeSet<&Hash<SCRIPT>>,
     witness_set: &'a WitnessSet,
-    protocol_version: ProtocolVersion,
-) -> Result<BTreeMap<Hash<SCRIPT>, ProvidedScript<'a>>, InvalidScripts>
+) -> BTreeMap<Hash<SCRIPT>, ProvidedScript<'a>>
 where
     C: WitnessSlice,
 {
-    let mut provided = validate_witness_scripts(arena_pool, witness_set, protocol_version)?;
+    let mut provided = collect_witness_scripts(witness_set);
 
-    // Reference-input scripts are not validated here — they were validated when the producing
-    // transaction's outputs went through the output rule. We only include those required by
-    // the transaction.
     for (script_hash, script_ref) in context.known_scripts() {
         if required.contains(&script_hash) {
             provided.insert(script_hash, ProvidedScript::from(script_ref));
         }
     }
 
-    Ok(provided)
+    provided
 }
 
 /// Ensures that the required and provided scripts match exactly (i.e. check that they're included
@@ -487,40 +457,18 @@ fn fail_on_missing_datums(missing: BTreeSet<u32>) -> Result<(), InvalidScripts> 
 }
 
 /// Attempts to flat decode the script bytes to validate they are well formed.
-/// Takes an arena to decode the script into, and then resets it.
 pub(crate) fn validate_plutus_script<const V: usize>(
     script: &PlutusScript<V>,
-    plutus_version: PlutusVersion,
     protocol_version: ProtocolVersion,
     arena: &Arena,
 ) -> Result<(), FlatDecodeError> {
-    let (_program, decoded_version) = decode_plutus_script(script, protocol_version, arena)?;
-
-    if plutus_version != decoded_version {
-        // TODO: Should not be a FlatDecodeError here, but something higher level.
-        return Err(FlatDecodeError::Message(format!(
-            "mismatch in Plutus version: declared={plutus_version:?}, found={decoded_version:?}"
-        )));
-    }
-
-    // TODO: Carry decoded programs throughout
-    //
-    // We decode the script bytes here and, if they're well-formed, again during phase 2 validations.
-    // We should decode the script bytes once, and then pass them to phase 2 validation for execution.
+    decode_plutus_script(script, protocol_version, arena)?;
     Ok(())
 }
 
-/// Validate every Plutus script in the witness set and return the witness set's scripts keyed
-/// by hash (native scripts are included as-is; Plutus scripts are included after their bytes
-/// successfully decode under the given protocol version). Fails with
-/// `MalformedScriptWitnesses` if any Plutus script's flat encoding doesn't decode.
-fn validate_witness_scripts<'a>(
-    arena_pool: &'_ ArenaPool,
-    witness_set: &'a WitnessSet,
-    protocol_version: ProtocolVersion,
-) -> Result<BTreeMap<Hash<SCRIPT>, ProvidedScript<'a>>, InvalidScripts> {
+/// Collect the witness set's scripts keyed by hash.
+fn collect_witness_scripts(witness_set: &WitnessSet) -> BTreeMap<Hash<SCRIPT>, ProvidedScript<'_>> {
     let mut provided = BTreeMap::new();
-    let mut malformed = BTreeSet::new();
 
     if let Some(scripts) = witness_set.native_script.as_deref() {
         for script in scripts {
@@ -528,79 +476,31 @@ fn validate_witness_scripts<'a>(
         }
     }
 
-    let arena = arena_pool.acquire();
+    collect_plutus_witness_scripts(witness_set.plutus_v1_script.as_deref(), PlutusVersion::V1, &mut provided);
 
-    collect_plutus_witness_scripts(
-        witness_set.plutus_v1_script.as_deref(),
-        PlutusVersion::V1,
-        protocol_version,
-        &arena,
-        &mut provided,
-        &mut malformed,
-    );
+    collect_plutus_witness_scripts(witness_set.plutus_v2_script.as_deref(), PlutusVersion::V2, &mut provided);
 
-    collect_plutus_witness_scripts(
-        witness_set.plutus_v2_script.as_deref(),
-        PlutusVersion::V2,
-        protocol_version,
-        &arena,
-        &mut provided,
-        &mut malformed,
-    );
+    collect_plutus_witness_scripts(witness_set.plutus_v3_script.as_deref(), PlutusVersion::V3, &mut provided);
 
-    collect_plutus_witness_scripts(
-        witness_set.plutus_v3_script.as_deref(),
-        PlutusVersion::V3,
-        protocol_version,
-        &arena,
-        &mut provided,
-        &mut malformed,
-    );
-
-    // TODO: Early return of ledger failures
-    //
-    // It is essential for the ledger to return as early as possible to minimize the amount of work
-    // being done. We could potentially adjust this behaviour at a later stage when running in a
-    // client mode to provide better errors; but that's not the goal _right now_. Note that I am
-    // not changing this now because:
-    //
-    // 1. I am in the middle of a review and it's not the time; it might break unrelated tests.
-    // 2. I would like to do a more extensive pass on the whole ledger regarding this; there might
-    //    be more similar occurences.
-    //
-    // TL; DR; do not decode ALL scripts if one is malformed, return at the first one.
-    if !malformed.is_empty() {
-        return Err(InvalidScripts::MalformedScriptWitnesses(malformed));
-    }
-
-    Ok(provided)
+    provided
 }
 
 fn collect_plutus_witness_scripts<const V: usize>(
     scripts: Option<&[PlutusScript<V>]>,
     plutus_version: PlutusVersion,
-    protocol_version: ProtocolVersion,
-    arena: &Arena,
     provided: &mut BTreeMap<Hash<SCRIPT>, ProvidedScript<'_>>,
-    malformed: &mut BTreeSet<Hash<SCRIPT>>,
 ) {
     let Some(scripts) = scripts else { return };
     for script in scripts {
         let hash = script.script_hash();
         provided.insert(hash, ProvidedScript::from(plutus_version));
-        if validate_plutus_script(script, plutus_version, protocol_version, arena).is_err() {
-            malformed.insert(hash);
-        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use amaru_kernel::{NonEmptyVec, PROTOCOL_VERSION_10, PlutusScript, WitnessSet};
-    use amaru_plutus::arena_pool::ArenaPool;
+    use amaru_kernel::{PROTOCOL_VERSION_10, PlutusScript, WitnessSet};
     use test_case::test_case;
-
-    use super::{InvalidScripts, PlutusVersion};
 
     /// Well-formedness is decided by the UPLC decoder, so a truncated or empty program is rejected
     /// before it is ever evaluated.
@@ -609,28 +509,13 @@ mod tests {
     fn malformed_plutus_script_rejected(bytes: Vec<u8>) {
         let script: PlutusScript<3> = PlutusScript(bytes.into());
         let arena = amaru_uplc::arena::Arena::new();
-        assert!(super::validate_plutus_script(&script, PlutusVersion::V3, PROTOCOL_VERSION_10, &arena).is_err());
+        assert!(super::validate_plutus_script(&script, PROTOCOL_VERSION_10, &arena).is_err());
     }
 
     #[test]
-    fn malformed_witness_script_detected() {
-        let witness_set = WitnessSet {
-            plutus_v3_script: Some(NonEmptyVec::singleton(PlutusScript(vec![0xDE, 0xAD].into()))),
-            ..WitnessSet::default()
-        };
-
-        assert!(matches!(
-            super::validate_witness_scripts(&ArenaPool::new(1, 1024), &witness_set, PROTOCOL_VERSION_10),
-            Err(InvalidScripts::MalformedScriptWitnesses(ref hashes)) if hashes.len() == 1
-        ));
-    }
-
-    #[test]
-    fn no_scripts_no_malformed() {
-        let arena_pool = ArenaPool::new(1, 1024);
+    fn no_witness_scripts() {
         let witness_set = WitnessSet::default();
-        let provided = super::validate_witness_scripts(&arena_pool, &witness_set, PROTOCOL_VERSION_10)
-            .expect("empty witness set should not produce malformed scripts");
+        let provided = super::collect_witness_scripts(&witness_set);
         assert!(provided.is_empty());
     }
 }

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/scripts.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/scripts.rs
@@ -20,14 +20,9 @@ use std::{
 
 use amaru_kernel::{
     ExUnits, HasExUnits, HasScriptHash, Hash, MemoizedDatum, MemoizedScript, NativeScript, PlutusScript, PlutusVersion,
-    ProtocolParameters, ProtocolVersion, RedeemerKey, RedeemerTag, RequiredScript, ScriptIntegrityData,
-    ValidityInterval, WitnessSet,
+    ProtocolParameters, RedeemerKey, RedeemerTag, RequiredScript, ScriptIntegrityData, ValidityInterval, WitnessSet,
     size::{DATUM, SCRIPT},
     utils::string::display_collection,
-};
-use amaru_uplc::{
-    arena::Arena,
-    flat::{FlatDecodeError, decode_plutus_script},
 };
 use thiserror::Error;
 
@@ -164,11 +159,17 @@ where
     let required_script_hashes: BTreeSet<&Hash<SCRIPT>> =
         required_scripts.iter().map(|RequiredScript { hash, .. }| hash).collect();
 
-    let provided_scripts = collect_provided_scripts(context, &required_script_hashes, witness_set);
+    let (provided_scripts, witnessed_script_hashes, reference_script_hashes) =
+        collect_provided_scripts(context, &required_script_hashes, witness_set);
 
     super::native_scripts::execute(&provided_scripts, &required_script_hashes, witness_set, validity_interval)?;
 
-    let required_scripts = fail_on_script_symmetric_differences(required_scripts, &provided_scripts)?;
+    let required_scripts = fail_on_script_symmetric_differences(
+        required_scripts,
+        &provided_scripts,
+        &witnessed_script_hashes,
+        &reference_script_hashes,
+    )?;
 
     let (mut required_redeemers, required_datums) = partition_scripts(required_scripts)?;
 
@@ -328,26 +329,31 @@ fn collect_provided_scripts<'a, C>(
     context: &'a mut C,
     required: &BTreeSet<&Hash<SCRIPT>>,
     witness_set: &'a WitnessSet,
-) -> BTreeMap<Hash<SCRIPT>, ProvidedScript<'a>>
+) -> (BTreeMap<Hash<SCRIPT>, ProvidedScript<'a>>, BTreeSet<Hash<SCRIPT>>, BTreeSet<Hash<SCRIPT>>)
 where
     C: WitnessSlice,
 {
     let mut provided = collect_witness_scripts(witness_set);
+    let witnessed = provided.keys().copied().collect();
+    let mut referenced = BTreeSet::new();
 
     for (script_hash, script_ref) in context.known_scripts() {
         if required.contains(&script_hash) {
+            referenced.insert(script_hash);
             provided.insert(script_hash, ProvidedScript::from(script_ref));
         }
     }
 
-    provided
+    (provided, witnessed, referenced)
 }
 
-/// Ensures that the required and provided scripts match exactly (i.e. check that they're included
-/// in each other).
+/// Ensures that every required script is available and that the witness set contains exactly the
+/// required scripts which are not supplied by a reference input.
 fn fail_on_script_symmetric_differences<'a>(
     required: BTreeSet<RequiredScript>,
     provided: &'_ BTreeMap<Hash<SCRIPT>, ProvidedScript<'a>>,
+    witnessed: &BTreeSet<Hash<SCRIPT>>,
+    referenced: &BTreeSet<Hash<SCRIPT>>,
 ) -> Result<Vec<(RequiredScript, ProvidedScript<'a>)>, InvalidScripts> {
     let mut missing = BTreeSet::new();
     let mut existing = BTreeSet::new();
@@ -369,7 +375,11 @@ fn fail_on_script_symmetric_differences<'a>(
         return Err(InvalidScripts::MissingRequiredScripts(missing));
     }
 
-    let extraneous: BTreeSet<Hash<SCRIPT>> = provided.keys().filter(|k| !existing.contains(k)).copied().collect();
+    let extraneous = witnessed
+        .iter()
+        .filter(|hash| !existing.contains(hash) || referenced.contains(hash))
+        .copied()
+        .collect::<BTreeSet<_>>();
 
     if !extraneous.is_empty() {
         return Err(InvalidScripts::ExtraneousScriptWitnesses(extraneous));
@@ -456,16 +466,6 @@ fn fail_on_missing_datums(missing: BTreeSet<u32>) -> Result<(), InvalidScripts> 
     Ok(())
 }
 
-/// Attempts to flat decode the script bytes to validate they are well formed.
-pub(crate) fn validate_plutus_script<const V: usize>(
-    script: &PlutusScript<V>,
-    protocol_version: ProtocolVersion,
-    arena: &Arena,
-) -> Result<(), FlatDecodeError> {
-    decode_plutus_script(script, protocol_version, arena)?;
-    Ok(())
-}
-
 /// Collect the witness set's scripts keyed by hash.
 fn collect_witness_scripts(witness_set: &WitnessSet) -> BTreeMap<Hash<SCRIPT>, ProvidedScript<'_>> {
     let mut provided = BTreeMap::new();
@@ -499,18 +499,7 @@ fn collect_plutus_witness_scripts<const V: usize>(
 
 #[cfg(test)]
 mod tests {
-    use amaru_kernel::{PROTOCOL_VERSION_10, PlutusScript, WitnessSet};
-    use test_case::test_case;
-
-    /// Well-formedness is decided by the UPLC decoder, so a truncated or empty program is rejected
-    /// before it is ever evaluated.
-    #[test_case(vec![0xDE, 0xAD]; "truncated program")]
-    #[test_case(vec![]; "empty program")]
-    fn malformed_plutus_script_rejected(bytes: Vec<u8>) {
-        let script: PlutusScript<3> = PlutusScript(bytes.into());
-        let arena = amaru_uplc::arena::Arena::new();
-        assert!(super::validate_plutus_script(&script, PROTOCOL_VERSION_10, &arena).is_err());
-    }
+    use amaru_kernel::WitnessSet;
 
     #[test]
     fn no_witness_scripts() {

--- a/crates/amaru-ledger/src/rules/transaction/phase_two/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_two/mod.rs
@@ -15,9 +15,9 @@
 use std::{collections::BTreeMap, fmt, time::Instant};
 
 use amaru_kernel::{
-    BorrowedScript, EraHistory, GlobalParameters, HasTransactionId, PlutusVersion, ProtocolParameters, RedeemerKey,
-    TransactionBody, TransactionInput, TransactionPointer, TxInfo, TxInfoTranslationError, Utxos, WitnessSet, cbor,
-    to_cbor,
+    BorrowedScript, EraHistory, GlobalParameters, HasScriptHash, HasTransactionId, Hash, PlutusVersion,
+    ProtocolParameters, RedeemerKey, TransactionBody, TransactionInput, TransactionPointer, TxInfo,
+    TxInfoTranslationError, Utxos, WitnessSet, cbor, size::SCRIPT, to_cbor,
     utils::{duration::elapsed_and_reset, string::display_collection},
 };
 use amaru_observability::debug_span;
@@ -30,7 +30,7 @@ use amaru_uplc::{
     binder::Binder,
     constant::Constant,
     data::PlutusData,
-    flat::{FlatDecodeError, decode_plutus_script},
+    flat::decode_plutus_script,
     machine::{CostModel, ExBudget, MachineInfo},
     program::Program,
     term::Term,
@@ -42,27 +42,47 @@ use crate::context::UtxoSlice;
 
 #[derive(Debug, Error)]
 pub enum PhaseTwoError {
+    #[error("script preparation failed: {0}")]
+    Preparation(#[from] PreparationError),
+
+    #[error("validation tag mismatch: {0}")]
+    ValidationTagMismatch(#[from] TagMismatch),
+}
+
+#[derive(Debug, Error)]
+pub enum PreparationError {
     #[error("missing input: {0}")]
     MissingInput(TransactionInput),
+
     #[error("failed to translate transaction to TxInfo: {0}")]
-    TransactionTranslationError(#[from] TxInfoTranslationError),
+    TransactionTranslation(#[from] TxInfoTranslationError),
+
     #[error("illegal state in ScriptContext: {0}")]
-    ScriptContextStateError(#[from] PlutusDataError),
+    ScriptContextState(#[from] PlutusDataError),
+
     #[error("failed to deserialize script: {0}")]
-    ScriptDeserializationError(cbor::decode::Error),
-    #[error("failed to flat decode script: {0}")]
-    FlatDecodingError(#[from] FlatDecodeError),
-    #[error("script evaluation failure: {0:?}")]
-    UplcMachineError(UplcMachineError),
-    #[error("expected scripts to fail but didn't")]
-    ValidityStateError,
+    ScriptDeserialization(#[from] cbor::decode::Error),
+
     #[error("missing cost models for version = {0:?}")]
     MissingCostModel(PlutusVersion),
+
+    #[error("malformed script witness: {0}")]
+    MalformedScriptWitness(Hash<SCRIPT>),
+
     #[error(
         "inputs included in both reference inputs and spent inputs: intersection [{}]",
         display_collection(.intersection),
     )]
     NonDisjointRefInputs { intersection: Vec<TransactionInput> },
+}
+
+#[derive(Debug, Error)]
+pub enum TagMismatch {
+    #[error("expected scripts to fail but they passed")]
+    PassedUnexpectedly,
+
+    #[error("expected scripts to pass but they failed: {0:?}")]
+    FailedUnexpectedly(Vec<UplcMachineError>),
 }
 
 #[derive(Debug)]
@@ -77,11 +97,34 @@ pub struct UplcMachineError {
     pub program: String,
 }
 
+#[derive(Debug)]
+enum ScriptOutcome {
+    Passed,
+    Failed(UplcMachineError),
+}
+
 fn encode_program<'a, V>(program: &'a Program<'a, V>) -> String
 where
     V: Binder<'a>,
 {
     amaru_uplc::flat::encode(program).map(hex::encode).unwrap_or_default()
+}
+
+fn verdict(is_valid: bool, script_results: Vec<Result<ScriptOutcome, PreparationError>>) -> Result<(), PhaseTwoError> {
+    let mut failures = Vec::new();
+
+    for result in script_results {
+        match result? {
+            ScriptOutcome::Passed => {}
+            ScriptOutcome::Failed(err) => failures.push(err),
+        }
+    }
+
+    match (is_valid, failures.is_empty()) {
+        (true, true) | (false, false) => Ok(()),
+        (true, false) => Err(TagMismatch::FailedUnexpectedly(failures).into()),
+        (false, true) => Err(TagMismatch::PassedUnexpectedly.into()),
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -102,7 +145,7 @@ where
     use amaru_observability::amaru::ledger::rules::PHASE_TWO;
 
     if transaction_witness_set.redeemer.is_none() {
-        return if is_valid { Ok(()) } else { Err(PhaseTwoError::ValidityStateError) };
+        return verdict(is_valid, Vec::new());
     }
 
     let span = debug_span!(ledger::rules::PHASE_TWO);
@@ -113,8 +156,8 @@ where
     let mut resolved_inputs = transaction_body
         .inputs
         .iter()
-        .map(|input| Ok((*input, context.lookup(input).ok_or(PhaseTwoError::MissingInput(*input))?.clone())))
-        .collect::<Result<BTreeMap<_, _>, PhaseTwoError>>()?;
+        .map(|input| Ok((*input, context.lookup(input).ok_or(PreparationError::MissingInput(*input))?.clone())))
+        .collect::<Result<BTreeMap<_, _>, PreparationError>>()?;
 
     let mut resolved_reference_inputs = transaction_body
         .reference_inputs
@@ -122,8 +165,8 @@ where
         .map(|reference_inputs| {
             reference_inputs
                 .iter()
-                .map(|input| Ok((*input, context.lookup(input).ok_or(PhaseTwoError::MissingInput(*input))?.clone())))
-                .collect::<Result<BTreeMap<_, _>, PhaseTwoError>>()
+                .map(|input| Ok((*input, context.lookup(input).ok_or(PreparationError::MissingInput(*input))?.clone())))
+                .collect::<Result<BTreeMap<_, _>, PreparationError>>()
         })
         .transpose()?
         .unwrap_or_default();
@@ -139,7 +182,8 @@ where
         &pointer.slot,
         era_history,
         global_parameters,
-    )?;
+    )
+    .map_err(PreparationError::from)?;
 
     let scripts_to_execute = tx_info.to_script_contexts();
 
@@ -154,7 +198,7 @@ where
             .collect::<Vec<_>>();
 
         if !non_disjoint_inputs.is_empty() {
-            return Err(PhaseTwoError::NonDisjointRefInputs { intersection: non_disjoint_inputs });
+            return Err(PreparationError::NonDisjointRefInputs { intersection: non_disjoint_inputs }.into());
         }
     }
 
@@ -185,7 +229,7 @@ where
                 BorrowedScript::PlutusV1(plutus_script) => {
                     let (program, plutus_version) =
                         decode_plutus_script(plutus_script, protocol_parameters.protocol_version, &arena)
-                            .map_err(PhaseTwoError::from)?;
+                            .map_err(|_| PreparationError::MalformedScriptWitness(plutus_script.script_hash()))?;
                     span_execute.record(EXECUTE::FIELD_DECODE_SCRIPT_MICROS, elapsed_and_reset(&mut meter));
 
                     let args = script_context.to_script_args(PLUTUS_V1)?;
@@ -194,14 +238,14 @@ where
                         .cost_models
                         .plutus_v1
                         .as_deref()
-                        .ok_or(PhaseTwoError::MissingCostModel(plutus_version))?;
+                        .ok_or(PreparationError::MissingCostModel(plutus_version))?;
 
-                    Ok::<_, PhaseTwoError>((program, plutus_version, args, cost_model))
+                    Ok::<_, PreparationError>((program, plutus_version, args, cost_model))
                 }
                 BorrowedScript::PlutusV2(plutus_script) => {
                     let (program, plutus_version) =
                         decode_plutus_script(plutus_script, protocol_parameters.protocol_version, &arena)
-                            .map_err(PhaseTwoError::from)?;
+                            .map_err(|_| PreparationError::MalformedScriptWitness(plutus_script.script_hash()))?;
                     span_execute.record(EXECUTE::FIELD_DECODE_SCRIPT_MICROS, elapsed_and_reset(&mut meter));
 
                     let args = script_context.to_script_args(PLUTUS_V2)?;
@@ -210,14 +254,14 @@ where
                         .cost_models
                         .plutus_v2
                         .as_deref()
-                        .ok_or(PhaseTwoError::MissingCostModel(plutus_version))?;
+                        .ok_or(PreparationError::MissingCostModel(plutus_version))?;
 
-                    Ok::<_, PhaseTwoError>((program, plutus_version, args, cost_model))
+                    Ok::<_, PreparationError>((program, plutus_version, args, cost_model))
                 }
                 BorrowedScript::PlutusV3(plutus_script) => {
                     let (program, plutus_version) =
                         decode_plutus_script(plutus_script, protocol_parameters.protocol_version, &arena)
-                            .map_err(PhaseTwoError::from)?;
+                            .map_err(|_| PreparationError::MalformedScriptWitness(plutus_script.script_hash()))?;
                     span_execute.record(EXECUTE::FIELD_DECODE_SCRIPT_MICROS, elapsed_and_reset(&mut meter));
 
                     let args = script_context.to_script_args(PLUTUS_V3)?;
@@ -226,9 +270,9 @@ where
                         .cost_models
                         .plutus_v3
                         .as_deref()
-                        .ok_or(PhaseTwoError::MissingCostModel(plutus_version))?;
+                        .ok_or(PreparationError::MissingCostModel(plutus_version))?;
 
-                    Ok::<_, PhaseTwoError>((program, plutus_version, args, cost_model))
+                    Ok::<_, PreparationError>((program, plutus_version, args, cost_model))
                 }
             }?;
 
@@ -262,42 +306,34 @@ where
             span_execute.record(EXECUTE::FIELD_EVALUATE_UPLC_PROGRAM_MICROS, elapsed_and_reset(&mut meter));
 
             let uplc_machine_error = |err| {
-                Err(PhaseTwoError::UplcMachineError(UplcMachineError {
+                ScriptOutcome::Failed(UplcMachineError {
                     plutus_version,
                     info: result.info,
                     err,
                     redeemer: *redeemer,
                     program: encode_program(program),
-                }))
+                })
             };
 
-            match plutus_version {
+            Ok(match plutus_version {
                 PlutusVersion::V1 | PlutusVersion::V2 => match result.term {
                     Ok(Term::Error) => uplc_machine_error("evaluated to error term".to_owned()),
-                    Ok(_) => Ok(()),
+                    Ok(_) => ScriptOutcome::Passed,
                     Err(e) => uplc_machine_error(e.to_string()),
                 },
 
                 // According to [CIP-117](https://cips.cardano.org/cip/CIP-0117),
                 // Plutus V3 scripts must evaluate to a constant term of unit
                 PlutusVersion::V3 => match result.term {
-                    Ok(Term::Constant(Constant::Unit)) => Ok(()),
+                    Ok(Term::Constant(Constant::Unit)) => ScriptOutcome::Passed,
                     Ok(_) => uplc_machine_error("evaluated to a non-unit term".to_owned()),
                     Err(e) => uplc_machine_error(e.to_string()),
                 },
-            }
+            })
         })
-        .collect::<Result<Vec<_>, _>>()
-        .map(|_| ());
+        .collect::<Vec<_>>();
 
-    if is_valid {
-        script_results
-    } else {
-        match script_results {
-            Ok(_) => Err(PhaseTwoError::ValidityStateError),
-            Err(_) => Ok(()),
-        }
-    }
+    verdict(is_valid, script_results)
 }
 
 #[cfg(test)]

--- a/crates/amaru-ledger/src/rules/transaction/phase_two/mod.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_two/mod.rs
@@ -17,7 +17,9 @@ use std::{collections::BTreeMap, fmt, time::Instant};
 use amaru_kernel::{
     BorrowedScript, EraHistory, GlobalParameters, HasScriptHash, HasTransactionId, Hash, PlutusVersion,
     ProtocolParameters, RedeemerKey, TransactionBody, TransactionInput, TransactionPointer, TxInfo,
-    TxInfoTranslationError, Utxos, WitnessSet, cbor, size::SCRIPT, to_cbor,
+    TxInfoTranslationError, Utxos, WitnessSet, cbor,
+    size::SCRIPT,
+    to_cbor,
     utils::{duration::elapsed_and_reset, string::display_collection},
 };
 use amaru_observability::debug_span;
@@ -40,8 +42,11 @@ use thiserror::Error;
 
 use crate::context::UtxoSlice;
 
+/// Everything that can go wrong while evaluating a transaction's scripts. Not all of it is a
+/// phase-two failure: [`TransactionInvalid`](crate::rules::block::TransactionInvalid) is where
+/// each variant is assigned a validation phase.
 #[derive(Debug, Error)]
-pub enum PhaseTwoError {
+pub enum ScriptEvaluationError {
     #[error("script preparation failed: {0}")]
     Preparation(#[from] PreparationError),
 
@@ -110,7 +115,10 @@ where
     amaru_uplc::flat::encode(program).map(hex::encode).unwrap_or_default()
 }
 
-fn verdict(is_valid: bool, script_results: Vec<Result<ScriptOutcome, PreparationError>>) -> Result<(), PhaseTwoError> {
+fn verdict(
+    is_valid: bool,
+    script_results: Vec<Result<ScriptOutcome, PreparationError>>,
+) -> Result<(), ScriptEvaluationError> {
     let mut failures = Vec::new();
 
     for result in script_results {
@@ -138,7 +146,7 @@ pub fn execute<C>(
     is_valid: bool,
     transaction_body: &TransactionBody,
     transaction_witness_set: &WitnessSet,
-) -> Result<(), PhaseTwoError>
+) -> Result<(), ScriptEvaluationError>
 where
     C: UtxoSlice + fmt::Debug,
 {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00256-fail-plutus-witness-script-that-cannot-be-flat-decoded.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00256-fail-plutus-witness-script-that-cannot-be-flat-decoded.json
@@ -2,13 +2,13 @@
   "title": "plutus witness script that cannot be flat decoded",
   "description": "A transaction marked valid spending an input locked by a Plutus V3 script whose flat encoding is truncated.",
   "network": "preprod",
-  "eraHistory": {
-    "$ref": "common/eraHistory/preprod-conway.json"
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
   },
-  "protocolParameters": {
-    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
   },
-  "initialState": {
+  "initial_state": {
     "utxo": [
       {
         "input": "8258201dd645d794b677b09837adb4cfa00c4b1f1453608e76972e63b547adf1b356c400",
@@ -22,7 +22,7 @@
   },
   "point": {
     "slot": 0,
-    "transactionIndex": 0
+    "transaction_index": 0
   },
   "transaction": "84a600d90102818258201dd645d794b677b09837adb4cfa00c4b1f1453608e76972e63b547adf1b356c4000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a0049b7d3021a0002936d0b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd9010281825820a71811b48f7a93cb53de690e81cc4b7b4413fcce44da3e1f82f3cbef62c716df000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584034b05c76f06e8980dc093816805d19a183f7a21d2f084b78b9c951a70f587bde5d719d9e904c0f820956711dd41120b07d008eac6d46099039af5dc504a23a0005a18200008200821907d01a000f424007d90102814342deadf5f6",
   "expected": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00256-fail-plutus-witness-script-that-cannot-be-flat-decoded.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00256-fail-plutus-witness-script-that-cannot-be-flat-decoded.json
@@ -1,0 +1,31 @@
+{
+  "title": "plutus witness script that cannot be flat decoded",
+  "description": "A transaction marked valid spending an input locked by a Plutus V3 script whose flat encoding is truncated.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "8258201dd645d794b677b09837adb4cfa00c4b1f1453608e76972e63b547adf1b356c400",
+        "output": "a200581d70a699ffd97973265b05ef23114b7989526cdce6807f2395f40ab77960011a004c4b40"
+      },
+      {
+        "input": "825820a71811b48f7a93cb53de690e81cc4b7b4413fcce44da3e1f82f3cbef62c716df00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002dc6c0"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a600d90102818258201dd645d794b677b09837adb4cfa00c4b1f1453608e76972e63b547adf1b356c4000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a0049b7d3021a0002936d0b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd9010281825820a71811b48f7a93cb53de690e81cc4b7b4413fcce44da3e1f82f3cbef62c716df000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584034b05c76f06e8980dc093816805d19a183f7a21d2f084b78b9c951a70f587bde5d719d9e904c0f820956711dd41120b07d008eac6d46099039af5dc504a23a0005a18200008200821907d01a000f424007d90102814342deadf5f6",
+  "expected": {
+    "predicate": "MalformedScriptWitnesses"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00257-fail-plutus-witness-script-that-cannot-be-flat-decoded-marked-invalid.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00257-fail-plutus-witness-script-that-cannot-be-flat-decoded-marked-invalid.json
@@ -1,0 +1,31 @@
+{
+  "title": "plutus witness script that cannot be flat decoded, marked invalid",
+  "description": "A transaction marked invalid spending an input locked by a Plutus V3 script whose flat encoding is truncated.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820c6268e1b46ef4a8a39f835d07fba81d8fb194ec1d0dd8dd371fad678d8a875de00",
+        "output": "a200581d70a699ffd97973265b05ef23114b7989526cdce6807f2395f40ab77960011a004c4b40"
+      },
+      {
+        "input": "82582082c43481a876db37489bb1a248e6985f6c143a4f0b77fe6a422c504873f1d4ee00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002dc6c0"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a600d9010281825820c6268e1b46ef4a8a39f835d07fba81d8fb194ec1d0dd8dd371fad678d8a875de000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a0049b7d3021a0002936d0b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd901028182582082c43481a876db37489bb1a248e6985f6c143a4f0b77fe6a422c504873f1d4ee000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840cf69ec96b6a4b7c4ea4797d2b0f5ef44e87b89563ddadbcc9b1d6311b48ad2ed42d158a124bd87028be376982c6fc056cc587335f22d404e7062c1082152e80705a18200008200821907d01a000f424007d90102814342deadf4f6",
+  "expected": {
+    "predicate": "MalformedScriptWitnesses"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00257-fail-plutus-witness-script-that-cannot-be-flat-decoded-marked-invalid.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00257-fail-plutus-witness-script-that-cannot-be-flat-decoded-marked-invalid.json
@@ -2,13 +2,13 @@
   "title": "plutus witness script that cannot be flat decoded, marked invalid",
   "description": "A transaction marked invalid spending an input locked by a Plutus V3 script whose flat encoding is truncated.",
   "network": "preprod",
-  "eraHistory": {
-    "$ref": "common/eraHistory/preprod-conway.json"
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
   },
-  "protocolParameters": {
-    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
   },
-  "initialState": {
+  "initial_state": {
     "utxo": [
       {
         "input": "825820c6268e1b46ef4a8a39f835d07fba81d8fb194ec1d0dd8dd371fad678d8a875de00",
@@ -22,7 +22,7 @@
   },
   "point": {
     "slot": 0,
-    "transactionIndex": 0
+    "transaction_index": 0
   },
   "transaction": "84a600d9010281825820c6268e1b46ef4a8a39f835d07fba81d8fb194ec1d0dd8dd371fad678d8a875de000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a0049b7d3021a0002936d0b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd901028182582082c43481a876db37489bb1a248e6985f6c143a4f0b77fe6a422c504873f1d4ee000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840cf69ec96b6a4b7c4ea4797d2b0f5ef44e87b89563ddadbcc9b1d6311b48ad2ed42d158a124bd87028be376982c6fc056cc587335f22d404e7062c1082152e80705a18200008200821907d01a000f424007d90102814342deadf4f6",
   "expected": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00258-fail-malformed-plutus-witness-script-alongside-a-failing-one-marked-invalid.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00258-fail-malformed-plutus-witness-script-alongside-a-failing-one-marked-invalid.json
@@ -2,13 +2,13 @@
   "title": "malformed plutus witness script alongside a failing one, marked invalid",
   "description": "A transaction marked invalid spending two Plutus V3 script-locked inputs, one script truncated and the other evaluating to an error term.",
   "network": "preprod",
-  "eraHistory": {
-    "$ref": "common/eraHistory/preprod-conway.json"
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
   },
-  "protocolParameters": {
-    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
   },
-  "initialState": {
+  "initial_state": {
     "utxo": [
       {
         "input": "825820745894123a4ed67d7cf4f4a3e1c5bff7c5b9c75eff8a2747e0b8bda3022ec1fc00",
@@ -26,7 +26,7 @@
   },
   "point": {
     "slot": 0,
-    "transactionIndex": 0
+    "transaction_index": 0
   },
   "transaction": "84a600d9010282825820745894123a4ed67d7cf4f4a3e1c5bff7c5b9c75eff8a2747e0b8bda3022ec1fc00825820cdfdc9dc0dc16efd0b7387584bc636c7a340377890f3e07400e8009f3214e0e9000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a0049ad78021a00029dc80b58207d3dc97ee25aa26868e5784e5405b3148aecf6b4138e38286fb7e81b868db4c20dd9010281825820da69bb60b261e1345f3d68bab1897145f3cb49f3eb1e7147cb2a686ad794809b000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840ac206723ca6900ac9cfc7897c90fce1740b6b5bb87152ddc6b17a595bad6dd5983f98a071f586be2f0e783b4227fb343ef03227bd750895d5a7cbf05a78de70905a28200008200821907d01a000f42408200018200821907d01a000f424007d90102824342dead454401010061f4f6",
   "expected": {

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00258-fail-malformed-plutus-witness-script-alongside-a-failing-one-marked-invalid.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00258-fail-malformed-plutus-witness-script-alongside-a-failing-one-marked-invalid.json
@@ -1,0 +1,35 @@
+{
+  "title": "malformed plutus witness script alongside a failing one, marked invalid",
+  "description": "A transaction marked invalid spending two Plutus V3 script-locked inputs, one script truncated and the other evaluating to an error term.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820745894123a4ed67d7cf4f4a3e1c5bff7c5b9c75eff8a2747e0b8bda3022ec1fc00",
+        "output": "a200581d70a699ffd97973265b05ef23114b7989526cdce6807f2395f40ab77960011a002625a0"
+      },
+      {
+        "input": "825820cdfdc9dc0dc16efd0b7387584bc636c7a340377890f3e07400e8009f3214e0e900",
+        "output": "a200581d70994b345acef955ada938b01e9f0405ab57743d41f0b398de604d0969011a002625a0"
+      },
+      {
+        "input": "825820da69bb60b261e1345f3d68bab1897145f3cb49f3eb1e7147cb2a686ad794809b00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002dc6c0"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a600d9010282825820745894123a4ed67d7cf4f4a3e1c5bff7c5b9c75eff8a2747e0b8bda3022ec1fc00825820cdfdc9dc0dc16efd0b7387584bc636c7a340377890f3e07400e8009f3214e0e9000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a0049ad78021a00029dc80b58207d3dc97ee25aa26868e5784e5405b3148aecf6b4138e38286fb7e81b868db4c20dd9010281825820da69bb60b261e1345f3d68bab1897145f3cb49f3eb1e7147cb2a686ad794809b000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840ac206723ca6900ac9cfc7897c90fce1740b6b5bb87152ddc6b17a595bad6dd5983f98a071f586be2f0e783b4227fb343ef03227bd750895d5a7cbf05a78de70905a28200008200821907d01a000f42408200018200821907d01a000f424007d90102824342dead454401010061f4f6",
+  "expected": {
+    "predicate": "MalformedScriptWitnesses"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00259-fail-plutus-v2-script-supplied-as-both-a-witness-and-a-reference-script.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00259-fail-plutus-v2-script-supplied-as-both-a-witness-and-a-reference-script.json
@@ -1,0 +1,41 @@
+{
+  "title": "plutus v2 script supplied as both a witness and a reference script",
+  "description": "Spends an input using the same PlutusV2 script from both the witness set and a reference input.",
+  "network": "preprod",
+  "eraHistory": {
+    "$ref": "common/eraHistory/preprod-conway.json"
+  },
+  "protocolParameters": {
+    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  },
+  "initialState": {
+    "utxo": [
+      {
+        "input": "825820c4e8a2d6b0f4c8e2a6d0b4f8c2e6a0d4b8f2c6e0a4d8b2f6c0e4a8d2b6f0c4e800",
+        "output": "a300581d7052c6af0c9b744b4eecce838538a52ceb155038b3de68e2bb2fa8fc37011a0098968002820058209e1199a988ba72ffd6e9c269cadb3b53b5f360ff99f112d9b2ee30c4d74ad88b"
+      },
+      {
+        "input": "825820e6a0d4b8f2c6e0a4d8b2f6c0e4a8d2b6f0c4e8a2d6b0f4c8e2a6d0b4f8c2e6a000",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      },
+      {
+        "input": "825820a2d6b0f4c8e2a6d0b4f8c2e6a0d4b8f2c6e0a4d8b2f6c0e4a8d2b6f0c4e8a2d600",
+        "output": "a300581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e848003d8184a82024746010000222499"
+      }
+    ],
+    "pools": [],
+    "accounts": [],
+    "dreps": [],
+    "governanceActivity": {
+      "consecutiveDormantEpochs": 0
+    }
+  },
+  "point": {
+    "slot": 0,
+    "transactionIndex": 0
+  },
+  "transaction": "84a700d9010281825820c4e8a2d6b0f4c8e2a6d0b4f8c2e6a0d4b8f2c6e0a4d8b2f6c0e4a8d2b6f0c4e8000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00895440021a000f42400b58204801a5208cacaa93c99dc76d1d5fb8b85cf662ffcb73389a7b8f138a741100250dd9010281825820e6a0d4b8f2c6e0a4d8b2f6c0e4a8d2b6f0c4e8a2d6b0f4c8e2a6d0b4f8c2e6a0000f0012d9010281825820a2d6b0f4c8e2a6d0b4f8c2e6a0d4b8f2c6e0a4d8b2f6c0e4a8d2b6f0c4e8a2d600a404d9010281182a05a18200008200821907d01a000f424000d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840e08c2c166f0ed986a4c5e973a52e0b92398dd84ecacfaa4b7a7bedd43308ff8126dfb496e7f8f3aca0c1287922e045f46c0a30f5375c1334f09248f14ced970506d90102814746010000222499f5f6",
+  "expected": {
+    "predicate": "ExtraneousScriptWitnessesUTXOW"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00259-fail-plutus-v2-script-supplied-as-both-a-witness-and-a-reference-script.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00259-fail-plutus-v2-script-supplied-as-both-a-witness-and-a-reference-script.json
@@ -2,13 +2,13 @@
   "title": "plutus v2 script supplied as both a witness and a reference script",
   "description": "Spends an input using the same PlutusV2 script from both the witness set and a reference input.",
   "network": "preprod",
-  "eraHistory": {
-    "$ref": "common/eraHistory/preprod-conway.json"
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
   },
-  "protocolParameters": {
-    "$ref": "common/protocolParameters/preprod-conway-v10.json"
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
   },
-  "initialState": {
+  "initial_state": {
     "utxo": [
       {
         "input": "825820c4e8a2d6b0f4c8e2a6d0b4f8c2e6a0d4b8f2c6e0a4d8b2f6c0e4a8d2b6f0c4e800",
@@ -23,16 +23,13 @@
         "output": "a300581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e848003d8184a82024746010000222499"
       }
     ],
-    "pools": [],
-    "accounts": [],
-    "dreps": [],
-    "governanceActivity": {
-      "consecutiveDormantEpochs": 0
+    "governance_activity": {
+      "consecutive_dormant_epochs": 0
     }
   },
   "point": {
     "slot": 0,
-    "transactionIndex": 0
+    "transaction_index": 0
   },
   "transaction": "84a700d9010281825820c4e8a2d6b0f4c8e2a6d0b4f8c2e6a0d4b8f2c6e0a4d8b2f6c0e4a8d2b6f0c4e8000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00895440021a000f42400b58204801a5208cacaa93c99dc76d1d5fb8b85cf662ffcb73389a7b8f138a741100250dd9010281825820e6a0d4b8f2c6e0a4d8b2f6c0e4a8d2b6f0c4e8a2d6b0f4c8e2a6d0b4f8c2e6a0000f0012d9010281825820a2d6b0f4c8e2a6d0b4f8c2e6a0d4b8f2c6e0a4d8b2f6c0e4a8d2b6f0c4e8a2d600a404d9010281182a05a18200008200821907d01a000f424000d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840e08c2c166f0ed986a4c5e973a52e0b92398dd84ecacfaa4b7a7bedd43308ff8126dfb496e7f8f3aca0c1287922e045f46c0a30f5375c1334f09248f14ced970506d90102814746010000222499f5f6",
   "expected": {

--- a/crates/amaru/tests/conformance/validation-rules/src/Command/ValidatePhaseOne/Run.hs
+++ b/crates/amaru/tests/conformance/validation-rules/src/Command/ValidatePhaseOne/Run.hs
@@ -391,6 +391,8 @@ normalizeUtxowFailure expectedHint = \case
         "ConflictingMetadataHash"
     MalformedReferenceScripts{} ->
         "MalformedReferenceScripts"
+    MalformedScriptWitnesses{} ->
+        "MalformedScriptWitnesses"
     otherFailure ->
         "unsupported:" <> showText expectedHint <> ":" <> showText otherFailure
 

--- a/crates/amaru/tests/conformance/validation-rules/src/Command/ValidatePhaseOne/Run.hs
+++ b/crates/amaru/tests/conformance/validation-rules/src/Command/ValidatePhaseOne/Run.hs
@@ -381,6 +381,8 @@ normalizeUtxowFailure expectedHint = \case
         normalizeUtxoFailure failure
     InvalidWitnessesUTXOW{} ->
         "InvalidWitnessesUTXOW"
+    ExtraneousScriptWitnessesUTXOW{} ->
+        "ExtraneousScriptWitnessesUTXOW"
     MissingVKeyWitnessesUTXOW{} ->
         "MissingVerificationKeyWitnessesUTXOW"
     MissingTxBodyMetadataHash{} ->


### PR DESCRIPTION
Previously, we would decode all scripts for a well-formed check, and then decode (some) of those scripts again for phase two validation. This PR moves some of the script decoding to the `phase_two` module, so the scripts are only decoded once. The check is still part of the "phase one" validation as defined by the Cardano protocol, highlighting the need for new module names for clarity, as things potentially move around.

Testing locally revealed that, in some cases (in particular, this measurement was from fixture `0035`), this sped up phase-one validation by ~11.5%

During this work, I also realized there was a bug in our extraneous script witness logic, where you could provide a script both in the witnesses *and* in a reference input. That should not be allowed, and this PR corrects that behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved ledger transaction validation and script-checking efficiency by up to approximately 11.5%.
* **Bug Fixes**
  * Corrected minimum lovelace calculations, transaction-size handling, mempool byte preservation, metric wording, protocol-specific input validation, and reward account decoding.
  * Transactions now reject scripts supplied both as witnesses and reference inputs.
  * Improved malformed script detection and validation error reporting.
* **Tests**
  * Added coverage for malformed scripts and duplicate script sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->