### PR TITLE
connection: Established session and no manager redial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Other guiding principles:
 
 ### Changed
 
+- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
 - **amaru-protocols**: mux times SDU assembly and send: unbounded wait for the first header byte, then 10s during the first Handshake and 30s afterwards for the rest of that SDU. Overflow of that timer tears the bearer down.
 - **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record. Outbound connections still offer initiator-only diffusion (duplex is not advertised until both halves run).
 - **amaru-protocols**: `NetworkOps::connect` takes a `Peer`. Outbound dialling no longer resolves names; that stays in peer selection.

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -80,36 +80,46 @@ struct Params {
     manager: StageRef<ManagerMessage>,
 }
 
+/// Local use of a bearer: which initiator groups we intend to run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+pub enum LocalUse {
+    None,
+    Maintenance,
+    Diffusion,
+}
+
+impl LocalUse {
+    pub fn default_for_role(role: Role) -> Self {
+        match role {
+            Role::Initiator => Self::Diffusion,
+            Role::Responder => Self::None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 enum State {
     Initial,
     Handshake { muxer: StageRef<MuxMessage>, handshake: StageRef<Inputs<Void>> },
-    Initiator(StateInitiator),
-    Responder(StateResponder),
+    Established(Established),
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-struct StateInitiator {
-    chainsync_initiator: StageRef<chainsync::InitiatorMessage>,
-    blockfetch_initiator: StageRef<blockfetch::BlockFetchMessage>,
-    peer_sharing_initiator: StageRef<PeerSharingMessage>,
+struct Established {
+    desired_use: LocalUse,
+    actual_use: LocalUse,
     version_number: VersionNumber,
     version_data: VersionData,
     muxer: StageRef<MuxMessage>,
     handshake: StageRef<Inputs<Void>>,
     keepalive: StageRef<HandlerMessage>,
     tx_submission: StageRef<HandlerMessage>,
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-struct StateResponder {
-    chainsync_responder: StageRef<chainsync::ResponderMessage>,
-    muxer: StageRef<MuxMessage>,
-    handshake: StageRef<Inputs<Void>>,
-    keepalive: StageRef<HandlerMessage>,
-    tx_submission: StageRef<HandlerMessage>,
-    blockfetch_responder: StageRef<StreamBlocks>,
-    peer_sharing_responder: StageRef<crate::peer_sharing::ResponderMessage>,
+    chainsync_initiator: Option<StageRef<chainsync::InitiatorMessage>>,
+    blockfetch_initiator: Option<StageRef<blockfetch::BlockFetchMessage>>,
+    peer_sharing_initiator: Option<StageRef<PeerSharingMessage>>,
+    chainsync_responder: Option<StageRef<chainsync::ResponderMessage>>,
+    blockfetch_responder: Option<StageRef<StreamBlocks>>,
+    peer_sharing_responder: Option<StageRef<crate::peer_sharing::ResponderMessage>>,
 }
 
 /// Identity of a supervised child stage of a connection.
@@ -145,6 +155,8 @@ pub enum ConnectionMessage {
     NewTip(Point, TraceContext),
     /// A supervised mini-protocol or mux stage terminated.
     ChildDied(ChildId),
+    /// Peer selection (or default after handshake) wants this local use.
+    SetLocalUse(LocalUse),
 }
 
 impl ConnectionMessage {
@@ -157,6 +169,7 @@ impl ConnectionMessage {
             ConnectionMessage::RequestSharePeers { .. } => "RequestSharePeers",
             ConnectionMessage::NewTip(_, _) => "NewTip",
             ConnectionMessage::ChildDied(_) => "ChildDied",
+            ConnectionMessage::SetLocalUse(_) => "SetLocalUse",
         }
     }
 
@@ -192,28 +205,32 @@ pub async fn stage(
             (State::Handshake { muxer, handshake }, ConnectionMessage::Handshake(handshake_result)) => {
                 do_handshake(&params, muxer, params.pipeline.clone(), handshake, handshake_result, eff).await
             }
-            (State::Initiator(s), ConnectionMessage::FetchBlocks { from, through, id, cr }) => {
-                eff.send(&s.blockfetch_initiator, BlockFetchMessage::RequestRange { from, through, id, cr }).await;
-                State::Initiator(s)
+            (State::Established(s), ConnectionMessage::FetchBlocks { from, through, id, cr }) => {
+                if let Some(blockfetch) = &s.blockfetch_initiator {
+                    eff.send(blockfetch, BlockFetchMessage::RequestRange { from, through, id, cr }).await;
+                }
+                State::Established(s)
             }
             (
-                State::Initiator(s),
+                State::Established(s),
                 ConnectionMessage::RequestSharePeers { amount, initial_delay, interval, reply_to },
             ) => {
-                eff.send(
-                    &s.peer_sharing_initiator,
-                    PeerSharingMessage::Start { amount, initial_delay, interval, reply_to },
-                )
-                .await;
-                State::Initiator(s)
+                if let Some(ps) = &s.peer_sharing_initiator {
+                    eff.send(ps, PeerSharingMessage::Start { amount, initial_delay, interval, reply_to }).await;
+                }
+                State::Established(s)
             }
-            (State::Responder(s), ConnectionMessage::NewTip(tip, trace_context)) => {
-                eff.send(&s.chainsync_responder, chainsync::ResponderMessage::NewTip(tip, trace_context)).await;
-                State::Responder(s)
+            (State::Established(s), ConnectionMessage::NewTip(tip, trace_context)) => {
+                if let Some(cs) = &s.chainsync_responder {
+                    eff.send(cs, chainsync::ResponderMessage::NewTip(tip, trace_context)).await;
+                }
+                State::Established(s)
             }
-            (State::Initiator(s), ConnectionMessage::NewTip(_, _)) => {
-                // don't propagate new tip messages when using the initiator side of a connection.
-                State::Initiator(s)
+            (State::Established(mut s), ConnectionMessage::SetLocalUse(desired)) => {
+                s.desired_use = desired;
+                // Starting extra groups on a duplex bearer is a later PR. Stopping is MsgDone.
+                // This commit only records the intent so later commits can converge actual_use.
+                State::Established(s)
             }
             (state @ (State::Initial | State::Handshake { .. }), msg @ ConnectionMessage::FetchBlocks { .. }) => {
                 // The peer might be still connecting. In that case we reschedule the message
@@ -229,6 +246,10 @@ pub async fn stage(
             }
             (state @ (State::Initial | State::Handshake { .. }), msg @ ConnectionMessage::NewTip(_, _)) => {
                 // The peer might be still connecting. Reschedule the NewTip message.
+                eff.schedule_after(msg, params.config.reconnect_delay).await;
+                state
+            }
+            (state @ (State::Initial | State::Handshake { .. }), msg @ ConnectionMessage::SetLocalUse(_)) => {
                 eff.schedule_after(msg, params.config.reconnect_delay).await;
                 state
             }
@@ -252,10 +273,10 @@ pub async fn stage(
 /// purge signal must be sent explicitly here whenever an initiator session may have been started.
 async fn teardown(state: State, params: &Params, eff: &Effects<ConnectionMessage>) -> Connection {
     match state {
-        State::Initiator(..) => {
+        State::Established(s) if s.chainsync_initiator.is_some() => {
             notify_chainsync_terminated(params, eff).await;
         }
-        State::Initial | State::Handshake { .. } | State::Responder(_) => {}
+        State::Initial | State::Handshake { .. } | State::Established(_) => {}
     }
     eff.terminate().await
 }
@@ -388,17 +409,37 @@ async fn do_handshake(
     )
     .await;
 
+    let local_use = LocalUse::default_for_role(*role);
+    let mut established = Established {
+        desired_use: local_use,
+        actual_use: local_use,
+        version_number,
+        version_data,
+        muxer: muxer.clone(),
+        handshake,
+        keepalive,
+        tx_submission,
+        chainsync_initiator: None,
+        blockfetch_initiator: None,
+        peer_sharing_initiator: None,
+        chainsync_responder: None,
+        blockfetch_responder: None,
+        peer_sharing_responder: None,
+    };
+
     if *role == Role::Initiator {
-        let chainsync_initiator = register_chainsync_initiator(
-            &muxer,
-            peer,
-            *conn_id,
-            pipeline_ref,
-            &eff,
-            ConnectionMessage::ChildDied(ChildId::ChainSync),
-        )
-        .await;
-        let blockfetch_initiator = if let Some(n) = config.blockfetch_pipeline_n {
+        established.chainsync_initiator = Some(
+            register_chainsync_initiator(
+                &muxer,
+                peer,
+                *conn_id,
+                pipeline_ref,
+                &eff,
+                ConnectionMessage::ChildDied(ChildId::ChainSync),
+            )
+            .await,
+        );
+        established.blockfetch_initiator = Some(if let Some(n) = config.blockfetch_pipeline_n {
             register_blockfetch_initiator_pipelined(
                 &muxer,
                 peer,
@@ -417,59 +458,46 @@ async fn do_handshake(
                 ConnectionMessage::ChildDied(ChildId::BlockFetch),
             )
             .await
-        };
-        let peer_sharing_initiator = register_peer_sharing_initiator(
-            &muxer,
-            peer,
-            *conn_id,
-            &eff,
-            ConnectionMessage::ChildDied(ChildId::PeerSharing),
-        )
-        .await;
-        State::Initiator(StateInitiator {
-            chainsync_initiator,
-            blockfetch_initiator,
-            peer_sharing_initiator,
-            version_number,
-            version_data,
-            muxer,
-            handshake,
-            keepalive,
-            tx_submission,
-        })
+        });
+        established.peer_sharing_initiator = Some(
+            register_peer_sharing_initiator(
+                &muxer,
+                peer,
+                *conn_id,
+                &eff,
+                ConnectionMessage::ChildDied(ChildId::PeerSharing),
+            )
+            .await,
+        );
     } else {
         let store = Store::new(eff.clone());
         let upstream = store.get_best_chain_tip().await;
-        let chainsync_responder = register_chainsync_responder(
-            &muxer,
-            upstream,
-            peer,
-            *conn_id,
-            &eff,
-            ConnectionMessage::ChildDied(ChildId::ChainSync),
-        )
-        .await;
-        let blockfetch_responder =
-            register_blockfetch_responder(&muxer, &eff, ConnectionMessage::ChildDied(ChildId::BlockFetch)).await;
-        let peer_sharing_responder = register_peer_sharing_responder(
-            &muxer,
-            peer,
-            manager.clone(),
-            &eff,
-            ConnectionMessage::ChildDied(ChildId::PeerSharing),
-        )
-        .await;
-
-        State::Responder(StateResponder {
-            chainsync_responder,
-            blockfetch_responder,
-            peer_sharing_responder,
-            muxer,
-            handshake,
-            keepalive,
-            tx_submission,
-        })
+        established.chainsync_responder = Some(
+            register_chainsync_responder(
+                &muxer,
+                upstream,
+                peer,
+                *conn_id,
+                &eff,
+                ConnectionMessage::ChildDied(ChildId::ChainSync),
+            )
+            .await,
+        );
+        established.blockfetch_responder =
+            Some(register_blockfetch_responder(&muxer, &eff, ConnectionMessage::ChildDied(ChildId::BlockFetch)).await);
+        established.peer_sharing_responder = Some(
+            register_peer_sharing_responder(
+                &muxer,
+                peer,
+                manager.clone(),
+                &eff,
+                ConnectionMessage::ChildDied(ChildId::PeerSharing),
+            )
+            .await,
+        );
     }
+
+    State::Established(established)
 }
 
 pub fn register_deserializers() -> DeserializerGuards {

--- a/crates/amaru-protocols/src/manager/mod.rs
+++ b/crates/amaru-protocols/src/manager/mod.rs
@@ -118,6 +118,8 @@ pub enum ManagerMessage {
         full_duplex: bool,
         advertisable: bool,
     },
+    /// Ask a live connection to converge toward this local use.
+    SetLocalUse { peer: Peer, conn_id: ConnectionId, local_use: crate::connection::LocalUse },
 }
 
 impl ManagerMessage {
@@ -135,6 +137,7 @@ impl ManagerMessage {
             ManagerMessage::ConnectionDied(..) => "ConnectionDied",
             ManagerMessage::Accepted(..) => "Accepted",
             ManagerMessage::HandshakeComplete { .. } => "HandshakeComplete",
+            ManagerMessage::SetLocalUse { .. } => "SetLocalUse",
         }
     }
 
@@ -171,9 +174,8 @@ impl ManagerMessage {
 /// An outbound connection is initiated by sending `ManagerMessage::AddPeer`. The manager will
 /// then try to connect to that peer until successful or retries exhausted. After a successful
 /// connection and handshake, the manager notifies `peer_selection` about the new connection.
-/// When the connection dies, the manager will inform `peer_selection` about the disconnection
-/// and then try to reconnect until successful or retries exhausted unless connections to this
-/// peer have died thrice within [`ManagerConfig::three_strike_window`].
+/// When the connection dies, the manager notifies `peer_selection` and does **not** redial.
+/// Peer selection decides whether to `AddPeer` again.
 ///
 /// ## Behavioural contracts
 ///
@@ -210,13 +212,10 @@ enum OutboundState {
     },
 }
 
-const MAX_OUTBOUND_DEATHS_TRACKED: usize = 2;
-
 #[derive(Default, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 struct PeerState {
     outbound: OutboundState,
     inbound: Option<ConnectionId>,
-    outbound_death_times: [Option<Instant>; MAX_OUTBOUND_DEATHS_TRACKED],
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -266,7 +265,6 @@ pub struct ManagerConfig {
     pub reconnect_delay: Duration,
     pub connect_retries: u16,
     pub accept_interval: Duration,
-    pub three_strike_window: Duration,
     pub tx_submission_params: ResponderParams,
     /// When `Some`, the BlockFetch initiator uses N lock-step typestate instances
     /// and a fused pipeline cursor. `None` keeps the lock-step `miniprotocol` handler.
@@ -312,7 +310,6 @@ impl Default for ManagerConfig {
             reconnect_delay: Duration::from_secs(2),
             connect_retries: 3,
             accept_interval: Duration::from_millis(100),
-            three_strike_window: Duration::from_secs(60),
             tx_submission_params: ResponderParams::default(),
             blockfetch_pipeline_n: None,
         }
@@ -580,30 +577,17 @@ impl Manager {
                 ConnectionDirection::Outbound => {
                     assert_eq!(peer_state.outbound, OutboundState::Connected { conn_id });
                     assert_eq!(role, Role::Initiator);
-                    let now = eff.clock().await;
-                    let times = &mut peer_state.outbound_death_times;
-                    // rotate to the left, so the oldest is in last position, then replace last with current time
-                    times.rotate_left(1);
-                    if let Some(oldest) = times[const { MAX_OUTBOUND_DEATHS_TRACKED - 1 }].replace(now)
-                        && now.saturating_since(oldest) < self.config.three_strike_window
-                    {
-                        info!(protocols::manager::peer::CONNECTION_DIED_HANDLED, peer, outcome = "retries_suppressed");
-                        if peer_state.inbound.is_none() {
-                            self.peers.remove(&peer);
-                        } else {
-                            peer_state.outbound = OutboundState::None;
-                        }
-                        eff.send(&self.peer_selection, PeerSelectionNotify::ConnectFailed { peer }).await;
+                    info!(protocols::manager::peer::CONNECTION_DIED_HANDLED, peer, outcome = "peer_selection_redial");
+                    if peer_state.inbound.is_none() {
+                        self.peers.remove(&peer);
                     } else {
-                        info!(protocols::manager::peer::CONNECTION_DIED_HANDLED, peer, outcome = "reconnect_scheduled");
-                        peer_state.outbound = OutboundState::Scheduled { retries: self.config.connect_retries };
-                        self.connect(peer, false, eff).await;
+                        peer_state.outbound = OutboundState::None;
                     }
                 }
             }
             eff.send(
                 &self.peer_selection,
-                PeerSelectionNotify::Disconnected { peer, conn_id, direction, will_retry: role == Role::Initiator },
+                PeerSelectionNotify::Disconnected { peer, conn_id, direction, will_retry: false },
             )
             .await;
         } else {
@@ -615,7 +599,13 @@ impl Manager {
                 conn_id = conn_id.as_u64()
             );
             if role == Role::Initiator {
-                self.connect(peer, false, eff).await;
+                if let Some(state) = self.peers.get_mut(&peer) {
+                    state.outbound = OutboundState::None;
+                    if state.inbound.is_none() {
+                        self.peers.remove(&peer);
+                    }
+                }
+                eff.send(&self.peer_selection, PeerSelectionNotify::ConnectFailed { peer }).await;
             }
             // inbound pre-HS deaths require no further action (peer entry is only created on HS success)
         }
@@ -772,6 +762,11 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
             }
             ManagerMessage::ConnectionResult(peer, conn_id) => {
                 manager.connection_result(peer, conn_id, &eff).await;
+            }
+            ManagerMessage::SetLocalUse { peer: _, conn_id, local_use } => {
+                if let Some(connection) = manager.connections.get(&conn_id) {
+                    eff.send(&connection.stage, ConnectionMessage::SetLocalUse(local_use)).await;
+                }
             }
         }
         manager

--- a/crates/amaru-protocols/src/tests/slow_manager_stage.rs
+++ b/crates/amaru-protocols/src/tests/slow_manager_stage.rs
@@ -42,6 +42,7 @@ pub async fn slow_manager_stage(manager: Manager, msg: ManagerMessage, eff: Effe
         ManagerMessage::RequestSharePeers { .. } => {}
         ManagerMessage::ShareRequest { .. } => {}
         ManagerMessage::ConnectionResult(..) => {}
+        ManagerMessage::SetLocalUse { .. } => {}
     }
     manager::stage(manager, msg, eff).await
 }

--- a/crates/amaru-protocols/src/tests/test_cases.rs
+++ b/crates/amaru-protocols/src/tests/test_cases.rs
@@ -51,7 +51,7 @@ use crate::{
 async fn test_connect_initiator_responder() -> anyhow::Result<()> {
     setup_logging();
     let (responder, addr, responder_done) = start_responder().await?;
-    let (initiator, initiator_done) = start_initiator_at(addr).await?;
+    let (initiator, initiator_done, _) = start_initiator_at(addr).await?;
 
     wait_for_termination(responder_done, initiator_done).await?;
     check_state(initiator, responder)?;
@@ -63,7 +63,7 @@ async fn test_connect_initiator_reconnection() -> anyhow::Result<()> {
     setup_logging();
     let addr = ephemeral_localhost_addr()?;
     tracing::info!("starting test at address {}", addr);
-    let (initiator, initiator_done) = start_initiator_with_configuration(
+    let (initiator, initiator_done, _) = start_initiator_with_configuration(
         Configuration::initiator().with_addr(addr).with_reconnect_delay(Duration::from_millis(500)),
     )
     .await?;
@@ -83,7 +83,7 @@ async fn test_connect_initiator_reconnection_on_responder_restart() -> anyhow::R
     // the initiator doesn't start synchronizing right away
     let (responder, addr, _) =
         start_responder_with_configuration(Configuration::responder().with_slow_manager()).await?;
-    let (initiator, initiator_done) = start_initiator_with_configuration(
+    let (initiator, initiator_done, initiator_sender) = start_initiator_with_configuration(
         Configuration::initiator()
             .with_addr(addr)
             .with_reconnect_delay(Duration::from_millis(1000))
@@ -102,6 +102,8 @@ async fn test_connect_initiator_reconnection_on_responder_restart() -> anyhow::R
     tracing::info!("restart the responder at address {}", addr);
     let responder_configuration = Configuration::responder().with_addr(addr);
     let (responder, _, responder_done) = start_responder_with_configuration(responder_configuration).await?;
+    let peer = Peer::try_from(addr).expect("test listen address is a peer");
+    initiator_sender.send(ManagerMessage::AddPeer(peer)).await.unwrap();
 
     // Both the initiator and the responder should eventually terminate with the same state
     tracing::info!("wait for termination");
@@ -128,7 +130,7 @@ async fn test_accept_stage_supervised_restart() -> anyhow::Result<()> {
         start_responder_with_failing_accept(Configuration::responder(), 1, 1).await?;
 
     // Start an initiator that will connect to the responder
-    let (initiator, initiator_done) = start_initiator_with_configuration(
+    let (initiator, initiator_done, _) = start_initiator_with_configuration(
         Configuration::initiator()
             .with_addr(addr)
             .with_reconnect_delay(Duration::from_millis(500))
@@ -195,7 +197,9 @@ async fn start_responder_with_configuration(
 
 /// Create and start an initiator node that connects to the given port.
 /// ChainSync events are sent to a stage that stores them in the in-memory store without further processing.
-async fn start_initiator_at(addr: impl Into<Option<SocketAddr>>) -> anyhow::Result<(TokioRunning, Arc<Notify>)> {
+async fn start_initiator_at(
+    addr: impl Into<Option<SocketAddr>>,
+) -> anyhow::Result<(TokioRunning, Arc<Notify>, amaru_pure_stage::Sender<ManagerMessage>)> {
     let addr = addr.into().unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 3000)));
     start_initiator_with_configuration(Configuration::initiator().with_addr(addr)).await
 }
@@ -204,7 +208,7 @@ async fn start_initiator_at(addr: impl Into<Option<SocketAddr>>) -> anyhow::Resu
 /// ChainSync events are sent to a stage that stores them in the in-memory store without further processing.
 async fn start_initiator_with_configuration(
     configuration: Configuration,
-) -> anyhow::Result<(TokioRunning, Arc<Notify>)> {
+) -> anyhow::Result<(TokioRunning, Arc<Notify>, amaru_pure_stage::Sender<ManagerMessage>)> {
     tracing::info!("Creating the initiator");
     let addr = configuration.addr;
     let peer = Peer::try_from(addr).expect("test listen address is a peer");
@@ -241,7 +245,7 @@ async fn start_initiator_with_configuration(
     let running_initiator = initiator_network.run(Handle::current());
     initiator_sender.send(ManagerMessage::AddPeer(peer)).await.unwrap();
 
-    Ok((running_initiator, notify))
+    Ok((running_initiator, notify, initiator_sender))
 }
 
 /// Create and start a responder node that uses the manager's supervised accept stage.


### PR DESCRIPTION
Stacked on #1306.

Connection is one `Established` session (not Initiator XOR Responder) with `LocalUse::{None, Maintenance, Diffusion}`. Defaults remain outbound Diffusion / inbound None and still start only the TCP-direction half.

The manager reports `Disconnected { will_retry: false }` (or `ConnectFailed` before handshake) and does not reconnect. Peer selection already refills on that path. `SetLocalUse` is recorded; MsgDone group stop is the next PR.

## Test plan
- `cargo test -p amaru-protocols --lib`
- Integration reconnect-after-responder-restart now re-issues `AddPeer`