### PR TITLE
handshake: combine version data per the node-to-node spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Other guiding principles:
 
 ### Changed
 
+- **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record. Outbound connections still offer initiator-only diffusion (duplex is not advertised until both halves run).
 - **amaru-protocols**: `NetworkOps::connect` takes a `Peer`. Outbound dialling no longer resolves names; that stays in peer selection.
 
 ### Removed

--- a/crates/amaru-protocols/src/handshake/initiator.rs
+++ b/crates/amaru-protocols/src/handshake/initiator.rs
@@ -21,7 +21,10 @@ use crate::{
     protocol::{
         Initiator, Inputs, Miniprotocol, Outcome, PROTO_HANDSHAKE, ProtocolState, StageState, miniprotocol, outcome,
     },
-    protocol_messages::{handshake::HandshakeResult, version_data::VersionData, version_table::VersionTable},
+    protocol_messages::{
+        handshake::HandshakeResult, version_data::VersionData, version_number::VersionNumber,
+        version_table::VersionTable,
+    },
 };
 
 pub fn register_deserializers() -> DeserializerGuards {
@@ -89,16 +92,18 @@ impl StageState<State, Initiator> for HandshakeInitiator {
                     eff.send(&self.connection, handshake_result).await;
                     (None, self)
                 }
+                InitiatorResult::Accept(version_number, version_data) => {
+                    let result = crate::handshake::verify_accept(&self.our_versions, version_number, version_data);
+                    debug!(protocols::handshake::initiator::CONCLUSION, handshake_result = format!("{result:?}"));
+                    eff.send(&self.connection, result).await;
+                    (None, self)
+                }
                 InitiatorResult::SimOpen(version_table) => {
                     debug!(
                         protocols::handshake::initiator::SIMULTANEOUS_OPEN,
                         version_table = format!("{version_table:?}")
                     );
-                    let result = crate::handshake::compute_negotiation_result(
-                        crate::protocol::Role::Initiator,
-                        self.our_versions.clone(),
-                        version_table,
-                    );
+                    let result = crate::handshake::compute_negotiation_result(&self.our_versions, &version_table);
                     eff.send(&self.connection, result).await;
                     (None, self)
                 }
@@ -135,10 +140,9 @@ impl ProtocolState<Initiator> for State {
                 // TCP simultaneous open
                 (outcome().result(InitiatorResult::SimOpen(version_table)), Self::Done)
             }
-            Message::Accept(version_number, version_data) => (
-                outcome().result(InitiatorResult::Conclusion(HandshakeResult::Accepted(version_number, version_data))),
-                Self::Done,
-            ),
+            Message::Accept(version_number, version_data) => {
+                (outcome().result(InitiatorResult::Accept(version_number, version_data)), Self::Done)
+            }
             Message::Refuse(refuse_reason) => {
                 (outcome().result(InitiatorResult::Conclusion(HandshakeResult::Refused(refuse_reason))), Self::Done)
             }
@@ -161,6 +165,7 @@ impl ProtocolState<Initiator> for State {
 #[derive(Debug, PartialEq)]
 pub enum InitiatorResult {
     Propose,
+    Accept(VersionNumber, VersionData),
     Conclusion(HandshakeResult),
     SimOpen(VersionTable<VersionData>),
 }
@@ -169,6 +174,7 @@ impl InitiatorResult {
     pub fn message_type(&self) -> &str {
         match self {
             Self::Propose => "Propose",
+            Self::Accept(..) => "Accept",
             Self::Conclusion(_) => "Conclusion",
             Self::SimOpen(_) => "SimOpen",
         }

--- a/crates/amaru-protocols/src/handshake/mod.rs
+++ b/crates/amaru-protocols/src/handshake/mod.rs
@@ -22,7 +22,7 @@ use amaru_kernel::NetworkMagic;
 pub use messages::Message;
 
 use crate::{
-    protocol::{ProtoSpec, ProtocolState, Role, RoleT},
+    protocol::{ProtoSpec, ProtocolState, RoleT},
     protocol_messages::{
         handshake::{HandshakeResult, RefuseReason},
         version_data::{PEER_SHARING_DISABLED, VersionData},
@@ -46,22 +46,47 @@ pub enum State {
 pub use initiator::{HandshakeInitiator, initiator};
 pub use responder::{HandshakeResponder, responder};
 
-// FIXME: proper implementation of network spec needed
+/// Pick the greatest common version and combine that version's data.
+///
+/// On `query`, the result carries **our** table (the responder sends `MsgQueryReply` with its own
+/// offer; the initiator only concludes locally). Simultaneous open uses the same combination.
 pub fn compute_negotiation_result(
-    _role: Role,
-    ours: VersionTable<VersionData>,
-    theirs: VersionTable<VersionData>,
+    ours: &VersionTable<VersionData>,
+    theirs: &VersionTable<VersionData>,
 ) -> HandshakeResult {
-    use crate::protocol_messages::handshake::RefuseReason;
-    let mut their_versions = theirs.values.keys().collect::<Vec<_>>();
-    their_versions.sort();
-    their_versions.reverse();
-    for their_version in their_versions {
-        if let Some(our_version) = ours.values.get(their_version) {
-            return HandshakeResult::Accepted(*their_version, our_version.clone());
-        }
+    let Some(version) = ours.values.keys().rev().find(|v| theirs.values.contains_key(v)).copied() else {
+        return HandshakeResult::Refused(RefuseReason::VersionMismatch(ours.values.keys().copied().collect()));
+    };
+    let our_data = &ours.values[&version];
+    let their_data = &theirs.values[&version];
+    match our_data.combine(their_data) {
+        Err(msg) => HandshakeResult::Refused(RefuseReason::Refused(version, msg.to_string())),
+        Ok(agreed) if agreed.query() => HandshakeResult::Query(ours.clone()),
+        Ok(agreed) => HandshakeResult::Accepted(version, agreed),
     }
-    HandshakeResult::Refused(RefuseReason::VersionMismatch(ours.values.keys().copied().collect()))
+}
+
+/// Initiator check of `MsgAcceptVersion`: the record must be the combination of our offer
+/// for that version with the record on the wire. `query` is not a session (`MsgQueryReply`).
+pub(crate) fn verify_accept(
+    ours: &VersionTable<VersionData>,
+    version: VersionNumber,
+    accepted: VersionData,
+) -> HandshakeResult {
+    let Some(our_data) = ours.values.get(&version) else {
+        return HandshakeResult::Refused(RefuseReason::Refused(version, "version not offered".to_string()));
+    };
+    match our_data.combine(&accepted) {
+        Err(msg) => HandshakeResult::Refused(RefuseReason::Refused(version, msg.to_string())),
+        Ok(agreed) if agreed.query() => {
+            HandshakeResult::Refused(RefuseReason::Refused(version, "query is not a session".to_string()))
+        }
+        Ok(agreed) if agreed != accepted => HandshakeResult::Refused(RefuseReason::Refused(
+            version,
+            "version data is not the agreed record".to_string(),
+        )),
+        Ok(agreed) => HandshakeResult::Accepted(version, agreed),
+    }
 }
 
 pub fn spec<R: RoleT>() -> ProtoSpec<State, Message<VersionData>, R>
@@ -88,4 +113,171 @@ where
     spec.resp(Confirm, refuse(), Done);
     spec.resp(Confirm, query_reply(), Done);
     spec
+}
+
+#[cfg(test)]
+#[expect(clippy::wildcard_enum_match_arm)]
+mod negotiation_tests {
+    use amaru_kernel::{NetworkMagic, cbor};
+
+    use super::*;
+    use crate::protocol_messages::version_data::PEER_SHARING_ENABLED;
+
+    fn data(magic: NetworkMagic, initiator_only: bool, sharing: bool, query: bool) -> VersionData {
+        VersionData::new(
+            magic,
+            initiator_only,
+            if sharing { PEER_SHARING_ENABLED } else { PEER_SHARING_DISABLED },
+            query,
+        )
+    }
+
+    fn table(entries: &[(u64, VersionData)]) -> VersionTable<VersionData> {
+        VersionTable { values: entries.iter().map(|(v, d)| (VersionNumber::new(*v), d.clone())).collect() }
+    }
+
+    #[test]
+    fn picks_greatest_common_version() {
+        let magic = NetworkMagic::PREPROD;
+        let ours = table(&[(11, data(magic, false, true, false)), (14, data(magic, false, true, false))]);
+        let theirs = table(&[(12, data(magic, false, false, false)), (14, data(magic, false, true, false))]);
+        assert_eq!(
+            compute_negotiation_result(&ours, &theirs),
+            HandshakeResult::Accepted(VersionNumber::V14, data(magic, false, true, false))
+        );
+    }
+
+    #[test]
+    fn version_mismatch_lists_our_versions() {
+        let magic = NetworkMagic::PREPROD;
+        let ours = table(&[(14, data(magic, false, false, false))]);
+        let theirs = table(&[(11, data(magic, false, false, false))]);
+        assert_eq!(
+            compute_negotiation_result(&ours, &theirs),
+            HandshakeResult::Refused(RefuseReason::VersionMismatch(vec![VersionNumber::V14]))
+        );
+    }
+
+    #[test]
+    fn refuses_network_magic_mismatch() {
+        let ours = table(&[(14, data(NetworkMagic::PREPROD, false, false, false))]);
+        let theirs = table(&[(14, data(NetworkMagic::MAINNET, false, false, false))]);
+        assert_eq!(
+            compute_negotiation_result(&ours, &theirs),
+            HandshakeResult::Refused(RefuseReason::Refused(VersionNumber::V14, "network magic mismatch".to_string()))
+        );
+    }
+
+    #[test]
+    fn initiator_only_is_or() {
+        let magic = NetworkMagic::PREPROD;
+        let ours = table(&[(14, data(magic, true, false, false))]);
+        let theirs = table(&[(14, data(magic, false, false, false))]);
+        match compute_negotiation_result(&ours, &theirs) {
+            HandshakeResult::Accepted(VersionNumber::V14, agreed) => {
+                assert!(agreed.initiator_only_diffusion_mode());
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn peer_sharing_is_and() {
+        let magic = NetworkMagic::PREPROD;
+        let ours = table(&[(14, data(magic, false, true, false))]);
+        let theirs = table(&[(14, data(magic, false, false, false))]);
+        match compute_negotiation_result(&ours, &theirs) {
+            HandshakeResult::Accepted(VersionNumber::V14, agreed) => {
+                assert!(!agreed.is_advertisable());
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn query_returns_our_table() {
+        let magic = NetworkMagic::PREPROD;
+        let ours = table(&[(14, data(magic, false, true, true))]);
+        let theirs = table(&[(14, data(magic, false, true, false))]);
+        assert_eq!(compute_negotiation_result(&ours, &theirs), HandshakeResult::Query(ours));
+    }
+
+    #[test]
+    fn verify_accept_requires_agreed_record() {
+        let magic = NetworkMagic::PREPROD;
+        let ours = table(&[(14, data(magic, true, true, false))]);
+        let honest = data(magic, true, true, false);
+        assert_eq!(
+            verify_accept(&ours, VersionNumber::V14, honest.clone()),
+            HandshakeResult::Accepted(VersionNumber::V14, honest)
+        );
+        let lying = data(magic, false, true, false);
+        assert_eq!(
+            verify_accept(&ours, VersionNumber::V14, lying),
+            HandshakeResult::Refused(RefuseReason::Refused(
+                VersionNumber::V14,
+                "version data is not the agreed record".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn verify_accept_rejects_query_as_session() {
+        let magic = NetworkMagic::PREPROD;
+        let ours = table(&[(14, data(magic, false, false, true))]);
+        assert_eq!(
+            verify_accept(&ours, VersionNumber::V14, data(magic, false, false, true)),
+            HandshakeResult::Refused(RefuseReason::Refused(VersionNumber::V14, "query is not a session".to_string()))
+        );
+    }
+
+    #[test]
+    fn outbound_offer_remains_initiator_only() {
+        let table = VersionTable::v11_and_above(NetworkMagic::PREPROD, true, true);
+        for data in table.values.values() {
+            assert!(data.initiator_only_diffusion_mode());
+        }
+    }
+
+    fn decode_hex(hex: &str) -> Message<VersionData> {
+        let bytes = hex::decode(hex).expect(hex);
+        cbor::decode(&bytes).unwrap_or_else(|e| panic!("{hex}: {e}"))
+    }
+
+    /// Blueprint `handshake/test-data` vectors (hex of one CBOR message).
+    #[test]
+    fn blueprint_handshake_vectors_decode() {
+        assert!(matches!(decode_hex("8200a0"), Message::Propose(t) if t.values.is_empty()));
+        assert_eq!(
+            decode_hex("820283020d617b"),
+            Message::Refuse(RefuseReason::Refused(VersionNumber::new(13), "{".to_string()))
+        );
+        match decode_hex("8200a10e8400f401f4") {
+            Message::Propose(t) => {
+                let d = t.values.get(&VersionNumber::V14).expect("v14");
+                assert_eq!(d.network_magic(), NetworkMagic::new(0));
+                assert!(!d.initiator_only_diffusion_mode());
+                assert!(d.is_advertisable());
+                assert!(!d.query());
+            }
+            other => panic!("{other:?}"),
+        }
+        match decode_hex("8200a20d8401f501f40e8402f501f4") {
+            Message::Propose(t) => {
+                assert_eq!(t.values.len(), 2);
+                assert_eq!(t.values[&VersionNumber::new(13)].network_magic(), NetworkMagic::new(1));
+                assert_eq!(t.values[&VersionNumber::V14].network_magic(), NetworkMagic::new(2));
+            }
+            other => panic!("{other:?}"),
+        }
+        match decode_hex("83010e8401f401f4") {
+            Message::Accept(VersionNumber::V14, d) => {
+                assert_eq!(d.network_magic(), NetworkMagic::new(1));
+                assert!(!d.initiator_only_diffusion_mode());
+                assert!(d.is_advertisable());
+                assert!(!d.query());
+            }
+            other => panic!("{other:?}"),
+        }
+    }
 }

--- a/crates/amaru-protocols/src/handshake/responder.rs
+++ b/crates/amaru-protocols/src/handshake/responder.rs
@@ -78,11 +78,7 @@ impl StageState<State, Responder> for HandshakeResponder {
         let version_table = input.0.to_string();
 
         async move {
-            let result = crate::handshake::compute_negotiation_result(
-                crate::protocol::Role::Responder,
-                self.our_versions.clone(),
-                input.0,
-            );
+            let result = crate::handshake::compute_negotiation_result(&self.our_versions, &input.0);
             eff.send(&self.connection, result.clone()).await;
             Ok((Some(result.into()), self))
         }

--- a/crates/amaru-protocols/src/protocol_messages/version_data.rs
+++ b/crates/amaru-protocols/src/protocol_messages/version_data.rs
@@ -40,6 +40,18 @@ impl VersionData {
         VersionData { network_magic, initiator_only_diffusion_mode, peer_sharing, query }
     }
 
+    pub fn network_magic(&self) -> NetworkMagic {
+        self.network_magic
+    }
+
+    pub fn initiator_only_diffusion_mode(&self) -> bool {
+        self.initiator_only_diffusion_mode
+    }
+
+    pub fn query(&self) -> bool {
+        self.query
+    }
+
     /// Returns whether this peer can act as both initiator and responder (full duplex).
     /// See initiator_only_diffusion_mode in the handshake spec.
     pub fn is_full_duplex_capable(&self) -> bool {
@@ -49,6 +61,27 @@ impl VersionData {
     /// Whether the remote peer is willing to be advertised via peer sharing (`peer_sharing == 1`).
     pub fn is_advertisable(&self) -> bool {
         self.peer_sharing == PEER_SHARING_ENABLED
+    }
+
+    /// Combine two version-data records for the same NTN version (v14/v15 rules).
+    ///
+    /// `networkMagic` must match. `initiatorOnlyDiffusionMode` and `query` are OR;
+    /// `peerSharing` is 1 only if both offers are 1.
+    pub(crate) fn combine(&self, other: &Self) -> Result<Self, &'static str> {
+        if self.network_magic != other.network_magic {
+            return Err("network magic mismatch");
+        }
+        let peer_sharing = if self.peer_sharing == PEER_SHARING_ENABLED && other.peer_sharing == PEER_SHARING_ENABLED {
+            PEER_SHARING_ENABLED
+        } else {
+            PEER_SHARING_DISABLED
+        };
+        Ok(Self {
+            network_magic: self.network_magic,
+            initiator_only_diffusion_mode: self.initiator_only_diffusion_mode || other.initiator_only_diffusion_mode,
+            peer_sharing,
+            query: self.query || other.query,
+        })
     }
 }
 


### PR DESCRIPTION
Stacked on #1303.

Handshake now picks the greatest common version and combines that version's records as specified: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. A true `query` flag is not a session (`MsgQueryReply` with our table). The initiator checks that `MsgAcceptVersion` carries the agreed record.

Outbound still offers initiator-only diffusion. Duplex is not advertised until a later PR actually runs both halves.

## Test plan
- `cargo test -p amaru-protocols --lib handshake`
- Negotiation unit tests for magic, OR/AND, query, accept verification
- Blueprint handshake test-data vectors decode