### PR TITLE
feat: consolidation telemetry global options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,9 @@ Other guiding principles:
 - **amaru-kernel**: `PeerCandidate` is `Socket` (already a `Peer`), `Host` (hostname+port, A/AAAA) or `Srv` (DNS name). `Host`/`Srv` names are a validated [`DnsName`] (no colons, brackets, or IP literals). Outbound mix pools are `PeerCandidate`s (static included); Host/SRV names are resolved on each dial so DNS changes are picked up. Host lookup takes the first viable A/AAAA; SRV lookup tries `_cardano._tcp.<name>` in RFC 2782 priority order and stops at the first viable target address. Ledger relays pass through as candidates (socket, hostname+port, or CIP-0155 SRV when the port is omitted).
 - **amaru-pure-stage**: `Effects::detach` runs an external effect without occupying the airlock. The transition is resumed with `()` immediately; when `run()` completes the interpreter applies the provided constructor and enqueues the value on the calling stage’s bulk mailbox.
 - **amaru-tui**: the Peers card shows the bootstrap `PeerCandidate` next to a resolved socket address when that name came from a Host or SRV lookup.
-- **amaru / amaru-node**: allow operators to select the OTLP providers constructed at startup with
-  `--open-telemetry-signals` or `AMARU_OPEN_TELEMETRY_SIGNALS`; it accepts any comma-separated subset of `metrics`,
-  `traces`, and `logs`, and defaults to all three signals for backward compatibility.
+- **amaru**: allow operators to select the OTLP providers constructed at startup with
+  `--with-open-telemetry=<SIGNALS>` or `AMARU_WITH_OPEN_TELEMETRY=<SIGNALS>`; it accepts any comma-separated subset of
+  `metrics`, `traces`, and `logs`, and defaults to all three signals when enabled without a value.
 
 ### Changed
 

--- a/crates/amaru/src/bin/amaru/cli.rs
+++ b/crates/amaru/src/bin/amaru/cli.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::str::FromStr;
+
 use amaru::{
     lifecycle::Runnable,
     observability::{Color, ObservabilityHints},
 };
 use amaru_kernel::GlobalParameters;
-use amaru_node::telemetry::OtelSignal;
+use amaru_node::telemetry::{OtelSignal, OtelSignals};
 use amaru_tui as tui;
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 
@@ -165,6 +167,37 @@ impl ObservabilityHints for Command {
     }
 }
 
+#[derive(Debug, Clone)]
+pub(crate) enum OpenTelemetryConfig {
+    Disabled,
+    Enabled(OtelSignals),
+}
+
+impl OpenTelemetryConfig {
+    pub(crate) fn into_parts(self) -> (bool, OtelSignals) {
+        match self {
+            Self::Disabled => (false, OtelSignals::default()),
+            Self::Enabled(signals) => (true, signals),
+        }
+    }
+}
+
+impl FromStr for OpenTelemetryConfig {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_ascii_lowercase().as_str() {
+            "true" | "t" | "yes" | "y" | "on" | "1" => Ok(Self::Enabled(OtelSignals::default())),
+            "false" | "f" | "no" | "n" | "off" | "0" => Ok(Self::Disabled),
+            _ => value
+                .split(',')
+                .map(OtelSignal::from_str)
+                .collect::<Result<Vec<_>, _>>()
+                .map(|signals| Self::Enabled(signals.into())),
+        }
+    }
+}
+
 #[derive(Debug, Parser)]
 #[clap(name = "Amaru")]
 #[clap(bin_name = "amaru")]
@@ -181,20 +214,17 @@ pub(crate) struct Cli {
     #[clap(long, global = true, action, env = "AMARU_WITH_JSON_TRACES")]
     pub(crate) with_json_traces: bool,
 
-    /// Export metrics, traces, and logs via OpenTelemetry (OTLP).
-    #[clap(long, global = true, action, env = "AMARU_WITH_OPEN_TELEMETRY")]
-    pub(crate) with_open_telemetry: bool,
-
-    /// Select which OpenTelemetry signals to export.
+    /// Export OpenTelemetry signals via OTLP; without a value, export all signals.
     #[clap(
-        long,
+        long = "with-open-telemetry",
         global = true,
-        env = "AMARU_OPEN_TELEMETRY_SIGNALS",
-        default_value = "metrics,traces,logs",
-        value_delimiter = ',',
+        env = "AMARU_WITH_OPEN_TELEMETRY",
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
         value_name = "SIGNALS"
     )]
-    pub(crate) open_telemetry_signals: Vec<OtelSignal>,
+    pub(crate) open_telemetry: Option<OpenTelemetryConfig>,
 }
 
 pub(crate) fn command(version: &'static str) -> clap::Command {

--- a/crates/amaru/src/bin/amaru/main.rs
+++ b/crates/amaru/src/bin/amaru/main.rs
@@ -58,8 +58,8 @@ fn try_main() -> anyhow::Result<()> {
     let signals = install_termination_signals().context("failed to install signal handlers")?;
 
     let color_enabled = Color::is_enabled(cli.color);
-    let with_open_telemetry = cli.with_open_telemetry;
-    let open_telemetry_signals = cli.open_telemetry_signals.into();
+    let (with_open_telemetry, open_telemetry_signals) =
+        cli.open_telemetry.unwrap_or(cli::OpenTelemetryConfig::Disabled).into_parts();
     let with_json_traces = cli.with_json_traces;
     let skip_logging = cli.command.skip_logging();
     let tui_settings = cli.command.tui_settings();

--- a/crates/amaru/tests/cli.rs
+++ b/crates/amaru/tests/cli.rs
@@ -266,28 +266,26 @@ fn color_option_accepts_all_variants() -> anyhow::Result<()> {
 }
 
 #[test]
-fn open_telemetry_signals_option_is_global() -> anyhow::Result<()> {
+fn with_open_telemetry_option_is_global_and_accepts_signals() -> anyhow::Result<()> {
     let amaru = cargo_bin("amaru");
     let output =
-        Command::new(amaru).args(["dev", "traces", "dump", "--open-telemetry-signals", "traces", "--help"]).output()?;
+        Command::new(amaru).args(["dev", "traces", "dump", "--with-open-telemetry=traces,logs", "--help"]).output()?;
 
-    assert!(output.status.success(), "global --open-telemetry-signals should be accepted after a subcommand");
+    assert!(output.status.success(), "global --with-open-telemetry should accept signals after a subcommand");
     Ok(())
 }
 
 #[test]
-fn open_telemetry_signals_option_reads_its_environment_variable() -> anyhow::Result<()> {
+fn with_open_telemetry_option_keeps_boolean_environment_values() -> anyhow::Result<()> {
     let amaru = cargo_bin("amaru");
-    let output = Command::new(amaru)
-        .args(["dev", "traces", "dump", "--compact"])
-        .env("AMARU_OPEN_TELEMETRY_SIGNALS", "unknown")
-        .output()?;
+    for value in ["true", "false"] {
+        let output = Command::new(&amaru)
+            .args(["dev", "traces", "dump", "--compact"])
+            .env("AMARU_WITH_OPEN_TELEMETRY", value)
+            .output()?;
 
-    assert!(!output.status.success());
-    assert!(
-        String::from_utf8_lossy(&output.stderr).contains("invalid value 'unknown'"),
-        "invalid environment value should be reported by clap"
-    );
+        assert!(output.status.success(), "AMARU_WITH_OPEN_TELEMETRY={value} should be accepted");
+    }
     Ok(())
 }
 

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -5,14 +5,13 @@ Amaru emits metrics, logs, and spans through [OpenTelemetry](https://opentelemet
 To turn on monitoring, use the following CLI options when running the application:
 
 - `--with-open-telemetry` (or env variable `AMARU_WITH_OPEN_TELEMETRY`) to export OpenTelemetry metrics, logs, and spans
-- `--open-telemetry-signals` (or env variable `AMARU_OPEN_TELEMETRY_SIGNALS`) to select the signals to export
 - `--with-json-traces` (or env variable `AMARU_WITH_JSON_TRACES`) to enable JSON traces on stdout
 
-By default, enabling OpenTelemetry exports all three signals. Set `--open-telemetry-signals` to a comma-separated subset
-of `metrics`, `traces`, and `logs` to construct and export only those signals. For example:
+By default, enabling OpenTelemetry exports all three signals. Pass a comma-separated subset of `metrics`, `traces`, and
+`logs` to construct and export only those signals. For example:
 
 ```console
-amaru --with-open-telemetry --open-telemetry-signals traces node run
+amaru --with-open-telemetry=traces node run
 ```
 
 Disabled signal providers are not constructed, so their signal-specific endpoints do not need to be available. An
@@ -143,8 +142,8 @@ Application metrics are exported by the collector at `http://localhost:8889/metr
 
 Amaru recognizes the following environment variables for its OpenTelemetry configuration:
 
-- `AMARU_OPEN_TELEMETRY_SIGNALS`: Environment equivalent of `--open-telemetry-signals`. Selects a comma-separated subset
-  of `metrics`, `traces`, and `logs`. Defaults to `metrics,traces,logs`.
+- `AMARU_WITH_OPEN_TELEMETRY`: Set to `true` to export all signals, `false` to disable OpenTelemetry, or a comma-separated
+  subset of `metrics`, `traces`, and `logs` to export only those signals.
 - `OTEL_SERVICE_NAME`: Sets the [service.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-name) key used to identify metrics, logs, and spans. Defaults to `amaru`.
 - `OTEL_SERVICE_INSTANCE_ID`: Sets the [service.instance.id](https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-instance-id) key used to identify this specific amaru instance
 - `OTEL_EXPORTER_OTLP_ENDPOINT`: Sets the OTLP/gRPC endpoint used to send metrics, logs, and spans. Defaults to `http://localhost:4317`

--- a/scripts/demos/common/telemetry.sh
+++ b/scripts/demos/common/telemetry.sh
@@ -22,7 +22,7 @@ open_telemetry_endpoint_reachable() {
   esac
 }
 
-# Turns auto|true|false into the true/false the nodes' --with-open-telemetry flag expects.
+# Turns auto|true|false into the boolean values accepted by AMARU_WITH_OPEN_TELEMETRY.
 resolve_open_telemetry() {
   case "${1:-auto}" in
     auto)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated OpenTelemetry configuration to use `--with-open-telemetry=<SIGNALS>` and `AMARU_WITH_OPEN_TELEMETRY=<SIGNALS>`.
  * Supports enabling telemetry with boolean values or selecting comma-separated signals such as traces and logs.
  * When enabled without a value, all supported signals are selected by default.

* **Documentation**
  * Updated monitoring guidance and examples for the new configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->