### PR TITLE
fix resume sync after static peer disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ Other guiding principles:
 
 ### Fixed
 
+- **amaru-consensus**: resume outbound sync after a mux drop: forget the dead `Connected` entry before the replacement handshake, and do not immediately re-dial a banned static peer while the manager still holds the live connection ([#1265](https://github.com/pragma-org/amaru/issues/1265)).
+- **amaru-consensus**: report clock-skew versus non-monotonic slot failures distinctly instead of the same “expected at least” message ([#1265](https://github.com/pragma-org/amaru/issues/1265)).
+- **amaru-protocols**: include the `Peer` on mux receive/send failure logs ([#1265](https://github.com/pragma-org/amaru/issues/1265)).
 - **workflows**: executable permissions are now correctly preserved in the release workflow.
 - **amaru-ledger**: Correctly calculate an output's minimum lovelace value.
 - **amaru-ledger**: do not re-encode locally submitted transactions to obtain their size.

--- a/crates/amaru-consensus/src/errors.rs
+++ b/crates/amaru-consensus/src/errors.rs
@@ -66,6 +66,8 @@ pub enum ConsensusError {
     InvalidHeaderVariant(EraName),
     #[error("header slot {0} is in the near future (permissible clock skew)")]
     HeaderSlotInNearFuture(Slot),
+    #[error("{0}")]
+    HeaderSlotTooFarInFuture(Box<HeaderSlotTooFarInFuture>),
     #[error("Failed to roll forward chain from {0}: {1}")]
     RollForwardChainFailed(amaru_kernel::Hash<32>, StoreError),
     #[error("Failed to rollback chain at {0}: {1}")]
@@ -115,11 +117,27 @@ impl Display for InvalidHeaderParentData {
 }
 
 #[derive(Error, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-#[error("Invalid header point {actual}, expected at least {parent} (upstream peer’s best validated is at {highest})")]
+#[error(
+    "Invalid header point {actual}: slot does not progress from parent {parent} (upstream peer’s best validated is at {highest})"
+)]
 pub struct InvalidHeaderPoint {
     pub actual: Point,
     pub parent: Point,
     pub highest: Point,
+}
+
+#[derive(Error, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[error(
+    "header point {actual} is {delta_millis}ms ahead of local time (slot onset {onset_millis}ms since system start, local {elapsed_millis}ms; max skew {max_skew_millis}ms; parent {parent}; peer tip {highest})"
+)]
+pub struct HeaderSlotTooFarInFuture {
+    pub actual: Point,
+    pub parent: Point,
+    pub highest: Point,
+    pub onset_millis: u64,
+    pub elapsed_millis: u64,
+    pub delta_millis: u64,
+    pub max_skew_millis: u64,
 }
 
 /// A ValidationFailed error is raised when some incoming data is invalid

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -97,12 +97,14 @@ pub const SHARE_REQUEST_AMOUNT: u8 = 20;
 /// - **Adversarial**: Debug-logs. Delegates to
 ///   `ban_peer`: removes the peer from `inbound_peers` (if present;
 ///   warns `"removing peer (inbound)"`) and/or `outbound_peers` (if present; warns
-///   `"removing peer (outbound)"`, calls `regulate_peers`, marks for removal).
+///   `"removing peer (outbound)"`).
 ///   If any removal occurred, sends `ManagerMessage::RemovePeer` to the manager.
 ///   Always calls `cool_down` (which computes `STATIC_PEER_BAN_PERIOD` (10s) for
 ///   static peers vs. configured cooldown, pushes onto the cool-down min-heap, and
 ///   arms `eff.schedule_at(CheckCooldowns)` only when the live cool-down set goes from
 ///   empty to one item, or when the new end time is earlier than the currently armed timer).
+///   After the ban is recorded, outbound removal refills via `regulate_peers` (the banned
+///   peer is excluded, so a static peer is not immediately re-added while still connected).
 ///
 /// - **AddPeer**: Manual/test hook. If the peer
 ///   has an active cool-down, removes it from `cooldown_until` (`was_banned = true`)
@@ -133,7 +135,9 @@ pub const SHARE_REQUEST_AMOUNT: u8 = 20;
 /// - **Disconnected**:
 ///   - `Inbound`: Removes from `inbound_peers` only on exact `ConnectionId` match
 ///     (via `Entry::Occupied` guard).
-///   - `Outbound` + `will_retry == true`: Clears availability claims only.
+///   - `Outbound` + `will_retry == true`: If present as `PeerState::Connected` with
+///     matching id, replaces it with `Connecting` so a reconnect handshake does
+///     not race a stale live entry; then clears availability if nothing remains.
 ///   - `Outbound` + `will_retry == false`: Removes only if present as exactly
 ///     `PeerState::Connected` with matching id; then `regulate_peers`.
 ///     (Share-request timers die with the connection's peer-sharing stage.)
@@ -172,7 +176,8 @@ pub const SHARE_REQUEST_AMOUNT: u8 = 20;
 /// ## Regulation, Schedules, and Effects
 ///
 /// `regulate_peers` (called from `CheckCooldowns`, outbound non-retry disconnect,
-/// `ConnectFailed`, `Regulate`, and outbound removal inside `ban_peer`)
+/// `ConnectFailed`, `Regulate`, and outbound removal inside `ban_peer` after the
+/// ban is recorded)
 /// early-returns if `outbound_peers.len() >= target_upstream_peers`. Otherwise it
 /// obtains a seed via `eff.external(GenerateRandomSeed)` and asks Performance to
 /// select dials (mix + quality-weighted sample within each
@@ -335,6 +340,7 @@ impl PeerSelection {
         let is_static = eff.external(Performance::is_static_peer(peer.clone())).await;
 
         let mut send_remove = false;
+        let mut refill_outbound = false;
         if let Some(peer_state) = self.inbound_peers.remove(&peer) {
             tracing::warn!(%peer, ?peer_state, is_static, "removing peer (inbound)");
             send_remove = true;
@@ -342,8 +348,8 @@ impl PeerSelection {
 
         if let Some(peer_state) = self.outbound_peers.remove(&peer) {
             tracing::warn!(%peer, ?peer_state, is_static, "removing peer (outbound)");
-            self.regulate_peers(eff).await;
             send_remove = true;
+            refill_outbound = true;
         }
 
         if send_remove {
@@ -353,6 +359,9 @@ impl PeerSelection {
         let now = eff.clock().await;
         eff.external(Performance::peer_adversarial(peer.clone(), now)).await;
         self.cool_down(peer, eff, is_static, now).await;
+        if refill_outbound {
+            self.regulate_peers(eff).await;
+        }
     }
 
     /// Drop availability claims when a peer has no remaining live connections (scores kept).
@@ -641,8 +650,21 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
             }
             state.clear_availability_if_gone(&peer, &eff).await;
         }
-        PeerSelectionMsg::Disconnected(peer, _, ConnectionDirection::Outbound, true) => {
-            eff.external(Performance::clear_peer_availability(peer)).await;
+        PeerSelectionMsg::Disconnected(peer, conn_id, ConnectionDirection::Outbound, true) => {
+            if let Entry::Occupied(mut entry) = state.outbound_peers.entry(peer.clone())
+                && let PeerState::Connected(conn) = entry.get()
+                && conn.id == conn_id
+            {
+                let _span = debug_span!(
+                    amaru::protocols::peer_selection::peer::DISCONNECTED,
+                    peer = &peer,
+                    conn_id = conn_id.as_u64(),
+                    direction = ConnectionDirection::Outbound,
+                )
+                .entered();
+                entry.insert(PeerState::Connecting);
+            }
+            state.clear_availability_if_gone(&peer, &eff).await;
         }
         PeerSelectionMsg::Disconnected(peer, conn_id, ConnectionDirection::Outbound, _) => {
             if let Entry::Occupied(entry) = state.outbound_peers.entry(peer.clone())

--- a/crates/amaru-consensus/src/stages/peer_selection/tests.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/tests.rs
@@ -593,6 +593,93 @@ fn test_disconnected_outbound_connecting_schedules_cooldown() {
     logs.assert_no_remaining_at([Level::WARN, Level::ERROR]);
 }
 
+#[test]
+fn test_outbound_retry_drops_dead_conn_before_reconnect() {
+    let mut prep = test_prep(&[]);
+    let p = TestPrep::peer("3.3.3.3:3");
+    let mut ids = ConnectionId::initial();
+    let id0 = ids.get_and_increment();
+    let id1 = ids.get_and_increment();
+    let conn0 = Connection::new(id0, true, false);
+    let conn1 = Connection::new(id1, true, false);
+
+    prep.state.outbound_peers.insert(p.clone(), PeerState::Connected(conn0));
+    let start = prep.state.clone();
+    let after_death = {
+        let mut s = start.clone();
+        s.outbound_peers.insert(p.clone(), PeerState::Connecting);
+        s
+    };
+    let after_reconnect = {
+        let mut s = start.clone();
+        s.outbound_peers.insert(p.clone(), PeerState::Connected(conn1));
+        s
+    };
+
+    let died = PeerSelectionMsg::Disconnected(p.clone(), id0, ConnectionDirection::Outbound, true);
+    let connected = PeerSelectionMsg::Connected(p.clone(), conn1, ConnectionDirection::Outbound, false);
+    let (running, _guards, mut logs) = setup_preload(&prep, [died.clone(), connected.clone()]);
+
+    assert_trace_contains(
+        &running,
+        &[
+            te_state("ps-1", &start).into(),
+            te_input("ps-1", &died).into(),
+            te_clear_peer_availability("ps-1", p.clone()).into(),
+            te_state("ps-1", &after_death).into(),
+            te_input("ps-1", &connected).into(),
+            te_clock_suspend("ps-1").into(),
+            te_record_advertisability("ps-1", p.clone(), false, sim_t0()).into(),
+            te_state("ps-1", &after_reconnect).into(),
+        ],
+    );
+    assert_trace_does_not_contain(
+        &running,
+        &[
+            te_send("ps-1", "manager", ManagerMessage::Disconnect(p.clone(), id0)).into(),
+            te_send("ps-1", "manager", ManagerMessage::AddPeer(p.clone())).into(),
+        ],
+    );
+    logs.assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_adversarial_static_outbound_does_not_readd_while_connected() {
+    let mut prep = test_prep(&["static.example:1"]);
+    let p = TestPrep::peer("static.example:1");
+    prep.state.outbound_peers.insert(p.clone(), PeerState::Connected(conn()));
+    let start = prep.state.clone();
+    let sid = first_static_schedule_id();
+    let after_ban = {
+        let mut s = start.clone();
+        s.outbound_peers.remove(&p);
+        s.cooldowns.add_and_is_first(p.clone(), static_cooldown_instant());
+        s.cooldown_timer = Some(sid);
+        s
+    };
+
+    let (running, _guards, mut logs) = setup(&prep, PeerSelectionMsg::adversarial(p.clone()));
+
+    // Ban must be recorded (and the live connection removed) before regulate refills.
+    // After the static ban expires, CheckCooldowns may dial the peer again.
+    assert_trace_contains(
+        &running,
+        &[
+            te_state("ps-1", &start).into(),
+            te_input("ps-1", &PeerSelectionMsg::adversarial(p.clone())).into(),
+            te_is_static_peer("ps-1", p.clone()).into(),
+            te_send("ps-1", "manager", ManagerMessage::RemovePeer(p.clone())).into(),
+            te_peer_adversarial("ps-1", p.clone()).into(),
+            te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid).into(),
+            te_state("ps-1", &after_ban).into(),
+        ],
+    );
+    logs.assert_and_remove(Level::DEBUG, &["peer_selection.adversarial"])
+        .assert_and_remove(Level::WARN, &["removing peer (outbound)"])
+        .assert_and_remove(Level::INFO, &["peer_selection.add_peer"])
+        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
 // ---------------------------------------------------------------------------
 // Double-remove (Adversarial twice)
 // ---------------------------------------------------------------------------

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -35,12 +35,16 @@ use tracing::Instrument;
 use super::peer_selection::PeerSelectionMsg;
 use crate::{
     effects::{Ledger, LedgerOps, VolatileTipEffect},
-    errors::{ConsensusError, InvalidHeaderParentData, InvalidHeaderPoint},
+    errors::{ConsensusError, HeaderSlotTooFarInFuture, InvalidHeaderParentData, InvalidHeaderPoint},
     performance::{HeaderLifecycleOutcome, Performance},
 };
 
 /// Poll interval while headers are deferred on applied ledger height.
 pub const HEIGHT_RECHECK_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Permissible header clock skew: slots whose onset is at most this far in the future are deferred.
+/// Further ahead is treated as adversarial.
+pub const MAX_HEADER_CLOCK_SKEW: Duration = Duration::from_secs(2);
 
 /// Stage that tracks chainsync sessions from whom we receive headers.
 ///
@@ -93,13 +97,16 @@ pub const HEIGHT_RECHECK_INTERVAL: Duration = Duration::from_millis(200);
 /// - **StakeDistribution** — pool stake for the header's epoch is not yet known (at most one
 ///   epoch ahead of `max_epoch`). `RequestNext` may already have been pipelined before validation
 ///   failed. Woken by [`TrackPeersMsg::StakeDistUpdated`] (no self-timer).
-/// - **ClockSkew** — header slot is at most two slots in the future. Contributes the header onset
-///   as the next recheck deadline; `RequestNext` may already have been sent.
+/// - **ClockSkew** — header slot onset is at most [`MAX_HEADER_CLOCK_SKEW`] in the future.
+///   Contributes the header onset as the next recheck deadline; `RequestNext` may already have been sent.
 /// - **FollowUp** — further headers arrived while the peer was already deferred. Held until
 ///   earlier deferred items for that peer clear; no `RequestNext` from this path.
 ///
-/// Far-ahead stake (more than one epoch beyond `max_epoch`), far-future slots (more than two),
-/// and other validation failures are adversarial (peer removed and `peer_selection` notified).
+/// Far-ahead stake (more than one epoch beyond `max_epoch`), far-future slots (onset more than
+/// [`MAX_HEADER_CLOCK_SKEW`] ahead of local time, or a slot so far ahead that onset cannot be
+/// computed), and other validation failures are adversarial (peer removed and `peer_selection`
+/// notified). Empty slots between consecutive headers are allowed as long as the header is not
+/// in the future.
 ///
 /// # Recheck
 ///
@@ -173,7 +180,7 @@ enum DeferReason {
     /// The header's validation requires a stake distribution that is not yet available; hold the
     /// data needed to re-validate and store once it arrives (via StakeDistUpdated).
     StakeDistribution { epoch: Epoch, header: Header, tip: Point, variant: EraName, rn_sent: bool },
-    /// Slot onset is in the near future (≤ 2s according to slot time); defer validation until
+    /// Slot onset is in the near future (≤ [`MAX_HEADER_CLOCK_SKEW`]); defer validation until
     /// local time reaches it. Carries data to re-process later.
     ClockSkew { min_time: Instant, header: Header, tip: Point, variant: EraName, rn_sent: bool },
     /// A follow-up header that was received after a previous header was deferred.
@@ -423,7 +430,7 @@ impl TrackPeers {
         // can be less advanced than the currently transmitted header
         let highest = tip;
 
-        // check that slot time progresses monotonically
+        // Successive headers must have increasing slots; empty slots between them are allowed.
         if header.slot() <= current.slot() {
             return Err(ConsensusError::InvalidHeaderPoint(Box::new(InvalidHeaderPoint {
                 actual: header.point(),
@@ -432,17 +439,23 @@ impl TrackPeers {
             })));
         }
 
-        // Clock skew using current time from clock (converted to slot via era params / slot length),
-        // instead of per_peer.current.
+        // Compare the header's slot onset to local time (a duration bound, not a slot count).
+        // Horizon-checked conversion: a peer-chosen slot beyond the foreseeable future is
+        // `PastTimeHorizon` / `SlotTooFar` and adversarial. Do not use the unchecked variant,
+        // which is only valid for slots already known to be in the past.
         let elapsed = current_time.duration_since_global_epoch();
-        let curr_slot = self.era_history.relative_time_to_slot(elapsed).unwrap_or_else(|_| Slot::from(0));
-        if header.slot() > curr_slot {
-            let delta_slots = header.slot() - curr_slot;
-            if delta_slots > 2 {
-                return Err(ConsensusError::InvalidHeaderPoint(Box::new(InvalidHeaderPoint {
+        let onset = self.era_history.slot_to_relative_time(header.slot(), current.slot())?;
+        if onset > elapsed {
+            let delta = onset - elapsed;
+            if delta > MAX_HEADER_CLOCK_SKEW {
+                return Err(ConsensusError::HeaderSlotTooFarInFuture(Box::new(HeaderSlotTooFarInFuture {
                     actual: header.point(),
                     parent: *current,
                     highest,
+                    onset_millis: onset.as_millis() as u64,
+                    elapsed_millis: elapsed.as_millis() as u64,
+                    delta_millis: delta.as_millis() as u64,
+                    max_skew_millis: MAX_HEADER_CLOCK_SKEW.as_millis() as u64,
                 })));
             }
             return Err(ConsensusError::HeaderSlotInNearFuture(header.slot()));
@@ -547,10 +560,11 @@ impl TrackPeers {
         if !matches!(error, ConsensusError::HeaderSlotInNearFuture(_)) {
             return None;
         }
-        // compute accurate wait using current clock and header onset from era; last clock check was before validation calculations
+        let (current, _) = self.upstream.get(&args.conn_id).and_then(PerPeer::established)?;
+        // Same horizon-checked conversion as `validate_header`; failure → no deferral (adversarial).
         let now = eff.clock().await;
         let elapsed = now.duration_since_global_epoch();
-        let onset = self.era_history.slot_to_relative_time_unchecked_horizon(args.header.slot()).unwrap_or_default();
+        let onset = self.era_history.slot_to_relative_time(args.header.slot(), current.slot()).ok()?;
         let wait = onset.saturating_sub(elapsed);
         Some(DeferredHeader {
             peer: args.peer.clone(),

--- a/crates/amaru-consensus/src/stages/track_peers/tests.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/tests.rs
@@ -260,6 +260,83 @@ fn test_intersect_found_tracks_peer() {
 }
 
 #[test]
+fn test_reconnect_intersect_then_roll_forward() {
+    let prep = test_prep();
+    let peer = Peer::new("peer1");
+    let mut ids = ConnectionId::initial();
+    let conn0 = ids.get_and_increment();
+    let conn1 = ids.get_and_increment();
+    let intersect_header = &prep.headers[0];
+    let next_header = &prep.headers[1];
+    let stale = &prep.headers[2];
+    let intersect = intersect_header.point();
+
+    let mut state = prep.state.clone();
+    state.insert_peer(peer.clone(), conn0, stale.point(), stale.point());
+
+    let terminated = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
+        peer: peer.clone(),
+        conn_id: conn0,
+        handler: prep.handler.clone(),
+        msg: chainsync::InitiatorResult::Terminated,
+    });
+    let initialize = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
+        peer: peer.clone(),
+        conn_id: conn1,
+        handler: prep.handler.clone(),
+        msg: chainsync::InitiatorResult::Initialize,
+    });
+    let intersect_found = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
+        peer: peer.clone(),
+        conn_id: conn1,
+        handler: prep.handler.clone(),
+        msg: chainsync::InitiatorResult::IntersectFound(intersect, stale.point()),
+    });
+    let roll_forward = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
+        peer: peer.clone(),
+        conn_id: conn1,
+        handler: prep.handler.clone(),
+        msg: chainsync::InitiatorResult::RollForward(HeaderContent::new(next_header, EraName::Conway), stale.point()),
+    });
+
+    let mut expected = prep.state.clone();
+    expected.insert_peer(peer.clone(), conn1, next_header.point(), stale.point());
+
+    let (running, _guards, mut logs) = setup_base(
+        &prep.rt_handle(),
+        state,
+        [terminated.clone(), initialize.clone(), intersect_found.clone(), roll_forward.clone()],
+        build_store(slice::from_ref(intersect_header)),
+        |running| {
+            running.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| {
+                OverrideResult::handled(Ok(Nonces::for_tests()))
+            });
+        },
+    );
+
+    assert_trace_contains(
+        &running,
+        &[
+            te_input("tp-1", &terminated).into(),
+            te_clear_peer_availability("tp-1", peer.clone()).into(),
+            te_input("tp-1", &initialize).into(),
+            te_input("tp-1", &intersect_found).into(),
+            te_load_point("tp-1", intersect.hash()).into(),
+            te_input("tp-1", &roll_forward).into(),
+            te_send("tp-1", &prep.handler, RequestNext).into(),
+            te_send("tp-1", "downstream", new_tip(next_header.point(), intersect)).into(),
+            te_state("tp-1", &expected).into(),
+        ],
+    );
+    assert_trace_does_not_contain(&running, &[tm_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer))]);
+    logs.assert_and_remove(Level::INFO, &["chainsync terminated"])
+        .assert_and_remove(Level::INFO, &["initializing chainsync"])
+        .assert_and_remove(Level::INFO, &["intersect found"])
+        .assert_and_remove(Level::DEBUG, &["roll forward", "new header"])
+        .assert_no_remaining_at([Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
 fn test_intersect_not_found_untracked_sends_done() {
     let prep = test_prep();
     let state = prep.state.clone();
@@ -511,6 +588,48 @@ fn test_roll_forward_known_peer_new_header_forwards_tip() {
     ]);
 }
 
+/// Consecutive headers may skip empty Praos slots; a later slot that is still in the past is valid.
+#[test]
+fn test_roll_forward_accepts_empty_slots_in_the_past() {
+    let prep = test_prep();
+    let peer = Peer::new("peer1");
+    let parent = &prep.headers[0];
+    let header = make_block_header(2, parent.slot().as_u64() + 130, Some(parent.hash()));
+    let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
+        peer: peer.clone(),
+        conn_id: prep.conn_id,
+        handler: prep.handler.clone(),
+        msg: chainsync::InitiatorResult::RollForward(HeaderContent::new(&header, EraName::Conway), header.point()),
+    });
+
+    let mut state = prep.state.clone();
+    state.insert_peer(peer.clone(), prep.conn_id, parent.point(), parent.point());
+
+    let mut expected = prep.state.clone();
+    expected.insert_peer(peer.clone(), prep.conn_id, header.point(), header.point());
+
+    let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
+    assert_trace_contains(
+        &running,
+        &[
+            te_state("tp-1", &state).into(),
+            te_input("tp-1", &msg).into(),
+            te_clock_suspend("tp-1").into(),
+            te_send("tp-1", &prep.handler, RequestNext).into(),
+            te_validate_header("tp-1", header.clone()).into(),
+            te_store_validated_header("tp-1", header.clone()).into(),
+            te_send("tp-1", "downstream", new_tip(header.point(), parent.point())).into(),
+            te_state("tp-1", &expected).into(),
+        ],
+    );
+    assert_trace_does_not_contain(&running, &[tm_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer))]);
+    logs.assert_and_remove(Level::DEBUG, &["roll forward", "new header"]).assert_no_remaining_at([
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
+}
+
 #[test]
 fn test_roll_forward_invalid_variant_removes_peer() {
     let prep = test_prep();
@@ -739,15 +858,16 @@ fn test_roll_forward_header_validation_failure_removes_peer() {
     );
 }
 
-/// Header slot more than 2 slots ahead of sim clock → adversarial.
-/// Slot math must use the same [`EraHistory`] as `TrackPeers` (`EraHistory::default()` in tests).
+/// Header onset more than two seconds ahead of sim clock → adversarial.
+/// Slot math must use the same `EraHistory` as `TrackPeers` (`EraHistory::default()` in tests).
 #[test]
 fn test_roll_forward_header_slot_too_far_future_adversarial() {
     let prep = test_prep();
     let peer = Peer::new("peer1");
-    let parent = &prep.headers[0];
     let elapsed = prep.start_times.relative_time + Duration::from_secs(10);
     let curr_slot = EraHistory::default().relative_time_to_slot(elapsed).expect("slot from start time").as_u64();
+    // Parent at "now" so the header is within the foreseeable horizon of `current`.
+    let parent = make_block_header(1, curr_slot, None);
     let header = make_block_header(2, curr_slot + 10, Some(parent.hash()));
     let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
         peer: peer.clone(),
@@ -762,7 +882,7 @@ fn test_roll_forward_header_slot_too_far_future_adversarial() {
 
     let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
 
-    logs.assert_and_remove(Level::ERROR, &["perf.header.lifecycle"]).assert_no_remaining_at([
+    logs.assert_and_remove(Level::ERROR, &["perf.header.lifecycle", "ahead of local time"]).assert_no_remaining_at([
         Level::INFO,
         Level::WARN,
         Level::ERROR,
@@ -781,15 +901,54 @@ fn test_roll_forward_header_slot_too_far_future_adversarial() {
     );
 }
 
-/// Header slot 1–2 ahead of sim clock → clock-skew defer (not adversarial).
+/// A slot beyond the foreseeable horizon (`EraHistoryError::PastTimeHorizon`) is adversarial.
+#[test]
+fn test_roll_forward_slot_past_time_horizon_is_adversarial() {
+    let prep = test_prep();
+    let peer = Peer::new("peer1");
+    let parent = &prep.headers[0];
+    // Default test era rounds the stability window up to a full epoch (86400 slots).
+    let header = make_block_header(2, parent.slot().as_u64() + 100_000, Some(parent.hash()));
+    let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
+        peer: peer.clone(),
+        conn_id: prep.conn_id,
+        handler: prep.handler.clone(),
+        msg: chainsync::InitiatorResult::RollForward(HeaderContent::new(&header, EraName::Conway), header.point()),
+    });
+
+    let expected = prep.state.clone();
+    let mut state = prep.state.clone();
+    state.insert_peer(peer.clone(), prep.conn_id, parent.point(), parent.point());
+
+    let (running, _guards, mut logs) = setup(&prep.rt_handle(), state.clone(), msg.clone(), build_store(&[]));
+    assert_trace_match(
+        &running,
+        &[
+            te_state("tp-1", &state).into(),
+            te_input("tp-1", &msg).into(),
+            te_clock_suspend("tp-1").into(),
+            te_send("tp-1", &prep.handler, RequestNext).into(),
+            te_header_rejected("invalid header").into(),
+            te_send("tp-1", "peer_selection", PeerSelectionMsg::adversarial(peer)).into(),
+            te_state("tp-1", &expected).into(),
+        ],
+    );
+    logs.assert_and_remove(Level::ERROR, &["perf.header.lifecycle", "past time horizon"]).assert_no_remaining_at([
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
+}
+
+/// Header onset 1–2s ahead of sim clock → clock-skew defer (not adversarial).
 #[test]
 fn test_roll_forward_header_slot_near_future_defers() {
     let prep = test_prep();
     let peer = Peer::new("peer1");
-    let parent = &prep.headers[0];
     let elapsed = prep.start_times.relative_time + Duration::from_secs(10);
     let curr_slot = EraHistory::default().relative_time_to_slot(elapsed).expect("slot from start time").as_u64();
-    // one slot ahead of sim clock → near-future defer
+    let parent = make_block_header(1, curr_slot, None);
+    // one second ahead of sim clock → near-future defer
     let header = make_block_header(2, curr_slot + 1, Some(parent.hash()));
     let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
         peer: peer.clone(),
@@ -1166,9 +1325,9 @@ fn test_height_defer_recheck_when_ledger_advances() {
 fn test_pipelined_headers_after_slot_near_future_defer() {
     let prep = test_prep();
     let peer = Peer::new("peer1");
-    let parent = &prep.headers[0];
     let elapsed = prep.start_times.relative_time + Duration::from_secs(10);
     let curr_slot = EraHistory::default().relative_time_to_slot(elapsed).expect("slot from start time").as_u64();
+    let parent = make_block_header(1, curr_slot, None);
     // first is near-future; second is FollowUp while peer deferred
     let h1 = make_block_header(2, curr_slot + 1, Some(parent.hash()));
     let h2 = make_block_header(3, curr_slot + 2, Some(h1.hash()));

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -268,10 +268,11 @@ async fn notify_chainsync_terminated(params: &Params, eff: &Effects<ConnectionMe
     .await;
 }
 
-async fn do_initialize(Params { conn_id, role, magic, .. }: &Params, eff: Effects<ConnectionMessage>) -> State {
+async fn do_initialize(Params { conn_id, role, magic, peer, .. }: &Params, eff: Effects<ConnectionMessage>) -> State {
     let muxer = eff.stage("mux", mux::stage).await;
     let muxer = eff.supervise(muxer, ConnectionMessage::ChildDied(ChildId::Mux));
-    let muxer = eff.wire_up(muxer, mux::State::new(*conn_id, &[(PROTO_HANDSHAKE.erase(), 5760)], *role)).await;
+    let muxer =
+        eff.wire_up(muxer, mux::State::new(*conn_id, &[(PROTO_HANDSHAKE.erase(), 5760)], *role, peer.clone())).await;
 
     let handshake_result = eff.me_ref().contramap(ConnectionMessage::Handshake);
 

--- a/crates/amaru-protocols/src/handshake/tests.rs
+++ b/crates/amaru-protocols/src/handshake/tests.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use amaru_kernel::NetworkMagic;
+use amaru_kernel::{NetworkMagic, Peer};
 use amaru_network::connection::TokioConnections;
 use amaru_ouroboros::ConnectionsResource;
 use amaru_pure_stage::{
@@ -59,7 +59,7 @@ fn test_against_node() {
     network.resources().put::<ConnectionsResource>(Arc::new(conn));
 
     let mux = network.stage("mux", mux::stage);
-    let mux = network.wire_up(mux, mux::State::new(conn_id, &[], Role::Initiator));
+    let mux = network.wire_up(mux, mux::State::new(conn_id, &[], Role::Initiator, Peer::new("handshake-test")));
 
     let (output, mut rx) = network.output::<handshake::HandshakeResult>("handshake_result", 10);
 
@@ -128,7 +128,7 @@ fn test_against_node_with_tokio() {
     network.resources().put::<ConnectionsResource>(Arc::new(conn));
 
     let mux = network.stage("mux", mux::stage);
-    let mux = network.wire_up(mux, mux::State::new(conn_id, &[], Role::Initiator));
+    let mux = network.wire_up(mux, mux::State::new(conn_id, &[], Role::Initiator, Peer::new("handshake-test")));
 
     let (output, mut rx) = network.output::<handshake::HandshakeResult>("handshake_result", 10);
 

--- a/crates/amaru-protocols/src/mux.rs
+++ b/crates/amaru-protocols/src/mux.rs
@@ -21,7 +21,7 @@ use std::{
     time::SystemTime,
 };
 
-use amaru_kernel::NonEmptyBytes;
+use amaru_kernel::{NonEmptyBytes, Peer};
 use amaru_observability::debug_span;
 use amaru_ouroboros::ConnectionId;
 use amaru_pure_stage::{Effects, Instant, OrTerminateWith, StageRef, TryInStage, Void};
@@ -43,6 +43,8 @@ pub fn register_deserializers() -> amaru_pure_stage::DeserializerGuards {
         amaru_pure_stage::register_data_deserializer::<HandlerMessage>().boxed(),
         amaru_pure_stage::register_data_deserializer::<Sent>().boxed(),
         amaru_pure_stage::register_data_deserializer::<Read>().boxed(),
+        amaru_pure_stage::register_data_deserializer::<Peer>().boxed(),
+        amaru_pure_stage::register_data_deserializer::<(ConnectionId, StageRef<MuxMessage>, Role, Peer)>().boxed(),
     ]
 }
 
@@ -143,6 +145,7 @@ pub struct State {
     conn: Connection,
     muxer: Muxer,
     sending: bool,
+    peer: Peer,
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -156,13 +159,13 @@ impl State {
     ///
     /// Note that upon receiving the first message, the stage will start reading from the network.
     /// Any data received for unregistered protocols will lead to stage termination.
-    pub fn new(conn: ConnectionId, buffer: &[(ProtocolId<Erased>, usize)], role: Role) -> Self {
+    pub fn new(conn: ConnectionId, buffer: &[(ProtocolId<Erased>, usize)], role: Role, peer: Peer) -> Self {
         let mut muxer = Muxer::new(role);
         for &(proto_id, limit) in buffer {
             #[expect(clippy::expect_used)]
             muxer.buffer(proto_id, limit).expect("no buffered data yet");
         }
-        Self { conn: Connection::Unint(conn), muxer, sending: false }
+        Self { conn: Connection::Unint(conn), muxer, sending: false, peer }
     }
 
     pub async fn init(
@@ -174,24 +177,24 @@ impl State {
                 let writer = eff
                     .stage(
                         format!("writer-{}", conn),
-                        move |(conn, muxer, role), data: NonEmptyBytes, eff| async move {
+                        move |(conn, muxer, role, peer), data: NonEmptyBytes, eff| async move {
                             Network::new(&eff)
                                 .send(conn, data)
                                 .or_terminate_with(
                                     &eff,
-                                    async |err| tracing::error!(%err, %role, "failed to send data to network"),
+                                    async |err| tracing::error!(%err, %role, %peer, "failed to send data to network"),
                                 )
                                 .await;
                             eff.send(&muxer, MuxMessage::Written).await;
-                            (conn, muxer, role)
+                            (conn, muxer, role, peer)
                         },
                     )
                     .await;
                 let writer = eff.supervise(writer, MuxMessage::Terminate);
-                let writer = eff.wire_up(writer, (*conn, eff.me(), self.muxer.role())).await;
+                let writer = eff.wire_up(writer, (*conn, eff.me(), self.muxer.role(), self.peer.clone())).await;
                 let reader = eff.stage(format!("reader-{}", conn), read_segment).await;
                 let reader = eff.supervise(reader, MuxMessage::Terminate);
-                let reader = eff.wire_up(reader, (*conn, eff.me(), self.muxer.role())).await;
+                let reader = eff.wire_up(reader, (*conn, eff.me(), self.muxer.role(), self.peer.clone())).await;
                 eff.send(&reader, Read).await;
                 self.conn = Connection::Init(writer, reader);
             }
@@ -203,6 +206,7 @@ impl State {
 }
 
 pub async fn stage(mut state: State, msg: MuxMessage, mut eff: Effects<MuxMessage>) -> State {
+    let peer = state.peer.clone();
     let (muxer, sending, writer, reader) = state.init(&mut eff).await;
 
     handle_msg(msg, &eff, muxer, sending, writer, reader)
@@ -216,7 +220,7 @@ pub async fn stage(mut state: State, msg: MuxMessage, mut eff: Effects<MuxMessag
                 }
                 write!(&mut err, "{}", error).ok();
             }
-            tracing::error!(%err, role=%muxer.role(), "muxing error")
+            tracing::error!(%err, role=%muxer.role(), %peer, "muxing error")
         })
         .await;
 
@@ -276,24 +280,24 @@ async fn handle_msg(
 }
 
 async fn read_segment(
-    (conn, muxer, role): (ConnectionId, StageRef<MuxMessage>, Role),
+    (conn, muxer, role, peer): (ConnectionId, StageRef<MuxMessage>, Role, Peer),
     _token: Read,
     eff: Effects<Read>,
-) -> (ConnectionId, StageRef<MuxMessage>, Role) {
+) -> (ConnectionId, StageRef<MuxMessage>, Role, Peer) {
     let header = loop {
         let data = Network::new(&eff)
             .recv(conn, HEADER_LEN)
             .or_terminate_with(
                 &eff,
-                async |err| tracing::error!(%role, %err, "failed to receive segment header from network"),
+                async |err| tracing::error!(%role, %peer, %err, "failed to receive segment header from network"),
             )
             .await;
         let Some(header) = Header::decode(&mut data.into_inner())
-            .or_terminate(&eff, async |err| tracing::error!(%role, %err, "failed to decode segment header"))
+            .or_terminate(&eff, async |err| tracing::error!(%role, %peer, %err, "failed to decode segment header"))
             .await
         else {
             // sending frames without payload data is not explicitly forbidden, so we just ignore them
-            tracing::info!(%role, "received empty segment header");
+            tracing::info!(%role, %peer, "received empty segment header");
             continue;
         };
         break header;
@@ -303,12 +307,12 @@ async fn read_segment(
         .recv(conn, header.length.into())
         .or_terminate_with(
             &eff,
-            async |err| tracing::error!(%role, %err, "failed to receive segment data from network"),
+            async |err| tracing::error!(%role, %peer, %err, "failed to receive segment data from network"),
         )
         .await;
 
     eff.send(&muxer, MuxMessage::FromNetwork(header.timestamp, header.proto_id, data)).await;
-    (conn, muxer, role)
+    (conn, muxer, role, peer)
 }
 
 /// A header for a segment of data.
@@ -643,6 +647,10 @@ mod tests {
     const SAFE_SLEEP: Duration = Duration::from_millis(400);
     const TIMEOUT: Duration = Duration::from_secs(1);
 
+    fn test_peer() -> Peer {
+        Peer::new("mux-test")
+    }
+
     async fn s<F: Future>(f: F)
     where
         F::Output: fmt::Debug,
@@ -675,7 +683,7 @@ mod tests {
         let mut graph = SimulationBuilder::default().with_trace_buffer(trace_buffer);
 
         let mux = graph.stage("mux", super::stage);
-        let mux = graph.wire_up(mux, State::new(conn_id, &[(PROTO_TEST.erase(), 0)], Role::Initiator));
+        let mux = graph.wire_up(mux, State::new(conn_id, &[(PROTO_TEST.erase(), 0)], Role::Initiator, test_peer()));
 
         let (output, mut rx) = graph.output::<HandlerMessage>("output", 10);
         let (sent, mut sent_rx) = graph.output::<Sent>("sent", 10);
@@ -756,6 +764,8 @@ mod tests {
         let _guard = amaru_pure_stage::register_effect_deserializer::<SendEffect>();
         let _guard = amaru_pure_stage::register_effect_deserializer::<RecvEffect>();
         let _guard = amaru_pure_stage::register_data_deserializer::<State>();
+        let _guard = amaru_pure_stage::register_data_deserializer::<Peer>();
+        let _guard = amaru_pure_stage::register_data_deserializer::<(ConnectionId, StageRef<MuxMessage>, Role, Peer)>();
 
         let trace_buffer = TraceBuffer::new_shared(100, 1_000_000);
         let drop_guard = TraceBuffer::drop_guard(&trace_buffer);
@@ -769,6 +779,7 @@ mod tests {
                 // sequence of registration is the sequence of round-robin
                 &[(PROTO_TEST.erase(), 1024), (PROTO_N2N_BLOCK_FETCH.erase(), 0), (PROTO_HANDSHAKE.erase(), 1)],
                 Role::Initiator,
+                test_peer(),
             ),
         );
 
@@ -793,11 +804,11 @@ mod tests {
             }],
         );
         let spawn1 = running.run_until_blocked().assert_breakpoint("spawn");
-        let writer = spawn1.extract_wire_stage(&mux, (conn_id, (*mux).clone(), Role::Initiator)).clone();
+        let writer = spawn1.extract_wire_stage(&mux, (conn_id, (*mux).clone(), Role::Initiator, test_peer())).clone();
         running.handle_effect(spawn1);
 
         let spawn2 = running.run_until_blocked().assert_breakpoint("spawn");
-        let reader = spawn2.extract_wire_stage(&mux, (conn_id, (*mux).clone(), Role::Initiator)).clone();
+        let reader = spawn2.extract_wire_stage(&mux, (conn_id, (*mux).clone(), Role::Initiator, test_peer())).clone();
         running.handle_effect(spawn2);
 
         {
@@ -961,7 +972,7 @@ mod tests {
         let mut graph = TokioBuilder::default().with_trace_buffer(trace_buffer);
 
         let mux = graph.stage("mux", super::stage);
-        let mux = graph.wire_up(mux, State::new(conn_id, &[(PROTO_TEST.erase(), 0)], Role::Initiator));
+        let mux = graph.wire_up(mux, State::new(conn_id, &[(PROTO_TEST.erase(), 0)], Role::Initiator, test_peer()));
 
         let (output, mut rx) = graph.output::<HandlerMessage>("output", 10);
         let (sent, mut sent_rx) = graph.output::<Sent>("sent", 10);


### PR DESCRIPTION
fixes #1265


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer validation for headers that are too far ahead of local time, distinguishing clock-skew and slot-order errors.
  * Network and multiplexer error messages now identify the affected peer.

* **Bug Fixes**
  * Prevented banned peers from being immediately re-added during outbound peer management.
  * Improved reconnect handling to avoid stale connections and duplicate peer actions.
  * Preserved valid empty-slot progression while rejecting invalid future or out-of-horizon headers.

* **Documentation**
  * Updated the changelog with recovery, validation, and peer-identification improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->