### PR TITLE
Increase Ledger Coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,10 +62,10 @@ Other guiding principles:
 - **amaru-ledger**: do not re-encode locally submitted transactions to obtain their size.
 - **amaru-protocols**: preserve bytes of transactions flowing through the mempool.
 - **amaru-tui**: tweak block dissemination metrics headers (fetch → select, sync → fetch)
-- **amaru-ledger**: Do not validate disjoint input sets in protocol version 11+. Similarly, do not allow non-disjoin input sets in PV3, regardless of protocol version.
 - **amaru-kernel**: decode reward accounts as a network tag plus stake credential, rejecting malformed reward accounts at deserialization.
 - **amaru-ledger**: Do not validate disjoint input sets in protocol version 11+. Similarly, do not allow non-disjoint input sets in PV3, regardless of protocol version.
 - **amaru-ledger**: do not allow the same script to exist in both the witness set and in a reference input
+- **amaru-ledger**: fix a panic when an `is_valid=false` transaction's certificates net to a negative value
 
 ## [v10.11.20260820](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260820)
 

--- a/crates/amaru-ledger/src/rules/transaction/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/fixture.rs
@@ -276,6 +276,7 @@ pub(super) enum Predicate {
     MalformedReferenceScripts,
     MalformedScriptWitnesses,
     MaxTxSizeUTxO,
+    MissingScriptWitnessesUTXOW,
     MissingTxBodyMetadataHash,
     MissingTxMetadata,
     MissingVerificationKeyWitnessesUTXOW,
@@ -400,6 +401,7 @@ impl From<PhaseOneError> for Predicate {
             PhaseOneError::Scripts(InvalidScripts::ExtraneousScriptWitnesses(_)) => {
                 Predicate::ExtraneousScriptWitnessesUTXOW
             }
+            PhaseOneError::Scripts(InvalidScripts::MissingRequiredScripts(_)) => Predicate::MissingScriptWitnessesUTXOW,
             PhaseOneError::ScriptPreparation(PreparationError::MalformedScriptWitness(_)) => {
                 Predicate::MalformedScriptWitnesses
             }

--- a/crates/amaru-ledger/src/rules/transaction/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/fixture.rs
@@ -374,7 +374,7 @@ impl From<PhaseOneError> for Predicate {
                 [WithPosition { element: InvalidOutput::MalformedReferenceScript(_), .. }] => {
                     Predicate::MalformedReferenceScripts
                 }
-                // The Haskelle node returns `OutputTooBigUTxO` instead of a `OutputBootAddrAttrsTooBig`
+                // The Haskell node returns `OutputTooBigUTxO` instead of a `OutputBootAddrAttrsTooBig`
                 [WithPosition { element: InvalidOutput::BootAddrAttrsTooBig { .. }, .. }] => {
                     Predicate::OutputTooBigUTxO
                 }
@@ -433,12 +433,11 @@ impl From<PhaseOneError> for Predicate {
                 DelegateError::UnknownTarget(_) => Predicate::DelegateeDRepNotRegistered,
                 DelegateError::AlreadyResigned => unreachable!("only applicable to CC"),
             },
-            PhaseOneError::Certificates(InvalidCertificates::CCMemberInvalidDelegation(
-                DelegateError::UnknownSource(_),
-            )) => Predicate::CommitteeIsUnknown,
-            PhaseOneError::Certificates(InvalidCertificates::CCMemberInvalidDelegation(
-                DelegateError::AlreadyResigned,
-            )) => Predicate::CommitteeHasPreviouslyResigned,
+            PhaseOneError::Certificates(InvalidCertificates::CCMemberInvalidDelegation(ref e)) => match e {
+                DelegateError::UnknownSource(_) => Predicate::CommitteeIsUnknown,
+                DelegateError::AlreadyResigned => Predicate::CommitteeHasPreviouslyResigned,
+                DelegateError::UnknownTarget(_) => unreachable!("hot credentials are not pre-registered"),
+            },
             PhaseOneError::Certificates(InvalidCertificates::StakeCredentialAlreadyRegistered(_)) => {
                 Predicate::StakeKeyRegistered
             }

--- a/crates/amaru-ledger/src/rules/transaction/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/fixture.rs
@@ -306,6 +306,7 @@ pub(super) enum Predicate {
     WithdrawalsNotInRewardsCERTS,
     WrongNetworkInTxBody,
     WrongNetworkInTxOutput,
+    WrongNetworkPOOL,
     WrongNetworkWithdrawal,
 }
 
@@ -447,6 +448,7 @@ impl From<PhaseOneError> for Predicate {
             PhaseOneError::Certificates(InvalidCertificates::PoolCostTooLow { .. }) => {
                 Predicate::StakePoolCostTooLowPOOL
             }
+            PhaseOneError::Certificates(InvalidCertificates::PoolWrongNetwork { .. }) => Predicate::WrongNetworkPOOL,
             PhaseOneError::Collateral(InvalidCollateral::UnknownInput(..)) => Predicate::BadInputsUTxO,
             PhaseOneError::Collateral(InvalidCollateral::InsufficientBalance { .. }) => {
                 Predicate::InsufficientCollateral

--- a/crates/amaru-ledger/src/rules/transaction/fixture.rs
+++ b/crates/amaru-ledger/src/rules/transaction/fixture.rs
@@ -280,10 +280,12 @@ pub(super) enum Predicate {
     MissingTxBodyMetadataHash,
     MissingTxMetadata,
     MissingVerificationKeyWitnessesUTXOW,
+    NoCollateralInputs,
     OutputTooBigUTxO,
     OutsideForecast,
     OutsideValidityIntervalUTxO,
     ProposalCantFollow,
+    ProposalProcedureNetworkIdMismatch,
     ScriptsNotPaidUTxO,
     TooManyCollateralInputs,
     ProposalReturnAccountDoesNotExist,
@@ -372,6 +374,10 @@ impl From<PhaseOneError> for Predicate {
                 [WithPosition { element: InvalidOutput::MalformedReferenceScript(_), .. }] => {
                     Predicate::MalformedReferenceScripts
                 }
+                // The Haskelle node returns `OutputTooBigUTxO` instead of a `OutputBootAddrAttrsTooBig`
+                [WithPosition { element: InvalidOutput::BootAddrAttrsTooBig { .. }, .. }] => {
+                    Predicate::OutputTooBigUTxO
+                }
                 _ => unreachable!("no predicate mapping yet for {err}"),
             },
             PhaseOneError::Proposals(InvalidProposals::TreasuryWithdrawalReturnAccountsDoNotExist(_)) => {
@@ -382,6 +388,9 @@ impl From<PhaseOneError> for Predicate {
             }
             PhaseOneError::Proposals(InvalidProposals::ProposalReturnAccountDoesNotExist(_)) => {
                 Predicate::ProposalReturnAccountDoesNotExist
+            }
+            PhaseOneError::Proposals(InvalidProposals::ReturnAddressWrongNetwork { .. }) => {
+                Predicate::ProposalProcedureNetworkIdMismatch
             }
             PhaseOneError::Proposals(InvalidProposals::InvalidPrevGovActionId { .. }) => {
                 Predicate::InvalidPrevGovActionId
@@ -459,10 +468,10 @@ impl From<PhaseOneError> for Predicate {
             PhaseOneError::Collateral(InvalidCollateral::DeclaredCollateralMismatch { .. }) => {
                 Predicate::IncorrectTotalCollateralField
             }
+            PhaseOneError::Collateral(InvalidCollateral::NoCollateral) => Predicate::NoCollateralInputs,
             PhaseOneError::Metadata(_)
             | PhaseOneError::Certificates(_)
             | PhaseOneError::Scripts(_)
-            | PhaseOneError::Collateral(_)
             | PhaseOneError::Proposals(_)
             | PhaseOneError::VotingProcedures(InvalidVotingProcedures::EraHistory(_)) => {
                 unreachable!("no predicate mapping yet for {err}")

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/certificates.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/certificates.rs
@@ -128,7 +128,11 @@ pub(crate) fn count_lovelace<C>(
         delta += count_lovelace_one(context, protocol_parameters, &mut pools, &mut accounts, &mut dreps, certificate);
     }
 
-    if delta > 0 { context.produce_lovelace(delta as u64) } else { context.consume_lovelace(delta as u64) }
+    if delta > 0 {
+        context.produce_lovelace(delta.unsigned_abs())
+    } else {
+        context.consume_lovelace(delta.unsigned_abs())
+    }
 }
 
 // FIXME: Perform all necessary rules validations down here.

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/certificates.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/certificates.rs
@@ -15,15 +15,14 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use amaru_kernel::{
-    Certificate, CertificatePointer, Credential, DRep, DRepRegistration, Epoch, EraHistory, EraHistoryError, Hash,
-    Lovelace, MemoizedDatum, Network, NonEmptySet, PoolId, PoolParams, ProtocolParameters, RedeemerTag, RequiredScript,
-    TransactionPointer, size::SCRIPT,
+    Certificate, CertificatePointer, Credential, DRep, DRepRegistration, Epoch, EraHistory, EraHistoryError, Lovelace,
+    MemoizedDatum, Network, NonEmptySet, PoolId, ProtocolParameters, RedeemerTag, RequiredScript, TransactionPointer,
 };
 use thiserror::Error;
 
 use crate::{
     context::{
-        AccountState, AccountsSlice, BalanceSlice, CCMember, CommitteeSlice, DRepsSlice, DelegateError, PoolsSlice,
+        AccountState, AccountsSlice, BalanceSlice, CommitteeSlice, DRepsSlice, DelegateError, PoolsSlice,
         RegisterError, UnregisterError, UpdateError, WitnessSlice,
     },
     epoch_transition::GovernanceActivity,
@@ -45,9 +44,6 @@ pub enum InvalidCertificates {
 
     #[error("invalid drep attempted update: {0}")]
     DRepInvalidUpdate(#[from] UpdateError<Credential>),
-
-    #[error("unknown cc member: {0}")]
-    CCMemberUnknown(#[from] UnregisterError<CCMember, Credential>),
 
     #[error("invalid cc member hot credential delegation: {0}")]
     CCMemberInvalidDelegation(#[from] DelegateError<Credential, Credential>),
@@ -95,7 +91,7 @@ pub(crate) fn execute<C>(
 where
     C: PoolsSlice + AccountsSlice + DRepsSlice + CommitteeSlice + WitnessSlice + BalanceSlice,
 {
-    certificates.map(|xs| xs.to_vec()).unwrap_or_default().into_iter().enumerate().try_for_each(
+    certificates.map(Vec::from).unwrap_or_default().into_iter().enumerate().try_for_each(
         |(certificate_index, certificate)| {
             execute_one(
                 context,
@@ -124,14 +120,29 @@ pub(crate) fn count_lovelace<C>(
     let mut dreps = BTreeMap::new();
 
     let mut delta: i64 = 0;
-    for certificate in certificates.map(|xs| xs.to_vec()).unwrap_or_default().into_iter() {
+    for certificate in certificates.map(Vec::from).unwrap_or_default() {
         delta += count_lovelace_one(context, protocol_parameters, &mut pools, &mut accounts, &mut dreps, certificate);
     }
 
     if delta > 0 {
         context.produce_lovelace(delta.unsigned_abs())
-    } else {
+    } else if delta < 0 {
         context.consume_lovelace(delta.unsigned_abs())
+    }
+}
+
+fn require_credential_witness<C>(context: &mut C, credential: Credential, certificate_index: usize)
+where
+    C: WitnessSlice,
+{
+    match credential {
+        Credential::ScriptHash(hash) => context.require_script_witness(RequiredScript {
+            hash,
+            index: certificate_index as u32,
+            purpose: RedeemerTag::Cert,
+            datum: MemoizedDatum::None,
+        }),
+        Credential::KeyHash(hash) => context.require_verification_key_witness(hash),
     }
 }
 
@@ -148,31 +159,20 @@ fn execute_one<C>(
 where
     C: PoolsSlice + AccountsSlice + DRepsSlice + CommitteeSlice + WitnessSlice + BalanceSlice,
 {
-    // Promote a ScriptHash into a RequiredScript, with additional context needed to defer the
-    // validation of the script.
-    let into_required_script = |hash: Hash<SCRIPT>| -> RequiredScript {
-        RequiredScript {
-            hash,
-            index: pointer.certificate_index as u32,
-            purpose: RedeemerTag::Cert,
-            datum: MemoizedDatum::None,
-        }
-    };
-
     match certificate {
         Certificate::PoolRegistration(params) => {
-            let PoolParams { id, cost, reward_account, owners, .. } = params.as_ref();
+            let params = *params;
 
-            context.require_verification_key_witness(*id);
+            context.require_verification_key_witness(params.id);
 
             // https://github.com/IntersectMBO/cardano-ledger/blob/master/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs#L250-L256
             // The Haskell node requires both the owners and the operators, which may be the same pkh.
             // TODO: We need coverage for this branch, we have none in either conformance tests or unit tests.
-            for owner in owners.iter() {
+            for owner in params.owners.iter() {
                 context.require_verification_key_witness(*owner);
             }
 
-            let reward_account_network = reward_account.network();
+            let reward_account_network = params.reward_account.network();
 
             if reward_account_network != network {
                 return Err(InvalidCertificates::PoolWrongNetwork {
@@ -181,17 +181,17 @@ where
                 });
             }
 
-            if cost < &protocol_parameters.min_pool_cost {
+            if params.cost < protocol_parameters.min_pool_cost {
                 return Err(InvalidCertificates::PoolCostTooLow {
-                    provided: *cost,
+                    provided: params.cost,
                     minimum: protocol_parameters.min_pool_cost,
                 });
             }
 
             // TODO: Have `register` return this information
-            let is_new_pool = !context.exists(*id);
+            let is_new_pool = !context.exists(params.id);
 
-            PoolsSlice::register(context, *params, pointer, protocol_parameters.stake_pool_deposit);
+            PoolsSlice::register(context, params, pointer, protocol_parameters.stake_pool_deposit);
 
             if is_new_pool {
                 context.produce_lovelace(protocol_parameters.stake_pool_deposit);
@@ -246,10 +246,7 @@ where
             //
             // See https://github.com/IntersectMBO/cardano-ledger/blob/81637a1c2250225fef47399dd56f80d87384df32/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs#L698
             if deposit > 0 {
-                match credential {
-                    Credential::ScriptHash(hash) => context.require_script_witness(into_required_script(hash)),
-                    Credential::KeyHash(hash) => context.require_verification_key_witness(hash),
-                };
+                require_credential_witness(context, credential, pointer.certificate_index);
             }
 
             let expected = protocol_parameters.stake_credential_deposit;
@@ -264,10 +261,7 @@ where
         }
 
         Certificate::StakeDeregistration(credential) => {
-            match credential {
-                Credential::ScriptHash(hash) => context.require_script_witness(into_required_script(hash)),
-                Credential::KeyHash(hash) => context.require_verification_key_witness(hash),
-            };
+            require_credential_witness(context, credential, pointer.certificate_index);
 
             let account = AccountsSlice::lookup(context, &credential)
                 .ok_or(InvalidCertificates::StakeCredentialNotRegistered(credential))?;
@@ -283,10 +277,7 @@ where
         }
 
         Certificate::UnReg(credential, refund) => {
-            match credential {
-                Credential::ScriptHash(hash) => context.require_script_witness(into_required_script(hash)),
-                Credential::KeyHash(hash) => context.require_verification_key_witness(hash),
-            };
+            require_credential_witness(context, credential, pointer.certificate_index);
 
             let account = AccountsSlice::lookup(context, &credential)
                 .ok_or(InvalidCertificates::StakeCredentialNotRegistered(credential))?;
@@ -306,10 +297,7 @@ where
         }
 
         Certificate::StakeDelegation(credential, pool) => {
-            match credential {
-                Credential::ScriptHash(hash) => context.require_script_witness(into_required_script(hash)),
-                Credential::KeyHash(hash) => context.require_verification_key_witness(hash),
-            };
+            require_credential_witness(context, credential, pointer.certificate_index);
 
             context.delegate_pool(credential, pool, pointer)?;
 
@@ -317,10 +305,7 @@ where
         }
 
         Certificate::RegDRepCert(drep, deposit, anchor) => {
-            match drep {
-                Credential::ScriptHash(hash) => context.require_script_witness(into_required_script(hash)),
-                Credential::KeyHash(hash) => context.require_verification_key_witness(hash),
-            };
+            require_credential_witness(context, drep, pointer.certificate_index);
 
             let expected = protocol_parameters.drep_deposit;
             if deposit != expected {
@@ -344,10 +329,7 @@ where
         }
 
         Certificate::UnRegDRepCert(drep, refund) => {
-            match drep {
-                Credential::ScriptHash(hash) => context.require_script_witness(into_required_script(hash)),
-                Credential::KeyHash(hash) => context.require_verification_key_witness(hash),
-            };
+            require_credential_witness(context, drep, pointer.certificate_index);
 
             let deposit = match DRepsSlice::lookup(context, &drep) {
                 Some(registration) => registration.deposit,
@@ -365,10 +347,7 @@ where
         }
 
         Certificate::UpdateDRepCert(drep, anchor) => {
-            match drep {
-                Credential::ScriptHash(hash) => context.require_script_witness(into_required_script(hash)),
-                Credential::KeyHash(hash) => context.require_verification_key_witness(hash),
-            };
+            require_credential_witness(context, drep, pointer.certificate_index);
 
             DRepsSlice::update(context, drep, anchor)?;
 
@@ -376,10 +355,7 @@ where
         }
 
         Certificate::VoteDeleg(credential, drep) => {
-            match credential {
-                Credential::ScriptHash(hash) => context.require_script_witness(into_required_script(hash)),
-                Credential::KeyHash(hash) => context.require_verification_key_witness(hash),
-            };
+            require_credential_witness(context, credential, pointer.certificate_index);
 
             AccountsSlice::delegate_vote(context, credential, drep, pointer)?;
 
@@ -387,19 +363,13 @@ where
         }
 
         Certificate::AuthCommitteeHot(cold_credential, hot_credential) => {
-            match cold_credential {
-                Credential::ScriptHash(hash) => context.require_script_witness(into_required_script(hash)),
-                Credential::KeyHash(hash) => context.require_verification_key_witness(hash),
-            };
+            require_credential_witness(context, cold_credential, pointer.certificate_index);
             CommitteeSlice::delegate_cold_key(context, cold_credential, hot_credential)?;
             Ok(())
         }
 
         Certificate::ResignCommitteeCold(cold_credential, anchor) => {
-            match cold_credential {
-                Credential::ScriptHash(hash) => context.require_script_witness(into_required_script(hash)),
-                Credential::KeyHash(hash) => context.require_verification_key_witness(hash),
-            };
+            require_credential_witness(context, cold_credential, pointer.certificate_index);
             CommitteeSlice::resign(context, cold_credential, anchor)?;
             Ok(())
         }

--- a/crates/amaru-ledger/src/rules/transaction/phase_one/outputs.rs
+++ b/crates/amaru-ledger/src/rules/transaction/phase_one/outputs.rs
@@ -49,10 +49,6 @@ pub enum InvalidOutput {
 
     #[error("bootstrap address attributes too big: {size} bytes, max 64")]
     BootAddrAttrsTooBig { size: usize },
-
-    // TODO: This error shouldn't exist, it's a placeholder for better error handling in less straight forward cases
-    #[error("uncategorized error: {0}")]
-    UncategorizedError(String),
 }
 
 /// Enum that is used to determine whether or not to allow a datum as supplemental in the context.
@@ -112,8 +108,7 @@ where
 
 fn validate_bootstrap_attributes(output: &MemoizedTransactionOutput) -> Result<(), InvalidOutput> {
     if let Address::Byron(addr) = &output.address {
-        let size: usize =
-            addr.attributes.iter().try_fold(0usize, |acc, attr| Ok::<_, InvalidOutput>(acc + attr.1.len()))?;
+        let size: usize = addr.attributes.iter().map(|attr| attr.1.len()).sum();
 
         if size > 64 {
             return Err(InvalidOutput::BootAddrAttrsTooBig { size });

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00183-pass-drep-unregistration-of-a-script-hash-drep.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00183-pass-drep-unregistration-of-a-script-hash-drep.json
@@ -1,0 +1,39 @@
+{
+  "title": "drep unregistration of a script-hash drep",
+  "description": "A DRep unregistration certificate deregisters a registered script-hash DRep, witnessed by its native script.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "8258208eb2c0684f549d1933b962302cf68719ed51dcedaab520a337d408827d36677a00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "dreps": [
+      {
+        "credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "deposit": 500000000,
+        "registered_at": {
+          "transaction": {
+            "slot": 0,
+            "transaction_index": 0
+          },
+          "certificate_index": 0
+        },
+        "valid_until": 1000
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a400d90102818258208eb2c0684f549d1933b962302cf68719ed51dcedaab520a337d408827d36677a000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a1e16a300021a00030d4004d901028183118201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf1a1dcd6500a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258403566bddfefc221e0b1853ff65ffafc41181508ff9d0d3070aae366805d4cdb0f6af84c1278dc458bb58316fe8bdaa4dcace59cbe1ab711f2c7b944d1d0959b0001d9010281820180f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00184-fail-drep-unregistration-of-a-script-hash-drep-missing-the-script-witness.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00184-fail-drep-unregistration-of-a-script-hash-drep-missing-the-script-witness.json
@@ -1,0 +1,41 @@
+{
+  "title": "drep unregistration of a script-hash drep missing the script witness",
+  "description": "A DRep unregistration certificate deregisters a registered script-hash DRep, but the witness set carries no script.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "8258208eb2c0684f549d1933b962302cf68719ed51dcedaab520a337d408827d36677a00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "dreps": [
+      {
+        "credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "deposit": 500000000,
+        "registered_at": {
+          "transaction": {
+            "slot": 0,
+            "transaction_index": 0
+          },
+          "certificate_index": 0
+        },
+        "valid_until": 1000
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a400d90102818258208eb2c0684f549d1933b962302cf68719ed51dcedaab520a337d408827d36677a000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a1e16a300021a00030d4004d901028183118201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf1a1dcd6500a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258403566bddfefc221e0b1853ff65ffafc41181508ff9d0d3070aae366805d4cdb0f6af84c1278dc458bb58316fe8bdaa4dcace59cbe1ab711f2c7b944d1d0959b00f5f6",
+  "expected": {
+    "predicate": "MissingScriptWitnessesUTXOW"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00185-pass-drep-update-of-a-script-hash-drep.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00185-pass-drep-update-of-a-script-hash-drep.json
@@ -1,0 +1,39 @@
+{
+  "title": "drep update of a script-hash drep",
+  "description": "A DRep update certificate updates a registered script-hash DRep with no anchor, witnessed by its native script.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "82582098374ce1a98af77e310b5a13d65e2b1e04147148c519b341ca5c6deb5d1236db00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "dreps": [
+      {
+        "credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "deposit": 500000000,
+        "registered_at": {
+          "transaction": {
+            "slot": 0,
+            "transaction_index": 0
+          },
+          "certificate_index": 0
+        },
+        "valid_until": 1000
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a400d901028182582098374ce1a98af77e310b5a13d65e2b1e04147148c519b341ca5c6deb5d1236db000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d4004d901028183128201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcff6a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258404c040091acbc17e54900e1348f95404e123b96b20bd9712d21cd8b62beb7c449ef1bc4221ae6e3dc4819ebd8077f14aa5a53eca4d5c061a258f3cbd18b87b70a01d9010281820180f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00186-fail-drep-update-of-a-script-hash-drep-missing-the-script-witness.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00186-fail-drep-update-of-a-script-hash-drep-missing-the-script-witness.json
@@ -1,0 +1,41 @@
+{
+  "title": "drep update of a script-hash drep missing the script witness",
+  "description": "A DRep update certificate updates a registered script-hash DRep with no anchor, but the witness set carries no script.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "82582098374ce1a98af77e310b5a13d65e2b1e04147148c519b341ca5c6deb5d1236db00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "dreps": [
+      {
+        "credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "deposit": 500000000,
+        "registered_at": {
+          "transaction": {
+            "slot": 0,
+            "transaction_index": 0
+          },
+          "certificate_index": 0
+        },
+        "valid_until": 1000
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a400d901028182582098374ce1a98af77e310b5a13d65e2b1e04147148c519b341ca5c6deb5d1236db000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d4004d901028183128201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcff6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258404c040091acbc17e54900e1348f95404e123b96b20bd9712d21cd8b62beb7c449ef1bc4221ae6e3dc4819ebd8077f14aa5a53eca4d5c061a258f3cbd18b87b70af5f6",
+  "expected": {
+    "predicate": "MissingScriptWitnessesUTXOW"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00187-pass-vote-delegation-from-a-script-hash-stake-credential.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00187-pass-vote-delegation-from-a-script-hash-stake-credential.json
@@ -1,0 +1,32 @@
+{
+  "title": "vote delegation from a script-hash stake credential",
+  "description": "A vote delegation certificate delegates a registered script-hash stake credential to the always-abstain DRep, witnessed by its native script.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "825820921c064f6df863dba0268757cef4771b01bd2e9d08479de9b86870b4959e532f00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "accounts": [
+      {
+        "credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a400d9010281825820921c064f6df863dba0268757cef4771b01bd2e9d08479de9b86870b4959e532f000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d4004d901028183098201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf8102a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840be09ed3b2faa27baf3064493c335d27a972e2b1780d985c1c6cfdcaf6e1ec0bf92a0c2409e96cbc49a98c6ab220b2a4c3833a0dc48ea18027c103568b678430501d9010281820180f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00188-fail-vote-delegation-from-a-script-hash-stake-credential-missing-the-script-witness.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00188-fail-vote-delegation-from-a-script-hash-stake-credential-missing-the-script-witness.json
@@ -1,0 +1,34 @@
+{
+  "title": "vote delegation from a script-hash stake credential missing the script witness",
+  "description": "A vote delegation certificate delegates a registered script-hash stake credential to the always-abstain DRep, but the witness set carries no script.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "825820921c064f6df863dba0268757cef4771b01bd2e9d08479de9b86870b4959e532f00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "accounts": [
+      {
+        "credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a400d9010281825820921c064f6df863dba0268757cef4771b01bd2e9d08479de9b86870b4959e532f000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d4004d901028183098201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf8102a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840be09ed3b2faa27baf3064493c335d27a972e2b1780d985c1c6cfdcaf6e1ec0bf92a0c2409e96cbc49a98c6ab220b2a4c3833a0dc48ea18027c103568b6784305f5f6",
+  "expected": {
+    "predicate": "MissingScriptWitnessesUTXOW"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00189-pass-committee-hot-key-authorization-by-a-script-hash-cold-credential.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00189-pass-committee-hot-key-authorization-by-a-script-hash-cold-credential.json
@@ -1,0 +1,32 @@
+{
+  "title": "committee hot key authorization by a script-hash cold credential",
+  "description": "A committee hot key authorization certificate authorizes a hot key credential for a script-hash cold credential in the committee, witnessed by its native script.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "82582013021cd06926924bd1aa607c4460d801456a680a54bed12ffcacd8d27b5e164e00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "committee": [
+      {
+        "cold_credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "status": null,
+        "valid_until": 200
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a400d901028182582013021cd06926924bd1aa607c4460d801456a680a54bed12ffcacd8d27b5e164e000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d4004d9010281830e8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf8200581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253ceca200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840910fd819e053b1a019c6d1adaef0fcdf000cf12e9c049172dc3eeedbef81527d3f0935d757017ad54db80cda258c2f226074a53192b07cd49684dd109aa4d20501d9010281820180f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00190-fail-committee-hot-key-authorization-by-a-script-hash-cold-credential-missing-the-script-witness.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00190-fail-committee-hot-key-authorization-by-a-script-hash-cold-credential-missing-the-script-witness.json
@@ -1,0 +1,34 @@
+{
+  "title": "committee hot key authorization by a script-hash cold credential missing the script witness",
+  "description": "A committee hot key authorization certificate authorizes a hot key credential for a script-hash cold credential in the committee, but the witness set carries no script.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "82582013021cd06926924bd1aa607c4460d801456a680a54bed12ffcacd8d27b5e164e00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "committee": [
+      {
+        "cold_credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "status": null,
+        "valid_until": 200
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a400d901028182582013021cd06926924bd1aa607c4460d801456a680a54bed12ffcacd8d27b5e164e000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d4004d9010281830e8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf8200581ce4ff642ed686b644c5cb39c230c24b0e8a5d850701971bdde3253ceca100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840910fd819e053b1a019c6d1adaef0fcdf000cf12e9c049172dc3eeedbef81527d3f0935d757017ad54db80cda258c2f226074a53192b07cd49684dd109aa4d205f5f6",
+  "expected": {
+    "predicate": "MissingScriptWitnessesUTXOW"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00261-pass-committee-resignation-by-a-script-hash-cold-credential.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00261-pass-committee-resignation-by-a-script-hash-cold-credential.json
@@ -1,0 +1,32 @@
+{
+  "title": "committee resignation by a script-hash cold credential",
+  "description": "A committee resignation certificate resigns a script-hash cold credential in the committee with no anchor, witnessed by its native script.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "8258205f03c9132e855ffb3d14b37a7577e5283a02b6a4ae63fca6f550434f60089e3400",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "committee": [
+      {
+        "cold_credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "status": null,
+        "valid_until": 200
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a400d90102818258205f03c9132e855ffb3d14b37a7577e5283a02b6a4ae63fca6f550434f60089e34000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d4004d9010281830f8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcff6a200d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258402c1cfdb05584d9edae2598bccec6d1f1c4f087a2aef91c3b0b6b2a2b0e228217ff5e38d62b1321fc7b7bda638fef75a376875f18ed40b13a2cfe738516da970101d9010281820180f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00262-fail-committee-resignation-by-a-script-hash-cold-credential-missing-the-script-witness.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00262-fail-committee-resignation-by-a-script-hash-cold-credential-missing-the-script-witness.json
@@ -1,0 +1,34 @@
+{
+  "title": "committee resignation by a script-hash cold credential missing the script witness",
+  "description": "A committee resignation certificate resigns a script-hash cold credential in the committee with no anchor, but the witness set carries no script.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "8258205f03c9132e855ffb3d14b37a7577e5283a02b6a4ae63fca6f550434f60089e3400",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "committee": [
+      {
+        "cold_credential": "8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf",
+        "status": null,
+        "valid_until": 200
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a400d90102818258205f03c9132e855ffb3d14b37a7577e5283a02b6a4ae63fca6f550434f60089e34000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d4004d9010281830f8201581cd441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcff6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258402c1cfdb05584d9edae2598bccec6d1f1c4f087a2aef91c3b0b6b2a2b0e228217ff5e38d62b1321fc7b7bda638fef75a376875f18ed40b13a2cfe738516da9701f5f6",
+  "expected": {
+    "predicate": "MissingScriptWitnessesUTXOW"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00263-pass-invalid-transaction-with-a-stake-registration.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00263-pass-invalid-transaction-with-a-stake-registration.json
@@ -1,0 +1,29 @@
+{
+  "title": "invalid transaction with a stake registration",
+  "description": "An is_valid=false transaction spending a Plutus V3 input whose script fails, carrying a Conway stake registration certificate whose deposit is accounted for by the outputs.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "825820bdb07d840403788c6c3fbe9b3a8dc092822060966b6667cb6b094d49a1fd77bd00",
+        "output": "a200581d70994b345acef955ada938b01e9f0405ab57743d41f0b398de604d0969011a004c4b40"
+      },
+      {
+        "input": "82582002501c66fe78c49412bab5c5aae760c5935d36daf448b7004a80a4bd7f29728000",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002dc6c0"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a700d9010281825820bdb07d840403788c6c3fbe9b3a8dc092822060966b6667cb6b094d49a1fd77bd000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a0029f630021a0003d09004d901028183078200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd81a001e84800b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd901028182582002501c66fe78c49412bab5c5aae760c5935d36daf448b7004a80a4bd7f297280000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840929e206d65905c5dfcc288d9eec628eb61435ca899ddccddb1ff01a33abbda02607f81dad0535c527a106302f6e14c38c64ff282759dc1bf265d3f539884120905a18200008200821907d01a000f424007d9010281454401010061f4f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00264-pass-invalid-transaction-with-a-stake-deregistration.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00264-pass-invalid-transaction-with-a-stake-deregistration.json
@@ -1,0 +1,36 @@
+{
+  "title": "invalid transaction with a stake deregistration",
+  "description": "An is_valid=false transaction spending a Plutus V3 input whose script fails, carrying a stake deregistration certificate whose refund is accounted for by the outputs.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "825820f4ef72d363acc5d4be0df5087b18a8778d3b2957a6f2c625de1d2f1a630b183200",
+        "output": "a200581d70994b345acef955ada938b01e9f0405ab57743d41f0b398de604d0969011a004c4b40"
+      },
+      {
+        "input": "82582017064722869e1c98131aeb3cf60142e4edd7e2512df86a8dfc54d24c050bf3b500",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002dc6c0"
+      }
+    ],
+    "accounts": [
+      {
+        "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a700d9010281825820f4ef72d363acc5d4be0df5087b18a8778d3b2957a6f2c625de1d2f1a630b1832000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a0066ff30021a0003d09004d901028183088200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd81a001e84800b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd901028182582017064722869e1c98131aeb3cf60142e4edd7e2512df86a8dfc54d24c050bf3b5000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258401d3acfbabee9c2d3df03b4f079de0e388c2224824b82d2ec13f55418d976b16f2380c9680aee1e263a1fe13173d1b1befc3ac4b44212dd3c32af4cdf897ac80a05a18200008200821907d01a000f424007d9010281454401010061f4f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00265-pass-invalid-transaction-with-a-new-pool-registration.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00265-pass-invalid-transaction-with-a-new-pool-registration.json
@@ -1,0 +1,29 @@
+{
+  "title": "invalid transaction with a new pool registration",
+  "description": "An is_valid=false transaction spending a Plutus V3 input whose script fails, carrying a registration certificate for a new stake pool whose deposit is accounted for by the outputs.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "8258200dda2acb82b153010db75f3b5fde0e7e1578bf609d0a35fd8dc930e9576462ac00",
+        "output": "a200581d70994b345acef955ada938b01e9f0405ab57743d41f0b398de604d0969011a1e19b040"
+      },
+      {
+        "input": "8258206c14fb5a21004a8a0bae8d090249eeb492d2eafdda1981b345b0c505a21a141400",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002dc6c0"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a700d90102818258200dda2acb82b153010db75f3b5fde0e7e1578bf609d0a35fd8dc930e9576462ac000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00487ab0021a0003d09004d90102818a03581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd85820beb4f4682ecd5ff2fdc7fb5e0ead8b8ce8596a4de2242ad8d4c988499762e0c9001a1443fd00d81e820001581de093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8d9010281581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd880f60b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd90102818258206c14fb5a21004a8a0bae8d090249eeb492d2eafdda1981b345b0c505a21a1414000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840d99d8f7159aeb006bd28032864075e8b91e44f3842f6e90ba8a255ecf7f563cbc55269581243464210c0545bc500bf29f06331c4d88e21173fc00be65e6ea70405a18200008200821907d01a000f424007d9010281454401010061f4f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00266-pass-invalid-transaction-with-a-re-registration-of-an-existing-pool.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00266-pass-invalid-transaction-with-a-re-registration-of-an-existing-pool.json
@@ -1,0 +1,32 @@
+{
+  "title": "invalid transaction with a re-registration of an existing pool",
+  "description": "An is_valid=false transaction spending a Plutus V3 input whose script fails, carrying a registration certificate for an already-registered stake pool.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "82582017bfb441ac3612f52a33dfde0673fac58b8edd40891d9a32c9bde63c785685f800",
+        "output": "a200581d70994b345acef955ada938b01e9f0405ab57743d41f0b398de604d0969011a004c4b40"
+      },
+      {
+        "input": "82582032eb00be0419786fb275df07011c692f3cb61e7921db61d34e046af9d958633f00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002dc6c0"
+      }
+    ],
+    "pools": [
+      "93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8"
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a700d901028182582017bfb441ac3612f52a33dfde0673fac58b8edd40891d9a32c9bde63c785685f8000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00487ab0021a0003d09004d90102818a03581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd85820beb4f4682ecd5ff2fdc7fb5e0ead8b8ce8596a4de2242ad8d4c988499762e0c9001a1443fd00d81e820001581de093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8d9010281581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd880f60b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd901028182582032eb00be0419786fb275df07011c692f3cb61e7921db61d34e046af9d958633f000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584092232cc1d5a11b278e6baed8b4017df5f567b022afba2ff6a2665a61e05a29cbcad2250301197827d03688223ffd394eeb92dc8b88f8fd37638c7ea81b94020305a18200008200821907d01a000f424007d9010281454401010061f4f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00267-pass-invalid-transaction-with-a-drep-registration.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00267-pass-invalid-transaction-with-a-drep-registration.json
@@ -1,0 +1,29 @@
+{
+  "title": "invalid transaction with a drep registration",
+  "description": "An is_valid=false transaction spending a Plutus V3 input whose script fails, carrying a DRep registration certificate whose deposit is accounted for by the outputs.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "825820a593256ccfacb6da2e4d8a0c35f43627924051f3d8950d881ed625e28a53fec600",
+        "output": "a200581d70994b345acef955ada938b01e9f0405ab57743d41f0b398de604d0969011a1e19b040"
+      },
+      {
+        "input": "825820a1676fde0494650ffc34cb319ee5f7757c22bf60d3b7522ebebf7191c35e9aa100",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002dc6c0"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a700d9010281825820a593256ccfacb6da2e4d8a0c35f43627924051f3d8950d881ed625e28a53fec6000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00487ab0021a0003d09004d901028184108200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd81a1dcd6500f60b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd9010281825820a1676fde0494650ffc34cb319ee5f7757c22bf60d3b7522ebebf7191c35e9aa1000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584068ba80b28e2ec98360bde4ff576e9672c6ac53b0e965c095102d58ea301c5a0b3eb13f38ca4238807a96384abdc8b308d3ef58cda37579b678d82f3f078efa0b05a18200008200821907d01a000f424007d9010281454401010061f4f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00268-pass-invalid-transaction-with-a-drep-unregistration.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00268-pass-invalid-transaction-with-a-drep-unregistration.json
@@ -1,0 +1,43 @@
+{
+  "title": "invalid transaction with a drep unregistration",
+  "description": "An is_valid=false transaction spending a Plutus V3 input whose script fails, carrying a DRep unregistration certificate whose refund is accounted for by the outputs.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "825820bca1bbff175fc03c12bab68122ede531f257a9f1cf150c60b54b4097de3ca7a000",
+        "output": "a200581d70994b345acef955ada938b01e9f0405ab57743d41f0b398de604d0969011a004c4b40"
+      },
+      {
+        "input": "82582059a2b87841dc35ccb7fe7d9c32b185e3678e6304cde8aae3cdbbb7430c2dc59800",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002dc6c0"
+      }
+    ],
+    "dreps": [
+      {
+        "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "deposit": 500000000,
+        "registered_at": {
+          "transaction": {
+            "slot": 0,
+            "transaction_index": 0
+          },
+          "certificate_index": 0
+        },
+        "valid_until": 1000
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a700d9010281825820bca1bbff175fc03c12bab68122ede531f257a9f1cf150c60b54b4097de3ca7a0000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a1e15dfb0021a0003d09004d901028183118200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd81a1dcd65000b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd901028182582059a2b87841dc35ccb7fe7d9c32b185e3678e6304cde8aae3cdbbb7430c2dc598000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258407184c8bbf46e2cf4abab4a2941527f0ab73b71d1987b2fd4abe0bae5e3fcbac9daf805e260a8119aaf34900da48f9d3f082f47fb71f578481af13e471649c20b05a18200008200821907d01a000f424007d9010281454401010061f4f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00269-pass-invalid-transaction-with-a-stake-registration-and-deregistration.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00269-pass-invalid-transaction-with-a-stake-registration-and-deregistration.json
@@ -1,0 +1,29 @@
+{
+  "title": "invalid transaction with a stake registration and deregistration",
+  "description": "An is_valid=false transaction spending a Plutus V3 input whose script fails, carrying a Conway stake registration certificate followed by a deregistration of the same credential.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "825820f0787c47473763ba5ca3f2f6d2a80dbbc16c3d0ec25ed52f0fa269b41024c08f00",
+        "output": "a200581d70994b345acef955ada938b01e9f0405ab57743d41f0b398de604d0969011a004c4b40"
+      },
+      {
+        "input": "82582054893f1670830b21b9a6dc5e0fb5cb073079d8b8a9ef1020dbc760e59764a6d800",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002dc6c0"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a700d9010281825820f0787c47473763ba5ca3f2f6d2a80dbbc16c3d0ec25ed52f0fa269b41024c08f000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00487ab0021a0003d09004d901028283078200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd81a001e848083088200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd81a001e84800b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd901028182582054893f1670830b21b9a6dc5e0fb5cb073079d8b8a9ef1020dbc760e59764a6d8000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258403c66e90ea341bfb78a2dad2f86c78f8dc0ea52ae4c214037ed23d0b1baba72a8eb98e301f72460d61f51fcc1fbcd02d61d8d255bef824d6f6813896c0afd640e05a18200008200821907d01a000f424007d9010281454401010061f4f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00270-pass-invalid-transaction-with-a-vote-delegation.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00270-pass-invalid-transaction-with-a-vote-delegation.json
@@ -1,0 +1,36 @@
+{
+  "title": "invalid transaction with a vote delegation",
+  "description": "An is_valid=false transaction spending a Plutus V3 input whose script fails, carrying a vote delegation certificate to the always-abstain DRep.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "8258200548397be46ff3d3d886b0af6009766b8873744322051f9ba738770965ed01f400",
+        "output": "a200581d70994b345acef955ada938b01e9f0405ab57743d41f0b398de604d0969011a004c4b40"
+      },
+      {
+        "input": "825820137f57afe3d883344091e5fa6c9a33f1ae9f1d89e5c74504a8ab0a5610eb8dee00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002dc6c0"
+      }
+    ],
+    "accounts": [
+      {
+        "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a700d90102818258200548397be46ff3d3d886b0af6009766b8873744322051f9ba738770965ed01f4000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00487ab0021a0003d09004d901028183098200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd881020b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd9010281825820137f57afe3d883344091e5fa6c9a33f1ae9f1d89e5c74504a8ab0a5610eb8dee000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584065ba3e94f9e012b442e6d1cce63c8282fc7ee2d5a42bd86ea43faaa651708b0c43a052a0725d8b3a4dd6c7739686770c83cc6947e60cc8ea62d61beb3204a60205a18200008200821907d01a000f424007d9010281454401010061f4f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00271-fail-pool-registration-with-a-mainnet-reward-account.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00271-fail-pool-registration-with-a-mainnet-reward-account.json
@@ -1,0 +1,27 @@
+{
+  "title": "pool registration with a mainnet reward account",
+  "description": "A pool registration certificate declares a mainnet reward account on the preprod network.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "825820cd7da7c1e4b49f3e6382597d596c8b633594100b844d799d3e6868e33b701bf000",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a1e19b040"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a400d9010281825820cd7da7c1e4b49f3e6382597d596c8b633594100b844d799d3e6868e33b701bf0000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d4004d90102818a03581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd85820beb4f4682ecd5ff2fdc7fb5e0ead8b8ce8596a4de2242ad8d4c988499762e0c9001a1443fd00d81e820001581de193c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8d9010281581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd880f6a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584082cc408f5e6b86331fe506198dbdf03f9cfbed51886640a6373a93c509b209ba00a71dddc8e6ac7b0fb6b4c9b23e3d2b6c6554146f1f296f597eeae96ac0ed0cf5f6",
+  "expected": {
+    "predicate": "WrongNetworkPOOL"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00272-fail-old-style-stake-registration-of-an-already-registered-credential.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00272-fail-old-style-stake-registration-of-an-already-registered-credential.json
@@ -1,0 +1,34 @@
+{
+  "title": "old-style stake registration of an already-registered credential",
+  "description": "A pre-Conway stake registration certificate registers a stake credential that is already registered.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "8258203766877caa399cd6fc81e4fc046dfbccbe4715f6a1f6e6afa17079ff6c55fd3c00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ],
+    "accounts": [
+      {
+        "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a400d90102818258203766877caa399cd6fc81e4fc046dfbccbe4715f6a1f6e6afa17079ff6c55fd3c000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002ab980021a00030d4004d901028182008200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840152a6b116c2c09a7c6b25dee1a8728fe7ada67d69b9c5e342ed6fb64ce33c76308eb9e5b6a22f849a522cfd46650380cd909470055728e1b1e1906d14196670ef5f6",
+  "expected": {
+    "predicate": "StakeKeyRegistered"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00273-fail-stake-registration-with-a-zero-deposit.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00273-fail-stake-registration-with-a-zero-deposit.json
@@ -1,0 +1,27 @@
+{
+  "title": "stake registration with a zero deposit",
+  "description": "A Conway stake registration certificate declares a zero deposit.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "825820280d13ba46895e4ee987470bfad6725d463a4c9b01ad681e6e4e98ed13148f3500",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a400d9010281825820280d13ba46895e4ee987470bfad6725d463a4c9b01ad681e6e4e98ed13148f35000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d4004d901028183078200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd800a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840dc50960c923dcfc3bffae1f9f5dfc718d14fdd4ae7eef09719bb8184be4030f7016a717aff9106aae23d0c9c693bd0594fe246fc38b83ffd32b0ccdd26e42302f5f6",
+  "expected": {
+    "predicate": "IncorrectDepositDELEG"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00274-pass-invalid-transaction-with-a-stake-registration-and-pool-delegation.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00274-pass-invalid-transaction-with-a-stake-registration-and-pool-delegation.json
@@ -1,0 +1,29 @@
+{
+  "title": "invalid transaction with a stake registration and pool delegation",
+  "description": "An is_valid=false transaction spending a Plutus V3 input whose script fails, carrying a combined stake registration and pool delegation certificate whose deposit is accounted for by the outputs.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "82582068f207a1a50bedbfc0be901465804bc93e44d244199a21f62eabb7d0076ac9ed00",
+        "output": "a200581d70994b345acef955ada938b01e9f0405ab57743d41f0b398de604d0969011a004c4b40"
+      },
+      {
+        "input": "82582039ffac0ab0b6e411a585938da683f01d4165ef1bbcda4489e194ef31ce29beb000",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002dc6c0"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a700d901028182582068f207a1a50bedbfc0be901465804bc93e44d244199a21f62eabb7d0076ac9ed000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a0029f630021a0003d09004d9010281840b8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8581c154512108969d53b4535459ff8581ad35072082bdc4b66550d3584131a001e84800b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd901028182582039ffac0ab0b6e411a585938da683f01d4165ef1bbcda4489e194ef31ce29beb0000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584030533f60dee47e8fba3058405e347c68d31a143fd2934ef550a0211e7e3ec9a99d37f719c77ff6e13bca060a972e9e744c1439a6675db19d2ecea76db4bde90205a18200008200821907d01a000f424007d9010281454401010061f4f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00275-pass-invalid-transaction-with-a-stake-registration-pool-delegation-and-vote-delegation.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00275-pass-invalid-transaction-with-a-stake-registration-pool-delegation-and-vote-delegation.json
@@ -1,0 +1,29 @@
+{
+  "title": "invalid transaction with a stake registration, pool delegation, and vote delegation",
+  "description": "An is_valid=false transaction spending a Plutus V3 input whose script fails, carrying a combined stake registration, pool delegation, and vote delegation certificate whose deposit is accounted for by the outputs.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "825820ac4a2bf6efc92de5a7407acc9112d0ef8d15d5d5e24938adc5834df2733a5b2a00",
+        "output": "a200581d70994b345acef955ada938b01e9f0405ab57743d41f0b398de604d0969011a004c4b40"
+      },
+      {
+        "input": "825820dfae01b6b608dcd51bcfd75f38b49c6a4c53e3a03163925da9e1f375cfe04b4500",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002dc6c0"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a700d9010281825820ac4a2bf6efc92de5a7407acc9112d0ef8d15d5d5e24938adc5834df2733a5b2a000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a0029f630021a0003d09004d9010281850d8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8581c154512108969d53b4535459ff8581ad35072082bdc4b66550d35841381021a001e84800b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd9010281825820dfae01b6b608dcd51bcfd75f38b49c6a4c53e3a03163925da9e1f375cfe04b45000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840d7d6d86b158bb3ec7cf487f398d48f1c3ec16c886b4833aea0a8bf9cca4b046f5825c6d67e84be607b0818b9a5dbbf628cea897ee7d64653208dcf5718462d0205a18200008200821907d01a000f424007d9010281454401010061f4f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00276-pass-invalid-transaction-with-a-stake-registration-and-vote-delegation.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00276-pass-invalid-transaction-with-a-stake-registration-and-vote-delegation.json
@@ -1,0 +1,29 @@
+{
+  "title": "invalid transaction with a stake registration and vote delegation",
+  "description": "An is_valid=false transaction spending a Plutus V3 input whose script fails, carrying a combined stake registration and vote delegation certificate whose deposit is accounted for by the outputs.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "8258203904f3a9825a199bb178d6c95bdde87fac6b64f8f5655d3940bbe9d06d5ee5b200",
+        "output": "a200581d70994b345acef955ada938b01e9f0405ab57743d41f0b398de604d0969011a004c4b40"
+      },
+      {
+        "input": "8258203f6f721964f785cd3b8b6886d863340645e8aa9a16d2ced4991951d337322ec300",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002dc6c0"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a700d90102818258203904f3a9825a199bb178d6c95bdde87fac6b64f8f5655d3940bbe9d06d5ee5b2000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a0029f630021a0003d09004d9010281840c8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd881021a001e84800b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd90102818258203f6f721964f785cd3b8b6886d863340645e8aa9a16d2ced4991951d337322ec3000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840895ddc4386b01f9be1dcd5683f2f6de1e554f80044d401c825d0f0f19a3aeac55913061a04a5fbf1e89dc2a7898dd656f97ca40c412542c26fb29715646fe40d05a18200008200821907d01a000f424007d9010281454401010061f4f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00277-pass-transfer-with-reference-inputs-carrying-datums.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00277-pass-transfer-with-reference-inputs-carrying-datums.json
@@ -1,0 +1,33 @@
+{
+  "title": "transfer with reference inputs carrying datums",
+  "description": "A simple transfer referencing two unspent outputs, one carrying an inline datum and one carrying a datum hash.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "8258205a0d4183faa546d421d84955934d958183a8d459d78e3d995664db1d17fd6d8b00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      },
+      {
+        "input": "825820cfe1e67f17bb29f9b3d7bcca3dd074507de27b06ddfe5d8f85047a1965af0f4c00",
+        "output": "a300581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e8480028201d81842182a"
+      },
+      {
+        "input": "8258202d88acddb00f1c19b3d6e9e7f872ba60a6a16791800ffe4f5eb670e8a977366000",
+        "output": "a300581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a001e84800282005820531c95817ee72f1c7de2e05abfde0bb1289f83318e37900506d7c866fd82cfa0"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a400d90102818258205a0d4183faa546d421d84955934d958183a8d459d78e3d995664db1d17fd6d8b000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d4012d9010282825820cfe1e67f17bb29f9b3d7bcca3dd074507de27b06ddfe5d8f85047a1965af0f4c008258202d88acddb00f1c19b3d6e9e7f872ba60a6a16791800ffe4f5eb670e8a977366000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840126900ac70fa2a489a4c8d626a9ac979506cdc4750233c207704a1c0fcefe1813a4088b11251e7bcc373574c8c78a4124efe1ad0b767be33743dd8113ef7c306f5f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00278-fail-transaction-with-redeemers-but-no-collateral-inputs.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00278-fail-transaction-with-redeemers-but-no-collateral-inputs.json
@@ -1,0 +1,27 @@
+{
+  "title": "transaction with redeemers but no collateral inputs",
+  "description": "A transaction spending a Plutus V3 input with a spend redeemer, declaring no collateral inputs.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "825820fd6f78254f114651b577d4670b917be24c08b611ca24dfc99d9a88b3b240bb9400",
+        "output": "a200581d70186e32faa80a26810392fda6d559c7ed4721a65ce1c9d4ef3e1c87b4011a004c4b40"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a400d9010281825820fd6f78254f114651b577d4670b917be24c08b611ca24dfc99d9a88b3b240bb94000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00487ab0021a0003d0900b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bba205a18200008200821907d01a000f424007d901028146450101002499f5f6",
+  "expected": {
+    "predicate": "NoCollateralInputs"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00279-pass-invalid-transaction-with-a-byron-collateral-input.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00279-pass-invalid-transaction-with-a-byron-collateral-input.json
@@ -1,0 +1,29 @@
+{
+  "title": "invalid transaction with a byron collateral input",
+  "description": "An is_valid=false transaction spending a Plutus V3 input whose script fails, with a collateral input held at a Byron address and its bootstrap witness.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "825820614b74f1ea1300c92bcbeed79daa3394306e8f541229cc01975e408740e7c4b700",
+        "output": "a200581d70994b345acef955ada938b01e9f0405ab57743d41f0b398de604d0969011a004c4b40"
+      },
+      {
+        "input": "8258206726f4f6afb0f52ed241457e54dbea8904e5367318893a7a22fcc18927f3354000",
+        "output": "a200582e82d818582483581c4958e32a5835b20b8d5d6842ad7288eddc3d461646b7d86d24b75449a1024101001afc54f996011a002dc6c0"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a600d9010281825820614b74f1ea1300c92bcbeed79daa3394306e8f541229cc01975e408740e7c4b7000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00487ab0021a0003d0900b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd90102818258206726f4f6afb0f52ed241457e54dbea8904e5367318893a7a22fcc18927f33540000f00a302d90102818458202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258406988f91bfcf0f4b7279f3fc913fa9fb14ee02fce8376aea491a7cb261ca5c3e06ce1db197326e4be71fa7e8a86b8e94de6dd766fe4474da8b8876cac673abb085820000000000000000000000000000000000000000000000000000000000000000044a102410105a18200008200821907d01a000f424007d9010281454401010061f4f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00280-fail-output-to-a-byron-address-with-oversized-attributes.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00280-fail-output-to-a-byron-address-with-oversized-attributes.json
@@ -1,0 +1,27 @@
+{
+  "title": "output to a byron address with oversized attributes",
+  "description": "A transaction with an output locked at a Byron address carrying 99 bytes of address attributes.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "8258201cb8c5d008d86e4ece720de3638d33e293ae677dcaf66b9918e7b65b40e57abf00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a004c4b40"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a300d90102818258201cb8c5d008d86e4ece720de3638d33e293ae677dcaf66b9918e7b65b40e57abf000182a200589382d818588983581c149ad4b736608c56aa72fba87b7f72343fed0f0b78b2fd39b5eff808a201586258605be51343581011594d82a1e32dfc2c5e0ab8be4a32aab4fbf3bcf9e17991a53c5be51343581011594d82a1e32dfc2c5e0ab8be4a32aab4fbf3bcf9e17991a53c5be51343581011594d82a1e32dfc2c5e0ab8be4a32aab4fbf3bcf9e17991a53c024101001ac21b9f30011a001e8480a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002ab980021a00030d40a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db1258408ad528fc0406623878b06f5a7f170d7d1d896e4e29eb8a0758baf97419cf7c3c22af5b0fc8131ddefad9f7502d7c2cdf6a723254ab3d0792d89f479f1ba4d00ef5f6",
+  "expected": {
+    "predicate": "OutputTooBigUTxO"
+  }
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00281-pass-invalid-transaction-with-a-plutus-v3-script-returning-a-non-unit-constant.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00281-pass-invalid-transaction-with-a-plutus-v3-script-returning-a-non-unit-constant.json
@@ -1,0 +1,29 @@
+{
+  "title": "invalid transaction with a plutus v3 script returning a non-unit constant",
+  "description": "An is_valid=false transaction spending a Plutus V3 input whose script evaluates to an integer constant instead of unit.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "8258203db77d9b497b59d8ec805f50618c30237c90264ae9d0c914989d74b7cd3691ef00",
+        "output": "a200581d7049f6f6d2511a9db9de8187fc949823362f31ada7d5b0adc7e556c3b5011a004c4b40"
+      },
+      {
+        "input": "825820aacc105ea48630896628f619fdc256b4b49c83751d4db13b9c083158deae5cef00",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a002dc6c0"
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a600d90102818258203db77d9b497b59d8ec805f50618c30237c90264ae9d0c914989d74b7cd3691ef000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00487ab0021a0003d0900b58200ddcceb08dbb394c29ef7fa4c16f8e738daf1333cafe4d28ba9e0f67aeaf97bb0dd9010281825820aacc105ea48630896628f619fdc256b4b49c83751d4db13b9c083158deae5cef000f00a300d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db125840dfa046fd307ba3f9a957619b8e2135bdc05cb0e2ec69b1800a412fc04b4ab7c29c5f375dc9e6399903ced118acc0990867de2e1dea549145593b833d8857780b05a18200008200821907d01a000f424007d90102814746010100248151f4f6",
+  "expected": "Pass"
+}

--- a/crates/amaru-ledger/tests/data/transaction/scenarios/00282-fail-info-proposal-with-a-mainnet-return-account.json
+++ b/crates/amaru-ledger/tests/data/transaction/scenarios/00282-fail-info-proposal-with-a-mainnet-return-account.json
@@ -1,0 +1,34 @@
+{
+  "title": "info proposal with a mainnet return account",
+  "description": "An info action proposal whose return (deposit refund) account carries a mainnet network tag.",
+  "network": "preprod",
+  "era_history": {
+    "$ref": "common/era-history/preprod-conway.json"
+  },
+  "protocol_parameters": {
+    "$ref": "common/protocol-parameters/preprod-conway-v10.json"
+  },
+  "initial_state": {
+    "utxo": [
+      {
+        "input": "82582075315235c9bc246f0b429dc9274d1bf25e6d8feef79086fcd6d4e257642dac0300",
+        "output": "a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011b0000001748c33340"
+      }
+    ],
+    "accounts": [
+      {
+        "credential": "8200581c93c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8",
+        "deposit": 2000000,
+        "rewards": 0
+      }
+    ]
+  },
+  "point": {
+    "slot": 0,
+    "transaction_index": 0
+  },
+  "transaction": "84a400d901028182582075315235c9bc246f0b429dc9274d1bf25e6d8feef79086fcd6d4e257642dac03000181a200581d6093c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd8011a00493e00021a00030d4014d9010281841b000000174876e800581de193c191b1094746961f6f00fba27f3d8eff6a66490baf806d4e179fd88106827368747470733a2f2f6578616d706c652e636f6d58200000000000000000000000000000000000000000000000000000000000000000a100d90102818258202152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12584033122251eaf3b709f294793783b12d5da452370044f54543351f4988c165036c48571fb4cc12015049b43d31fcf67e516083cf693505dce3e83d8bb1ed940101f5f6",
+  "expected": {
+    "predicate": "ProposalProcedureNetworkIdMismatch"
+  }
+}

--- a/crates/amaru/tests/conformance/validation-rules/src/Command/ValidatePhaseOne/Run.hs
+++ b/crates/amaru/tests/conformance/validation-rules/src/Command/ValidatePhaseOne/Run.hs
@@ -385,6 +385,8 @@ normalizeUtxowFailure expectedHint = \case
         "ExtraneousScriptWitnessesUTXOW"
     MissingVKeyWitnessesUTXOW{} ->
         "MissingVerificationKeyWitnessesUTXOW"
+    MissingScriptWitnessesUTXOW{} ->
+        "MissingScriptWitnessesUTXOW"
     MissingTxBodyMetadataHash{} ->
         "MissingTxBodyMetadataHash"
     MissingTxMetadata{} ->

--- a/crates/amaru/tests/conformance/validation-rules/src/Command/ValidatePhaseOne/Run.hs
+++ b/crates/amaru/tests/conformance/validation-rules/src/Command/ValidatePhaseOne/Run.hs
@@ -438,6 +438,8 @@ normalizeUtxoFailure = \case
         "BabbageOutputTooSmallUTxO"
     BabbageNonDisjointRefInputs{} ->
         "BabbageNonDisjointRefInputs"
+    NoCollateralInputs{} ->
+        "NoCollateralInputs"
     UtxosFailure failure
         | "TimeTranslationPastHorizon" `Text.isInfixOf` showText failure ->
             "OutsideForecast"
@@ -507,6 +509,8 @@ normalizeGovFailure :: ConwayGovPredFailure ConwayEra -> Text
 normalizeGovFailure = \case
     ProposalReturnAccountDoesNotExist{} ->
         "ProposalReturnAccountDoesNotExist"
+    ProposalProcedureNetworkIdMismatch{} ->
+        "ProposalProcedureNetworkIdMismatch"
     TreasuryWithdrawalReturnAccountsDoNotExist{} ->
         "TreasuryWithdrawalReturnAccountsDoNotExist"
     InvalidPrevGovActionId{} ->

--- a/crates/amaru/tests/conformance/validation-rules/src/Command/ValidatePhaseOne/Run.hs
+++ b/crates/amaru/tests/conformance/validation-rules/src/Command/ValidatePhaseOne/Run.hs
@@ -498,6 +498,8 @@ normalizePoolFailure = \case
         "StakePoolRetirementWrongEpochPOOL"
     StakePoolCostTooLowPOOL{} ->
         "StakePoolCostTooLowPOOL"
+    WrongNetworkPOOL{} ->
+        "WrongNetworkPOOL"
     otherFailure ->
         "unsupported:" <> showText otherFailure
 


### PR DESCRIPTION
Closes #885

After introducing the new JSON fixtures, there were some parts of the ledger left without coverage. This PR closes that gap, introducing fixtures to cover untested cases.

This brings the coverage percentage of `../rules/transaction` to 98.2%. Remaining uncovered lines in the `amaru-ledger` crate are mostly state/setup logic these fixtures cannot cover.

It's important to note that the JSON fixtures cannot test every aspect of the code. They only compare error state (pass or fail with specific case), they do *not* compare a final state to an initial state. So coverage here does not necessarily suggest complete and thorough testing.

I also noticed a panic when `is_valid=false` and a tx is negatively balanced, which has been fixed as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected negative certificate balance accounting and prevented panics when processing invalid transactions.
  - Improved validation for script witnesses, collateral inputs, reward-account networks, proposal return-account networks, and oversized Byron outputs.
  - Fixed handling of invalid transactions containing certificates, deposits, and stake-pool updates.

- **Tests**
  - Expanded coverage for governance, delegation, stake, pool, collateral, reference-input, and invalid-transaction scenarios.
  - Added validation cases for missing witnesses, invalid deposits, duplicate registrations, network mismatches, and oversized outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->