### PR TITLE
fix: incorrect cleanup procedure

### DIFF
--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -128,6 +128,24 @@ where
     tip_update_emitter: TipUpdateEmitter,
 }
 
+impl<S: Store, HS: HistoricalStores> Drop for State<S, HS> {
+    fn drop(&mut self) {
+        // Dropping a JoinHandle detaches its worker, which may otherwise keep using snapshot stores
+        // after the ledger and even the process-wide RocksDB environment start shutting down.
+        if let Some(handle) = self.rewards_join_handle.take() {
+            join_background_thread(handle);
+        }
+    }
+}
+
+fn join_background_thread<T>(handle: JoinHandle<T>) {
+    // A synchronous callback can release the last State owner on this worker. The thread is
+    // already winding down in that case, and attempting to join it from itself would panic.
+    if handle.thread().id() != std::thread::current().id() {
+        let _ = handle.join();
+    }
+}
+
 impl<S: Store, HS: HistoricalStores> State<S, HS> {
     /// The last known epoch; or said differently, the epoch the volatile overlay is valid for.
     pub fn epoch(&self) -> Epoch {


### PR DESCRIPTION
Fixes sporadic bug https://github.com/pragma-org/amaru/actions/runs/33373621169/job/99430035168?pr=1287

Skip-Changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Ensured background rewards and stake-distribution processing completes cleanly before ledger state shuts down.
* Improved shutdown reliability by preventing incomplete background work from affecting ledger state cleanup.
* Avoided shutdown errors in scenarios where background processing finishes on the same execution thread.
* Reduced the risk of interrupted or inconsistent ledger state during application shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->