### PR TITLE
mux: SDU assembly and send timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Other guiding principles:
 
 ### Changed
 
+- **amaru-protocols**: mux times SDU assembly and send: unbounded wait for the first header byte, then 10s during the first Handshake and 30s afterwards for the rest of that SDU. Overflow of that timer tears the bearer down.
 - **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record. Outbound connections still offer initiator-only diffusion (duplex is not advertised until both halves run).
 - **amaru-protocols**: `NetworkOps::connect` takes a `Peer`. Outbound dialling no longer resolves names; that stays in peer selection.
 

--- a/crates/amaru-protocols/Cargo.toml
+++ b/crates/amaru-protocols/Cargo.toml
@@ -30,6 +30,7 @@ amaru-observability.workspace = true
 amaru-ouroboros-traits = { "workspace" = true, features = ["test-utils"] }
 amaru-ouroboros.workspace = true
 amaru-pure-stage.workspace = true
+tokio = { workspace = true, features = ["time"] }
 
 [target.'cfg(all(not(target_family="wasm"), not(target_arch="riscv32")))'.dependencies]
 amaru-deps.workspace = true

--- a/crates/amaru-protocols/src/blockfetch/pipelined.rs
+++ b/crates/amaru-protocols/src/blockfetch/pipelined.rs
@@ -646,7 +646,8 @@ mod tests {
             | MuxMessage::Buffer(..)
             | MuxMessage::FromNetwork(..)
             | MuxMessage::Written
-            | MuxMessage::Terminate => {}
+            | MuxMessage::Terminate
+            | MuxMessage::SetSduTimeout(_) => {}
         }
         log
     }

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -364,6 +364,8 @@ async fn do_handshake(
     )
     .await;
 
+    eff.send(&muxer, mux::MuxMessage::SetSduTimeout(mux::SDU_TIMEOUT_ESTABLISHED)).await;
+
     let keepalive = register_keepalive(
         *role,
         peer,

--- a/crates/amaru-protocols/src/mux.rs
+++ b/crates/amaru-protocols/src/mux.rs
@@ -18,7 +18,7 @@ use std::{
     cell::RefCell,
     collections::{VecDeque, hash_map::Entry},
     num::{NonZeroU16, NonZeroUsize},
-    time::SystemTime,
+    time::{Duration, SystemTime},
 };
 
 use amaru_kernel::{NonEmptyBytes, Peer};
@@ -42,12 +42,21 @@ pub fn register_deserializers() -> amaru_pure_stage::DeserializerGuards {
         amaru_pure_stage::register_data_deserializer::<HandlerMessage>().boxed(),
         amaru_pure_stage::register_data_deserializer::<Sent>().boxed(),
         amaru_pure_stage::register_data_deserializer::<Read>().boxed(),
+        amaru_pure_stage::register_data_deserializer::<OutgoingSdu>().boxed(),
         amaru_pure_stage::register_data_deserializer::<Peer>().boxed(),
         amaru_pure_stage::register_data_deserializer::<(ConnectionId, StageRef<MuxMessage>, Role, Peer)>().boxed(),
     ]
 }
 
 const MAX_SEGMENT_SIZE: usize = 65535;
+
+/// Mux SDU assembly/send timer during the first Handshake on a bearer.
+pub const SDU_TIMEOUT_HANDSHAKE: Duration = Duration::from_secs(10);
+/// Mux SDU assembly/send timer after that Handshake has finished.
+pub const SDU_TIMEOUT_ESTABLISHED: Duration = Duration::from_secs(30);
+
+const HEADER_LEADING_EDGE: NonZeroUsize = NonZeroUsize::MIN;
+const HEADER_REST: NonZeroUsize = NonZeroUsize::new(7).expect("7 is non-zero");
 
 /// microseconds part of the wall clock time
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -112,7 +121,16 @@ pub enum HandlerMessage {
 pub struct Sent;
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct Read;
+pub struct Read {
+    pub sdu_timeout: Duration,
+}
+
+/// One mux SDU to write, with the assembly/send timer that applies to that write.
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct OutgoingSdu {
+    pub data: NonEmptyBytes,
+    pub timeout: Duration,
+}
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum MuxMessage {
@@ -137,6 +155,8 @@ pub enum MuxMessage {
     WantNext(ProtocolId<Erased>),
     /// Reading or writing error occurred
     Terminate,
+    /// Switch the SDU assembly/send timer (10s during first Handshake, 30s afterwards).
+    SetSduTimeout(Duration),
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -150,7 +170,7 @@ pub struct State {
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 enum Connection {
     Unint(ConnectionId),
-    Init(StageRef<NonEmptyBytes>, StageRef<Read>),
+    Init(StageRef<OutgoingSdu>, StageRef<Read>),
 }
 
 impl State {
@@ -170,17 +190,17 @@ impl State {
     pub async fn init(
         &mut self,
         eff: &mut Effects<MuxMessage>,
-    ) -> (&mut Muxer, &mut bool, &StageRef<NonEmptyBytes>, &StageRef<Read>) {
+    ) -> (&mut Muxer, &mut bool, &StageRef<OutgoingSdu>, &StageRef<Read>) {
         match &mut self.conn {
             Connection::Unint(conn) => {
                 let writer = eff
                     .stage(
                         format!("writer-{}", conn),
                         move |(conn, muxer, role, peer): (ConnectionId, StageRef<MuxMessage>, Role, Peer),
-                              data: NonEmptyBytes,
+                              OutgoingSdu { data, timeout }: OutgoingSdu,
                               eff| async move {
                             Network::new(&eff)
-                                .send(conn, data)
+                                .send(conn, data, Some(timeout))
                                 .or_terminate_with(&eff, async |err| {
                                     error!(
                                         protocols::mux::FAILED,
@@ -201,7 +221,7 @@ impl State {
                 let reader = eff.stage(format!("reader-{}", conn), read_segment).await;
                 let reader = eff.supervise(reader, MuxMessage::Terminate);
                 let reader = eff.wire_up(reader, (*conn, eff.me(), self.muxer.role(), self.peer)).await;
-                eff.send(&reader, Read).await;
+                eff.send(&reader, Read { sdu_timeout: self.muxer.sdu_timeout }).await;
                 self.conn = Connection::Init(writer, reader);
             }
             Connection::Init(..) => {}
@@ -244,7 +264,7 @@ async fn handle_msg(
     eff: &Effects<MuxMessage>,
     muxer: &mut Muxer,
     sending: &mut bool,
-    writer: &StageRef<NonEmptyBytes>,
+    writer: &StageRef<OutgoingSdu>,
     reader: &StageRef<Read>,
 ) -> anyhow::Result<()> {
     match msg {
@@ -258,7 +278,7 @@ async fn handle_msg(
             if !*sending && let Some((proto_id, bytes)) = muxer.next_segment(eff).await {
                 *sending = true;
                 let header = muxer.encode_header(eff, proto_id, &bytes).await;
-                eff.send(writer, header).await;
+                eff.send(writer, OutgoingSdu { data: header, timeout: muxer.sdu_timeout }).await;
             }
             Ok(())
         }
@@ -272,7 +292,7 @@ async fn handle_msg(
                 .received(timestamp, proto_id.opposite(), bytes.into(), eff)
                 .await
                 .with_context(|| format!("reading network message for protocol {}", proto_id))?;
-            eff.send(reader, Read).await;
+            eff.send(reader, Read { sdu_timeout: muxer.sdu_timeout }).await;
             Ok(())
         }
         MuxMessage::WantNext(proto_id) => {
@@ -283,7 +303,7 @@ async fn handle_msg(
             if let Some((proto_id, bytes)) = muxer.next_segment(eff).await {
                 *sending = true;
                 let header = muxer.encode_header(eff, proto_id, &bytes).await;
-                eff.send(writer, header).await;
+                eff.send(writer, OutgoingSdu { data: header, timeout: muxer.sdu_timeout }).await;
             }
             Ok(())
         }
@@ -292,28 +312,52 @@ async fn handle_msg(
             eff.terminate::<Void>().await;
             Ok(())
         }
+        MuxMessage::SetSduTimeout(timeout) => {
+            muxer.sdu_timeout = timeout;
+            Ok(())
+        }
     }
 }
 
 async fn read_segment(
     (conn, muxer, role, peer): (ConnectionId, StageRef<MuxMessage>, Role, Peer),
-    _token: Read,
+    Read { sdu_timeout }: Read,
     eff: Effects<Read>,
 ) -> (ConnectionId, StageRef<MuxMessage>, Role, Peer) {
     let header = loop {
-        let data = Network::new(&eff)
-            .recv(conn, HEADER_LEN)
+        let first = Network::new(&eff)
+            .recv(conn, HEADER_LEADING_EDGE, None)
             .or_terminate_with(&eff, async |err| {
                 error!(
                     protocols::mux::FAILED,
                     role = role.to_string(),
                     peer,
-                    operation = "recv_header",
+                    operation = "recv_header_leading_edge",
                     error = err.to_string()
                 );
             })
             .await;
-        let Some(header) = Header::decode(&mut data.into_inner())
+
+        let started = eff.clock().await;
+        let rest = Network::new(&eff)
+            .recv(conn, HEADER_REST, Some(sdu_timeout))
+            .or_terminate_with(&eff, async |err| {
+                error!(
+                    protocols::mux::FAILED,
+                    role = role.to_string(),
+                    peer,
+                    operation = "recv_header_rest",
+                    error = err.to_string()
+                );
+            })
+            .await;
+
+        let mut header_bytes = BytesMut::with_capacity(HEADER_LEN.get());
+        header_bytes.extend_from_slice(first.as_ref());
+        header_bytes.extend_from_slice(rest.as_ref());
+        let mut header_bytes = header_bytes.freeze();
+
+        let Some(header) = Header::decode(&mut header_bytes)
             .or_terminate(&eff, async |err| {
                 error!(
                     protocols::mux::FAILED,
@@ -325,26 +369,31 @@ async fn read_segment(
             })
             .await
         else {
-            // sending frames without payload data is not explicitly forbidden, so we just ignore them
             info!(protocols::mux::EMPTY_SEGMENT, peer, role = role.to_string());
             continue;
         };
-        break header;
+
+        let now = eff.clock().await;
+        let remaining = sdu_timeout.saturating_sub(now.saturating_since(started));
+        let payload_timeout = Some(remaining.max(Duration::from_nanos(1)));
+
+        let data = Network::new(&eff)
+            .recv(conn, header.length.into(), payload_timeout)
+            .or_terminate_with(&eff, async |err| {
+                error!(
+                    protocols::mux::FAILED,
+                    peer,
+                    role = role.to_string(),
+                    operation = "recv_data",
+                    error = err.to_string()
+                );
+            })
+            .await;
+
+        break (header, data);
     };
 
-    let data = Network::new(&eff)
-        .recv(conn, header.length.into())
-        .or_terminate_with(&eff, async |err| {
-            error!(
-                protocols::mux::FAILED,
-                peer,
-                role = role.to_string(),
-                operation = "recv_data",
-                error = err.to_string()
-            );
-        })
-        .await;
-
+    let (header, data) = header;
     eff.send(&muxer, MuxMessage::FromNetwork(header.timestamp, header.proto_id, data)).await;
     (conn, muxer, role, peer)
 }
@@ -394,11 +443,18 @@ pub struct Muxer {
     outgoing: Vec<ProtocolId<Erased>>,
     next_out: usize,
     role: Role,
+    sdu_timeout: Duration,
 }
 
 impl Muxer {
     pub fn new(role: Role) -> Self {
-        Self { protocols: Protocols::new(), outgoing: Vec::new(), next_out: 0, role }
+        Self {
+            protocols: Protocols::new(),
+            outgoing: Vec::new(),
+            next_out: 0,
+            role,
+            sdu_timeout: SDU_TIMEOUT_HANDSHAKE,
+        }
     }
 
     pub fn role(&self) -> Role {
@@ -893,7 +949,7 @@ mod tests {
         {
             let hit = running.breakpoint_effect();
             let got = external::<RecvEffect>(hit.effect());
-            assert_eq!(got, &RecvEffect { conn: conn_id, bytes: HEADER_LEN });
+            assert_eq!(got, &RecvEffect::leading_edge(conn_id));
         }
         running.discard_breakpoint();
         running.run(Run::skip_wakeups()).assert_breakpoint("mux");
@@ -982,20 +1038,34 @@ mod tests {
         assert_respond(running, &cr4);
         assert_and_resume_send(running, &[(465, 4)], PROTO_HANDSHAKE);
 
-        let recv_header = RecvEffect { conn: conn_id, bytes: HEADER_LEN };
+        let recv_header = RecvEffect::leading_edge(conn_id);
+        let recv_header_rest = RecvEffect::assembly(conn_id, HEADER_REST, SDU_TIMEOUT_HANDSHAKE);
         let recv_msg =
             |running: &mut SimulationRunning, proto_id: ProtocolId<Responder>, bytes: &[u8], recv: &[&[u8]]| {
                 let mut msg = Header::encode(proto_id, bytes, Timestamp::now()).into_inner();
                 running.discard_breakpoint();
                 running.complete_external(
                     &reader,
-                    Ok::<NonEmptyBytes, ReceiveError>(msg.split_to(HEADER_LEN.get()).try_into().unwrap()),
+                    Ok::<NonEmptyBytes, ReceiveError>(msg.split_to(HEADER_LEADING_EDGE.get()).try_into().unwrap()),
+                );
+                running.run(Run::skip_wakeups()).assert_breakpoint("recv");
+                {
+                    let hit = running.breakpoint_effect();
+                    assert_eq!(external::<RecvEffect>(hit.effect()), &recv_header_rest);
+                }
+                running.discard_breakpoint();
+                running.complete_external(
+                    &reader,
+                    Ok::<NonEmptyBytes, ReceiveError>(msg.split_to(HEADER_REST.get()).try_into().unwrap()),
                 );
                 let msg = NonEmptyBytes::new(msg).unwrap();
                 running.run(Run::skip_wakeups()).assert_breakpoint("recv");
                 {
                     let hit = running.breakpoint_effect();
-                    assert_eq!(external::<RecvEffect>(hit.effect()), &RecvEffect { conn: conn_id, bytes: msg.len() });
+                    assert_eq!(
+                        external::<RecvEffect>(hit.effect()),
+                        &RecvEffect::assembly(conn_id, msg.len(), SDU_TIMEOUT_HANDSHAKE)
+                    );
                 }
                 running.discard_breakpoint();
                 running.complete_external(&reader, Ok::<NonEmptyBytes, ReceiveError>(msg));
@@ -1034,6 +1104,63 @@ mod tests {
         recv_msg(running, PROTO_HANDSHAKE.responder(), &[1, 2, 3], &[]);
         running.run(Run::skip_wakeups()).assert_terminated(mux.name());
 
+        drop_guard.defuse();
+    }
+
+    #[test]
+    fn test_sdu_timeout_after_leading_edge() {
+        let _guard = amaru_pure_stage::register_data_deserializer::<MuxMessage>();
+        let _guard = amaru_pure_stage::register_effect_deserializer::<RecvEffect>();
+        let _guard = amaru_pure_stage::register_data_deserializer::<State>();
+        let _guard = amaru_pure_stage::register_data_deserializer::<Peer>();
+        let _guard = amaru_pure_stage::register_data_deserializer::<(ConnectionId, StageRef<MuxMessage>, Role, Peer)>();
+
+        let trace_buffer = TraceBuffer::new_shared(100, 1_000_000);
+        let drop_guard = TraceBuffer::drop_guard(&trace_buffer);
+        let mut network = SimulationBuilder::default().with_trace_buffer(trace_buffer);
+        let mux = network.stage("mux", super::stage);
+        let conn_id = ConnectionId::initial();
+        let mux =
+            network.wire_up(mux, State::new(conn_id, &[(PROTO_TEST.erase(), 1024)], Role::Initiator, test_peer()));
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut running = network.run(rt.handle());
+        running.breakpoint("recv", |eff| matches!(eff, Effect::External { effect, .. } if effect.is::<RecvEffect>()));
+        running.breakpoint("spawn", |eff| matches!(eff, Effect::WireStage { .. }));
+
+        running.enqueue_msg(
+            &mux,
+            [MuxMessage::Register {
+                protocol: PROTO_TEST.erase(),
+                frame: Frame::OneCborItem,
+                handler: StageRef::named_for_tests("handler"),
+                max_buffer: 1024,
+            }],
+        );
+        running.run(Run::skip_wakeups()).assert_breakpoint("spawn");
+        let _writer = wire_child_name(&running, mux.name(), (conn_id, (*mux).clone(), Role::Initiator, test_peer()));
+        running.run(Run::skip_wakeups()).assert_breakpoint("spawn");
+        let reader = wire_child_name(&running, mux.name(), (conn_id, (*mux).clone(), Role::Initiator, test_peer()));
+
+        running.run(Run::skip_wakeups()).assert_breakpoint("recv");
+        assert_eq!(external::<RecvEffect>(running.breakpoint_effect().effect()), &RecvEffect::leading_edge(conn_id));
+        running.discard_breakpoint();
+        running.complete_external(
+            &reader,
+            Ok::<NonEmptyBytes, ReceiveError>(Bytes::copy_from_slice(&[0]).try_into().unwrap()),
+        );
+
+        running.run(Run::skip_wakeups()).assert_breakpoint("recv");
+        assert_eq!(
+            external::<RecvEffect>(running.breakpoint_effect().effect()),
+            &RecvEffect::assembly(conn_id, HEADER_REST, SDU_TIMEOUT_HANDSHAKE)
+        );
+        running.discard_breakpoint();
+        running.complete_external(
+            &reader,
+            Err::<NonEmptyBytes, ReceiveError>(ReceiveError::sdu_timeout(conn_id, SDU_TIMEOUT_HANDSHAKE)),
+        );
+        running.run(Run::skip_wakeups()).assert_terminated(mux.name());
         drop_guard.defuse();
     }
 

--- a/crates/amaru-protocols/src/network_effects.rs
+++ b/crates/amaru-protocols/src/network_effects.rs
@@ -42,9 +42,19 @@ pub trait NetworkOps {
 
     fn connect(&self, peer: Peer, timeout: Duration) -> BoxFuture<'static, Result<ConnectionId, ConnectError>>;
 
-    fn send(&self, conn: ConnectionId, data: NonEmptyBytes) -> BoxFuture<'static, Result<(), SendError>>;
+    fn send(
+        &self,
+        conn: ConnectionId,
+        data: NonEmptyBytes,
+        timeout: Option<Duration>,
+    ) -> BoxFuture<'static, Result<(), SendError>>;
 
-    fn recv(&self, conn: ConnectionId, bytes: NonZeroUsize) -> BoxFuture<'static, Result<NonEmptyBytes, ReceiveError>>;
+    fn recv(
+        &self,
+        conn: ConnectionId,
+        bytes: NonZeroUsize,
+        timeout: Option<Duration>,
+    ) -> BoxFuture<'static, Result<NonEmptyBytes, ReceiveError>>;
 
     fn close(&self, conn: ConnectionId) -> BoxFuture<'static, Result<(), CloseError>>;
 }
@@ -70,12 +80,22 @@ impl<T> NetworkOps for Network<'_, T> {
         self.0.external(ConnectEffect { peer, timeout })
     }
 
-    fn send(&self, conn: ConnectionId, data: NonEmptyBytes) -> BoxFuture<'static, Result<(), SendError>> {
-        self.0.external(SendEffect { conn, data })
+    fn send(
+        &self,
+        conn: ConnectionId,
+        data: NonEmptyBytes,
+        timeout: Option<Duration>,
+    ) -> BoxFuture<'static, Result<(), SendError>> {
+        self.0.external(SendEffect { conn, data, timeout })
     }
 
-    fn recv(&self, conn: ConnectionId, bytes: NonZeroUsize) -> BoxFuture<'static, Result<NonEmptyBytes, ReceiveError>> {
-        self.0.external(RecvEffect { conn, bytes })
+    fn recv(
+        &self,
+        conn: ConnectionId,
+        bytes: NonZeroUsize,
+        timeout: Option<Duration>,
+    ) -> BoxFuture<'static, Result<NonEmptyBytes, ReceiveError>> {
+        self.0.external(RecvEffect { conn, bytes, timeout })
     }
 
     fn close(&self, conn: ConnectionId) -> BoxFuture<'static, Result<(), CloseError>> {
@@ -190,6 +210,7 @@ impl Display for ConnectError {
 pub struct SendEffect {
     pub conn: ConnectionId,
     pub data: NonEmptyBytes,
+    pub timeout: Option<Duration>,
 }
 
 impl ExternalEffectAPI for SendEffect {
@@ -201,7 +222,17 @@ impl ExternalEffectAPI for SendEffect {
             #[expect(clippy::expect_used)]
             let resource =
                 resources.get::<ConnectionsResource>().expect("SendEffect requires a ConnectionsResource").clone();
-            resource.send(this.conn, this.data).await.map_err(|e| SendError { conn: this.conn, error: format!("{e}") })
+            let send = resource.send(this.conn, this.data);
+            let result = match this.timeout {
+                None => send.await,
+                Some(limit) => match tokio::time::timeout(limit, send).await {
+                    Ok(r) => r,
+                    Err(_) => {
+                        return Err(SendError { conn: this.conn, error: format!("sdu timeout ({limit:?})") });
+                    }
+                },
+            };
+            result.map_err(|e| SendError { conn: this.conn, error: format!("{e}") })
         })
     }
 }
@@ -223,6 +254,17 @@ impl Display for SendError {
 pub struct RecvEffect {
     pub conn: ConnectionId,
     pub bytes: NonZeroUsize,
+    pub timeout: Option<Duration>,
+}
+
+impl RecvEffect {
+    pub(crate) fn leading_edge(conn: ConnectionId) -> Self {
+        Self { conn, bytes: NonZeroUsize::MIN, timeout: None }
+    }
+
+    pub(crate) fn assembly(conn: ConnectionId, bytes: NonZeroUsize, timeout: Duration) -> Self {
+        Self { conn, bytes, timeout: Some(timeout) }
+    }
 }
 
 impl ExternalEffectAPI for RecvEffect {
@@ -234,10 +276,17 @@ impl ExternalEffectAPI for RecvEffect {
             #[expect(clippy::expect_used)]
             let resource =
                 resources.get::<ConnectionsResource>().expect("RecvEffect requires a ConnectionsResource").clone();
-            resource
-                .recv(this.conn, this.bytes)
-                .await
-                .map_err(|e| ReceiveError { conn: this.conn, error: format!("{e}") })
+            let recv = resource.recv(this.conn, this.bytes);
+            let result = match this.timeout {
+                None => recv.await,
+                Some(limit) => match tokio::time::timeout(limit, recv).await {
+                    Ok(r) => r,
+                    Err(_) => {
+                        return Err(ReceiveError::sdu_timeout(this.conn, limit));
+                    }
+                },
+            };
+            result.map_err(|e| ReceiveError { conn: this.conn, error: format!("{e}") })
         })
     }
 }
@@ -246,6 +295,12 @@ impl ExternalEffectAPI for RecvEffect {
 pub struct ReceiveError {
     conn: ConnectionId,
     error: String,
+}
+
+impl ReceiveError {
+    pub(crate) fn sdu_timeout(conn: ConnectionId, limit: Duration) -> Self {
+        Self { conn, error: format!("sdu timeout ({limit:?})") }
+    }
 }
 
 impl Display for ReceiveError {

--- a/crates/amaru-protocols/src/tx_submission/responder.rs
+++ b/crates/amaru-protocols/src/tx_submission/responder.rs
@@ -1105,7 +1105,8 @@ mod tests {
                 | MuxMessage::Buffer(..)
                 | MuxMessage::FromNetwork(..)
                 | MuxMessage::Written
-                | MuxMessage::Terminate => panic!("unexpected mux message: {msg:?}"),
+                | MuxMessage::Terminate
+                | MuxMessage::SetSduTimeout(_) => panic!("unexpected mux message: {msg:?}"),
             }
             state
         });


### PR DESCRIPTION
Stacked on #1304.

The mux now implements the blueprint SDU timer: unbounded wait for the leading edge of a header, then 10s (first Handshake) / 30s (after `SetSduTimeout`) for the rest of that SDU on receive and for writing the matching segment. Unknown protocol IDs still terminate the bearer.

Simulation cannot yet race an `UntilResolved` recv against the stage clock (that needs the later timeout-verification work). The stall test completes the post-leading-edge recv with `ReceiveError::sdu_timeout`.

## Test plan
- `cargo test -p amaru-protocols --lib mux`
- `cargo test -p amaru-protocols --lib handshake`