### PR TITLE
feat: test e2e tx submission

### DIFF
--- a/.github/workflows/ci-build-and-test.yml
+++ b/.github/workflows/ci-build-and-test.yml
@@ -98,6 +98,7 @@ jobs:
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
       CARDANO_NODE_BUCKET_NAME: ${{ secrets.CARDANO_NODE_BUCKET_NAME }}
+      PREPROD_TX_PAYMENT_SKEY_BASE64: ${{ secrets.PREPROD_TX_PAYMENT_SKEY_BASE64 }}
 
   benches:
     name: Bench

--- a/.github/workflows/template-ledger-epoch-snapshots.yml
+++ b/.github/workflows/template-ledger-epoch-snapshots.yml
@@ -17,6 +17,8 @@ on:
         required: true
       CARDANO_NODE_BUCKET_NAME:
         required: true
+      PREPROD_TX_PAYMENT_SKEY_BASE64:
+        required: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -30,6 +32,9 @@ jobs:
   snapshots:
     name: End-to-end snapshot tests
     runs-on: ubuntu-24.04
+    concurrency:
+      group: ${{ matrix.network.name == 'preprod' && 'preprod-e2e-transaction-submission' || format('ledger-epoch-snapshots-{0}-{1}', github.run_id, matrix.network.name) }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:
@@ -190,6 +195,47 @@ jobs:
             --check \
             --output "metrics-report-${{ matrix.network.name }}.json" \
             --summary
+
+      - name: Run transaction submission test
+        if: ${{ matrix.network.name == 'preprod' && (inputs.network == '' || inputs.network == matrix.network.name) }}
+        timeout-minutes: 30
+        shell: bash
+        env:
+          AMARU_CHAIN_DIR: ${{ github.workspace }}/chain.${{ matrix.network.name }}.db
+          AMARU_LEDGER_DIR: ${{ github.workspace }}/ledger.${{ matrix.network.name }}.db
+          CARDANO_NODE_DB: ${{ runner.temp }}/db-${{ matrix.network.name }}
+          CARDANO_NODE_SOCKET_FILE: ${{ runner.temp }}/ipc/node.socket
+          CARDANO_NODE_SYNC_TIMEOUT_SECONDS: 1200
+          E2E_TX_MANAGE_CARDANO_NODE: "false"
+          E2E_TX_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.network.name }}
+          E2E_TX_WORK_DIR: ${{ github.workspace }}/e2e-tx-submission-output
+          TX_PAYMENT_SKEY: ${{ runner.temp }}/preprod-e2e-payment.skey
+          TX_PAYMENT_SKEY_BASE64: ${{ secrets.PREPROD_TX_PAYMENT_SKEY_BASE64 }}
+          TX_SYNC_TIMEOUT_SECONDS: 1200
+        run: |
+          set -euo pipefail
+          trap 'rm -f "$TX_PAYMENT_SKEY"' EXIT
+          umask 077
+          printf '%s' "$TX_PAYMENT_SKEY_BASE64" | base64 --decode > "$TX_PAYMENT_SKEY"
+          test -s "$TX_PAYMENT_SKEY"
+          ./scripts/e2e/tx-submission.sh run
+
+      - name: Collect transaction submission logs
+        if: ${{ always() && matrix.network.name == 'preprod' && (inputs.network == '' || inputs.network == matrix.network.name) }}
+        shell: bash
+        run: |
+          mkdir -p e2e-tx-submission-output/logs
+          docker logs cardano-node > e2e-tx-submission-output/logs/cardano-node-docker.log 2>&1 || true
+
+      - name: Upload transaction submission artifacts
+        if: ${{ always() && matrix.network.name == 'preprod' && (inputs.network == '' || inputs.network == matrix.network.name) }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: transaction-submission-${{ matrix.network.name }}
+          path: |
+            e2e-tx-submission-output/logs
+            e2e-tx-submission-output/results
+          if-no-files-found: warn
 
       - name: Upload metrics report
         if: ${{ always() && (inputs.network == '' || inputs.network == matrix.network.name) }}

--- a/.github/workflows/template-ledger-epoch-snapshots.yml
+++ b/.github/workflows/template-ledger-epoch-snapshots.yml
@@ -73,6 +73,15 @@ jobs:
 
       - uses: actions/checkout@v6
 
+      - name: Configure runner paths
+        shell: bash
+        run: |
+          {
+            echo "CARDANO_NODE_DB=$RUNNER_TEMP/db-${{ matrix.network.name }}"
+            echo "CARDANO_NODE_SOCKET_FILE=$RUNNER_TEMP/ipc/node.socket"
+            echo "TX_PAYMENT_SKEY=$RUNNER_TEMP/preprod-e2e-payment.skey"
+          } >> "$GITHUB_ENV"
+
       - name: Reclaim Disk Space
         run: |
           chmod +x ./scripts/cleanup-runner.sh
@@ -83,9 +92,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p "${{ runner.temp }}/db-${{ matrix.network.name }}"
-          aws s3 cp "$OBJECT" - --endpoint-url "$ENDPOINT" | tar --zstd -xf - -C "${{ runner.temp }}/db-${{ matrix.network.name }}"
-          touch "${{ runner.temp }}/db-${{ matrix.network.name }}/clean"
+          mkdir -p "$CARDANO_NODE_DB" "$(dirname "$CARDANO_NODE_SOCKET_FILE")"
+          aws s3 cp "$OBJECT" - --endpoint-url "$ENDPOINT" | tar --zstd -xf - -C "$CARDANO_NODE_DB"
+          touch "$CARDANO_NODE_DB/clean"
 
       - name: Spawn Haskell Node
         id: spawn-cardano-node
@@ -120,8 +129,8 @@ jobs:
           jq '.hasPrometheus = ["0.0.0.0", 12798]' "./$CONFIG_DIR/config.json" > "$CONFIG_DIR/config.patched.json"
           mv "$CONFIG_DIR/config.patched.json" "$CONFIG_DIR/config.json"
           docker run -d --name cardano-node \
-            -v ${{ runner.temp }}/db-${{ matrix.network.name }}:/db \
-            -v ${{ runner.temp }}/ipc:/ipc \
+            -v "$CARDANO_NODE_DB:/db" \
+            -v "$(dirname "$CARDANO_NODE_SOCKET_FILE"):/ipc" \
             -v "./$CONFIG_DIR:/config" \
             -v "./$CONFIG_DIR:/genesis" \
             -p 3001:3001 \
@@ -203,13 +212,10 @@ jobs:
         env:
           AMARU_CHAIN_DIR: ${{ github.workspace }}/chain.${{ matrix.network.name }}.db
           AMARU_LEDGER_DIR: ${{ github.workspace }}/ledger.${{ matrix.network.name }}.db
-          CARDANO_NODE_DB: ${{ runner.temp }}/db-${{ matrix.network.name }}
-          CARDANO_NODE_SOCKET_FILE: ${{ runner.temp }}/ipc/node.socket
           CARDANO_NODE_SYNC_TIMEOUT_SECONDS: 1200
           E2E_TX_MANAGE_CARDANO_NODE: "false"
           E2E_TX_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.network.name }}
           E2E_TX_WORK_DIR: ${{ github.workspace }}/e2e-tx-submission-output
-          TX_PAYMENT_SKEY: ${{ runner.temp }}/preprod-e2e-payment.skey
           TX_PAYMENT_SKEY_BASE64: ${{ secrets.PREPROD_TX_PAYMENT_SKEY_BASE64 }}
           TX_SYNC_TIMEOUT_SECONDS: 1200
         run: |

--- a/.github/workflows/template-ledger-epoch-snapshots.yml
+++ b/.github/workflows/template-ledger-epoch-snapshots.yml
@@ -35,6 +35,7 @@ jobs:
     concurrency:
       group: ${{ matrix.network.name == 'preprod' && 'preprod-e2e-transaction-submission' || format('ledger-epoch-snapshots-{0}-{1}', github.run_id, matrix.network.name) }}
       cancel-in-progress: false
+      queue: max
     strategy:
       fail-fast: false
       matrix:
@@ -58,6 +59,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: auto
       ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+      E2E_TX_WORK_DIR: ${{ github.workspace }}/e2e-tx-submission-output
       OBJECT: "s3://${{ secrets.CARDANO_NODE_BUCKET_NAME }}/${{ matrix.network.name }}.tar.zstd"
       TRACE_CONTRACT: data/${{ matrix.network.name }}/run-until-trace-contract.json
       TRACE_COMPARE_LOG: trace-compare.log
@@ -215,23 +217,18 @@ jobs:
           CARDANO_NODE_SYNC_TIMEOUT_SECONDS: 1200
           E2E_TX_MANAGE_CARDANO_NODE: "false"
           E2E_TX_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.network.name }}
-          E2E_TX_WORK_DIR: ${{ github.workspace }}/e2e-tx-submission-output
           TX_PAYMENT_SKEY_BASE64: ${{ secrets.PREPROD_TX_PAYMENT_SKEY_BASE64 }}
           TX_SYNC_TIMEOUT_SECONDS: 1200
         run: |
           set -euo pipefail
-          trap 'rm -f "$TX_PAYMENT_SKEY"' EXIT
-          umask 077
-          printf '%s' "$TX_PAYMENT_SKEY_BASE64" | base64 --decode > "$TX_PAYMENT_SKEY"
-          test -s "$TX_PAYMENT_SKEY"
           ./scripts/e2e/tx-submission.sh run
 
       - name: Collect transaction submission logs
         if: ${{ always() && matrix.network.name == 'preprod' && (inputs.network == '' || inputs.network == matrix.network.name) }}
         shell: bash
         run: |
-          mkdir -p e2e-tx-submission-output/logs
-          docker logs cardano-node > e2e-tx-submission-output/logs/cardano-node-docker.log 2>&1 || true
+          mkdir -p "$E2E_TX_WORK_DIR/logs"
+          docker logs cardano-node > "$E2E_TX_WORK_DIR/logs/cardano-node-docker.log" 2>&1 || true
 
       - name: Upload transaction submission artifacts
         if: ${{ always() && matrix.network.name == 'preprod' && (inputs.network == '' || inputs.network == matrix.network.name) }}
@@ -239,8 +236,8 @@ jobs:
         with:
           name: transaction-submission-${{ matrix.network.name }}
           path: |
-            e2e-tx-submission-output/logs
-            e2e-tx-submission-output/results
+            ${{ env.E2E_TX_WORK_DIR }}/logs
+            ${{ env.E2E_TX_WORK_DIR }}/results
           if-no-files-found: warn
 
       - name: Upload metrics report

--- a/.github/workflows/template-ledger-epoch-snapshots.yml
+++ b/.github/workflows/template-ledger-epoch-snapshots.yml
@@ -78,10 +78,23 @@ jobs:
       - name: Configure runner paths
         shell: bash
         run: |
+          mkdir -p "$E2E_TX_WORK_DIR" "$RUNNER_TEMP/ipc"
+          runner_identity="$(id -u):$(id -g)"
+          printf '%s\n' \
+            '#!/usr/bin/env bash' \
+            'docker exec cardano-node cardano-cli "$@"' \
+            'status=$?' \
+            "docker exec cardano-node chown -R \"$runner_identity\" \"$E2E_TX_WORK_DIR\"" \
+            'ownership_status=$?' \
+            '((status != 0)) && exit "$status"' \
+            'exit "$ownership_status"' \
+            > "$RUNNER_TEMP/cardano-cli"
+          chmod +x "$RUNNER_TEMP/cardano-cli"
           {
+            echo "CARDANO_CLI=$RUNNER_TEMP/cardano-cli"
             echo "CARDANO_NODE_DB=$RUNNER_TEMP/db-${{ matrix.network.name }}"
             echo "CARDANO_NODE_SOCKET_FILE=$RUNNER_TEMP/ipc/node.socket"
-            echo "TX_PAYMENT_SKEY=$RUNNER_TEMP/preprod-e2e-payment.skey"
+            echo "TX_PAYMENT_SKEY=$E2E_TX_WORK_DIR/private/payment.skey"
           } >> "$GITHUB_ENV"
 
       - name: Reclaim Disk Space
@@ -130,9 +143,12 @@ jobs:
           mv "$CONFIG_DIR/topology.patched.json" "$CONFIG_DIR/topology.json"
           jq '.hasPrometheus = ["0.0.0.0", 12798]' "./$CONFIG_DIR/config.json" > "$CONFIG_DIR/config.patched.json"
           mv "$CONFIG_DIR/config.patched.json" "$CONFIG_DIR/config.json"
+          # The container CLI receives host paths, so expose its socket and work directory at those paths too.
           docker run -d --name cardano-node \
             -v "$CARDANO_NODE_DB:/db" \
             -v "$(dirname "$CARDANO_NODE_SOCKET_FILE"):/ipc" \
+            -v "$(dirname "$CARDANO_NODE_SOCKET_FILE"):$(dirname "$CARDANO_NODE_SOCKET_FILE")" \
+            -v "$E2E_TX_WORK_DIR:$E2E_TX_WORK_DIR" \
             -v "./$CONFIG_DIR:/config" \
             -v "./$CONFIG_DIR:/genesis" \
             -p 3001:3001 \
@@ -211,14 +227,15 @@ jobs:
         if: ${{ matrix.network.name == 'preprod' && (inputs.network == '' || inputs.network == matrix.network.name) }}
         timeout-minutes: 30
         shell: bash
+        # The epoch-comparison databases intentionally stop in the past; use the E2E script's latest bootstrap instead.
         env:
-          AMARU_CHAIN_DIR: ${{ github.workspace }}/chain.${{ matrix.network.name }}.db
-          AMARU_LEDGER_DIR: ${{ github.workspace }}/ledger.${{ matrix.network.name }}.db
+          AMARU_LOG: "info,amaru::consensus=debug"
+          CARDANO_NODE_QUERY_TIMEOUT_SECONDS: 60
           CARDANO_NODE_SYNC_TIMEOUT_SECONDS: 1200
           E2E_TX_MANAGE_CARDANO_NODE: "false"
           E2E_TX_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.network.name }}
           TX_PAYMENT_SKEY_BASE64: ${{ secrets.PREPROD_TX_PAYMENT_SKEY_BASE64 }}
-          TX_SYNC_TIMEOUT_SECONDS: 1200
+          TX_SYNC_TIMEOUT_SECONDS: 300
         run: |
           set -euo pipefail
           ./scripts/e2e/tx-submission.sh run

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ CARDANO_NODE_CONFIG_COMMIT := 791baff19a998a0cee840d6abbd8fcaa23e8f826
 COVERAGE_DIR ?= coverage
 COVERAGE_CRATES ?=
 BUILD_PROFILE ?= release
-E2E_BUILD_PROFILE ?= dev
 DIST_DIR ?= dist
 BUILD_OUTPUT_DIR ?= $(if $(filter dev,$(BUILD_PROFILE)),debug,$(BUILD_PROFILE))
 AMARU_BIN ?= target/$(BUILD_OUTPUT_DIR)/amaru
@@ -55,7 +54,7 @@ else
 TRACE_SUMMARY_OUTPUT_ENABLED := 0
 endif
 
-.PHONY: help download-haskell-config coverage-html coverage-lconv check-llvm-cov check-rust-toolchain-version generate-traces-doc compare-trace-contract update-trace-contract serve-traces-doc validate-trace-schemas clean-dist cli-assets dist tarball zip zipball homebrew nix-flake winget deb rpm msi check-zip check-cargo-deb check-cargo-generate-rpm check-cargo-wix refresh e2e-tx-submission e2e-tx-submission-prepare
+.PHONY: help download-haskell-config coverage-html coverage-lconv check-llvm-cov check-rust-toolchain-version generate-traces-doc compare-trace-contract update-trace-contract serve-traces-doc validate-trace-schemas clean-dist cli-assets dist tarball zip zipball homebrew nix-flake winget deb rpm msi check-zip check-cargo-deb check-cargo-generate-rpm check-cargo-wix refresh
 
 help:
 	@echo "\033[1;4mGetting Started:\033[00m"
@@ -86,12 +85,6 @@ download-haskell-config: ## &start Download Haskell node configuration files for
 
 refresh: ## &start Refresh chain and ledger databases from the latest Mithril snapshot, moving the current ones to *.backup
 	AMARU_NETWORK="$(AMARU_NETWORK)" BUILD_PROFILE="$(BUILD_PROFILE)" INSTALL=true REPLACE_EXISTING=true ./scripts/refresh-from-mithril
-
-e2e-tx-submission-prepare: ## &test Prepare a fast local transaction submission E2E environment
-	AMARU_NETWORK="$(AMARU_NETWORK)" BUILD_PROFILE="$(E2E_BUILD_PROFILE)" ./scripts/e2e/tx-submission.sh prepare
-
-e2e-tx-submission: ## &test Submit a transaction through Amaru and verify diffusion to cardano-node
-	AMARU_NETWORK="$(AMARU_NETWORK)" BUILD_PROFILE="$(E2E_BUILD_PROFILE)" ./scripts/e2e/tx-submission.sh run
 
 generate-traces-doc: ## &build Generate documentation for Amaru's tracing spans
 	@./scripts/generate-traces-doc

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ CARDANO_NODE_CONFIG_COMMIT := 791baff19a998a0cee840d6abbd8fcaa23e8f826
 COVERAGE_DIR ?= coverage
 COVERAGE_CRATES ?=
 BUILD_PROFILE ?= release
+E2E_BUILD_PROFILE ?= dev
 DIST_DIR ?= dist
 BUILD_OUTPUT_DIR ?= $(if $(filter dev,$(BUILD_PROFILE)),debug,$(BUILD_PROFILE))
 AMARU_BIN ?= target/$(BUILD_OUTPUT_DIR)/amaru
@@ -54,7 +55,7 @@ else
 TRACE_SUMMARY_OUTPUT_ENABLED := 0
 endif
 
-.PHONY: help download-haskell-config coverage-html coverage-lconv check-llvm-cov check-rust-toolchain-version generate-traces-doc compare-trace-contract update-trace-contract serve-traces-doc validate-trace-schemas clean-dist cli-assets dist tarball zip zipball homebrew nix-flake winget deb rpm msi check-zip check-cargo-deb check-cargo-generate-rpm check-cargo-wix refresh
+.PHONY: help download-haskell-config coverage-html coverage-lconv check-llvm-cov check-rust-toolchain-version generate-traces-doc compare-trace-contract update-trace-contract serve-traces-doc validate-trace-schemas clean-dist cli-assets dist tarball zip zipball homebrew nix-flake winget deb rpm msi check-zip check-cargo-deb check-cargo-generate-rpm check-cargo-wix refresh e2e-tx-submission e2e-tx-submission-prepare
 
 help:
 	@echo "\033[1;4mGetting Started:\033[00m"
@@ -85,6 +86,12 @@ download-haskell-config: ## &start Download Haskell node configuration files for
 
 refresh: ## &start Refresh chain and ledger databases from the latest Mithril snapshot, moving the current ones to *.backup
 	AMARU_NETWORK="$(AMARU_NETWORK)" BUILD_PROFILE="$(BUILD_PROFILE)" INSTALL=true REPLACE_EXISTING=true ./scripts/refresh-from-mithril
+
+e2e-tx-submission-prepare: ## &test Prepare a fast local transaction submission E2E environment
+	AMARU_NETWORK="$(AMARU_NETWORK)" BUILD_PROFILE="$(E2E_BUILD_PROFILE)" ./scripts/e2e/tx-submission.sh prepare
+
+e2e-tx-submission: ## &test Submit a transaction through Amaru and verify diffusion to cardano-node
+	AMARU_NETWORK="$(AMARU_NETWORK)" BUILD_PROFILE="$(E2E_BUILD_PROFILE)" ./scripts/e2e/tx-submission.sh run
 
 generate-traces-doc: ## &build Generate documentation for Amaru's tracing spans
 	@./scripts/generate-traces-doc

--- a/scripts/configure-github-secrets
+++ b/scripts/configure-github-secrets
@@ -65,7 +65,7 @@ if ! gh auth status --hostname github.com >/dev/null 2>&1; then
 fi
 
 if [[ -z "$repo" ]]; then
-  repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+  repo="$(cd "$ROOT_DIR" && gh repo view --json nameWithOwner --jq '.nameWithOwner')"
 fi
 [[ "$repo" == */* ]] || { echo "error: expected OWNER/REPO, got: $repo" >&2; exit 1; }
 

--- a/scripts/configure-github-secrets
+++ b/scripts/configure-github-secrets
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/configure-github-secrets [--repo OWNER/REPO]
+  scripts/configure-github-secrets [--repo OWNER/REPO] --set-base64-file SECRET FILE
+
+Interactively show GitHub Actions secrets referenced by this repository and
+set or update repository-level values without exposing them in command-line
+arguments.
+
+With --set-base64-file, base64-encode FILE and set SECRET without prompting.
+EOF
+}
+
+repo="${GH_REPO:-}"
+base64_secret_name=""
+base64_file_path=""
+while (($# > 0)); do
+  case "$1" in
+    --repo)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      repo="$2"
+      shift 2
+      ;;
+    --set-base64-file)
+      [[ $# -ge 3 ]] || { usage >&2; exit 2; }
+      [[ -z "$base64_secret_name" ]] || { echo "error: --set-base64-file may only be specified once" >&2; exit 2; }
+      base64_secret_name="$2"
+      base64_file_path="$3"
+      shift 3
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "error: required command '$1' is not available" >&2
+    exit 1
+  }
+}
+
+require_command gh
+require_command grep
+require_command sed
+require_command sort
+
+if ! gh auth status --hostname github.com >/dev/null 2>&1; then
+  echo "error: GitHub CLI is not authenticated; run: gh auth login --hostname github.com" >&2
+  exit 1
+fi
+
+if [[ -z "$repo" ]]; then
+  repo="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+fi
+[[ "$repo" == */* ]] || { echo "error: expected OWNER/REPO, got: $repo" >&2; exit 1; }
+
+required_secrets=()
+while IFS= read -r secret_name; do
+  [[ -n "$secret_name" && "$secret_name" != GITHUB_TOKEN ]] || continue
+  required_secrets+=("$secret_name")
+done < <(
+  LC_ALL=C grep -RhoE 'secrets\.[A-Za-z_][A-Za-z0-9_]*' \
+    "$ROOT_DIR/.github/workflows" "$ROOT_DIR/.github/actions" 2>/dev/null \
+    | sed 's/^secrets\.//' \
+    | sort -u
+)
+
+((${#required_secrets[@]} > 0)) || {
+  echo "error: no GitHub Actions secret references found" >&2
+  exit 1
+}
+
+configured_secrets=()
+refresh_configured_secrets() {
+  local secret_list
+  if ! secret_list="$(gh secret list --repo "$repo" --json name --jq '.[].name')"; then
+    echo "error: unable to list GitHub Actions secrets for $repo" >&2
+    return 1
+  fi
+  configured_secrets=()
+  while IFS= read -r secret_name; do
+    [[ -n "$secret_name" ]] && configured_secrets+=("$secret_name")
+  done <<<"$secret_list"
+  return 0
+}
+
+secret_is_configured() {
+  local expected="$1" configured
+  ((${#configured_secrets[@]} > 0)) || return 1
+  for configured in "${configured_secrets[@]}"; do
+    [[ "$configured" == "$expected" ]] && return 0
+  done
+  return 1
+}
+
+show_status() {
+  local index secret_name status missing=0
+  printf '\nGitHub Actions repository secrets for %s\n' "$repo"
+  printf 'Status only includes repository-level secrets visible to your GitHub account.\n\n'
+  for index in "${!required_secrets[@]}"; do
+    secret_name="${required_secrets[$index]}"
+    if secret_is_configured "$secret_name"; then
+      status="configured"
+    else
+      status="MISSING"
+      missing=$((missing + 1))
+    fi
+    printf '  %2d) %-42s %s\n' "$((index + 1))" "$secret_name" "$status"
+  done
+  printf '\n%d of %d referenced secrets missing at repository level.\n' "$missing" "${#required_secrets[@]}"
+}
+
+set_from_hidden_prompt() {
+  local secret_name="$1" secret_value
+  printf 'Enter value for %s (input hidden): ' "$secret_name"
+  IFS= read -r -s secret_value
+  printf '\n'
+  [[ -n "$secret_value" ]] || { echo "error: refusing to set an empty secret" >&2; return 1; }
+  if printf '%s' "$secret_value" | gh secret set "$secret_name" --repo "$repo"; then
+    unset secret_value
+    return 0
+  fi
+  unset secret_value
+  return 1
+}
+
+read_file_path() {
+  local prompt="$1" path
+  printf '%s' "$prompt" >&2
+  IFS= read -r path
+  [[ -f "$path" && -r "$path" ]] || { echo "error: file is not readable: $path" >&2; return 1; }
+  printf '%s' "$path"
+}
+
+set_from_file() {
+  local secret_name="$1" path
+  path="$(read_file_path 'File containing the secret value: ')" || return 1
+  [[ -s "$path" ]] || { echo "error: refusing to set a secret from an empty file" >&2; return 1; }
+  gh secret set "$secret_name" --repo "$repo" <"$path"
+}
+
+set_from_base64_file() {
+  local secret_name="$1" path="${2:-}"
+  require_command base64
+  if [[ -z "$path" ]]; then
+    path="$(read_file_path 'File to base64-encode: ')" || return 1
+  elif [[ ! -f "$path" || ! -r "$path" ]]; then
+    echo "error: file is not readable: $path" >&2
+    return 1
+  fi
+  [[ -s "$path" ]] || { echo "error: refusing to encode an empty file" >&2; return 1; }
+  base64 <"$path" | gh secret set "$secret_name" --repo "$repo"
+}
+
+secret_is_required() {
+  local expected="$1" required
+  for required in "${required_secrets[@]}"; do
+    [[ "$required" == "$expected" ]] && return 0
+  done
+  return 1
+}
+
+configure_secret() {
+  local secret_name="$1" choice
+  while true; do
+    printf '\nSet %s using:\n' "$secret_name"
+    printf '  1) Hidden prompt\n'
+    printf '  2) File contents as-is\n'
+    printf '  3) Base64-encoded file\n'
+    printf '  b) Back\n'
+    printf 'Choice: '
+    IFS= read -r choice || return 1
+    case "$choice" in
+      1) set_from_hidden_prompt "$secret_name" && return ;;
+      2) set_from_file "$secret_name" && return ;;
+      3) set_from_base64_file "$secret_name" && return ;;
+      b | B) return ;;
+      *) echo "error: choose 1, 2, 3, or b" >&2 ;;
+    esac
+  done
+}
+
+if [[ -n "$base64_secret_name" ]]; then
+  secret_is_required "$base64_secret_name" || {
+    echo "error: secret is not referenced by this repository: $base64_secret_name" >&2
+    exit 1
+  }
+  set_from_base64_file "$base64_secret_name" "$base64_file_path"
+  printf 'Set %s from the base64-encoded contents of %s.\n' "$base64_secret_name" "$base64_file_path"
+  exit 0
+fi
+
+refresh_configured_secrets
+while true; do
+  show_status
+  printf '\nChoose a secret number to set/update, r to refresh, or q to quit: '
+  IFS= read -r choice || exit 0
+  case "$choice" in
+    q | Q) exit 0 ;;
+    r | R)
+      refresh_configured_secrets
+      ;;
+    *[!0-9]* | '')
+      echo "error: enter a listed number, r, or q" >&2
+      ;;
+    *)
+      choice_number=$((10#$choice))
+      if ((choice_number < 1 || choice_number > ${#required_secrets[@]})); then
+        echo "error: secret number is out of range" >&2
+        continue
+      fi
+      configure_secret "${required_secrets[$((choice_number - 1))]}"
+      refresh_configured_secrets
+      ;;
+  esac
+done

--- a/scripts/demos/common/amaru.sh
+++ b/scripts/demos/common/amaru.sh
@@ -123,40 +123,48 @@ eta_hint() {
 }
 
 wait_for_downstream_slot() {
-  local target_slot="$1"
-  local timeout="$TX_SYNC_TIMEOUT_SECONDS"
-  local start now elapsed downstream remaining prev_down prev_t poll_interval eta
-  validate_amaru_runtime_network "${AMARU_DOWNSTREAM_LOG_FILE:-$LOGDIR/amaru-downstream.log}" "downstream"
+  wait_for_amaru_slot \
+    "${AMARU_DOWNSTREAM_LOG_FILE:-$LOGDIR/amaru-downstream.log}" \
+    "downstream" \
+    "$1" \
+    "$TX_SYNC_TIMEOUT_SECONDS"
+}
+
+# Waits until an Amaru process has adopted a target slot according to its structured log.
+wait_for_amaru_slot() {
+  local log="$1" label="$2" target_slot="$3" timeout="${4:-$TX_SYNC_TIMEOUT_SECONDS}"
+  local start now elapsed adopted remaining prev_adopted prev_t poll_interval eta
+  validate_amaru_runtime_network "$log" "$label"
   poll_interval="$(sync_poll_interval_seconds)"
   start="$(date +%s)"
-  prev_down=""
+  prev_adopted=""
   prev_t=""
-  echo "[submit-tx] waiting for downstream Amaru to reach selected input availability slot ${target_slot} (timeout: ${timeout}s)..."
+  echo "[submit-tx] waiting for $label Amaru to reach selected input availability slot ${target_slot} (timeout: ${timeout}s)..."
   while true; do
     now="$(date +%s)"
     elapsed=$(( now - start ))
-    downstream="$(downstream_adopted_slot)"
-    if [[ -n "$downstream" ]]; then
-      remaining=$(( target_slot - downstream ))
+    adopted="$(adopted_slot_from_log "$log")"
+    if [[ -n "$adopted" ]]; then
+      remaining=$(( target_slot - adopted ))
       eta=""
       if (( remaining <= 0 )); then
-        echo "[submit-tx] downstream Amaru reached slot ${downstream}; selected input UTxO should be available"
+        echo "[submit-tx] $label Amaru reached slot ${adopted}; selected input UTxO should be available"
         return 0
       fi
-      if [[ -n "$prev_down" && -n "$prev_t" && "$now" -gt "$prev_t" ]]; then
+      if [[ -n "$prev_adopted" && -n "$prev_t" && "$now" -gt "$prev_t" ]]; then
         local d_slots d_secs
-        d_slots=$(( downstream - prev_down ))
+        d_slots=$(( adopted - prev_adopted ))
         d_secs=$(( now - prev_t ))
         eta="$(eta_hint "$remaining" "$d_slots" "$d_secs" "$poll_interval")"
       fi
-      printf '[submit-tx] elapsed=%ss target=%s downstream=%s remaining=%s%s\n' "$elapsed" "$target_slot" "$downstream" "$remaining" "$eta"
-      prev_down="$downstream"
+      printf '[submit-tx] elapsed=%ss target=%s %s=%s remaining=%s%s\n' "$elapsed" "$target_slot" "$label" "$adopted" "$remaining" "$eta"
+      prev_adopted="$adopted"
       prev_t="$now"
     else
-      echo "[submit-tx] elapsed=${elapsed}s target=${target_slot} downstream=? (still initializing)"
+      echo "[submit-tx] elapsed=${elapsed}s target=${target_slot} ${label}=? (still initializing)"
     fi
     if (( elapsed > timeout )); then
-      die "downstream Amaru did not reach selected input availability slot ${target_slot} within ${timeout}s (last downstream slot: ${downstream:-unknown})"
+      die "$label Amaru did not reach selected input availability slot ${target_slot} within ${timeout}s (last adopted slot: ${adopted:-unknown})"
     fi
     sleep "$poll_interval"
   done

--- a/scripts/demos/common/cardano-node.sh
+++ b/scripts/demos/common/cardano-node.sh
@@ -150,7 +150,7 @@ download_official_cardano_node_config() {
   done <<< "$files"
 
   mkdir -p "$CARDANO_NODE_CONFIG_DIR"
-  fd --hidden --no-ignore --type f . "$tmp_dir" | while IFS= read -r file_name; do
+  find "$tmp_dir" -type f | while IFS= read -r file_name; do
     local relative target
     relative="${file_name#"$tmp_dir"/}"
     target="$CARDANO_NODE_CONFIG_DIR/$relative"
@@ -163,6 +163,10 @@ download_official_cardano_node_config() {
 
 cardano_node_socket_file() {
   echo "$CARDANO_NODE_SOCKET_FILE"
+}
+
+cardano_node_database_dir() {
+  echo "${CARDANO_NODE_DB:-$CARDANO_NODE_CONFIG_DIR/db}"
 }
 
 cardano_node_bundled_peer_snapshot_file() {
@@ -227,6 +231,18 @@ cardano_node_effective_topology_file() {
   echo "${CARDANO_NODE_EFFECTIVE_TOPOLOGY_FILE:-$(cardano_node_topology_file)}"
 }
 
+managed_cardano_node_stopped() {
+  [[ -n "${CARDANO_NODE_PID:-}" ]] && ! kill -0 "$CARDANO_NODE_PID" 2>/dev/null
+}
+
+cardano_node_stopped_error() {
+  local phase="$1" log_hint=""
+  if [[ -n "${CARDANO_NODE_LOG_FILE:-}" ]]; then
+    log_hint="; see $CARDANO_NODE_LOG_FILE"
+  fi
+  die "cardano-node stopped $phase$log_hint"
+}
+
 # Waits until the configured Cardano node socket is available.
 wait_for_cardano_socket() {
   local socket
@@ -234,6 +250,7 @@ wait_for_cardano_socket() {
   local timeout="${CARDANO_NODE_SOCKET_TIMEOUT_SECONDS:-1800}"
   for (( elapsed = 0; elapsed < timeout; elapsed++ )); do
     [[ -S "$socket" ]] && return 0
+    managed_cardano_node_stopped && cardano_node_stopped_error "before creating its socket"
     sleep 1
   done
   die "cardano-node socket not found: $socket"
@@ -245,6 +262,7 @@ wait_for_cardano_query() {
     if cardano_node_tip >/dev/null 2>&1; then
       return 0
     fi
+    managed_cardano_node_stopped && cardano_node_stopped_error "before answering local queries"
     sleep 1
   done
   die "cardano-node socket did not answer local queries within ${timeout}s"
@@ -264,6 +282,7 @@ wait_for_cardano_sync_progress() {
         echo "[cardano-upstream] waiting for cardano-node sync progress: ${progress}%/${threshold}%"
       fi
     fi
+    managed_cardano_node_stopped && cardano_node_stopped_error "before reaching the requested sync progress"
     sleep 1
   done
   die "cardano-node did not reach ${threshold}% sync progress within ${timeout}s"
@@ -280,6 +299,52 @@ cardano_node_tip() {
 # Queries the current Cardano node tip slot.
 cardano_node_tip_slot() {
   cardano_node_tip | jq -r '.slot // empty'
+}
+
+# Parses the JSON returned by `query tx-mempool tx-exists`, verifies that it describes the expected
+# transaction, and prints either "present" or "absent". Any schema or transaction-id mismatch is an
+# error rather than an implicit absence.
+parse_cardano_node_mempool_tx_state() {
+  local expected_tx_id="$1" response_file="$2"
+
+  jq -er --arg expected_tx_id "$expected_tx_id" '
+    if type != "object"
+      or (.txId | type) != "string"
+      or (.txId | ascii_downcase) != ($expected_tx_id | ascii_downcase)
+      or (.exists | type) != "boolean"
+    then error("unexpected tx-mempool response")
+    elif .exists then "present"
+    else "absent"
+    end
+  ' "$response_file"
+}
+
+# Queries whether a transaction has diffused into the connected cardano-node mempool.
+cardano_node_mempool_tx_state() {
+  local tx_id="$1" response_file="${2:-}"
+  local temporary_response=false result
+
+  if [[ -z "$response_file" ]]; then
+    response_file="${TMPDIR:-/tmp}/cardano-node-mempool-$$.json"
+    temporary_response=true
+  fi
+
+  if ! "$CARDANO_CLI" conway query tx-mempool \
+    $(cardano_cli_network_args) \
+    --socket-path "$(cardano_node_socket_file)" \
+    tx-exists "$tx_id" \
+    --output-json >"$response_file"; then
+    [[ "$temporary_response" == false ]] || rm -f "$response_file"
+    return 1
+  fi
+
+  if parse_cardano_node_mempool_tx_state "$tx_id" "$response_file"; then
+    result=0
+  else
+    result=$?
+  fi
+  [[ "$temporary_response" == false ]] || rm -f "$response_file"
+  return "$result"
 }
 
 # Returns whether the demo uses a public upstream peer instead of a local cardano-node.
@@ -430,7 +495,7 @@ run_cardano_upstream() {
   "$CARDANO_NODE" run \
     --config "$(cardano_node_config_file)" \
     --topology "$(cardano_node_effective_topology_file)" \
-    --database-path "$CARDANO_NODE_CONFIG_DIR/db" \
+    --database-path "$(cardano_node_database_dir)" \
     --socket-path "$(cardano_node_socket_file)" \
     --port "$UPSTREAM_PORT" \
     2>&1 | tee "$LOGDIR/cardano-upstream.log"

--- a/scripts/demos/common/cardano-node.sh
+++ b/scripts/demos/common/cardano-node.sh
@@ -325,7 +325,7 @@ cardano_node_mempool_tx_state() {
   local temporary_response=false result
 
   if [[ -z "$response_file" ]]; then
-    response_file="${TMPDIR:-/tmp}/cardano-node-mempool-$$.json"
+    response_file="$(mktemp "${TMPDIR:-/tmp}/cardano-node-mempool.XXXXXX")" || return 1
     temporary_response=true
   fi
 

--- a/scripts/demos/common/cardano-node.sh
+++ b/scripts/demos/common/cardano-node.sh
@@ -265,6 +265,8 @@ wait_for_cardano_query() {
     managed_cardano_node_stopped && cardano_node_stopped_error "before answering local queries"
     sleep 1
   done
+  echo "[cardano-upstream] final local query error:" >&2
+  cardano_node_tip >/dev/null || true
   die "cardano-node socket did not answer local queries within ${timeout}s"
 }
 

--- a/scripts/demos/common/tx.sh
+++ b/scripts/demos/common/tx.sh
@@ -92,6 +92,10 @@ tx_query_uses_koios() {
   [[ "$TX_QUERY_SOURCE" == "koios" ]]
 }
 
+submit_tx_response_is_duplicate() {
+  grep -qi 'transaction is a duplicate' <<<"$1"
+}
+
 # Submits a transaction to the downstream submit API with retryable rejection handling.
 submit_tx_with_retry() {
   local tx_file="$1" response_file="$2" attempt=1
@@ -109,7 +113,7 @@ submit_tx_with_retry() {
       if [[ "$status" == 2* ]]; then
         return 0
       fi
-      if grep -qi 'transaction is a duplicate' <<<"$body"; then
+      if submit_tx_response_is_duplicate "$body"; then
         echo "[submit-tx] downstream already knows this transaction; keeping claim"
         return 0
       fi
@@ -141,9 +145,10 @@ submit_tx_response_matches_id() {
 }
 
 # Submits a transaction and verifies the complete public contract used by the end-to-end test:
-# HTTP 202 and a response body containing exactly the expected transaction id. A missing-input
-# rejection is retryable because Amaru may still be catching up to the cardano-node used to select
-# the input.
+# HTTP 202 and a response body containing exactly the expected transaction id. A duplicate response
+# also completes the submission because an earlier attempt may have timed out after acceptance. A
+# missing-input rejection is retryable because Amaru may still be catching up to the cardano-node
+# used to select the input.
 submit_tx_and_expect_id() {
   local tx_file="$1" expected_tx_id="$2" response_file="$3" attempt=1
   local status body retries="$TX_SUBMIT_RETRY_LIMIT" delay="$TX_SUBMIT_RETRY_DELAY"
@@ -164,6 +169,10 @@ submit_tx_and_expect_id() {
       if [[ "$status" == 202 ]]; then
         echo "[submit-tx] HTTP 202 response did not contain the expected transaction id"
         return 1
+      fi
+      if submit_tx_response_is_duplicate "$body"; then
+        echo "[submit-tx] downstream already knows this transaction; submission is complete"
+        return 0
       fi
       if grep -qi 'missing transaction inputs' <<<"$body"; then
         echo "[submit-tx] Amaru has not indexed the input UTxO yet; waiting ${delay}s before retry"

--- a/scripts/demos/common/tx.sh
+++ b/scripts/demos/common/tx.sh
@@ -129,6 +129,58 @@ submit_tx_with_retry() {
   return 1
 }
 
+# Validates the successful Submit API response for a known transaction. The endpoint returns the
+# accepted transaction id as a JSON string; accepting a generic 2xx here would not prove that the
+# request body was decoded as the transaction the caller built.
+submit_tx_response_matches_id() {
+  local expected_tx_id="$1" response_file="$2"
+
+  jq -e --arg expected_tx_id "$expected_tx_id" '
+    type == "string" and (ascii_downcase == ($expected_tx_id | ascii_downcase))
+  ' "$response_file" >/dev/null
+}
+
+# Submits a transaction and verifies the complete public contract used by the end-to-end test:
+# HTTP 202 and a response body containing exactly the expected transaction id. A missing-input
+# rejection is retryable because Amaru may still be catching up to the cardano-node used to select
+# the input.
+submit_tx_and_expect_id() {
+  local tx_file="$1" expected_tx_id="$2" response_file="$3" attempt=1
+  local status body retries="$TX_SUBMIT_RETRY_LIMIT" delay="$TX_SUBMIT_RETRY_DELAY"
+
+  while ((attempt <= retries)); do
+    echo "[submit-tx] attempt $attempt/$retries: submitting tx_id=$expected_tx_id to the Amaru Submit API at $TX_SUBMIT_API_ADDRESS"
+    if curl --max-time "${TX_SUBMIT_HTTP_TIMEOUT_SECONDS:-30}" -sS -o "$response_file" -w '%{http_code}' \
+      -X POST -H 'Content-Type: application/cbor' \
+      --data-binary "@$tx_file" \
+      "http://$TX_SUBMIT_API_ADDRESS/api/submit/tx" >"$response_file.status"; then
+      status="$(cat "$response_file.status")"
+      body="$(cat "$response_file")"
+      echo "[submit-tx] response: HTTP $status"
+      echo "$body"
+      if [[ "$status" == 202 ]] && submit_tx_response_matches_id "$expected_tx_id" "$response_file"; then
+        return 0
+      fi
+      if [[ "$status" == 202 ]]; then
+        echo "[submit-tx] HTTP 202 response did not contain the expected transaction id"
+        return 1
+      fi
+      if grep -qi 'missing transaction inputs' <<<"$body"; then
+        echo "[submit-tx] Amaru has not indexed the input UTxO yet; waiting ${delay}s before retry"
+      else
+        echo "[submit-tx] expected HTTP 202 for tx_id=$expected_tx_id, got HTTP $status; aborting retries"
+        return 1
+      fi
+    else
+      echo "[submit-tx] Submit API request failed; waiting ${delay}s before retry"
+    fi
+    sleep "$delay"
+    attempt=$((attempt + 1))
+  done
+  echo "[submit-tx] giving up after $retries attempts"
+  return 1
+}
+
 # Whether TX_PAYMENT_SKEY holds the key itself rather than a path to a file holding it, which lets a
 # container run without mounting anything.
 #

--- a/scripts/demos/common/tx.sh
+++ b/scripts/demos/common/tx.sh
@@ -4,6 +4,7 @@
 TX_PAYMENT_SKEY="${TX_PAYMENT_SKEY:-}"
 TX_GENERATED_COUNT="${TX_GENERATED_COUNT:-1}"
 TX_SYNC_TIMEOUT_SECONDS="${TX_SYNC_TIMEOUT_SECONDS:-14400}"
+TX_SUBMIT_HTTP_TIMEOUT_SECONDS="${TX_SUBMIT_HTTP_TIMEOUT_SECONDS:-30}"
 TX_SUBMIT_RETRY_LIMIT="${TX_SUBMIT_RETRY_LIMIT:-12}"
 TX_SUBMIT_RETRY_DELAY="${TX_SUBMIT_RETRY_DELAY:-30}"
 TX_OUTPUT_LOVELACE="${TX_OUTPUT_LOVELACE:-1000000}"
@@ -96,43 +97,6 @@ submit_tx_response_is_duplicate() {
   grep -qi 'transaction is a duplicate' <<<"$1"
 }
 
-# Submits a transaction to the downstream submit API with retryable rejection handling.
-submit_tx_with_retry() {
-  local tx_file="$1" response_file="$2" attempt=1
-  local response status body retries="$TX_SUBMIT_RETRY_LIMIT" delay="$TX_SUBMIT_RETRY_DELAY"
-  while ((attempt <= retries)); do
-    echo "[submit-tx] attempt $attempt/$retries: submitting $tx_file to the Amaru submit API at $TX_SUBMIT_API_ADDRESS"
-    if curl -sS -o "$response_file" -w '%{http_code}' \
-      -X POST -H 'Content-Type: application/cbor' \
-      --data-binary "@$tx_file" \
-      "http://$TX_SUBMIT_API_ADDRESS/api/submit/tx" >"$response_file.status"; then
-      status="$(cat "$response_file.status")"
-      body="$(cat "$response_file")"
-      echo "[submit-tx] response: HTTP $status"
-      echo "$body"
-      if [[ "$status" == 2* ]]; then
-        return 0
-      fi
-      if submit_tx_response_is_duplicate "$body"; then
-        echo "[submit-tx] downstream already knows this transaction; keeping claim"
-        return 0
-      fi
-      if grep -qi 'missing transaction inputs' <<<"$body"; then
-        echo "[submit-tx] downstream ledger does not yet contain the input UTxO; waiting ${delay}s before retry"
-      else
-        echo "[submit-tx] non-retryable rejection; aborting retries for this tx"
-        return 1
-      fi
-    else
-      echo "[submit-tx] curl failed; will retry in ${delay}s"
-    fi
-    sleep "$delay"
-    attempt=$((attempt + 1))
-  done
-  echo "[submit-tx] giving up after $retries attempts"
-  return 1
-}
-
 # Validates the successful Submit API response for a known transaction. The endpoint returns the
 # accepted transaction id as a JSON string; accepting a generic 2xx here would not prove that the
 # request body was decoded as the transaction the caller built.
@@ -144,18 +108,30 @@ submit_tx_response_matches_id() {
   ' "$response_file" >/dev/null
 }
 
-# Submits a transaction and verifies the complete public contract used by the end-to-end test:
-# HTTP 202 and a response body containing exactly the expected transaction id. A duplicate response
-# also completes the submission because an earlier attempt may have timed out after acceptance. A
-# missing-input rejection is retryable because Amaru may still be catching up to the cardano-node
-# used to select the input.
-submit_tx_and_expect_id() {
-  local tx_file="$1" expected_tx_id="$2" response_file="$3" attempt=1
-  local status body retries="$TX_SUBMIT_RETRY_LIMIT" delay="$TX_SUBMIT_RETRY_DELAY"
+submit_tx_accept_any_success() {
+  local status="$1"
+  [[ "$status" == 2* ]]
+}
 
+submit_tx_accept_expected_id() {
+  local status="$1" response_file="$2" expected_tx_id="$3"
+
+  [[ "$status" == 202 ]] || return 1
+  if submit_tx_response_matches_id "$expected_tx_id" "$response_file"; then
+    return 0
+  fi
+  echo "[submit-tx] HTTP 202 response did not contain the expected transaction id"
+  return 2
+}
+
+submit_tx_with_retry_policy() {
+  local tx_file="$1" response_file="$2" accept_response="$3" expected_tx_id="${4:-}" attempt=1
+  local status body acceptance_status retries="$TX_SUBMIT_RETRY_LIMIT" delay="$TX_SUBMIT_RETRY_DELAY" subject="$tx_file"
+
+  [[ -z "$expected_tx_id" ]] || subject="tx_id=$expected_tx_id"
   while ((attempt <= retries)); do
-    echo "[submit-tx] attempt $attempt/$retries: submitting tx_id=$expected_tx_id to the Amaru Submit API at $TX_SUBMIT_API_ADDRESS"
-    if curl --max-time "${TX_SUBMIT_HTTP_TIMEOUT_SECONDS:-30}" -sS -o "$response_file" -w '%{http_code}' \
+    echo "[submit-tx] attempt $attempt/$retries: submitting $subject to the Amaru submit API at $TX_SUBMIT_API_ADDRESS"
+    if curl --max-time "$TX_SUBMIT_HTTP_TIMEOUT_SECONDS" -sS -o "$response_file" -w '%{http_code}' \
       -X POST -H 'Content-Type: application/cbor' \
       --data-binary "@$tx_file" \
       "http://$TX_SUBMIT_API_ADDRESS/api/submit/tx" >"$response_file.status"; then
@@ -163,11 +139,12 @@ submit_tx_and_expect_id() {
       body="$(cat "$response_file")"
       echo "[submit-tx] response: HTTP $status"
       echo "$body"
-      if [[ "$status" == 202 ]] && submit_tx_response_matches_id "$expected_tx_id" "$response_file"; then
+      if "$accept_response" "$status" "$response_file" "$expected_tx_id"; then
         return 0
+      else
+        acceptance_status=$?
       fi
-      if [[ "$status" == 202 ]]; then
-        echo "[submit-tx] HTTP 202 response did not contain the expected transaction id"
+      if ((acceptance_status != 1)); then
         return 1
       fi
       if submit_tx_response_is_duplicate "$body"; then
@@ -177,17 +154,31 @@ submit_tx_and_expect_id() {
       if grep -qi 'missing transaction inputs' <<<"$body"; then
         echo "[submit-tx] Amaru has not indexed the input UTxO yet; waiting ${delay}s before retry"
       else
-        echo "[submit-tx] expected HTTP 202 for tx_id=$expected_tx_id, got HTTP $status; aborting retries"
+        echo "[submit-tx] non-retryable HTTP $status rejection; aborting retries for this transaction"
         return 1
       fi
     else
-      echo "[submit-tx] Submit API request failed; waiting ${delay}s before retry"
+      echo "[submit-tx] request failed; waiting ${delay}s before retry"
     fi
     sleep "$delay"
     attempt=$((attempt + 1))
   done
   echo "[submit-tx] giving up after $retries attempts"
   return 1
+}
+
+# Submits a transaction to the downstream Submit API and accepts any successful HTTP status.
+submit_tx_with_retry() {
+  submit_tx_with_retry_policy "$1" "$2" submit_tx_accept_any_success
+}
+
+# Submits a transaction and verifies the complete public contract used by the end-to-end test:
+# HTTP 202 and a response body containing exactly the expected transaction id. A duplicate response
+# also completes the submission because an earlier attempt may have timed out after acceptance. A
+# missing-input rejection is retryable because Amaru may still be catching up to the cardano-node
+# used to select the input.
+submit_tx_and_expect_id() {
+  submit_tx_with_retry_policy "$1" "$3" submit_tx_accept_expected_id "$2"
 }
 
 # Whether TX_PAYMENT_SKEY holds the key itself rather than a path to a file holding it, which lets a

--- a/scripts/e2e/tx-submission.sh
+++ b/scripts/e2e/tx-submission.sh
@@ -73,7 +73,7 @@ MITHRIL_CLIENT_DISTRIBUTION="${MITHRIL_CLIENT_DISTRIBUTION:-2630.0}"
 MITHRIL_CLIENT_HOME="${MITHRIL_CLIENT_HOME:-$RUNDIR/tools/mithril-client}"
 MITHRIL_CLIENT="${MITHRIL_CLIENT:-$MITHRIL_CLIENT_HOME/mithril-client}"
 
-CARDANO_CLI_RELEASE_VERSION="${CARDANO_CLI_RELEASE_VERSION:-11.2.1.0}"
+CARDANO_CLI_RELEASE_VERSION="${CARDANO_CLI_RELEASE_VERSION:-11.0.0.0}"
 CARDANO_CLI_HOME="${CARDANO_CLI_HOME:-$RUNDIR/tools/cardano-cli-$CARDANO_CLI_RELEASE_VERSION}"
 CARDANO_CLI="${CARDANO_CLI:-$CARDANO_CLI_HOME/bin/cardano-cli}"
 
@@ -90,7 +90,7 @@ TX_SUBMIT_API_ADDRESS="$AMARU_SUBMIT_API_ADDRESS"
 TX_QUERY_SOURCE=local
 TX_METADATA_MESSAGE="${TX_METADATA_MESSAGE:-amaru e2e $RUN_ID}"
 TX_SYNC_TIMEOUT_SECONDS="${TX_SYNC_TIMEOUT_SECONDS:-3600}"
-TX_SYNC_POLL_INTERVAL_SECONDS="${TX_SYNC_POLL_INTERVAL_SECONDS:-5}"
+TX_SYNC_POLL_INTERVAL_SECONDS="${TX_SYNC_POLL_INTERVAL_SECONDS:-15}"
 TX_SUBMIT_RETRY_LIMIT="${TX_SUBMIT_RETRY_LIMIT:-20}"
 TX_SUBMIT_RETRY_DELAY="${TX_SUBMIT_RETRY_DELAY:-5}"
 TX_INPUT_TIMEOUT_SECONDS="${TX_INPUT_TIMEOUT_SECONDS:-900}"
@@ -137,13 +137,18 @@ EOF
 
 target_profile_dir() {
   case "$BUILD_PROFILE" in
-    dev) echo debug ;;
+    dev | test) echo debug ;;
+    release | bench) echo release ;;
     *) echo "$BUILD_PROFILE" ;;
   esac
 }
 
 amaru_binary() {
-  echo "${AMARU_NODE_BINARY:-${CARGO_TARGET_DIR:-$AMARU_DIR/target}/$(target_profile_dir)/amaru}"
+  local target_dir="${CARGO_TARGET_DIR:-$AMARU_DIR/target}"
+  if [[ -n "${CARGO_BUILD_TARGET:-}" ]]; then
+    target_dir="$target_dir/$CARGO_BUILD_TARGET"
+  fi
+  echo "${AMARU_NODE_BINARY:-$target_dir/$(target_profile_dir)/amaru}"
 }
 
 require_base_tools() {
@@ -639,7 +644,7 @@ cleanup() {
 }
 
 runner_self_test() {
-  local work tx_id state selected managed_before
+  local work tx_id state selected managed_before binary
   work="$(mktemp -d)"
   tx_id=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
   printf '"%s"\n' "$tx_id" >"$work/submit.json"
@@ -685,8 +690,11 @@ runner_self_test() {
   start_amaru >/dev/null
   [[ -z "$AMARU_PID" ]] || die "externally managed Amaru mode started a process"
   AMARU_MANAGED="$managed_before"
+  binary="$(CARGO_TARGET_DIR="$work/target" CARGO_BUILD_TARGET=x86_64-unknown-linux-gnu BUILD_PROFILE=test amaru_binary)"
+  [[ "$binary" == "$work/target/x86_64-unknown-linux-gnu/debug/amaru" ]] ||
+    die "Amaru binary path ignored CARGO_BUILD_TARGET: $binary"
   rm -rf "$work"
-  self_test_success "response parsers, duplicate handling, input selection, slot wait, and external Amaru mode passed"
+  self_test_success "response parsers, duplicate handling, input selection, slot wait, binary path, and external Amaru mode passed"
 }
 
 run_e2e() {

--- a/scripts/e2e/tx-submission.sh
+++ b/scripts/e2e/tx-submission.sh
@@ -596,6 +596,11 @@ runner_self_test() {
   if submit_tx_response_matches_id "${tx_id%?}0" "$work/submit.json"; then
     die "Submit API response parser accepted the wrong transaction id"
   fi
+  submit_tx_response_is_duplicate 'Transaction is a duplicate.' ||
+    die "Submit API duplicate response matcher rejected the expected response"
+  if submit_tx_response_is_duplicate 'Transaction input is missing.'; then
+    die "Submit API duplicate response matcher accepted a different rejection"
+  fi
   printf '%s\n' \
     '{"small#0":{"value":{"lovelace":2000000}},"asset#0":{"value":{"lovelace":3000000,"policy":{"token":1}}},"large#0":{"value":{"lovelace":4000000}}}' \
     >"$work/utxo.json"
@@ -613,7 +618,7 @@ runner_self_test() {
   [[ -z "$AMARU_PID" ]] || die "externally managed Amaru mode started a process"
   AMARU_MANAGED="$managed_before"
   rm -rf "$work"
-  self_test_success "response parsers, input selection, slot wait, and external Amaru mode passed"
+  self_test_success "response parsers, duplicate handling, input selection, slot wait, and external Amaru mode passed"
 }
 
 run_e2e() {

--- a/scripts/e2e/tx-submission.sh
+++ b/scripts/e2e/tx-submission.sh
@@ -104,13 +104,17 @@ TX_MEMPOOL_POLL_INTERVAL_SECONDS="${TX_MEMPOOL_POLL_INTERVAL_SECONDS:-1}"
 . "$COMMON_DIR/amaru.sh"
 . "$COMMON_DIR/tx.sh"
 
+E2E_FAILURE_MESSAGE=""
+
 die() {
+  E2E_FAILURE_MESSAGE="$*"
   printf '%serror:%s %s\n' "$E2E_COLOR_ERROR" "$E2E_COLOR_RESET" "$*" >&2
   exit 1
 }
 
 AMARU_PID=""
 CARDANO_NODE_PID=""
+TX_PAYMENT_SKEY_INSTALLED=false
 
 usage() {
   cat <<'EOF'
@@ -331,6 +335,25 @@ runner_prepare() {
   setup_log "fast transaction submission E2E environment is ready"
 }
 
+install_base64_payment_key() {
+  if [[ "${TX_PAYMENT_SKEY_BASE64+x}" != x ]]; then
+    return
+  fi
+  [[ -n "$TX_PAYMENT_SKEY_BASE64" ]] || die "TX_PAYMENT_SKEY_BASE64 is empty"
+  have base64 || die "base64 is required to install TX_PAYMENT_SKEY_BASE64"
+  mkdir -p "$(dirname "$TX_PAYMENT_SKEY")"
+  if ! (umask 077 && printf '%s' "$TX_PAYMENT_SKEY_BASE64" | base64 --decode >"$TX_PAYMENT_SKEY"); then
+    rm -f "$TX_PAYMENT_SKEY"
+    die "TX_PAYMENT_SKEY_BASE64 is not valid base64"
+  fi
+  if [[ ! -s "$TX_PAYMENT_SKEY" ]]; then
+    rm -f "$TX_PAYMENT_SKEY"
+    die "TX_PAYMENT_SKEY_BASE64 decoded to an empty key"
+  fi
+  TX_PAYMENT_SKEY_INSTALLED=true
+  unset TX_PAYMENT_SKEY_BASE64
+}
+
 prepare_cardano_database() {
   if [[ -d "$CARDANO_NODE_DB/immutable" ]]; then
     setup_log "using cardano-node database $CARDANO_NODE_DB"
@@ -350,7 +373,8 @@ prepare_cardano_node_config_file() {
   CARDANO_NODE_EFFECTIVE_CONFIG_FILE="$config"
   [[ "$(uname -s)" == Darwin ]] || return 0
 
-  generated="$CARDANO_NODE_CONFIG_DIR/config.e2e.json"
+  mkdir -p "$RUNDIR/generated"
+  generated="$RUNDIR/generated/cardano-config.json"
   jq '
     .TraceOptionResourceFrequency = 0
     | .TraceOptions[""].backends = (
@@ -490,6 +514,7 @@ wait_for_cardano_mempool() {
 run_transaction_test() {
   local socket address utxo_file protocol_params_file tx_body tx_signed tx_cbor
   local response_file mempool_response_file input_available_slot record tx_in lovelace tx_id mempool_state submitted_at
+  local -a network_args=()
   socket="$(cardano_node_socket_file)"
   utxo_file="$PRIVATE_DIR/utxo.json"
   protocol_params_file="$PRIVATE_DIR/protocol-params.json"
@@ -513,9 +538,12 @@ run_transaction_test() {
   IFS=$'\t' read -r tx_in lovelace <<<"$record"
   e2e_log "selected input $tx_in with $lovelace lovelace at slot $input_available_slot"
 
+  while IFS= read -r arg; do
+    network_args+=("$arg")
+  done < <(cardano_cli_network_args)
   build_drain_transaction "$tx_in" "$lovelace" "$address" "$tx_body" "$protocol_params_file"
   "$CARDANO_CLI" conway transaction sign \
-    $(cardano_cli_network_args) \
+    "${network_args[@]}" \
     --tx-body-file "$tx_body" \
     --signing-key-file "$TX_PAYMENT_SKEY" \
     --out-canonical-cbor \
@@ -558,6 +586,35 @@ run_transaction_test() {
   e2e_log "result: $RESULT_DIR/result.json"
 }
 
+write_failure_result() {
+  local status="$1" failed_at failure_message result_tmp
+  failed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  failure_message="${E2E_FAILURE_MESSAGE:-command exited without an explicit error}"
+  mkdir -p "$RESULT_DIR" || return 1
+  result_tmp="$(mktemp "$RESULT_DIR/result.XXXXXX")" || return 1
+  if ! jq -n \
+    --arg network "$NETWORK" \
+    --arg run_id "$RUN_ID" \
+    --arg error "$failure_message" \
+    --arg failed_at "$failed_at" \
+    --argjson exit_code "$status" \
+    '{
+      outcome: "failed",
+      network: $network,
+      run_id: $run_id,
+      exit_code: $exit_code,
+      error: $error,
+      failed_at: $failed_at
+    }' >"$result_tmp"; then
+    rm -f "$result_tmp"
+    return 1
+  fi
+  if ! mv "$result_tmp" "$RESULT_DIR/result.json"; then
+    rm -f "$result_tmp"
+    return 1
+  fi
+}
+
 cleanup() {
   local status=$?
   trap - EXIT INT TERM
@@ -569,8 +626,12 @@ cleanup() {
     kill "$CARDANO_NODE_PID" 2>/dev/null || true
     wait "$CARDANO_NODE_PID" 2>/dev/null || true
   fi
+  [[ "$TX_PAYMENT_SKEY_INSTALLED" == false ]] || rm -f "$TX_PAYMENT_SKEY"
   rm -rf "$PRIVATE_DIR"
   if ((status != 0)); then
+    if ! write_failure_result "$status"; then
+      e2e_warning "could not write failure result to $RESULT_DIR/result.json"
+    fi
     printf '%s[e2e] failed; logs are in %s and partial results are in %s%s\n' \
       "$E2E_COLOR_ERROR" "$LOGDIR" "$RESULT_DIR" "$E2E_COLOR_RESET" >&2
   fi
@@ -582,7 +643,8 @@ runner_self_test() {
   work="$(mktemp -d)"
   tx_id=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
   printf '"%s"\n' "$tx_id" >"$work/submit.json"
-  submit_tx_response_matches_id "$tx_id" "$work/submit.json"
+  submit_tx_response_matches_id "$tx_id" "$work/submit.json" ||
+    die "Submit API response parser rejected the expected transaction id"
   printf '{"exists":true,"txId":"%s","slot":1}\n' "$tx_id" >"$work/mempool.json"
   state="$(parse_cardano_node_mempool_tx_state "$tx_id" "$work/mempool.json")"
   [[ "$state" == present ]] || die "expected present, got $state"
@@ -601,6 +663,12 @@ runner_self_test() {
   if submit_tx_response_is_duplicate 'Transaction input is missing.'; then
     die "Submit API duplicate response matcher accepted a different rejection"
   fi
+  RESULT_DIR="$work/results" E2E_FAILURE_MESSAGE="expected failure" write_failure_result 17
+  jq -e '
+    .outcome == "failed"
+      and .exit_code == 17
+      and .error == "expected failure"
+  ' "$work/results/result.json" >/dev/null || die "failure result is not machine-readable"
   printf '%s\n' \
     '{"small#0":{"value":{"lovelace":2000000}},"asset#0":{"value":{"lovelace":3000000,"policy":{"token":1}}},"large#0":{"value":{"lovelace":4000000}}}' \
     >"$work/utxo.json"
@@ -622,10 +690,11 @@ runner_self_test() {
 }
 
 run_e2e() {
-  runner_setup
-  prepare_cardano_database
   trap cleanup EXIT
   trap 'exit 130' INT TERM
+  install_base64_payment_key
+  runner_setup
+  prepare_cardano_database
   start_cardano_node
   wait_for_cardano_node
   start_amaru

--- a/scripts/e2e/tx-submission.sh
+++ b/scripts/e2e/tx-submission.sh
@@ -1,0 +1,640 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AMARU_DIR="${AMARU_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+COMMON_DIR="$AMARU_DIR/scripts/demos/common"
+
+NETWORK="${AMARU_NETWORK:-preprod}"
+BUILD_PROFILE="${BUILD_PROFILE:-dev}"
+RUNDIR="${E2E_TX_WORK_DIR:-$AMARU_DIR/scripts/demos/relay-1/run/e2e-tx-submission}"
+LOGDIR="${E2E_TX_LOG_DIR:-$RUNDIR/logs}"
+RESULTS_DIR="${E2E_TX_RESULTS_DIR:-$RUNDIR/results}"
+RUN_ID="${E2E_TX_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+PRIVATE_DIR="$RUNDIR/private/$RUN_ID"
+RESULT_DIR="$RESULTS_DIR/$RUN_ID"
+
+[[ "$RUNDIR" != / ]] || { echo "error: unsafe E2E_TX_WORK_DIR: $RUNDIR" >&2; exit 1; }
+[[ "$RUN_ID" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "error: E2E_TX_RUN_ID contains unsafe characters: $RUN_ID" >&2; exit 1; }
+
+E2E_COLOR_RESET=""
+E2E_COLOR_SETUP=""
+E2E_COLOR_INFO=""
+E2E_COLOR_SUCCESS=""
+E2E_COLOR_WARNING=""
+E2E_COLOR_ERROR=""
+if [[ -t 1 && -z "${NO_COLOR:-}" && "${TERM:-}" != dumb ]]; then
+  E2E_COLOR_RESET=$'\033[0m'
+  E2E_COLOR_SETUP=$'\033[36m'
+  E2E_COLOR_INFO=$'\033[34m'
+  E2E_COLOR_SUCCESS=$'\033[1;32m'
+  E2E_COLOR_WARNING=$'\033[33m'
+  E2E_COLOR_ERROR=$'\033[1;31m'
+fi
+
+setup_log() { printf '%s[setup]%s %s\n' "$E2E_COLOR_SETUP" "$E2E_COLOR_RESET" "$*"; }
+snapshot_log() { printf '%s[snapshot]%s %s\n' "$E2E_COLOR_SETUP" "$E2E_COLOR_RESET" "$*"; }
+e2e_log() { printf '%s[e2e]%s %s\n' "$E2E_COLOR_INFO" "$E2E_COLOR_RESET" "$*"; }
+e2e_success() { printf '%s[e2e] %s%s\n' "$E2E_COLOR_SUCCESS" "$*" "$E2E_COLOR_RESET"; }
+e2e_warning() { printf '%s[e2e] %s%s\n' "$E2E_COLOR_WARNING" "$*" "$E2E_COLOR_RESET"; }
+self_test_success() { printf '%s[self-test] %s%s\n' "$E2E_COLOR_SUCCESS" "$*" "$E2E_COLOR_RESET"; }
+
+AMARU_CHAIN_DIR="${AMARU_CHAIN_DIR:-$RUNDIR/amaru/chain.$NETWORK.db}"
+AMARU_LEDGER_DIR="${AMARU_LEDGER_DIR:-$RUNDIR/amaru/ledger.$NETWORK.db}"
+AMARU_LOG_FILE="${AMARU_LOG_FILE:-$LOGDIR/amaru.log}"
+AMARU_LISTEN_ADDRESS="${AMARU_LISTEN_ADDRESS:-127.0.0.1:4001}"
+AMARU_SUBMIT_API_ADDRESS="${AMARU_SUBMIT_API_ADDRESS:-127.0.0.1:8090}"
+AMARU_PEER_ADDRESS="${AMARU_PEER_ADDRESS:-127.0.0.1:3001}"
+AMARU_UPSTREAM_PEERS="${AMARU_UPSTREAM_PEERS:-1}"
+AMARU_MANAGED="${E2E_TX_MANAGE_AMARU:-true}"
+
+CARDANO_NODE_RELEASE_VERSION="${CARDANO_NODE_RELEASE_VERSION:-11.0.1}"
+CARDANO_NODE_HOME_WAS_SET=false
+if [[ -n "${CARDANO_NODE_HOME:-}" ]]; then
+  CARDANO_NODE_HOME_WAS_SET=true
+else
+  CARDANO_NODE_HOME="$RUNDIR/tools/cardano-node-$CARDANO_NODE_RELEASE_VERSION"
+fi
+CARDANO_NODE="${CARDANO_NODE:-$CARDANO_NODE_HOME/bin/cardano-node}"
+CARDANO_NODE_CONFIG_DIR="${CARDANO_NODE_CONFIG_DIR:-$AMARU_DIR/cardano-node-config/$NETWORK}"
+CARDANO_NODE_DB="${CARDANO_NODE_DB:-$CARDANO_NODE_CONFIG_DIR/db}"
+CARDANO_NODE_SOCKET_FILE="${CARDANO_NODE_SOCKET_FILE:-/tmp/amaru-e2e-${UID:-0}-${CARDANO_NODE_PORT:-3001}.socket}"
+CARDANO_NODE_LOG_FILE="${CARDANO_NODE_LOG_FILE:-$LOGDIR/cardano-node.log}"
+CARDANO_NODE_MANAGED="${E2E_TX_MANAGE_CARDANO_NODE:-true}"
+CARDANO_NODE_SYNC_PROGRESS="${CARDANO_NODE_SYNC_PROGRESS:-99.9}"
+CARDANO_NODE_SYNC_TIMEOUT_SECONDS="${CARDANO_NODE_SYNC_TIMEOUT_SECONDS:-14400}"
+CARDANO_NODE_SOCKET_TIMEOUT_SECONDS="${CARDANO_NODE_SOCKET_TIMEOUT_SECONDS:-1800}"
+CARDANO_NODE_QUERY_TIMEOUT_SECONDS="${CARDANO_NODE_QUERY_TIMEOUT_SECONDS:-1800}"
+CARDANO_UPSTREAM_MODE=local
+UPSTREAM_PORT="${CARDANO_NODE_PORT:-3001}"
+
+MITHRIL_INSTALLER_COMMIT="${MITHRIL_INSTALLER_COMMIT:-791dca3c035452ae35a0361303c6e674aacf617c}"
+MITHRIL_CLIENT_DISTRIBUTION="${MITHRIL_CLIENT_DISTRIBUTION:-2630.0}"
+MITHRIL_CLIENT_HOME="${MITHRIL_CLIENT_HOME:-$RUNDIR/tools/mithril-client}"
+MITHRIL_CLIENT="${MITHRIL_CLIENT:-$MITHRIL_CLIENT_HOME/mithril-client}"
+
+CARDANO_CLI_RELEASE_VERSION="${CARDANO_CLI_RELEASE_VERSION:-11.2.1.0}"
+CARDANO_CLI_HOME="${CARDANO_CLI_HOME:-$RUNDIR/tools/cardano-cli-$CARDANO_CLI_RELEASE_VERSION}"
+CARDANO_CLI="${CARDANO_CLI:-$CARDANO_CLI_HOME/bin/cardano-cli}"
+
+TX_PAYMENT_SKEY_WAS_SET=false
+if [[ -n "${TX_PAYMENT_SKEY:-}" ]]; then
+  TX_PAYMENT_SKEY_WAS_SET=true
+fi
+TX_WALLET_DIR="${TX_WALLET_DIR:-$RUNDIR/wallet/$NETWORK}"
+TX_WALLET_SKEY="${TX_WALLET_SKEY:-$TX_WALLET_DIR/payment.skey}"
+TX_WALLET_VKEY="${TX_WALLET_VKEY:-$TX_WALLET_DIR/payment.vkey}"
+TX_WALLET_ADDRESS_FILE="${TX_WALLET_ADDRESS_FILE:-$TX_WALLET_DIR/payment.addr}"
+TX_PAYMENT_SKEY="${TX_PAYMENT_SKEY:-$TX_WALLET_SKEY}"
+TX_SUBMIT_API_ADDRESS="$AMARU_SUBMIT_API_ADDRESS"
+TX_QUERY_SOURCE=local
+TX_METADATA_MESSAGE="${TX_METADATA_MESSAGE:-amaru e2e $RUN_ID}"
+TX_SYNC_TIMEOUT_SECONDS="${TX_SYNC_TIMEOUT_SECONDS:-3600}"
+TX_SYNC_POLL_INTERVAL_SECONDS="${TX_SYNC_POLL_INTERVAL_SECONDS:-5}"
+TX_SUBMIT_RETRY_LIMIT="${TX_SUBMIT_RETRY_LIMIT:-20}"
+TX_SUBMIT_RETRY_DELAY="${TX_SUBMIT_RETRY_DELAY:-5}"
+TX_INPUT_TIMEOUT_SECONDS="${TX_INPUT_TIMEOUT_SECONDS:-900}"
+TX_INPUT_POLL_INTERVAL_SECONDS="${TX_INPUT_POLL_INTERVAL_SECONDS:-2}"
+TX_MEMPOOL_TIMEOUT_SECONDS="${TX_MEMPOOL_TIMEOUT_SECONDS:-60}"
+TX_MEMPOOL_POLL_INTERVAL_SECONDS="${TX_MEMPOOL_POLL_INTERVAL_SECONDS:-1}"
+
+. "$COMMON_DIR/common.sh"
+. "$COMMON_DIR/cardano-cli.sh"
+. "$COMMON_DIR/cardano-node.sh"
+. "$COMMON_DIR/amaru.sh"
+. "$COMMON_DIR/tx.sh"
+
+die() {
+  printf '%serror:%s %s\n' "$E2E_COLOR_ERROR" "$E2E_COLOR_RESET" "$*" >&2
+  exit 1
+}
+
+AMARU_PID=""
+CARDANO_NODE_PID=""
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/e2e/tx-submission.sh <wallet|snapshot|prepare|setup|run|self-test>
+
+  wallet     Create the dedicated development payment key and print its faucet address.
+  snapshot   Install mithril-client and download a cardano-node database snapshot.
+  prepare    Run setup and snapshot for a fast first development run.
+  setup      Download pinned tools/config, create the wallet, build Amaru, and bootstrap its databases.
+  run        Start the topology, submit one transaction, and verify cardano-node's mempool.
+  self-test  Test the strict response parsers without starting either node.
+
+The managed development topology uses CARDANO_NODE_DB (default:
+cardano-node-config/<network>/db). An existing synchronized database makes startup fast;
+otherwise cardano-node initializes and synchronizes one. CI can start cardano-node itself
+and set E2E_TX_MANAGE_CARDANO_NODE=false. Set E2E_TX_MANAGE_AMARU=false when
+the workflow already started Amaru with its Submit API enabled.
+EOF
+}
+
+target_profile_dir() {
+  case "$BUILD_PROFILE" in
+    dev) echo debug ;;
+    *) echo "$BUILD_PROFILE" ;;
+  esac
+}
+
+amaru_binary() {
+  echo "${AMARU_NODE_BINARY:-${CARGO_TARGET_DIR:-$AMARU_DIR/target}/$(target_profile_dir)/amaru}"
+}
+
+require_base_tools() {
+  local tool missing=()
+  for tool in jq curl xxd awk sort tail date tar; do
+    have "$tool" || missing+=("$tool")
+  done
+  [[ ${#missing[@]} -eq 0 ]] || die "required tools are missing: ${missing[*]}"
+}
+
+ensure_amaru_binary() {
+  if [[ -n "${AMARU_NODE_BINARY:-}" ]]; then
+    [[ -x "$AMARU_NODE_BINARY" ]] || die "AMARU_NODE_BINARY is not executable: $AMARU_NODE_BINARY"
+    return
+  fi
+  have cargo || die "cargo not found"
+  setup_log "building the current Amaru source with BUILD_PROFILE=$BUILD_PROFILE"
+  (cd "$AMARU_DIR" && cargo build --locked --profile "$BUILD_PROFILE" --bin amaru)
+}
+
+amaru_databases_ready() {
+  [[ -d "$AMARU_CHAIN_DIR" && -d "$AMARU_LEDGER_DIR" ]]
+}
+
+ensure_amaru_databases() {
+  if amaru_databases_ready; then
+    setup_log "using Amaru databases $AMARU_CHAIN_DIR and $AMARU_LEDGER_DIR"
+    return
+  fi
+  if [[ -e "$AMARU_CHAIN_DIR" || -e "$AMARU_LEDGER_DIR" ]]; then
+    die "only one Amaru database exists; provide a matching AMARU_CHAIN_DIR and AMARU_LEDGER_DIR or remove the incomplete E2E database"
+  fi
+  setup_log "bootstrapping Amaru databases for $NETWORK"
+  "$(amaru_binary)" node bootstrap \
+    --network "$NETWORK" \
+    --chain-dir "$AMARU_CHAIN_DIR" \
+    --ledger-dir "$AMARU_LEDGER_DIR"
+}
+
+ensure_cardano_node_tools() {
+  if ! truthy "$CARDANO_NODE_MANAGED"; then
+    setup_log "cardano-node is externally managed; skipping its release download"
+    return
+  fi
+  if [[ "$CARDANO_NODE_HOME_WAS_SET" == true ]]; then
+    require_cardano_node
+  elif [[ ! -x "$CARDANO_NODE" ]]; then
+    download_cardano_node_home
+  fi
+  require_cardano_node
+  repair_downloaded_cardano_node_home
+}
+
+ensure_payment_wallet() {
+  local address address_tmp
+  local -a network_args=()
+
+  if [[ "$TX_PAYMENT_SKEY_WAS_SET" == true ]]; then
+    setup_log "using configured transaction signing key"
+    return
+  fi
+
+  mkdir -p "$TX_WALLET_DIR"
+  if [[ ! -f "$TX_WALLET_SKEY" ]]; then
+    [[ ! -e "$TX_WALLET_VKEY" ]] ||
+      die "wallet verification key exists without its signing key: $TX_WALLET_VKEY"
+    setup_log "creating dedicated $NETWORK E2E payment key in $TX_WALLET_DIR"
+    (umask 077 && "$CARDANO_CLI" conway address key-gen \
+      --verification-key-file "$TX_WALLET_VKEY" \
+      --signing-key-file "$TX_WALLET_SKEY")
+  elif [[ ! -f "$TX_WALLET_VKEY" ]]; then
+    "$CARDANO_CLI" conway key verification-key \
+      --signing-key-file "$TX_WALLET_SKEY" \
+      --verification-key-file "$TX_WALLET_VKEY"
+  fi
+  chmod 600 "$TX_WALLET_SKEY"
+
+  while IFS= read -r arg; do
+    network_args+=("$arg")
+  done < <(cardano_cli_network_args)
+  address="$("$CARDANO_CLI" conway address build \
+    --payment-verification-key-file "$TX_WALLET_VKEY" \
+    "${network_args[@]}")"
+  address_tmp="$TX_WALLET_ADDRESS_FILE.tmp.$$"
+  printf '%s\n' "$address" >"$address_tmp"
+  mv "$address_tmp" "$TX_WALLET_ADDRESS_FILE"
+
+  setup_log "E2E payment address: $address"
+  setup_log "fund it on $NETWORK before running the test: https://docs.cardano.org/cardano-testnets/tools/faucet/"
+  setup_log "signing key: $TX_WALLET_SKEY"
+}
+
+runner_wallet() {
+  require_base_tools
+  mkdir -p "$RUNDIR" "$LOGDIR"
+  download_official_cardano_node_config
+  validate_network_config
+  ensure_cardano_cli
+  require_cardano_cli
+  ensure_payment_wallet
+  validate_configured_tx_inputs
+}
+
+mithril_network_name() {
+  case "$NETWORK" in
+    preprod) echo release-preprod ;;
+    *) die "automatic cardano-node snapshot download is currently supported only for preprod, not $NETWORK" ;;
+  esac
+}
+
+ensure_mithril_client() {
+  local installer="$LOGDIR/mithril-install-$MITHRIL_INSTALLER_COMMIT.sh"
+
+  if [[ -x "$MITHRIL_CLIENT" ]]; then
+    snapshot_log "using mithril-client at $MITHRIL_CLIENT"
+    return
+  fi
+  mkdir -p "$MITHRIL_CLIENT_HOME" "$LOGDIR"
+  if [[ ! -f "$installer" ]]; then
+    snapshot_log "downloading the pinned official Mithril installer"
+    curl -fsSL \
+      "https://raw.githubusercontent.com/IntersectMBO/mithril/$MITHRIL_INSTALLER_COMMIT/mithril-install.sh" \
+      -o "$installer"
+  fi
+  sh "$installer" \
+    -c mithril-client \
+    -d "$MITHRIL_CLIENT_DISTRIBUTION" \
+    -p "$MITHRIL_CLIENT_HOME"
+  [[ -x "$MITHRIL_CLIENT" ]] || die "Mithril installer did not create $MITHRIL_CLIENT"
+}
+
+runner_snapshot() {
+  local mithril_network genesis_verification_key ancillary_verification_key config_base download_dir
+
+  require_base_tools
+  if [[ -d "$CARDANO_NODE_DB/immutable" ]]; then
+    snapshot_log "using existing cardano-node database $CARDANO_NODE_DB"
+    return
+  fi
+
+  if ! truthy "$CARDANO_NODE_MANAGED"; then
+    die "cardano-node is externally managed; its database snapshot must be managed externally too"
+  fi
+
+  mithril_network="$(mithril_network_name)"
+  config_base="https://raw.githubusercontent.com/IntersectMBO/mithril/$MITHRIL_INSTALLER_COMMIT/mithril-infra/configuration/$mithril_network"
+  ensure_mithril_client
+  snapshot_log "downloading Mithril verification keys for $mithril_network"
+  genesis_verification_key="$(curl -fsSL "$config_base/genesis.vkey")"
+  ancillary_verification_key="$(curl -fsSL "$config_base/ancillary.vkey")"
+  [[ -n "$genesis_verification_key" ]] || die "empty Mithril genesis verification key"
+  [[ -n "$ancillary_verification_key" ]] || die "empty Mithril ancillary verification key"
+
+  [[ "$(basename "$CARDANO_NODE_DB")" == db ]] ||
+    die "Mithril creates a db subdirectory; CARDANO_NODE_DB must end in /db: $CARDANO_NODE_DB"
+  download_dir="$(dirname "$CARDANO_NODE_DB")"
+  mkdir -p "$download_dir"
+  if [[ -d "$CARDANO_NODE_DB" ]]; then
+    rmdir "$CARDANO_NODE_DB" 2>/dev/null ||
+      die "incomplete cardano-node database exists at $CARDANO_NODE_DB; move it aside before retrying"
+  elif [[ -e "$CARDANO_NODE_DB" ]]; then
+    die "CARDANO_NODE_DB exists and is not a directory: $CARDANO_NODE_DB"
+  fi
+  snapshot_log "downloading the latest $NETWORK cardano-node database to $CARDANO_NODE_DB"
+  AGGREGATOR_ENDPOINT="https://aggregator.$mithril_network.api.mithril.network/aggregator" \
+    GENESIS_VERIFICATION_KEY="$genesis_verification_key" \
+    "$MITHRIL_CLIENT" cardano-db download \
+      --download-dir "$download_dir" \
+      --include-ancillary \
+      --ancillary-verification-key "$ancillary_verification_key" \
+      latest
+  [[ -d "$CARDANO_NODE_DB/immutable" ]] ||
+    die "Mithril download completed without creating $CARDANO_NODE_DB/immutable"
+  snapshot_log "cardano-node database is ready"
+}
+
+runner_setup() {
+  runner_wallet
+  mkdir -p "$RESULTS_DIR"
+  ensure_cardano_node_tools
+  ensure_amaru_binary
+  ensure_amaru_databases
+  setup_log "transaction submission E2E prerequisites are ready"
+}
+
+runner_prepare() {
+  runner_setup
+  runner_snapshot
+  setup_log "fast transaction submission E2E environment is ready"
+}
+
+prepare_cardano_database() {
+  if [[ -d "$CARDANO_NODE_DB/immutable" ]]; then
+    setup_log "using cardano-node database $CARDANO_NODE_DB"
+    return
+  fi
+  if ! truthy "$CARDANO_NODE_MANAGED"; then
+    die "synchronized external cardano-node database not found at $CARDANO_NODE_DB"
+  fi
+  mkdir -p "$CARDANO_NODE_DB"
+  e2e_warning "no cardano-node snapshot found at $CARDANO_NODE_DB; cardano-node will initialize and synchronize it"
+  e2e_warning "set CARDANO_NODE_DB to an existing synchronized database for a faster first run"
+}
+
+prepare_cardano_node_config_file() {
+  local config generated
+  config="$(cardano_node_config_file)"
+  CARDANO_NODE_EFFECTIVE_CONFIG_FILE="$config"
+  [[ "$(uname -s)" == Darwin ]] || return 0
+
+  generated="$CARDANO_NODE_CONFIG_DIR/config.e2e.json"
+  jq '
+    .TraceOptionResourceFrequency = 0
+    | .TraceOptions[""].backends = (
+        (.TraceOptions[""].backends // [])
+        | map(select(startswith("PrometheusSimple") | not))
+      )
+  ' "$config" >"$generated"
+  CARDANO_NODE_EFFECTIVE_CONFIG_FILE="$generated"
+  e2e_log "disabled resource metrics for the managed macOS cardano-node"
+}
+
+cardano_node_effective_config_file() {
+  echo "${CARDANO_NODE_EFFECTIVE_CONFIG_FILE:-$(cardano_node_config_file)}"
+}
+
+start_cardano_node() {
+  if ! truthy "$CARDANO_NODE_MANAGED"; then
+    e2e_log "using externally managed cardano-node socket $CARDANO_NODE_SOCKET_FILE"
+    return
+  fi
+  require_cardano_node
+  validate_network_config
+  prepare_cardano_node_config_file
+  prepare_cardano_node_topology_file
+  ((${#CARDANO_NODE_SOCKET_FILE} <= 100)) ||
+    die "cardano-node socket path is too long (${#CARDANO_NODE_SOCKET_FILE} bytes, maximum supported is 100): $CARDANO_NODE_SOCKET_FILE"
+  mkdir -p "$(dirname "$CARDANO_NODE_SOCKET_FILE")" "$LOGDIR"
+  rm -f "$CARDANO_NODE_SOCKET_FILE"
+  e2e_log "starting cardano-node on 127.0.0.1:$UPSTREAM_PORT"
+  "$CARDANO_NODE" run \
+    --config "$(cardano_node_effective_config_file)" \
+    --topology "$(cardano_node_effective_topology_file)" \
+    --database-path "$(cardano_node_database_dir)" \
+    --socket-path "$CARDANO_NODE_SOCKET_FILE" \
+    --port "$UPSTREAM_PORT" \
+    >"$CARDANO_NODE_LOG_FILE" 2>&1 &
+  CARDANO_NODE_PID=$!
+}
+
+wait_for_cardano_node() {
+  wait_for_cardano_socket
+  wait_for_cardano_query
+  wait_for_cardano_sync_progress "$CARDANO_NODE_SYNC_PROGRESS" "$CARDANO_NODE_SYNC_TIMEOUT_SECONDS"
+  e2e_log "cardano-node is ready at slot $(cardano_node_tip_slot)"
+}
+
+start_amaru() {
+  if ! truthy "$AMARU_MANAGED"; then
+    e2e_log "using externally managed Amaru Submit API at $AMARU_SUBMIT_API_ADDRESS"
+    return
+  fi
+  mkdir -p "$LOGDIR"
+  : >"$AMARU_LOG_FILE"
+  e2e_log "starting Amaru from current source; upstream=$AMARU_PEER_ADDRESS submit_api=$AMARU_SUBMIT_API_ADDRESS"
+  AMARU_WITH_OPEN_TELEMETRY=false \
+    AMARU_COLOR=never \
+    AMARU_LOG="${AMARU_LOG:-info}" \
+    AMARU_TRACE="${AMARU_TRACE:-info}" \
+    "$(amaru_binary)" node run \
+      --migrate-chain-db \
+      --no-tui \
+      --network "$NETWORK" \
+      --peer-address "$AMARU_PEER_ADDRESS" \
+      --upstream-peers "$AMARU_UPSTREAM_PEERS" \
+      --listen-address "$AMARU_LISTEN_ADDRESS" \
+      --submit-api-address "$AMARU_SUBMIT_API_ADDRESS" \
+      --chain-dir "$AMARU_CHAIN_DIR" \
+      --ledger-dir "$AMARU_LEDGER_DIR" \
+      >"$AMARU_LOG_FILE" 2>&1 &
+  AMARU_PID=$!
+}
+
+wait_for_amaru_submit_api() {
+  local timeout="${AMARU_SUBMIT_API_TIMEOUT_SECONDS:-300}" elapsed
+  for ((elapsed = 0; elapsed < timeout; elapsed++)); do
+    if curl --max-time 2 -s -o /dev/null "http://$AMARU_SUBMIT_API_ADDRESS/"; then
+      e2e_log "Amaru Submit API is ready"
+      return
+    fi
+    if [[ -n "$AMARU_PID" ]] && ! kill -0 "$AMARU_PID" 2>/dev/null; then
+      die "Amaru stopped before its Submit API became ready; see $AMARU_LOG_FILE"
+    fi
+    sleep 1
+  done
+  die "Amaru Submit API did not become ready within ${timeout}s; see $AMARU_LOG_FILE"
+}
+
+select_transaction_input() {
+  local utxo_file="$1"
+  jq -er --argjson minimum "$((TX_OUTPUT_LOVELACE + TX_FEE_BUFFER_LOVELACE))" '
+    [
+      to_entries[]
+      | select(((.value.value | keys) - ["lovelace"] | length) == 0)
+      | {tx_in: .key, lovelace: (.value.value.lovelace // 0)}
+      | select(.lovelace >= $minimum)
+    ]
+    | sort_by(.lovelace)
+    | first
+    | select(. != null)
+    | [.tx_in, .lovelace]
+    | @tsv
+  ' "$utxo_file"
+}
+
+wait_for_transaction_input() {
+  local socket="$1" address="$2" utxo_file="$3"
+  local timeout="$TX_INPUT_TIMEOUT_SECONDS" interval="$TX_INPUT_POLL_INTERVAL_SECONDS" elapsed record
+
+  for ((elapsed = 0; elapsed < timeout; elapsed += interval)); do
+    if query_payment_utxo "$socket" "$address" "$utxo_file" && record="$(select_transaction_input "$utxo_file")"; then
+      SELECTED_TX_RECORD="$record"
+      return
+    fi
+    if ((elapsed % 30 == 0)); then
+      e2e_warning "waiting for a spendable UTxO at $address (${elapsed}s/${timeout}s)"
+    fi
+    managed_cardano_node_stopped && cardano_node_stopped_error "while waiting for the payment UTxO"
+    sleep "$interval"
+  done
+  die "no pure-ADA UTxO covering the minimum output and fee became visible at $address within ${timeout}s"
+}
+
+wait_for_cardano_mempool() {
+  local tx_id="$1" response_file="$2" timeout="$TX_MEMPOOL_TIMEOUT_SECONDS" elapsed state
+  for ((elapsed = 0; elapsed < timeout; elapsed += TX_MEMPOOL_POLL_INTERVAL_SECONDS)); do
+    state="$(cardano_node_mempool_tx_state "$tx_id" "$response_file")" ||
+      die "cardano-node returned an invalid tx-mempool response for tx_id=$tx_id"
+    if [[ "$state" == present ]]; then
+      e2e_log "cardano-node mempool contains tx_id=$tx_id"
+      return
+    fi
+    sleep "$TX_MEMPOOL_POLL_INTERVAL_SECONDS"
+  done
+  die "tx_id=$tx_id did not diffuse to cardano-node within ${timeout}s"
+}
+
+run_transaction_test() {
+  local socket address utxo_file protocol_params_file tx_body tx_signed tx_cbor
+  local response_file mempool_response_file input_available_slot record tx_in lovelace tx_id mempool_state submitted_at
+  socket="$(cardano_node_socket_file)"
+  utxo_file="$PRIVATE_DIR/utxo.json"
+  protocol_params_file="$PRIVATE_DIR/protocol-params.json"
+  tx_body="$PRIVATE_DIR/tx.body"
+  tx_signed="$PRIVATE_DIR/tx.signed"
+  tx_cbor="$PRIVATE_DIR/tx.cbor"
+  response_file="$RESULT_DIR/submit-response.json"
+  mempool_response_file="$RESULT_DIR/cardano-node-mempool.json"
+
+  mkdir -p "$PRIVATE_DIR" "$RESULT_DIR"
+  TX_PAYMENT_SKEY="$(resolve_payment_skey "$PRIVATE_DIR")"
+  prepare_tx_metadata "$PRIVATE_DIR"
+  address="$(payment_address "$PRIVATE_DIR/payment.vkey")"
+  e2e_log "using payment address $address"
+
+  wait_for_transaction_input "$socket" "$address" "$utxo_file"
+  query_protocol_parameters "$socket" "$protocol_params_file"
+  input_available_slot="$(cardano_node_tip_slot)"
+  [[ "$input_available_slot" =~ ^[0-9]+$ ]] || die "could not determine cardano-node tip slot"
+  record="$SELECTED_TX_RECORD"
+  IFS=$'\t' read -r tx_in lovelace <<<"$record"
+  e2e_log "selected input $tx_in with $lovelace lovelace at slot $input_available_slot"
+
+  build_drain_transaction "$tx_in" "$lovelace" "$address" "$tx_body" "$protocol_params_file"
+  "$CARDANO_CLI" conway transaction sign \
+    $(cardano_cli_network_args) \
+    --tx-body-file "$tx_body" \
+    --signing-key-file "$TX_PAYMENT_SKEY" \
+    --out-canonical-cbor \
+    --out-file "$tx_signed"
+  jq -er '.cborHex' "$tx_signed" | xxd -r -p >"$tx_cbor"
+  tx_id="$("$CARDANO_CLI" conway transaction txid --tx-file "$tx_signed" --output-text)"
+  [[ "$tx_id" =~ ^[0-9a-fA-F]{64}$ ]] || die "cardano-cli returned an invalid transaction id: $tx_id"
+  e2e_log "built tx_id=$tx_id"
+
+  mempool_state="$(cardano_node_mempool_tx_state "$tx_id" "$mempool_response_file")" ||
+    die "cardano-node returned an invalid tx-mempool response for tx_id=$tx_id"
+  [[ "$mempool_state" == absent ]] ||
+    die "new tx_id=$tx_id unexpectedly existed in cardano-node's mempool before submission"
+  e2e_log "pre-submit mempool check: tx_id=$tx_id is absent from cardano-node"
+  wait_for_amaru_slot "$AMARU_LOG_FILE" "E2E" "$input_available_slot" "$TX_SYNC_TIMEOUT_SECONDS"
+  submit_tx_and_expect_id "$tx_cbor" "$tx_id" "$response_file"
+  wait_for_cardano_mempool "$tx_id" "$mempool_response_file"
+
+  submitted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  jq -n \
+    --arg network "$NETWORK" \
+    --arg tx_id "$tx_id" \
+    --arg tx_in "$tx_in" \
+    --arg address "$address" \
+    --arg submitted_at "$submitted_at" \
+    --argjson input_available_slot "$input_available_slot" \
+    '{
+      outcome: "passed",
+      network: $network,
+      tx_id: $tx_id,
+      tx_in: $tx_in,
+      address: $address,
+      input_available_slot: $input_available_slot,
+      submit_http_status: 202,
+      cardano_node_mempool_before_submission: "absent",
+      cardano_node_mempool: "present",
+      submitted_at: $submitted_at
+    }' >"$RESULT_DIR/result.json"
+  e2e_success "PASS: Submit API accepted tx_id=$tx_id and the connected cardano-node received it"
+  e2e_log "result: $RESULT_DIR/result.json"
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM
+  if [[ -n "$AMARU_PID" ]] && kill -0 "$AMARU_PID" 2>/dev/null; then
+    kill "$AMARU_PID" 2>/dev/null || true
+    wait "$AMARU_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$CARDANO_NODE_PID" ]] && kill -0 "$CARDANO_NODE_PID" 2>/dev/null; then
+    kill "$CARDANO_NODE_PID" 2>/dev/null || true
+    wait "$CARDANO_NODE_PID" 2>/dev/null || true
+  fi
+  rm -rf "$PRIVATE_DIR"
+  if ((status != 0)); then
+    printf '%s[e2e] failed; logs are in %s and partial results are in %s%s\n' \
+      "$E2E_COLOR_ERROR" "$LOGDIR" "$RESULT_DIR" "$E2E_COLOR_RESET" >&2
+  fi
+  exit "$status"
+}
+
+runner_self_test() {
+  local work tx_id state selected managed_before
+  work="$(mktemp -d)"
+  tx_id=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  printf '"%s"\n' "$tx_id" >"$work/submit.json"
+  submit_tx_response_matches_id "$tx_id" "$work/submit.json"
+  printf '{"exists":true,"txId":"%s","slot":1}\n' "$tx_id" >"$work/mempool.json"
+  state="$(parse_cardano_node_mempool_tx_state "$tx_id" "$work/mempool.json")"
+  [[ "$state" == present ]] || die "expected present, got $state"
+  printf '{"exists":false,"txId":"%s","slot":1}\n' "$tx_id" >"$work/mempool.json"
+  state="$(parse_cardano_node_mempool_tx_state "$tx_id" "$work/mempool.json")"
+  [[ "$state" == absent ]] || die "expected absent, got $state"
+  printf '{"exists":true,"txId":"%s","slot":1}\n' "${tx_id%?}0" >"$work/mempool.json"
+  if parse_cardano_node_mempool_tx_state "$tx_id" "$work/mempool.json" >/dev/null 2>&1; then
+    die "cardano-node mempool parser accepted the wrong transaction id"
+  fi
+  if submit_tx_response_matches_id "${tx_id%?}0" "$work/submit.json"; then
+    die "Submit API response parser accepted the wrong transaction id"
+  fi
+  printf '%s\n' \
+    '{"small#0":{"value":{"lovelace":2000000}},"asset#0":{"value":{"lovelace":3000000,"policy":{"token":1}}},"large#0":{"value":{"lovelace":4000000}}}' \
+    >"$work/utxo.json"
+  selected="$(select_transaction_input "$work/utxo.json")"
+  [[ "$selected" == $'small#0\t2000000' ]] || die "transaction input selector returned: $selected"
+  printf '{}\n' >"$work/utxo.json"
+  if select_transaction_input "$work/utxo.json" >/dev/null; then
+    die "transaction input selector accepted an empty UTxO set"
+  fi
+  printf '%s\n' 'tip.adopt slot=42' >"$work/amaru.log"
+  wait_for_amaru_slot "$work/amaru.log" "self-test" 42 1 >/dev/null
+  managed_before="$AMARU_MANAGED"
+  AMARU_MANAGED=false
+  start_amaru >/dev/null
+  [[ -z "$AMARU_PID" ]] || die "externally managed Amaru mode started a process"
+  AMARU_MANAGED="$managed_before"
+  rm -rf "$work"
+  self_test_success "response parsers, input selection, slot wait, and external Amaru mode passed"
+}
+
+run_e2e() {
+  runner_setup
+  prepare_cardano_database
+  trap cleanup EXIT
+  trap 'exit 130' INT TERM
+  start_cardano_node
+  wait_for_cardano_node
+  start_amaru
+  wait_for_amaru_submit_api
+  run_transaction_test
+}
+
+case "${1:-}" in
+  wallet) runner_wallet ;;
+  snapshot) runner_snapshot ;;
+  prepare) runner_prepare ;;
+  setup) runner_setup ;;
+  run) run_e2e ;;
+  self-test) runner_self_test ;;
+  -h | --help | help) usage ;;
+  *) usage >&2; exit 2 ;;
+esac


### PR DESCRIPTION
Allow to easily test e2e tx submission, up to the point it is properly included in a peer mempool.
Both from CI and local scripts.

Set the preprod key details as GH secret via:

```shell
./scripts/e2e/tx-submission.sh wallet && scripts/configure-github-secrets --repo pragma-org/amaru --set-base64-file PREPROD_TX_PAYMENT_SKEY_BASE64 scripts/demos/relay-1/run/e2e-tx-submission/wallet/preprod/payment.skey
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added an end-to-end transaction submission tool with wallet creation, snapshot preparation, setup, execution, and self-tests.
- Added configurable node database locations and transaction submission timeouts.
- Added an interactive repository-secret configuration tool.
- Added stricter mempool and transaction-response validation.
- Added progress reporting and clearer synchronization, readiness, and timeout errors.

## CI/CD
- Added secure pre-production signing-key configuration and coordinated transaction test runs.
- Centralized transaction outputs and improved log and artifact collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->