### PR TITLE
feat: improve log progress for non-tty use cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,9 +55,6 @@ Other guiding principles:
 
 - **amaru-node**: the stake-distribution callback no longer holds a strong `Resources` handle, so dropping a node graph closes its dummy RocksDB ledgers instead of leaking file descriptors across simulation runs.
 - **amaru**: replace repeated low-level OpenTelemetry export errors with batched state-transition messages: one warning listing unavailable signals, one info listing recovered signals, and a fresh warning after a later failure.
-
-### Fixed
-
 - **amaru-bootstrap**: emit phase lifecycle events and periodic progress heartbeats when bootstrap runs without a terminal, so redirected and service logs no longer appear stuck during long imports.
 
 ## [v10.11.20260827](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260827)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ Other guiding principles:
 - **amaru-node**: the stake-distribution callback no longer holds a strong `Resources` handle, so dropping a node graph closes its dummy RocksDB ledgers instead of leaking file descriptors across simulation runs.
 - **amaru**: replace repeated low-level OpenTelemetry export errors with batched state-transition messages: one warning listing unavailable signals, one info listing recovered signals, and a fresh warning after a later failure.
 
+### Fixed
+
+- **amaru-bootstrap**: emit phase lifecycle events and periodic progress heartbeats when bootstrap runs without a terminal, so redirected and service logs no longer appear stuck during long imports.
+
 ## [v10.11.20260827](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260827)
 
 ### Added

--- a/crates/amaru-bootstrap/src/aws.rs
+++ b/crates/amaru-bootstrap/src/aws.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 use amaru_kernel::{NetworkName, NetworkPoint};
-use amaru_progress_bar::{ProgressBar, TerminalProgressBar};
+use amaru_progress_bar::{ProgressBar, ProgressBarFactory, TerminalProgressBar};
 use anyhow::{Context, anyhow};
 use aws_credential_types::{Credentials, provider::SharedCredentialsProvider};
 use aws_sdk_s3::{
@@ -30,6 +30,8 @@ use aws_sdk_s3::{
     primitives::{ByteStream, SdkBody},
 };
 use http_body_util::BodyExt as _;
+
+use crate::progress::BootstrapProgressFactory;
 
 /// Default S3 bucket name for Amaru bootstrap snapshots.
 pub const DEFAULT_BUCKET: &str = "cardano-ledger-snapshots";
@@ -302,7 +304,7 @@ impl AnonymousS3Client {
 
         let url = format!("{}/{key}", self.base_url);
         let response = self.http.get(&url).send().await?.error_for_status().context("download failed")?;
-        let progress = transfer_progress_bar("Downloading", response.content_length().unwrap_or(0));
+        let progress = bootstrap_transfer_progress_bar(response.content_length().unwrap_or(0));
         let mut stream = response.bytes_stream();
 
         let result: anyhow::Result<()> = async {
@@ -315,9 +317,23 @@ impl AnonymousS3Client {
             Ok(())
         }
         .await;
-        progress.clear();
+        if result.is_ok() {
+            progress.finish();
+        } else {
+            progress.clear();
+        }
         result
     }
+}
+
+fn bootstrap_transfer_progress_bar(size: u64) -> Box<dyn ProgressBar> {
+    let progress = BootstrapProgressFactory.create_for(
+        "download_snapshot",
+        usize::try_from(size).unwrap_or(usize::MAX),
+        "{spinner:.green} Downloading {bytes_per_sec:>10} {bar:40.green} [{bytes:>10}/{total_bytes:<10}] ({eta} remaining)",
+    );
+    progress.tick(0);
+    progress
 }
 
 fn transfer_progress_bar(action: &str, size: u64) -> TerminalProgressBar {

--- a/crates/amaru-bootstrap/src/aws.rs
+++ b/crates/amaru-bootstrap/src/aws.rs
@@ -221,7 +221,7 @@ impl S3Client {
             .await
             .map(|_| ())
             .map_err(Into::into);
-        progress.clear();
+        progress.finish_and_clear();
         result
     }
 
@@ -332,7 +332,7 @@ fn bootstrap_transfer_progress_bar(size: u64) -> Box<dyn ProgressBar> {
         usize::try_from(size).unwrap_or(usize::MAX),
         "{spinner:.green} Downloading {bytes_per_sec:>10} {bar:40.green} [{bytes:>10}/{total_bytes:<10}] ({eta} remaining)",
     );
-    progress.tick(0);
+    progress.refresh();
     progress
 }
 
@@ -343,7 +343,7 @@ fn transfer_progress_bar(action: &str, size: u64) -> TerminalProgressBar {
             "{{spinner:.green}} {action} {{bytes_per_sec:>10}} {{bar:40.green}} [{{bytes:>10}}/{{total_bytes:<10}}] ({{eta}} remaining)"
         ),
     );
-    progress.tick(0);
+    progress.refresh();
     progress
 }
 

--- a/crates/amaru-bootstrap/src/bootstrap/mod.rs
+++ b/crates/amaru-bootstrap/src/bootstrap/mod.rs
@@ -799,7 +799,7 @@ fn import_node_snapshot_archive_data(
                 previous_accounts.take().ok_or_else(|| {
                     anyhow!("multiple {SNAPSHOT_STATE_FILE_NAME} in archive {}?", archive_path.display())
                 })?,
-                BootstrapProgressFactory,
+                &BootstrapProgressFactory,
             )?);
         } else if snapshot_archive_entry_matches(&path, Path::new(SNAPSHOT_UTXO_FILE_NAME)) {
             let (epoch, point, era_history, chain_state) = imported_state.take().ok_or_else(|| {
@@ -809,7 +809,7 @@ fn import_node_snapshot_archive_data(
                 )
             })?;
 
-            import_utxo_from_tvar(&mut entry, db, BootstrapProgressFactory, &point, &era_history, network)?;
+            import_utxo_from_tvar(&mut entry, db, &BootstrapProgressFactory, &point, &era_history, network)?;
 
             return Ok((epoch, point, chain_state));
         }

--- a/crates/amaru-bootstrap/src/bootstrap/mod.rs
+++ b/crates/amaru-bootstrap/src/bootstrap/mod.rs
@@ -17,7 +17,7 @@ use std::{
     fs,
     io::{self, Read},
     path::{Component, Path, PathBuf},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use amaru_kernel::{
@@ -27,7 +27,7 @@ use amaru_kernel::{
 use amaru_ledger::store::{EpochTransitionProgress, ReadStore, Store, TransactionalContext};
 use amaru_observability::{error, info};
 use amaru_ouroboros::{BaseReadChainStore, ChainStore, Nonces, OpcertSequenceNumbers, WriteChainStore};
-use amaru_progress_bar::{ProgressBar, TerminalProgressBar};
+use amaru_progress_bar::ProgressBarFactory;
 use amaru_stores::rocksdb::{ReadOnlyRocksDB, RocksDB, RocksDbConfig, consensus::RocksDBStore};
 use anyhow::anyhow;
 use pallas_network::{facades::PeerClient, miniprotocols::chainsync::NextResponse};
@@ -42,6 +42,7 @@ use chain_sync_client::{ChainSyncClient, from_pallas_point, from_pallas_tip};
 use crate::{
     aws::{AnonymousS3Client, S3Config},
     cardano_node::tvar::{import_state_from_tvar, import_utxo_from_tvar},
+    progress::BootstrapProgressFactory,
 };
 
 /// S3-backed snapshot descriptor used during bootstrap.
@@ -442,6 +443,7 @@ pub async fn bootstrap(
     target_epoch: Option<Epoch>,
     s3_config: S3Config,
 ) -> anyhow::Result<()> {
+    let started_at = Instant::now();
     let s3 = AnonymousS3Client::new(s3_config);
     let snapshots = bootstrap_snapshots(network, &s3, &snapshots_dir).await?;
     let [first_snapshot, second_snapshot, third_snapshot] = select_bootstrap_snapshots(&snapshots, target_epoch)?;
@@ -496,6 +498,13 @@ pub async fn bootstrap(
         third_snapshot,
     )?;
     import_packaged_blocks(&chain_db, blocks).await?;
+
+    info!(
+        bootstrap::COMPLETE,
+        duration_seconds = started_at.elapsed().as_secs_f64(),
+        epoch = imported_third_snapshot.epoch,
+        point = third_snapshot.point.clone(),
+    );
 
     Ok(())
 }
@@ -718,7 +727,11 @@ async fn import_node_snapshot_source(
     fs::create_dir_all(ledger_dir)?;
 
     let previous_accounts = if fs::exists(ledger_dir.join("live"))? {
-        let progress = TerminalProgressBar::new(0_u64, "{spinner:.green} Loading previous accounts");
+        let progress = BootstrapProgressFactory.create_for(
+            "load_previous_accounts",
+            0,
+            "{spinner:.green} Loading previous accounts",
+        );
 
         let live = ReadOnlyRocksDB::new(&RocksDbConfig::new(ledger_dir.to_path_buf()))?;
         let previous_accounts = live
@@ -729,7 +742,7 @@ async fn import_node_snapshot_source(
 
         fs::remove_dir_all(ledger_dir.join("live"))?;
 
-        progress.clear();
+        progress.finish();
 
         previous_accounts
     } else {
@@ -792,7 +805,7 @@ fn import_node_snapshot_archive_data(
                 previous_accounts.take().ok_or_else(|| {
                     anyhow!("multiple {SNAPSHOT_STATE_FILE_NAME} in archive {}?", archive_path.display())
                 })?,
-                |size, template| TerminalProgressBar::new(size as u64, template).boxed(),
+                BootstrapProgressFactory,
             )?);
         } else if snapshot_archive_entry_matches(&path, Path::new(SNAPSHOT_UTXO_FILE_NAME)) {
             let (epoch, point, era_history, chain_state) = imported_state.take().ok_or_else(|| {
@@ -802,14 +815,7 @@ fn import_node_snapshot_archive_data(
                 )
             })?;
 
-            import_utxo_from_tvar(
-                &mut entry,
-                db,
-                |size, template| TerminalProgressBar::new(size as u64, template).boxed(),
-                &point,
-                &era_history,
-                network,
-            )?;
+            import_utxo_from_tvar(&mut entry, db, BootstrapProgressFactory, &point, &era_history, network)?;
 
             return Ok((epoch, point, chain_state));
         }

--- a/crates/amaru-bootstrap/src/bootstrap/mod.rs
+++ b/crates/amaru-bootstrap/src/bootstrap/mod.rs
@@ -17,7 +17,7 @@ use std::{
     fs,
     io::{self, Read},
     path::{Component, Path, PathBuf},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use amaru_kernel::{
@@ -27,13 +27,15 @@ use amaru_kernel::{
 use amaru_ledger::store::{EpochTransitionProgress, ReadStore, Store, TransactionalContext};
 use amaru_observability::{error, info};
 use amaru_ouroboros::{BaseReadChainStore, ChainStore, Nonces, OpcertSequenceNumbers, WriteChainStore};
-use amaru_progress_bar::ProgressBarFactory;
 use amaru_stores::rocksdb::{ReadOnlyRocksDB, RocksDB, RocksDbConfig, consensus::RocksDBStore};
 use anyhow::anyhow;
 use pallas_network::{facades::PeerClient, miniprotocols::chainsync::NextResponse};
 use serde::{Deserialize, Serialize};
 use tar::Archive;
-use tokio::{fs as async_fs, time::timeout};
+use tokio::{
+    fs as async_fs,
+    time::{Instant, timeout},
+};
 use zstd::Decoder as ZstdDecoder;
 
 mod chain_sync_client;
@@ -727,12 +729,6 @@ async fn import_node_snapshot_source(
     fs::create_dir_all(ledger_dir)?;
 
     let previous_accounts = if fs::exists(ledger_dir.join("live"))? {
-        let progress = BootstrapProgressFactory.create_for(
-            "load_previous_accounts",
-            0,
-            "{spinner:.green} Loading previous accounts",
-        );
-
         let live = ReadOnlyRocksDB::new(&RocksDbConfig::new(ledger_dir.to_path_buf()))?;
         let previous_accounts = live
             .iter_accounts()?
@@ -741,8 +737,6 @@ async fn import_node_snapshot_source(
             .collect();
 
         fs::remove_dir_all(ledger_dir.join("live"))?;
-
-        progress.finish();
 
         previous_accounts
     } else {

--- a/crates/amaru-bootstrap/src/cardano_node/tvar.rs
+++ b/crates/amaru-bootstrap/src/cardano_node/tvar.rs
@@ -53,7 +53,7 @@ pub fn import_snapshot_from_tvar<S, F, State, Utxo>(
 ) -> anyhow::Result<(Epoch, Point, Option<ChainState>)>
 where
     S: Store,
-    F: ProgressBarFactory + Copy,
+    F: ProgressBarFactory,
     State: Read,
     Utxo: Read,
 {
@@ -64,26 +64,25 @@ where
         global_parameters,
         nonce_tail,
         previous_accounts,
-        with_progress,
+        &with_progress,
     )?;
 
-    import_utxo_from_tvar(utxo_file, db, with_progress, &point, &era_history, network)?;
+    import_utxo_from_tvar(utxo_file, db, &with_progress, &point, &era_history, network)?;
 
     Ok((epoch, point, chain_state))
 }
 
-pub(crate) fn import_state_from_tvar<S, F, State>(
+pub(crate) fn import_state_from_tvar<S, State>(
     db: &S,
     state_file: &mut State,
     network: NetworkName,
     global_parameters: &GlobalParameters,
     nonce_tail: Option<HeaderHash>,
     previous_accounts: BTreeSet<Credential>,
-    with_progress: F,
+    with_progress: &impl ProgressBarFactory,
 ) -> anyhow::Result<(Epoch, Point, EraHistory, Option<ChainState>)>
 where
     S: Store,
-    F: ProgressBarFactory + Copy,
     State: Read,
 {
     let mut decoder = LazyDecoder::new(state_file);
@@ -109,34 +108,32 @@ where
     Ok((epoch, point, parsed_snapshot.era_history, chain_state))
 }
 
-pub(crate) fn import_utxo_from_tvar<S, F, Utxo>(
+pub(crate) fn import_utxo_from_tvar<S, Utxo>(
     utxo_file: &mut Utxo,
     db: &S,
-    with_progress: F,
+    with_progress: &impl ProgressBarFactory,
     point: &Point,
     era_history: &EraHistory,
     network: NetworkName,
 ) -> anyhow::Result<()>
 where
     S: Store,
-    F: ProgressBarFactory + Copy,
     Utxo: Read,
 {
     let mut decoder = LazyDecoder::new(utxo_file);
     import_tvar_utxo(&mut decoder, db, with_progress, point, era_history, network)
 }
 
-fn import_tvar_utxo<S, F>(
+fn import_tvar_utxo<S>(
     decoder: &mut LazyDecoder<'_>,
     db: &S,
-    with_progress: F,
+    with_progress: &impl ProgressBarFactory,
     point: &Point,
     era_history: &EraHistory,
     network: NetworkName,
 ) -> anyhow::Result<()>
 where
     S: Store,
-    F: ProgressBarFactory + Copy,
 {
     let protocol_parameters = db.protocol_parameters()?;
 

--- a/crates/amaru-bootstrap/src/cardano_node/tvar.rs
+++ b/crates/amaru-bootstrap/src/cardano_node/tvar.rs
@@ -34,7 +34,7 @@ use amaru_ledger::{
     store::{Columns, Store, TransactionalContext},
 };
 use amaru_observability::info;
-use amaru_progress_bar::ProgressBar;
+use amaru_progress_bar::ProgressBarFactory;
 use anyhow::anyhow;
 
 use super::{extract_snapshot_chain_state_after_ledger, mempack, parse_state_snapshot_prefix};
@@ -53,7 +53,7 @@ pub fn import_snapshot_from_tvar<S, F, State, Utxo>(
 ) -> anyhow::Result<(Epoch, Point, Option<ChainState>)>
 where
     S: Store,
-    F: Fn(usize, &str) -> Box<dyn ProgressBar> + Copy,
+    F: ProgressBarFactory + Copy,
     State: Read,
     Utxo: Read,
 {
@@ -83,7 +83,7 @@ pub(crate) fn import_state_from_tvar<S, F, State>(
 ) -> anyhow::Result<(Epoch, Point, EraHistory, Option<ChainState>)>
 where
     S: Store,
-    F: Fn(usize, &str) -> Box<dyn ProgressBar> + Copy,
+    F: ProgressBarFactory + Copy,
     State: Read,
 {
     let mut decoder = LazyDecoder::new(state_file);
@@ -119,7 +119,7 @@ pub(crate) fn import_utxo_from_tvar<S, F, Utxo>(
 ) -> anyhow::Result<()>
 where
     S: Store,
-    F: Fn(usize, &str) -> Box<dyn ProgressBar> + Copy,
+    F: ProgressBarFactory + Copy,
     Utxo: Read,
 {
     let mut decoder = LazyDecoder::new(utxo_file);
@@ -136,7 +136,7 @@ fn import_tvar_utxo<S, F>(
 ) -> anyhow::Result<()>
 where
     S: Store,
-    F: Fn(usize, &str) -> Box<dyn ProgressBar> + Copy,
+    F: ProgressBarFactory + Copy,
 {
     let protocol_parameters = db.protocol_parameters()?;
 
@@ -147,7 +147,8 @@ where
 
     let estimated_size = size.unwrap_or(network.estimated_utxo_size());
 
-    let progress = with_progress(
+    let progress = with_progress.create_for(
+        "import_utxo",
         estimated_size,
         "{spinner:.green} Importing UTxO entries {bar:40.green} [{pos:>7}/{len:7}] ({eta} remaining)",
     );
@@ -225,7 +226,7 @@ where
         }
     }
 
-    progress.clear();
+    progress.finish();
     info!(bootstrap::import::UTXO, size = actual_size);
 
     Ok(())

--- a/crates/amaru-bootstrap/src/lib.rs
+++ b/crates/amaru-bootstrap/src/lib.rs
@@ -125,6 +125,7 @@
 pub mod aws;
 pub mod bootstrap;
 pub mod cardano_node;
+mod progress;
 
 pub use aws::{
     ARCHIVE_EXTENSION, AnonymousS3Client, DEFAULT_BUCKET, DEFAULT_ENDPOINT, DEFAULT_PUBLIC_URL, DEFAULT_REGION,

--- a/crates/amaru-bootstrap/src/progress.rs
+++ b/crates/amaru-bootstrap/src/progress.rs
@@ -65,6 +65,25 @@ impl StructuredProgressBar {
             elapsed_seconds = self.started_at.elapsed().as_secs_f64(),
         );
     }
+
+    fn cancel(&self) {
+        let current = self.state().cancel();
+        if let Some(current) = current {
+            info!(
+                bootstrap::progress::CANCEL,
+                phase = self.phase.to_owned(),
+                current,
+                total = @self.total,
+                elapsed_seconds = self.started_at.elapsed().as_secs_f64(),
+            );
+        }
+    }
+}
+
+impl Drop for StructuredProgressBar {
+    fn drop(&mut self) {
+        self.cancel();
+    }
 }
 
 impl ProgressBar for StructuredProgressBar {
@@ -76,16 +95,7 @@ impl ProgressBar for StructuredProgressBar {
     }
 
     fn clear(self: Box<Self>) {
-        let current = self.state().cancel();
-        if let Some(current) = current {
-            info!(
-                bootstrap::progress::CANCEL,
-                phase = self.phase.to_owned(),
-                current,
-                total = @self.total,
-                elapsed_seconds = self.started_at.elapsed().as_secs_f64(),
-            );
-        }
+        self.cancel();
     }
 
     fn finish(self: Box<Self>) {
@@ -148,7 +158,21 @@ impl ProgressState {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::mpsc::sync_channel;
+
+    use amaru_observability::{TelemetryCaptureLayer, tracing, tracing_subscriber};
+    use tracing_subscriber::prelude::*;
+
     use super::*;
+
+    fn capture_progress_events(run: impl FnOnce()) -> Vec<String> {
+        let (tx, rx) = sync_channel(8);
+        let subscriber = tracing_subscriber::registry().with(TelemetryCaptureLayer::new(tx));
+
+        tracing::subscriber::with_default(subscriber, run);
+
+        rx.try_iter().map(|record| record.name).collect()
+    }
 
     #[test]
     fn tracks_updates_and_always_reports_final_position() {
@@ -173,5 +197,28 @@ mod tests {
         state.cancel();
 
         assert_eq!(state.finish(), None);
+    }
+
+    #[test]
+    fn dropping_an_unfinished_progress_bar_cancels_it() {
+        let events = capture_progress_events(|| {
+            let progress = StructuredProgressBar::new("test", Some(10));
+            progress.tick(3);
+        });
+
+        assert_eq!(events, ["progress.start", "progress.cancel"]);
+    }
+
+    #[test]
+    fn terminal_calls_do_not_emit_an_additional_cancel_on_drop() {
+        let cleared = capture_progress_events(|| {
+            Box::new(StructuredProgressBar::new("test", Some(10))).clear();
+        });
+        assert_eq!(cleared, ["progress.start", "progress.cancel"]);
+
+        let finished = capture_progress_events(|| {
+            Box::new(StructuredProgressBar::new("test", Some(10))).finish();
+        });
+        assert_eq!(finished, ["progress.start", "progress.complete"]);
     }
 }

--- a/crates/amaru-bootstrap/src/progress.rs
+++ b/crates/amaru-bootstrap/src/progress.rs
@@ -14,25 +14,21 @@
 
 use std::{
     io::{self, IsTerminal},
-    sync::{Arc, Mutex, Weak},
-    thread,
-    time::{Duration, Instant},
+    sync::Mutex,
+    time::Duration,
 };
 
 use amaru_observability::info;
 use amaru_progress_bar::{ProgressBar, ProgressBarFactory, TerminalProgressBar};
+use tokio::time::Instant;
 
-const LOG_INTERVAL: Duration = Duration::from_secs(30);
+const LOG_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Selects an interactive progress bar or structured progress events for bootstrap work.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct BootstrapProgressFactory;
 
 impl ProgressBarFactory for BootstrapProgressFactory {
-    fn create(&self, length: usize, template: &str) -> Box<dyn ProgressBar> {
-        self.create_for("bootstrap", length, template)
-    }
-
     fn create_for(&self, phase: &'static str, length: usize, template: &str) -> Box<dyn ProgressBar> {
         if io::stderr().is_terminal() {
             TerminalProgressBar::new(length as u64, template).boxed()
@@ -43,10 +39,6 @@ impl ProgressBarFactory for BootstrapProgressFactory {
 }
 
 struct StructuredProgressBar {
-    inner: Arc<StructuredProgress>,
-}
-
-struct StructuredProgress {
     phase: &'static str,
     total: Option<usize>,
     started_at: Instant,
@@ -57,13 +49,9 @@ impl StructuredProgressBar {
     fn new(phase: &'static str, total: Option<usize>) -> Self {
         let started_at = Instant::now();
         info!(bootstrap::progress::START, phase = phase.to_owned(), total = @total);
-        let inner = Arc::new(StructuredProgress { phase, total, started_at, state: Mutex::new(ProgressState::new()) });
-        spawn_heartbeat(Arc::downgrade(&inner));
-        Self { inner }
+        Self { phase, total, started_at, state: Mutex::new(ProgressState::new()) }
     }
-}
 
-impl StructuredProgress {
     fn state(&self) -> std::sync::MutexGuard<'_, ProgressState> {
         self.state.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
     }
@@ -81,67 +69,71 @@ impl StructuredProgress {
 
 impl ProgressBar for StructuredProgressBar {
     fn tick(&self, size: usize) {
-        self.inner.state().advance(size);
+        let current = self.state().advance(size, self.started_at.elapsed());
+        if let Some(current) = current {
+            self.emit_update(current);
+        }
     }
 
-    fn clear(&self) {
-        self.inner.state().cancel();
+    fn clear(self: Box<Self>) {
+        let current = self.state().cancel();
+        if let Some(current) = current {
+            info!(
+                bootstrap::progress::CANCEL,
+                phase = self.phase.to_owned(),
+                current,
+                total = @self.total,
+                elapsed_seconds = self.started_at.elapsed().as_secs_f64(),
+            );
+        }
     }
 
-    fn finish(&self) {
-        let current = self.inner.state().finish();
+    fn finish(self: Box<Self>) {
+        let current = self.state().finish();
         if let Some(current) = current {
             info!(
                 bootstrap::progress::COMPLETE,
-                phase = self.inner.phase.to_owned(),
+                phase = self.phase.to_owned(),
                 current,
-                total = @self.inner.total,
-                elapsed_seconds = self.inner.started_at.elapsed().as_secs_f64(),
+                total = @self.total,
+                elapsed_seconds = self.started_at.elapsed().as_secs_f64(),
             );
         }
     }
 }
 
-fn spawn_heartbeat(progress: Weak<StructuredProgress>) {
-    let _heartbeat = thread::Builder::new().name("amaru-bootstrap-progress".to_owned()).spawn(move || {
-        loop {
-            thread::sleep(LOG_INTERVAL);
-            let Some(progress) = progress.upgrade() else {
-                break;
-            };
-            let state = progress.state();
-            match state.snapshot() {
-                Some(current) => progress.emit_update(current),
-                None => break,
-            }
-        }
-    });
-}
-
 struct ProgressState {
     current: usize,
     finished: bool,
+    last_emitted_at: Duration,
 }
 
 impl ProgressState {
     fn new() -> Self {
-        Self { current: 0, finished: false }
+        Self { current: 0, finished: false, last_emitted_at: Duration::ZERO }
     }
 
-    fn advance(&mut self, size: usize) {
+    fn advance(&mut self, size: usize, elapsed: Duration) -> Option<usize> {
         if self.finished {
-            return;
+            return None;
         }
 
         self.current = self.current.saturating_add(size);
+        if size == 0 || elapsed.saturating_sub(self.last_emitted_at) < LOG_INTERVAL {
+            return None;
+        }
+
+        self.last_emitted_at = elapsed;
+        Some(self.current)
     }
 
-    fn snapshot(&self) -> Option<usize> {
-        (!self.finished).then_some(self.current)
-    }
+    fn cancel(&mut self) -> Option<usize> {
+        if self.finished {
+            return None;
+        }
 
-    fn cancel(&mut self) {
         self.finished = true;
+        Some(self.current)
     }
 
     fn finish(&mut self) -> Option<usize> {
@@ -162,21 +154,22 @@ mod tests {
     fn tracks_updates_and_always_reports_final_position() {
         let mut state = ProgressState::new();
 
-        state.advance(10);
-        state.advance(5);
-        assert_eq!(state.snapshot(), Some(15));
-        state.advance(7);
-        assert_eq!(state.finish(), Some(22));
+        assert_eq!(state.advance(10, Duration::ZERO), None);
+        assert_eq!(state.advance(5, LOG_INTERVAL - Duration::from_millis(1)), None);
+        assert_eq!(state.advance(7, LOG_INTERVAL), Some(22));
+        assert_eq!(state.advance(3, LOG_INTERVAL + Duration::from_secs(1)), None);
+        assert_eq!(state.advance(4, LOG_INTERVAL + LOG_INTERVAL), Some(29));
+
+        assert_eq!(state.finish(), Some(29));
         assert_eq!(state.finish(), None);
-        state.advance(1);
-        assert_eq!(state.snapshot(), None);
+        assert_eq!(state.advance(1, LOG_INTERVAL + LOG_INTERVAL + LOG_INTERVAL), None);
     }
 
     #[test]
     fn cancellation_does_not_report_completion() {
         let mut state = ProgressState::new();
 
-        state.advance(10);
+        state.advance(10, Duration::ZERO);
         state.cancel();
 
         assert_eq!(state.finish(), None);

--- a/crates/amaru-bootstrap/src/progress.rs
+++ b/crates/amaru-bootstrap/src/progress.rs
@@ -1,0 +1,184 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    io::{self, IsTerminal},
+    sync::{Arc, Mutex, Weak},
+    thread,
+    time::{Duration, Instant},
+};
+
+use amaru_observability::info;
+use amaru_progress_bar::{ProgressBar, ProgressBarFactory, TerminalProgressBar};
+
+const LOG_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Selects an interactive progress bar or structured progress events for bootstrap work.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BootstrapProgressFactory;
+
+impl ProgressBarFactory for BootstrapProgressFactory {
+    fn create(&self, length: usize, template: &str) -> Box<dyn ProgressBar> {
+        self.create_for("bootstrap", length, template)
+    }
+
+    fn create_for(&self, phase: &'static str, length: usize, template: &str) -> Box<dyn ProgressBar> {
+        if io::stderr().is_terminal() {
+            TerminalProgressBar::new(length as u64, template).boxed()
+        } else {
+            Box::new(StructuredProgressBar::new(phase, (length > 0).then_some(length)))
+        }
+    }
+}
+
+struct StructuredProgressBar {
+    inner: Arc<StructuredProgress>,
+}
+
+struct StructuredProgress {
+    phase: &'static str,
+    total: Option<usize>,
+    started_at: Instant,
+    state: Mutex<ProgressState>,
+}
+
+impl StructuredProgressBar {
+    fn new(phase: &'static str, total: Option<usize>) -> Self {
+        let started_at = Instant::now();
+        info!(bootstrap::progress::START, phase = phase.to_owned(), total = @total);
+        let inner = Arc::new(StructuredProgress { phase, total, started_at, state: Mutex::new(ProgressState::new()) });
+        spawn_heartbeat(Arc::downgrade(&inner));
+        Self { inner }
+    }
+}
+
+impl StructuredProgress {
+    fn state(&self) -> std::sync::MutexGuard<'_, ProgressState> {
+        self.state.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn emit_update(&self, current: usize) {
+        info!(
+            bootstrap::progress::UPDATE,
+            phase = self.phase.to_owned(),
+            current,
+            total = @self.total,
+            elapsed_seconds = self.started_at.elapsed().as_secs_f64(),
+        );
+    }
+}
+
+impl ProgressBar for StructuredProgressBar {
+    fn tick(&self, size: usize) {
+        self.inner.state().advance(size);
+    }
+
+    fn clear(&self) {
+        self.inner.state().cancel();
+    }
+
+    fn finish(&self) {
+        let current = self.inner.state().finish();
+        if let Some(current) = current {
+            info!(
+                bootstrap::progress::COMPLETE,
+                phase = self.inner.phase.to_owned(),
+                current,
+                total = @self.inner.total,
+                elapsed_seconds = self.inner.started_at.elapsed().as_secs_f64(),
+            );
+        }
+    }
+}
+
+fn spawn_heartbeat(progress: Weak<StructuredProgress>) {
+    let _heartbeat = thread::Builder::new().name("amaru-bootstrap-progress".to_owned()).spawn(move || {
+        loop {
+            thread::sleep(LOG_INTERVAL);
+            let Some(progress) = progress.upgrade() else {
+                break;
+            };
+            let state = progress.state();
+            match state.snapshot() {
+                Some(current) => progress.emit_update(current),
+                None => break,
+            }
+        }
+    });
+}
+
+struct ProgressState {
+    current: usize,
+    finished: bool,
+}
+
+impl ProgressState {
+    fn new() -> Self {
+        Self { current: 0, finished: false }
+    }
+
+    fn advance(&mut self, size: usize) {
+        if self.finished {
+            return;
+        }
+
+        self.current = self.current.saturating_add(size);
+    }
+
+    fn snapshot(&self) -> Option<usize> {
+        (!self.finished).then_some(self.current)
+    }
+
+    fn cancel(&mut self) {
+        self.finished = true;
+    }
+
+    fn finish(&mut self) -> Option<usize> {
+        if self.finished {
+            return None;
+        }
+
+        self.finished = true;
+        Some(self.current)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tracks_updates_and_always_reports_final_position() {
+        let mut state = ProgressState::new();
+
+        state.advance(10);
+        state.advance(5);
+        assert_eq!(state.snapshot(), Some(15));
+        state.advance(7);
+        assert_eq!(state.finish(), Some(22));
+        assert_eq!(state.finish(), None);
+        state.advance(1);
+        assert_eq!(state.snapshot(), None);
+    }
+
+    #[test]
+    fn cancellation_does_not_report_completion() {
+        let mut state = ProgressState::new();
+
+        state.advance(10);
+        state.cancel();
+
+        assert_eq!(state.finish(), None);
+    }
+}

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -378,8 +378,10 @@ fn decode_initial_snapshot(
     decoder.skip()?; // dsPtrs
     decoder.skip()?; // dsFutureGenDelegs
     decoder.skip()?; // dsGenDelegs
+    remaining_state_progress.increment();
 
     skip_embedded_utxo(decoder).map_err(|err| anyhow!("skip embedded utxo: {err}"))?;
+    remaining_state_progress.increment();
 
     decoder.skip().map_err(|err| anyhow!("decode deposited: {err}"))?;
     let fees: i64 = decoder.decode().map_err(|err| anyhow!("decode fees: {err}"))?;
@@ -414,6 +416,7 @@ fn decode_initial_snapshot(
             minimum_version: e.minimum_version,
         },
     )?;
+    remaining_state_progress.increment();
 
     import_default_account_deposits(
         db,
@@ -426,6 +429,7 @@ fn decode_initial_snapshot(
     let (pools, pools_updates, pools_retirements) =
         decode_node_pool_state(&mut cbor::Decoder::new(&raw_pool_state), network, protocol_parameters.protocol_version)
             .map_err(|err| anyhow!("{}", format_pool_state_decode_error(err)))?;
+    remaining_state_progress.increment();
 
     decoder.skip()?; // Previous Protocol Params
     decoder.skip()?; // Future Protocol Params
@@ -435,6 +439,7 @@ fn decode_initial_snapshot(
     decoder.skip()?; // DRep distr
     decoder.skip()?; // DRep state
     decoder.skip()?; // Pool distr
+    remaining_state_progress.increment();
 
     let (enacted_proposals, SerialisedAsSet(expired_proposals)): (
         Vec<ProposalState>,
@@ -450,12 +455,14 @@ fn decode_initial_snapshot(
             Ok((enacted, expired))
         })
         .map_err(|err| anyhow!("decode ratify state: {err}"))?;
+    remaining_state_progress.increment();
 
     // Epoch State / Ledger State / UTxO State / utxosStakeDistr
     decoder.skip()?;
 
     // Epoch State / Ledger State / UTxO State / utxosDonation
     let donations: u64 = decoder.decode()?;
+    remaining_state_progress.increment();
 
     // Epoch State / Snapshots
     decoder.begin_array()?;
@@ -464,6 +471,7 @@ fn decode_initial_snapshot(
     skip_stake_snapshot_lazy(decoder)?; // Epoch State / Snapshots / Go
     decoder.skip()?; // Epoch State / Snapshots / Fee
     decoder.skip()?; // Epoch State / NonMyopic
+    remaining_state_progress.increment();
 
     let is_complete = decoder
         .with_decoder(|d| {
@@ -485,6 +493,7 @@ fn decode_initial_snapshot(
             Ok(is_complete)
         })
         .map_err(|err| anyhow!("decode rewards update: {err}"))?;
+    remaining_state_progress.increment();
 
     remaining_state_progress.finish();
 

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -566,7 +566,7 @@ pub fn import_initial_snapshot(
         point,
         era_history,
         network,
-        with_progress,
+        &with_progress,
     )
 }
 
@@ -580,7 +580,7 @@ pub fn import_initial_snapshot_with_decoder(
     point: &Point,
     era_history: &EraHistory,
     network: NetworkName,
-    with_progress: impl ProgressBarFactory,
+    with_progress: &impl ProgressBarFactory,
 ) -> anyhow::Result<Epoch> {
     let tip = point.slot_or_default();
     let expected_epoch = era_history.slot_to_epoch(tip, tip)?;
@@ -617,7 +617,7 @@ pub fn import_initial_snapshot_with_decoder(
         expected_epoch,
         network,
         era_history,
-        &with_progress,
+        with_progress,
     )?;
 
     import_protocol_parameters(db, &protocol_parameters)?;

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -32,7 +32,7 @@ use amaru_kernel::{
     utils::cbor::{SerialisedAsArray, SerialisedAsSet},
 };
 use amaru_observability::{info, warn};
-use amaru_progress_bar::ProgressBar;
+use amaru_progress_bar::ProgressBarFactory;
 use anyhow::anyhow;
 
 use crate::{
@@ -161,7 +161,7 @@ fn import_rewards(
     decoder: &mut LazyDecoder<'_>,
     db: &impl Store,
     rewards_size: usize,
-    with_progress: &impl Fn(usize, &str) -> Box<dyn ProgressBar>,
+    with_progress: &impl ProgressBarFactory,
 ) -> anyhow::Result<u64> {
     let (progress, unclaimed_rewards) = decoder.stream_map(
         |d| {
@@ -172,7 +172,8 @@ fn import_rewards(
         },
         |length| {
             (
-                with_progress(
+                with_progress.create_for(
+                    "import_rewards",
                     length.map(|size| size as usize).unwrap_or(rewards_size),
                     "{spinner:.green} Importing rewards {bar:40.green} [{pos:>7}/{len:7}] ({eta} remaining)",
                 ),
@@ -192,7 +193,7 @@ fn import_rewards(
         },
     )?;
 
-    progress.clear();
+    progress.finish();
     Ok(unclaimed_rewards)
 }
 
@@ -202,7 +203,7 @@ fn import_accounts(
     point: &Point,
     network: NetworkName,
     mut recently_unregistered_accounts: BTreeSet<Credential>,
-    with_progress: &impl Fn(usize, &str) -> Box<dyn ProgressBar>,
+    with_progress: &impl ProgressBarFactory,
 ) -> anyhow::Result<ImportedAccounts> {
     if db.iter_accounts()?.next().is_some() {
         warn!(bootstrap::accounts::IS_NOT_EMPTY);
@@ -220,7 +221,8 @@ fn import_accounts(
                 NetworkName::Testnet(_) => 1,
             });
             (
-                with_progress(
+                with_progress.create_for(
+                    "import_accounts",
                     estimated_size,
                     "{spinner:.green} Importing accounts {bar:40.green} [{pos:>7}/{len:7}] ({eta} remaining)",
                 ),
@@ -246,7 +248,7 @@ fn import_accounts(
         },
     )?;
 
-    progress.clear();
+    progress.finish();
 
     info!(bootstrap::accounts::IMPORT, size);
 
@@ -290,14 +292,15 @@ fn import_default_account_deposits(
     db: &impl Store,
     point: &Point,
     default_deposit: Lovelace,
-    with_progress: &impl Fn(usize, &str) -> Box<dyn ProgressBar>,
+    with_progress: &impl ProgressBarFactory,
     mut accounts: Vec<(Credential, NodeAccount)>,
 ) -> anyhow::Result<()> {
     if accounts.is_empty() {
         return Ok(());
     }
 
-    let progress = with_progress(
+    let progress = with_progress.create_for(
+        "adjust_account_deposits",
         accounts.len(),
         "{spinner:.green} Adjusting default account deposits {bar:40.green} [{pos:>7}/{len:7}] ({eta} remaining)",
     );
@@ -307,7 +310,7 @@ fn import_default_account_deposits(
 
     save_bootstrap_account_batches(db, awaiting, |size| progress.tick(size))?;
 
-    progress.clear();
+    progress.finish();
     Ok(())
 }
 
@@ -326,7 +329,7 @@ fn decode_initial_snapshot(
     expected_epoch: Epoch,
     network: NetworkName,
     era_history: &EraHistory,
-    with_progress: &impl Fn(usize, &str) -> Box<dyn ProgressBar>,
+    with_progress: &impl ProgressBarFactory,
 ) -> anyhow::Result<InitialSnapshot> {
     let epoch: Epoch = decoder.with_decoder(|d| decode_initial_snapshot_prefix(d, expected_epoch))?;
 
@@ -355,7 +358,7 @@ fn decode_initial_snapshot(
     let governance_activity = GovernanceActivity { consecutive_dormant_epochs: u64::from(dormant_epoch) as u32 };
     info!(bootstrap::governance_activity::IMPORT, dormant_epochs = governance_activity.consecutive_dormant_epochs);
 
-    let pool_state_progress = with_progress(0, "{spinner:.green} Reading pool state");
+    let pool_state_progress = with_progress.create_for("read_pool_state", 0, "{spinner:.green} Reading pool state");
     // Pool parameters contain protocol-version-sensitive byte strings, but the snapshot's
     // protocol version appears later in the payload. Keep the encoded pool state until then.
     let raw_pool_state: Vec<u8> = decoder.with_decoder(|d| {
@@ -363,13 +366,14 @@ fn decode_initial_snapshot(
         d.skip()?;
         Ok(d.input()[start..d.position()].to_vec())
     })?;
-    pool_state_progress.clear();
+    pool_state_progress.finish();
 
     let ImportedAccounts { recently_unregistered_accounts, awaiting_default_deposit, account_len } =
         import_accounts(decoder, db, point, network, previous_accounts, with_progress)
             .map_err(|err| anyhow!("decode accounts: {err}"))?;
 
-    let remaining_state_progress = with_progress(0, "{spinner:.green} Reading remaining ledger state");
+    let remaining_state_progress =
+        with_progress.create_for("read_ledger_state", 0, "{spinner:.green} Reading remaining ledger state");
 
     decoder.skip()?; // dsPtrs
     decoder.skip()?; // dsFutureGenDelegs
@@ -482,7 +486,7 @@ fn decode_initial_snapshot(
         })
         .map_err(|err| anyhow!("decode rewards update: {err}"))?;
 
-    remaining_state_progress.clear();
+    remaining_state_progress.finish();
 
     let (delta_treasury, delta_reserves, unclaimed_rewards, delta_fees) = if is_complete {
         let delta_treasury: i64 = decoder.decode()?;
@@ -543,7 +547,7 @@ pub fn import_initial_snapshot(
     point: &Point,
     era_history: &EraHistory,
     network: NetworkName,
-    with_progress: impl Fn(usize, &str) -> Box<dyn ProgressBar>,
+    with_progress: impl ProgressBarFactory,
 ) -> anyhow::Result<Epoch> {
     let mut decoder = LazyDecoder::new(reader);
     import_initial_snapshot_with_decoder(
@@ -567,7 +571,7 @@ pub fn import_initial_snapshot_with_decoder(
     point: &Point,
     era_history: &EraHistory,
     network: NetworkName,
-    with_progress: impl Fn(usize, &str) -> Box<dyn ProgressBar>,
+    with_progress: impl ProgressBarFactory,
 ) -> anyhow::Result<Epoch> {
     let tip = point.slot_or_default();
     let expected_epoch = era_history.slot_to_epoch(tip, tip)?;

--- a/crates/amaru-mithril/src/download.rs
+++ b/crates/amaru-mithril/src/download.rs
@@ -70,7 +70,7 @@ impl FeedbackReceiver for MithrilFeedbackReceiver {
                 MithrilEventCardanoDatabase::ImmutableDownloadCompleted { .. }
                 | MithrilEventCardanoDatabase::AncillaryDownloadCompleted { .. } => {
                     if let Some(pb) = self.cardano_database_pb.lock().await.as_ref() {
-                        pb.tick(1);
+                        pb.increment();
                     }
                 }
                 _ => {}
@@ -84,7 +84,7 @@ impl FeedbackReceiver for MithrilFeedbackReceiver {
             }
             MithrilEvent::CertificateValidated { .. } | MithrilEvent::CertificateFetchedFromCache { .. } => {
                 if let Some(pb) = self.certificate_validation_pb.lock().await.as_ref() {
-                    pb.tick(1);
+                    pb.increment();
                 }
             }
             MithrilEvent::CertificateChainValidated { .. } => {

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -1119,6 +1119,12 @@ define_schemas! {
             }
         }
         bootstrap {
+            /// Bootstrap completed successfully
+            public COMPLETE {
+                required duration_seconds: f64
+                required epoch: amaru_kernel::Epoch
+                required point: String
+            }
             accounts {
                 /// Existing accounts found in the store before import
                 public IS_NOT_EMPTY {}
@@ -1228,6 +1234,27 @@ define_schemas! {
                     required constitutional_committee: String
                     required hard_fork: String
                     required protocol_parameters: String
+                }
+            }
+            progress {
+                /// Start a long-running bootstrap phase
+                public START {
+                    required phase: String
+                    optional total: usize
+                }
+                /// Report non-terminal progress for a long-running bootstrap phase
+                public UPDATE {
+                    required phase: String
+                    required current: usize
+                    optional total: usize
+                    required elapsed_seconds: f64
+                }
+                /// Complete a long-running bootstrap phase
+                public COMPLETE {
+                    required phase: String
+                    required current: usize
+                    optional total: usize
+                    required elapsed_seconds: f64
                 }
             }
             proposals {

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -1249,6 +1249,13 @@ define_schemas! {
                     optional total: usize
                     required elapsed_seconds: f64
                 }
+                /// Cancel a long-running bootstrap phase
+                public CANCEL {
+                    required phase: String
+                    required current: usize
+                    optional total: usize
+                    required elapsed_seconds: f64
+                }
                 /// Complete a long-running bootstrap phase
                 public COMPLETE {
                     required phase: String

--- a/crates/amaru-progress-bar/src/lib.rs
+++ b/crates/amaru-progress-bar/src/lib.rs
@@ -16,38 +16,67 @@
 ///
 /// The main use case is to allow decoupling certain long-running functions from their UI elements,
 /// so that they can be re-used in tests and be part of crates that must compile irrespective of
-/// the platform
+/// the platform.
+///
+/// A progress bar is active from creation until either [`ProgressBar::clear`] or
+/// [`ProgressBar::finish`] consumes it. It cannot be restarted after either terminal operation.
 pub trait ProgressBar: Send + Sync {
+    /// Advance the reported progress by `size` caller-defined units.
+    ///
+    /// The unit must match the `length` passed to [`ProgressBarFactory::create_for`]: for example,
+    /// bytes for a download, entries for an import, or milestones for a multi-step operation.
+    /// A declared length may be an estimate, so implementations must tolerate cumulative progress
+    /// exceeding it.
     fn tick(&self, size: usize);
-    fn clear(&self);
+
+    /// Advance the reported progress by one unit.
+    ///
+    /// This is equivalent to `tick(1)` and is intended for a completed item or milestone.
+    fn increment(&self) {
+        self.tick(1);
+    }
+
+    /// Refresh the visual indicator without advancing the reported progress.
+    ///
+    /// Implementations without an animated or interactive representation may ignore this.
+    fn refresh(&self) {
+        self.tick(0);
+    }
+
+    /// Cancel the tracked operation and remove its visual indicator.
+    ///
+    /// Cancellation is terminal, so this consumes the progress-bar handle. No subsequent ticks or
+    /// terminal operation are possible through that handle.
+    fn clear(self: Box<Self>);
 
     /// Mark the tracked operation as successfully completed and remove its visual indicator.
     ///
     /// Renderers that distinguish completion from cancellation can override this method. The
-    /// default keeps existing progress bars source-compatible by treating completion as a clear.
-    fn finish(&self) {
+    /// default treats completion as a clear. Completion is terminal and may occur before the
+    /// declared length is reached, so this consumes the progress-bar handle.
+    fn finish(self: Box<Self>) {
         self.clear();
     }
 }
 
 /// Creates progress indicators while allowing callers to attach a stable phase name.
 ///
-/// The blanket implementation preserves the existing `(length, template)` closure API. Renderers
-/// that need semantic phase names, such as structured non-terminal logging, can implement this
-/// trait directly and override [`ProgressBarFactory::create_for`].
+/// The blanket implementation preserves the existing `(length, template)` closure API by ignoring
+/// the phase name. Renderers that need semantic phase names, such as structured non-terminal
+/// logging, can implement this trait directly.
 pub trait ProgressBarFactory {
-    fn create(&self, length: usize, template: &str) -> Box<dyn ProgressBar>;
-
-    fn create_for(&self, _phase: &'static str, length: usize, template: &str) -> Box<dyn ProgressBar> {
-        self.create(length, template)
-    }
+    /// Create a progress bar for a named phase.
+    ///
+    /// `length` is the expected total in the same caller-defined unit later passed to
+    /// [`ProgressBar::tick`]. A length of zero means that the total is unknown.
+    fn create_for(&self, phase: &'static str, length: usize, template: &str) -> Box<dyn ProgressBar>;
 }
 
 impl<F> ProgressBarFactory for F
 where
     F: Fn(usize, &str) -> Box<dyn ProgressBar>,
 {
-    fn create(&self, length: usize, template: &str) -> Box<dyn ProgressBar> {
+    fn create_for(&self, _phase: &'static str, length: usize, template: &str) -> Box<dyn ProgressBar> {
         self(length, template)
     }
 }

--- a/crates/amaru-progress-bar/src/lib.rs
+++ b/crates/amaru-progress-bar/src/lib.rs
@@ -20,6 +20,36 @@
 pub trait ProgressBar: Send + Sync {
     fn tick(&self, size: usize);
     fn clear(&self);
+
+    /// Mark the tracked operation as successfully completed and remove its visual indicator.
+    ///
+    /// Renderers that distinguish completion from cancellation can override this method. The
+    /// default keeps existing progress bars source-compatible by treating completion as a clear.
+    fn finish(&self) {
+        self.clear();
+    }
+}
+
+/// Creates progress indicators while allowing callers to attach a stable phase name.
+///
+/// The blanket implementation preserves the existing `(length, template)` closure API. Renderers
+/// that need semantic phase names, such as structured non-terminal logging, can implement this
+/// trait directly and override [`ProgressBarFactory::create_for`].
+pub trait ProgressBarFactory {
+    fn create(&self, length: usize, template: &str) -> Box<dyn ProgressBar>;
+
+    fn create_for(&self, _phase: &'static str, length: usize, template: &str) -> Box<dyn ProgressBar> {
+        self.create(length, template)
+    }
+}
+
+impl<F> ProgressBarFactory for F
+where
+    F: Fn(usize, &str) -> Box<dyn ProgressBar>,
+{
+    fn create(&self, length: usize, template: &str) -> Box<dyn ProgressBar> {
+        self(length, template)
+    }
 }
 
 mod no_progress_bar;

--- a/crates/amaru-progress-bar/src/no_progress_bar.rs
+++ b/crates/amaru-progress-bar/src/no_progress_bar.rs
@@ -23,5 +23,5 @@ pub fn no_progress_bar(_length: usize, _template: &str) -> Box<dyn ProgressBar> 
 
 impl ProgressBar for NoProgressBar {
     fn tick(&self, _size: usize) {}
-    fn clear(&self) {}
+    fn clear(self: Box<Self>) {}
 }

--- a/crates/amaru-progress-bar/src/terminal_progress_bar.rs
+++ b/crates/amaru-progress-bar/src/terminal_progress_bar.rs
@@ -38,6 +38,11 @@ impl TerminalProgressBar {
     pub fn boxed(self) -> Box<dyn ProgressBar> {
         Box::new(self)
     }
+
+    /// Finish a terminal progress bar that is shared with progress-reporting callbacks.
+    pub fn finish_and_clear(&self) {
+        self.inner.finish_and_clear();
+    }
 }
 
 impl ProgressBar for TerminalProgressBar {
@@ -45,7 +50,7 @@ impl ProgressBar for TerminalProgressBar {
         self.inner.inc(size as u64);
     }
 
-    fn clear(&self) {
-        self.inner.finish_and_clear();
+    fn clear(self: Box<Self>) {
+        self.finish_and_clear();
     }
 }

--- a/crates/amaru/src/bin/amaru/cmd/snapshot/create/db_analyser.rs
+++ b/crates/amaru/src/bin/amaru/cmd/snapshot/create/db_analyser.rs
@@ -126,7 +126,7 @@ impl TrackedProgress {
                 if let Ok(s) = s.lock()
                     && let Some(pb) = s.bar.as_ref()
                 {
-                    pb.tick(0);
+                    pb.refresh();
                 }
                 thread::sleep(std::time::Duration::from_millis(100));
             }
@@ -206,7 +206,11 @@ where
                                 ));
                             }
                             if let Some(pb) = s.bar.as_ref() {
-                                pb.tick(done.map(|d| d as usize).unwrap_or(0));
+                                if let Some(done) = done {
+                                    pb.tick(done as usize);
+                                } else {
+                                    pb.refresh();
+                                }
                             }
                         }
                         continue;

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -242,9 +242,21 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
+| `cancel` | `TRACE` | public | Cancel a long-running bootstrap phase | phase, current, elapsed_seconds | total |
 | `complete` | `TRACE` | public | Complete a long-running bootstrap phase | phase, current, elapsed_seconds | total |
 | `start` | `TRACE` | public | Start a long-running bootstrap phase | phase | total |
 | `update` | `TRACE` | public | Report non-terminal progress for a long-running bootstrap phase | phase, current, elapsed_seconds | total |
+
+<details><summary>span: `cancel`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `phase` | `string` | ✓ |
+| `current` | `integer` | ✓ |
+| `elapsed_seconds` | `number` | ✓ |
+| `total` | `integer` |  |
+
+</details>
 
 <details><summary>span: `complete`</summary>
 

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -5,6 +5,22 @@ This document lists all available spans in Amaru, auto-generated from the code.
 For information on how to use and filter these spans, see [monitoring/README.md](../monitoring/README.md).
 
 
+## target: `amaru::bootstrap`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `complete` | `TRACE` | public | Bootstrap completed successfully | duration_seconds, epoch, point |  |
+
+<details><summary>span: `complete`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `duration_seconds` | `number` | ✓ |
+| `epoch` | `integer` | ✓ |
+| `point` | `string` | ✓ |
+
+</details>
+
 ## target: `amaru::bootstrap::accounts`
 
 | name | level | public | description | required fields | optional fields |
@@ -219,6 +235,45 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | `reserves` | `integer` | ✓ |
 | `fees` | `integer` | ✓ |
 | `donations` | `integer` | ✓ |
+
+</details>
+
+## target: `amaru::bootstrap::progress`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `complete` | `TRACE` | public | Complete a long-running bootstrap phase | phase, current, elapsed_seconds | total |
+| `start` | `TRACE` | public | Start a long-running bootstrap phase | phase | total |
+| `update` | `TRACE` | public | Report non-terminal progress for a long-running bootstrap phase | phase, current, elapsed_seconds | total |
+
+<details><summary>span: `complete`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `phase` | `string` | ✓ |
+| `current` | `integer` | ✓ |
+| `elapsed_seconds` | `number` | ✓ |
+| `total` | `integer` |  |
+
+</details>
+
+<details><summary>span: `start`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `phase` | `string` | ✓ |
+| `total` | `integer` |  |
+
+</details>
+
+<details><summary>span: `update`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `phase` | `string` | ✓ |
+| `current` | `integer` | ✓ |
+| `elapsed_seconds` | `number` | ✓ |
+| `total` | `integer` |  |
 
 </details>
 

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -4,6 +4,35 @@
   "title": "Amaru Trace Schemas",
   "description": "JSON Schema definitions for all registered traces in Amaru",
   "definitions": {
+    "amaru::bootstrap::COMPLETE": {
+      "type": "object",
+      "properties": {
+        "duration_seconds": {
+          "type": "number"
+        },
+        "epoch": {
+          "title": "uint64",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "point": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "duration_seconds",
+        "epoch",
+        "point"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "complete",
+      "level": "TRACE",
+      "target": "amaru::bootstrap",
+      "description": "Bootstrap completed successfully",
+      "public": true
+    },
     "amaru::bootstrap::accounts::IMPORT": {
       "type": "object",
       "properties": {
@@ -425,6 +454,91 @@
       "level": "TRACE",
       "target": "amaru::bootstrap::pots",
       "description": "Import treasury/reserves/fees pots from a snapshot",
+      "public": true
+    },
+    "amaru::bootstrap::progress::COMPLETE": {
+      "type": "object",
+      "properties": {
+        "phase": {
+          "type": "string"
+        },
+        "current": {
+          "type": "integer"
+        },
+        "elapsed_seconds": {
+          "type": "number"
+        },
+        "total": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "phase",
+        "current",
+        "elapsed_seconds"
+      ],
+      "optional": [
+        "total"
+      ],
+      "additionalProperties": false,
+      "name": "complete",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::progress",
+      "description": "Complete a long-running bootstrap phase",
+      "public": true
+    },
+    "amaru::bootstrap::progress::START": {
+      "type": "object",
+      "properties": {
+        "phase": {
+          "type": "string"
+        },
+        "total": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "phase"
+      ],
+      "optional": [
+        "total"
+      ],
+      "additionalProperties": false,
+      "name": "start",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::progress",
+      "description": "Start a long-running bootstrap phase",
+      "public": true
+    },
+    "amaru::bootstrap::progress::UPDATE": {
+      "type": "object",
+      "properties": {
+        "phase": {
+          "type": "string"
+        },
+        "current": {
+          "type": "integer"
+        },
+        "elapsed_seconds": {
+          "type": "number"
+        },
+        "total": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "phase",
+        "current",
+        "elapsed_seconds"
+      ],
+      "optional": [
+        "total"
+      ],
+      "additionalProperties": false,
+      "name": "update",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::progress",
+      "description": "Report non-terminal progress for a long-running bootstrap phase",
       "public": true
     },
     "amaru::bootstrap::proposal_roots::IMPORT": {

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -456,6 +456,37 @@
       "description": "Import treasury/reserves/fees pots from a snapshot",
       "public": true
     },
+    "amaru::bootstrap::progress::CANCEL": {
+      "type": "object",
+      "properties": {
+        "phase": {
+          "type": "string"
+        },
+        "current": {
+          "type": "integer"
+        },
+        "elapsed_seconds": {
+          "type": "number"
+        },
+        "total": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "phase",
+        "current",
+        "elapsed_seconds"
+      ],
+      "optional": [
+        "total"
+      ],
+      "additionalProperties": false,
+      "name": "cancel",
+      "level": "TRACE",
+      "target": "amaru::bootstrap::progress",
+      "description": "Cancel a long-running bootstrap phase",
+      "public": true
+    },
     "amaru::bootstrap::progress::COMPLETE": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
When user run amaru on non-tty env (like embedded, as part of systemd,..) ouput appears stuck as interactive progress bar is diabled. Improve this by detecting when tty is not enabled on printing periodic progress as regular logs.

Experiment with ` cargo run --release -- node bootstrap --network mainnet 2> >(tee /tmp/amaru.log >&2)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Bootstrap operations now report phase starts, updates, cancellations, completions, and total duration through structured logs.
  - Redirected and service logs receive periodic progress heartbeats during long imports.
  - Terminal users retain interactive progress indicators with improved completion behavior.

- **Documentation**
  - Added documentation and schemas for bootstrap lifecycle and progress events.

- **Bug Fixes**
  - Prevented long-running bootstrap imports from appearing stalled when output is redirected.
  - Improved progress tracking during snapshot imports, downloads, and ledger-state processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->