### PR TITLE
feat: allow to cancel bootstrap process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,11 @@ Other guiding principles:
   ```
 -->
 
+## v10.11.20260910 _[unreleased; planned for 2026-09-10]_
 
+### Fixed
+
+- **amaru-bootstrap**: allow cancellation of the bootstrap process.
 
 ## v10.11.20260903 _[unreleased; planned for 2026-09-03]_
 
@@ -57,7 +61,6 @@ Other guiding principles:
 
 ### Fixed
 
-- **amaru-bootstrap**: allow cancellation of the bootstrap process.
 - **amaru-node**: the stake-distribution callback no longer holds a strong `Resources` handle, so dropping a node graph closes its dummy RocksDB ledgers instead of leaking file descriptors across simulation runs.
 - **amaru**: replace repeated low-level OpenTelemetry export errors with batched state-transition messages: one warning listing unavailable signals, one info listing recovered signals, and a fresh warning after a later failure.
 - **amaru-bootstrap**: emit phase lifecycle events and periodic progress heartbeats when bootstrap runs without a terminal, so redirected and service logs no longer appear stuck during long imports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Other guiding principles:
 
 ### Fixed
 
+- **amaru-bootstrap**: allow cancellation of the bootstrap process.
 - **amaru-node**: the stake-distribution callback no longer holds a strong `Resources` handle, so dropping a node graph closes its dummy RocksDB ledgers instead of leaking file descriptors across simulation runs.
 - **amaru**: replace repeated low-level OpenTelemetry export errors with batched state-transition messages: one warning listing unavailable signals, one info listing recovered signals, and a fresh warning after a later failure.
 - **amaru-bootstrap**: emit phase lifecycle events and periodic progress heartbeats when bootstrap runs without a terminal, so redirected and service logs no longer appear stuck during long imports.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
  "zstd",
 ]
 

--- a/crates/amaru-bootstrap/Cargo.toml
+++ b/crates/amaru-bootstrap/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = { workspace = true, features = ["std"] }
 tar.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "io-util", "rt", "rt-multi-thread", "time"] }
+tokio-util.workspace = true
 zstd.workspace = true
 
 # Internal dependencies ───────────────────────────────────────────────────────┐

--- a/crates/amaru-bootstrap/src/bootstrap/mod.rs
+++ b/crates/amaru-bootstrap/src/bootstrap/mod.rs
@@ -66,9 +66,6 @@ pub enum BootstrapError {
     #[error("bootstrap cancelled")]
     Cancelled,
 
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
-
     #[error("Can not create snapshots directory {0}: {1}")]
     CreateSnapshotsDir(PathBuf, io::Error),
 
@@ -103,10 +100,6 @@ pub enum BootstrapError {
 
 pub(crate) fn checkpoint(cancellation: &BootstrapCancellation) -> Result<(), BootstrapError> {
     if cancellation.is_cancelled() { Err(BootstrapError::Cancelled) } else { Ok(()) }
-}
-
-fn operation_error(cancellation: &BootstrapCancellation, error: impl FnOnce() -> BootstrapError) -> BootstrapError {
-    if cancellation.is_cancelled() { BootstrapError::Cancelled } else { error() }
 }
 
 pub const BOOTSTRAP_HEADERS_PER_POINT: usize = 2;
@@ -354,10 +347,13 @@ async fn download_snapshots(
 
         info!(bootstrap::snapshot::DOWNLOAD, epoch = snapshot.epoch, point = snapshot.point);
 
-        s3.download_object(&snapshot.key, &partial_archive_path).await.map_err(|error| {
-            operation_error(cancellation, || BootstrapError::DownloadError(snapshot.key.clone(), error.to_string()))
-        })?;
-        checkpoint(cancellation)?;
+        tokio::select! {
+            biased;
+            result = s3.download_object(&snapshot.key, &partial_archive_path) => {
+                result.map_err(|error| BootstrapError::DownloadError(snapshot.key.clone(), error.to_string()))?;
+            }
+            () = cancellation.cancelled() => return Err(BootstrapError::Cancelled),
+        }
 
         validate_snapshot_archive(&partial_archive_path)
             .map_err(|err| BootstrapError::InvalidSnapshotArchive(partial_archive_path.clone(), err.to_string()))?;
@@ -456,12 +452,12 @@ fn snapshot_archive_entry_root(path: &Path, expected: &Path) -> Option<PathBuf> 
 /// Bootstrap with cooperative cancellation at decoder and database work-unit boundaries.
 ///
 /// To stop bootstrap, call [`BootstrapCancellation::cancel`] on a cloned handle and continue
-/// awaiting this function until it returns [`BootstrapError::Cancelled`]. Do not drop the bootstrap
-/// future after requesting cancellation. The cancellation result is returned only after the
-/// importer has stopped and released its store handles. During snapshot import, cancellation
-/// latency is bounded by the decoder read/sequence chunk or RocksDB batch currently in progress;
-/// an active network request completes at its normal await boundary. Cancellation can leave partial
-/// bootstrap stores, which must be removed and bootstrapped again rather than opened as node stores.
+/// awaiting this function until it returns an error containing [`BootstrapError::Cancelled`]. Do not
+/// drop the bootstrap future after requesting cancellation. The cancellation result is returned only
+/// after the importer has stopped and released its store handles. During snapshot import,
+/// cancellation latency is bounded by the decoder read/sequence chunk or RocksDB batch currently in
+/// progress; snapshot downloads are interrupted immediately. Cancellation can leave partial bootstrap
+/// stores, which must be removed and bootstrapped again rather than opened as node stores.
 #[expect(clippy::too_many_arguments)]
 pub async fn bootstrap(
     network: NetworkName,
@@ -472,7 +468,7 @@ pub async fn bootstrap(
     target_epoch: Option<Epoch>,
     s3_config: S3Config,
     cancellation: BootstrapCancellation,
-) -> Result<(), BootstrapError> {
+) -> anyhow::Result<()> {
     let cancel_on_drop = cancellation.clone().drop_guard();
     let result = bootstrap_inner(
         network,
@@ -499,17 +495,15 @@ async fn bootstrap_inner(
     target_epoch: Option<Epoch>,
     s3_config: S3Config,
     cancellation: BootstrapCancellation,
-) -> Result<(), BootstrapError> {
+) -> anyhow::Result<()> {
     let started_at = Instant::now();
     checkpoint(&cancellation)?;
     let s3 = AnonymousS3Client::new(s3_config);
-    let snapshots = bootstrap_snapshots(network, &s3, &snapshots_dir)
-        .await
-        .map_err(|error| operation_error(&cancellation, || error.into()))?;
-    checkpoint(&cancellation)?;
+    let snapshots = bootstrap_snapshots(network, &s3, &snapshots_dir).await?;
     let [first_snapshot, second_snapshot, third_snapshot] = select_bootstrap_snapshots(&snapshots, target_epoch)?;
 
     download_snapshots(&[first_snapshot, second_snapshot, third_snapshot], &snapshots_dir, &s3, &cancellation).await?;
+    checkpoint(&cancellation)?;
 
     let first_snapshot_path = resolve_snapshot_path(&snapshots_dir, first_snapshot)
         .ok_or_else(|| BootstrapError::MissingSnapshot(snapshot_archive_path(&snapshots_dir, first_snapshot)))?;
@@ -527,6 +521,7 @@ async fn bootstrap_inner(
         &cancellation,
     )
     .await?;
+    checkpoint(&cancellation)?;
 
     // Extract nonces for the second snapshot tip as well: packaged bootstrap headers must enter
     // the chain store already carrying nonces so that "nonces present ⇔ header validated" holds
@@ -540,6 +535,7 @@ async fn bootstrap_inner(
         &cancellation,
     )
     .await?;
+    checkpoint(&cancellation)?;
 
     let imported_third_snapshot = import_snapshot_with_optional_nonces(
         network,
@@ -552,9 +548,7 @@ async fn bootstrap_inner(
     .await?;
 
     checkpoint(&cancellation)?;
-    let chain_db = RocksDBStore::create(RocksDbConfig::new(chain_dir.clone()))
-        .map_err(|error| operation_error(&cancellation, || anyhow::Error::from(error).into()))?;
-    checkpoint(&cancellation)?;
+    let chain_db = RocksDBStore::create(RocksDbConfig::new(chain_dir.clone())).map_err(anyhow::Error::from)?;
     let second_chain_state = imported_second_snapshot
         .chain_state
         .ok_or_else(|| anyhow!("bootstrap import must produce the chain state for the second snapshot"))?;
@@ -563,20 +557,16 @@ async fn bootstrap_inner(
         .ok_or_else(|| anyhow!("bootstrap import must produce the chain state for the latest snapshot"))?;
     // Nonces for both packaged tips are stored before the headers so
     // `import_packaged_blocks` can attach each header via `store_validated_header`.
-    checkpoint(&cancellation)?;
-    store_chain_state(imported_second_snapshot.epoch, &chain_db, second_chain_state)
-        .map_err(|error| operation_error(&cancellation, || error.into()))?;
-    checkpoint(&cancellation)?;
-    store_chain_state(imported_third_snapshot.epoch, &chain_db, third_chain_state)
-        .map_err(|error| operation_error(&cancellation, || error.into()))?;
-    checkpoint(&cancellation)?;
+    store_chain_state(imported_second_snapshot.epoch, &chain_db, second_chain_state)?;
+    store_chain_state(imported_third_snapshot.epoch, &chain_db, third_chain_state)?;
     let blocks = load_packaged_blocks_for_bootstrap(
         &second_snapshot_path,
         second_snapshot,
         &third_snapshot_path,
         third_snapshot,
     )?;
-    import_packaged_blocks(&chain_db, blocks, &cancellation).await?;
+    import_packaged_blocks(&chain_db, blocks).await?;
+    checkpoint(&cancellation)?;
 
     info!(
         bootstrap::COMPLETE,
@@ -588,14 +578,9 @@ async fn bootstrap_inner(
     Ok(())
 }
 
-pub async fn import_packaged_blocks(
-    db: &RocksDBStore,
-    blocks: Vec<Vec<u8>>,
-    cancellation: &BootstrapCancellation,
-) -> Result<(), BootstrapError> {
+pub async fn import_packaged_blocks(db: &RocksDBStore, blocks: Vec<Vec<u8>>) -> anyhow::Result<()> {
     for block in blocks {
-        checkpoint(cancellation)?;
-        let header_cbor = extract_block_header_cbor(&block).map_err(anyhow::Error::from)?;
+        let header_cbor = extract_block_header_cbor(&block)?;
         let block_header: Header =
             from_cbor(header_cbor).ok_or_else(|| anyhow!("failed to decode packaged bootstrap block header"))?;
         let hash = block_header.hash();
@@ -608,11 +593,8 @@ pub async fn import_packaged_blocks(
         let nonces = db.get_nonces(&hash).ok_or_else(|| {
             anyhow!("bootstrap packaged header {hash} is missing nonces; refuse to store incomplete tip")
         })?;
-        db.store_validated_header(&block_header, &nonces)
-            .map_err(|error| operation_error(cancellation, || anyhow::Error::from(error).into()))?;
-        db.store_block(&hash, &RawBlock::from(block.as_slice()))
-            .map_err(|error| operation_error(cancellation, || anyhow::Error::from(error).into()))?;
-        checkpoint(cancellation)?;
+        db.store_validated_header(&block_header, &nonces)?;
+        db.store_block(&hash, &RawBlock::from(block.as_slice()))?;
     }
 
     Ok(())
@@ -768,10 +750,6 @@ struct ImportedSnapshot {
     chain_state: Option<ChainState>,
 }
 
-fn controlled_snapshot_import_error(error: anyhow::Error, cancellation: &BootstrapCancellation) -> BootstrapError {
-    if cancellation.is_cancelled() { BootstrapError::Cancelled } else { error.into() }
-}
-
 async fn import_snapshot(
     network: NetworkName,
     global_parameters: &GlobalParameters,
@@ -790,8 +768,7 @@ async fn import_snapshot_with_optional_nonces(
     ledger_dir: &Path,
     nonce_tail: Option<HeaderHash>,
     cancellation: &BootstrapCancellation,
-) -> Result<ImportedSnapshot, BootstrapError> {
-    checkpoint(cancellation)?;
+) -> anyhow::Result<ImportedSnapshot> {
     if snapshot.is_file() && has_snapshot_archive_extension(snapshot) {
         return import_node_snapshot_archive(
             network,
@@ -804,7 +781,7 @@ async fn import_snapshot_with_optional_nonces(
         .await;
     }
 
-    Err(anyhow::Error::from(ImportError::UnsupportedSnapshotPath(snapshot.to_path_buf())).into())
+    Err(ImportError::UnsupportedSnapshotPath(snapshot.to_path_buf()).into())
 }
 
 async fn import_node_snapshot_archive(
@@ -814,7 +791,7 @@ async fn import_node_snapshot_archive(
     ledger_dir: &Path,
     nonce_tail: Option<HeaderHash>,
     cancellation: &BootstrapCancellation,
-) -> Result<ImportedSnapshot, BootstrapError> {
+) -> anyhow::Result<ImportedSnapshot> {
     info!(bootstrap::snapshot::IMPORT_ARCHIVE, path = snapshot_archive.display().to_string());
     import_node_snapshot_source(network, global_parameters, snapshot_archive, ledger_dir, nonce_tail, cancellation)
         .await
@@ -827,8 +804,7 @@ async fn import_node_snapshot_source(
     ledger_dir: &Path,
     nonce_tail: Option<HeaderHash>,
     cancellation: &BootstrapCancellation,
-) -> Result<ImportedSnapshot, BootstrapError> {
-    checkpoint(cancellation)?;
+) -> anyhow::Result<ImportedSnapshot> {
     fs::create_dir_all(ledger_dir)?;
 
     let previous_accounts = if fs::exists(ledger_dir.join("live"))? {
@@ -866,19 +842,17 @@ async fn import_node_snapshot_source(
 
     let (db, epoch, chain_state) = await_import_thread(import_thread).await?;
 
-    checkpoint(cancellation)?;
     db.next_snapshot(epoch).map_err(anyhow::Error::from)?;
 
     db.with_transaction(|batch| batch.try_epoch_transition(None, Some(EpochTransitionProgress::SnapshotTaken)))
         .map_err(anyhow::Error::from)?;
-    checkpoint(cancellation)?;
 
     Ok(ImportedSnapshot { epoch, chain_state })
 }
 
 async fn await_import_thread<T: Send + 'static>(
-    import_thread: std::thread::JoinHandle<Result<T, BootstrapError>>,
-) -> Result<T, BootstrapError> {
+    import_thread: std::thread::JoinHandle<anyhow::Result<T>>,
+) -> anyhow::Result<T> {
     let joined = tokio::task::spawn_blocking(move || import_thread.join())
         .await
         .map_err(|error| anyhow!("bootstrap import join task failed: {error}"))?;
@@ -893,35 +867,35 @@ fn import_node_snapshot_archive_data(
     nonce_tail: Option<HeaderHash>,
     previous_accounts: BTreeSet<Credential>,
     cancellation: &BootstrapCancellation,
-) -> Result<(Epoch, Point, Option<ChainState>), BootstrapError> {
-    checkpoint(cancellation)?;
+) -> anyhow::Result<(Epoch, Point, Option<ChainState>)> {
     let archive_file = fs::File::open(archive_path)?;
     let mut archive = Archive::new(ZstdDecoder::new(archive_file)?);
 
     let mut imported_state = None;
     let mut previous_accounts: Option<BTreeSet<Credential>> = Some(previous_accounts);
 
-    for entry in archive.entries()? {
+    let mut entries = archive.entries()?;
+    loop {
         checkpoint(cancellation)?;
+        let Some(entry) = entries.next() else {
+            break;
+        };
         let mut entry = entry?;
         let path = entry.path()?.into_owned();
 
         if snapshot_archive_entry_matches(&path, Path::new(SNAPSHOT_STATE_FILE_NAME)) {
-            imported_state = Some(
-                import_state_from_tvar(
-                    db,
-                    &mut entry,
-                    network,
-                    global_parameters,
-                    nonce_tail,
-                    previous_accounts.take().ok_or_else(|| {
-                        anyhow!("multiple {SNAPSHOT_STATE_FILE_NAME} in archive {}?", archive_path.display())
-                    })?,
-                    &BootstrapProgressFactory,
-                    cancellation,
-                )
-                .map_err(|error| controlled_snapshot_import_error(error, cancellation))?,
-            );
+            imported_state = Some(import_state_from_tvar(
+                db,
+                &mut entry,
+                network,
+                global_parameters,
+                nonce_tail,
+                previous_accounts.take().ok_or_else(|| {
+                    anyhow!("multiple {SNAPSHOT_STATE_FILE_NAME} in archive {}?", archive_path.display())
+                })?,
+                &BootstrapProgressFactory,
+                cancellation,
+            )?);
         } else if snapshot_archive_entry_matches(&path, Path::new(SNAPSHOT_UTXO_FILE_NAME)) {
             let (epoch, point, era_history, chain_state) = imported_state.take().ok_or_else(|| {
                 anyhow!(
@@ -937,14 +911,13 @@ fn import_node_snapshot_archive_data(
                 &era_history,
                 network,
                 cancellation,
-            )
-            .map_err(|error| controlled_snapshot_import_error(error, cancellation))?;
+            )?;
 
             return Ok((epoch, point, chain_state));
         }
     }
 
-    Err(anyhow!("snapshot archive {} does not contain {SNAPSHOT_UTXO_FILE_NAME}", archive_path.display()).into())
+    Err(anyhow!("snapshot archive {} does not contain {SNAPSHOT_UTXO_FILE_NAME}", archive_path.display()))
 }
 
 #[cfg(test)]
@@ -965,10 +938,9 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        BootstrapCancellation, BootstrapError, Snapshot, await_import_thread, checkpoint, operation_error,
-        read_snapshot_archive_entry, select_bootstrap_snapshots, should_download_snapshot,
-        snapshot_archive_entry_matches, sort_snapshots_by_slot, validate_publishable_snapshot_archive,
-        validate_snapshot_archive,
+        BootstrapCancellation, BootstrapError, Snapshot, await_import_thread, checkpoint, read_snapshot_archive_entry,
+        select_bootstrap_snapshots, should_download_snapshot, snapshot_archive_entry_matches, sort_snapshots_by_slot,
+        validate_publishable_snapshot_archive, validate_snapshot_archive,
     };
     use crate::cardano_node::ParsedStateSnapshot;
 
@@ -1012,17 +984,6 @@ mod tests {
     }
 
     #[test]
-    fn cancellation_takes_precedence_over_an_operation_error() {
-        let cancellation = BootstrapCancellation::new();
-        cancellation.cancel();
-
-        let error =
-            operation_error(&cancellation, || panic!("operation error must not be converted after cancellation"));
-
-        assert!(matches!(error, BootstrapError::Cancelled));
-    }
-
-    #[test]
     fn cancellation_waits_for_the_import_thread_to_release_its_resources() {
         struct Released(Arc<AtomicBool>);
 
@@ -1041,7 +1002,7 @@ mod tests {
             let importer_ready = Arc::clone(&importer_ready);
             let importer_continue = Arc::clone(&importer_continue);
             let released = Arc::clone(&released);
-            std::thread::spawn(move || -> Result<(), BootstrapError> {
+            std::thread::spawn(move || -> anyhow::Result<()> {
                 let _released = Released(released);
                 importer_ready.wait();
                 importer_continue.wait();
@@ -1056,7 +1017,7 @@ mod tests {
         let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         let error = runtime.block_on(await_import_thread(import_thread)).unwrap_err();
 
-        assert!(matches!(error, BootstrapError::Cancelled));
+        assert!(matches!(error.downcast_ref(), Some(BootstrapError::Cancelled)));
         assert!(released.load(Ordering::SeqCst));
     }
 

--- a/crates/amaru-bootstrap/src/bootstrap/mod.rs
+++ b/crates/amaru-bootstrap/src/bootstrap/mod.rs
@@ -36,6 +36,7 @@ use tokio::{
     fs as async_fs,
     time::{Instant, timeout},
 };
+pub use tokio_util::sync::CancellationToken as BootstrapCancellation;
 use zstd::Decoder as ZstdDecoder;
 
 mod chain_sync_client;
@@ -62,6 +63,12 @@ impl Snapshot {
 
 #[derive(Debug, thiserror::Error)]
 pub enum BootstrapError {
+    #[error("bootstrap cancelled")]
+    Cancelled,
+
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+
     #[error("Can not create snapshots directory {0}: {1}")]
     CreateSnapshotsDir(PathBuf, io::Error),
 
@@ -92,6 +99,14 @@ pub enum BootstrapError {
         display_collection(required_epochs)
     )]
     SnapshotSelectionLatestEpoch { latest_epoch: Epoch, required_epochs: [Epoch; 3], available_epochs: Vec<Epoch> },
+}
+
+pub(crate) fn checkpoint(cancellation: &BootstrapCancellation) -> Result<(), BootstrapError> {
+    if cancellation.is_cancelled() { Err(BootstrapError::Cancelled) } else { Ok(()) }
+}
+
+fn operation_error(cancellation: &BootstrapCancellation, error: impl FnOnce() -> BootstrapError) -> BootstrapError {
+    if cancellation.is_cancelled() { BootstrapError::Cancelled } else { error() }
 }
 
 pub const BOOTSTRAP_HEADERS_PER_POINT: usize = 2;
@@ -310,12 +325,14 @@ async fn download_snapshots(
     snapshots: &[&Snapshot],
     snapshots_dir: &Path,
     s3: &AnonymousS3Client,
+    cancellation: &BootstrapCancellation,
 ) -> Result<(), BootstrapError> {
     async_fs::create_dir_all(snapshots_dir)
         .await
         .map_err(|err| BootstrapError::CreateSnapshotsDir(snapshots_dir.to_path_buf(), err))?;
 
     for snapshot in snapshots {
+        checkpoint(cancellation)?;
         let archive_path = snapshot_archive_path(snapshots_dir, snapshot);
 
         if !should_download_snapshot(snapshots_dir, snapshot) {
@@ -337,9 +354,10 @@ async fn download_snapshots(
 
         info!(bootstrap::snapshot::DOWNLOAD, epoch = snapshot.epoch, point = snapshot.point);
 
-        s3.download_object(&snapshot.key, &partial_archive_path)
-            .await
-            .map_err(|e| BootstrapError::DownloadError(snapshot.key.clone(), e.to_string()))?;
+        s3.download_object(&snapshot.key, &partial_archive_path).await.map_err(|error| {
+            operation_error(cancellation, || BootstrapError::DownloadError(snapshot.key.clone(), error.to_string()))
+        })?;
+        checkpoint(cancellation)?;
 
         validate_snapshot_archive(&partial_archive_path)
             .map_err(|err| BootstrapError::InvalidSnapshotArchive(partial_archive_path.clone(), err.to_string()))?;
@@ -435,7 +453,16 @@ fn snapshot_archive_entry_root(path: &Path, expected: &Path) -> Option<PathBuf> 
     }
 }
 
-/// Set the internal dbs in such a state that amaru can run
+/// Bootstrap with cooperative cancellation at decoder and database work-unit boundaries.
+///
+/// To stop bootstrap, call [`BootstrapCancellation::cancel`] on a cloned handle and continue
+/// awaiting this function until it returns [`BootstrapError::Cancelled`]. Do not drop the bootstrap
+/// future after requesting cancellation. The cancellation result is returned only after the
+/// importer has stopped and released its store handles. During snapshot import, cancellation
+/// latency is bounded by the decoder read/sequence chunk or RocksDB batch currently in progress;
+/// an active network request completes at its normal await boundary. Cancellation can leave partial
+/// bootstrap stores, which must be removed and bootstrapped again rather than opened as node stores.
+#[expect(clippy::too_many_arguments)]
 pub async fn bootstrap(
     network: NetworkName,
     global_parameters: &GlobalParameters,
@@ -444,13 +471,45 @@ pub async fn bootstrap(
     snapshots_dir: PathBuf,
     target_epoch: Option<Epoch>,
     s3_config: S3Config,
-) -> anyhow::Result<()> {
+    cancellation: BootstrapCancellation,
+) -> Result<(), BootstrapError> {
+    let cancel_on_drop = cancellation.clone().drop_guard();
+    let result = bootstrap_inner(
+        network,
+        global_parameters,
+        ledger_dir,
+        chain_dir,
+        snapshots_dir,
+        target_epoch,
+        s3_config,
+        cancellation,
+    )
+    .await;
+    cancel_on_drop.disarm();
+    result
+}
+
+#[expect(clippy::too_many_arguments)]
+async fn bootstrap_inner(
+    network: NetworkName,
+    global_parameters: &GlobalParameters,
+    ledger_dir: PathBuf,
+    chain_dir: PathBuf,
+    snapshots_dir: PathBuf,
+    target_epoch: Option<Epoch>,
+    s3_config: S3Config,
+    cancellation: BootstrapCancellation,
+) -> Result<(), BootstrapError> {
     let started_at = Instant::now();
+    checkpoint(&cancellation)?;
     let s3 = AnonymousS3Client::new(s3_config);
-    let snapshots = bootstrap_snapshots(network, &s3, &snapshots_dir).await?;
+    let snapshots = bootstrap_snapshots(network, &s3, &snapshots_dir)
+        .await
+        .map_err(|error| operation_error(&cancellation, || error.into()))?;
+    checkpoint(&cancellation)?;
     let [first_snapshot, second_snapshot, third_snapshot] = select_bootstrap_snapshots(&snapshots, target_epoch)?;
 
-    download_snapshots(&[first_snapshot, second_snapshot, third_snapshot], &snapshots_dir, &s3).await?;
+    download_snapshots(&[first_snapshot, second_snapshot, third_snapshot], &snapshots_dir, &s3, &cancellation).await?;
 
     let first_snapshot_path = resolve_snapshot_path(&snapshots_dir, first_snapshot)
         .ok_or_else(|| BootstrapError::MissingSnapshot(snapshot_archive_path(&snapshots_dir, first_snapshot)))?;
@@ -459,7 +518,15 @@ pub async fn bootstrap(
     let third_snapshot_path = resolve_snapshot_path(&snapshots_dir, third_snapshot)
         .ok_or_else(|| BootstrapError::MissingSnapshot(snapshot_archive_path(&snapshots_dir, third_snapshot)))?;
 
-    import_snapshot(network, global_parameters, &first_snapshot_path, &ledger_dir).await?;
+    import_snapshot_with_optional_nonces(
+        network,
+        global_parameters,
+        &first_snapshot_path,
+        &ledger_dir,
+        None,
+        &cancellation,
+    )
+    .await?;
 
     // Extract nonces for the second snapshot tip as well: packaged bootstrap headers must enter
     // the chain store already carrying nonces so that "nonces present ⇔ header validated" holds
@@ -470,6 +537,7 @@ pub async fn bootstrap(
         &second_snapshot_path,
         &ledger_dir,
         Some(snapshot_hash(first_snapshot)?),
+        &cancellation,
     )
     .await?;
 
@@ -479,10 +547,14 @@ pub async fn bootstrap(
         &third_snapshot_path,
         &ledger_dir,
         Some(snapshot_hash(second_snapshot)?),
+        &cancellation,
     )
     .await?;
 
-    let chain_db = RocksDBStore::create(RocksDbConfig::new(chain_dir.clone()))?;
+    checkpoint(&cancellation)?;
+    let chain_db = RocksDBStore::create(RocksDbConfig::new(chain_dir.clone()))
+        .map_err(|error| operation_error(&cancellation, || anyhow::Error::from(error).into()))?;
+    checkpoint(&cancellation)?;
     let second_chain_state = imported_second_snapshot
         .chain_state
         .ok_or_else(|| anyhow!("bootstrap import must produce the chain state for the second snapshot"))?;
@@ -491,15 +563,20 @@ pub async fn bootstrap(
         .ok_or_else(|| anyhow!("bootstrap import must produce the chain state for the latest snapshot"))?;
     // Nonces for both packaged tips are stored before the headers so
     // `import_packaged_blocks` can attach each header via `store_validated_header`.
-    store_chain_state(imported_second_snapshot.epoch, &chain_db, second_chain_state)?;
-    store_chain_state(imported_third_snapshot.epoch, &chain_db, third_chain_state)?;
+    checkpoint(&cancellation)?;
+    store_chain_state(imported_second_snapshot.epoch, &chain_db, second_chain_state)
+        .map_err(|error| operation_error(&cancellation, || error.into()))?;
+    checkpoint(&cancellation)?;
+    store_chain_state(imported_third_snapshot.epoch, &chain_db, third_chain_state)
+        .map_err(|error| operation_error(&cancellation, || error.into()))?;
+    checkpoint(&cancellation)?;
     let blocks = load_packaged_blocks_for_bootstrap(
         &second_snapshot_path,
         second_snapshot,
         &third_snapshot_path,
         third_snapshot,
     )?;
-    import_packaged_blocks(&chain_db, blocks).await?;
+    import_packaged_blocks(&chain_db, blocks, &cancellation).await?;
 
     info!(
         bootstrap::COMPLETE,
@@ -511,9 +588,14 @@ pub async fn bootstrap(
     Ok(())
 }
 
-pub async fn import_packaged_blocks(db: &RocksDBStore, blocks: Vec<Vec<u8>>) -> anyhow::Result<()> {
+pub async fn import_packaged_blocks(
+    db: &RocksDBStore,
+    blocks: Vec<Vec<u8>>,
+    cancellation: &BootstrapCancellation,
+) -> Result<(), BootstrapError> {
     for block in blocks {
-        let header_cbor = extract_block_header_cbor(&block)?;
+        checkpoint(cancellation)?;
+        let header_cbor = extract_block_header_cbor(&block).map_err(anyhow::Error::from)?;
         let block_header: Header =
             from_cbor(header_cbor).ok_or_else(|| anyhow!("failed to decode packaged bootstrap block header"))?;
         let hash = block_header.hash();
@@ -526,8 +608,11 @@ pub async fn import_packaged_blocks(db: &RocksDBStore, blocks: Vec<Vec<u8>>) -> 
         let nonces = db.get_nonces(&hash).ok_or_else(|| {
             anyhow!("bootstrap packaged header {hash} is missing nonces; refuse to store incomplete tip")
         })?;
-        db.store_validated_header(&block_header, &nonces)?;
-        db.store_block(&hash, &RawBlock::from(block.as_slice()))?;
+        db.store_validated_header(&block_header, &nonces)
+            .map_err(|error| operation_error(cancellation, || anyhow::Error::from(error).into()))?;
+        db.store_block(&hash, &RawBlock::from(block.as_slice()))
+            .map_err(|error| operation_error(cancellation, || anyhow::Error::from(error).into()))?;
+        checkpoint(cancellation)?;
     }
 
     Ok(())
@@ -683,13 +768,18 @@ struct ImportedSnapshot {
     chain_state: Option<ChainState>,
 }
 
+fn controlled_snapshot_import_error(error: anyhow::Error, cancellation: &BootstrapCancellation) -> BootstrapError {
+    if cancellation.is_cancelled() { BootstrapError::Cancelled } else { error.into() }
+}
+
 async fn import_snapshot(
     network: NetworkName,
     global_parameters: &GlobalParameters,
     snapshot: &Path,
     ledger_dir: &Path,
 ) -> anyhow::Result<()> {
-    import_snapshot_with_optional_nonces(network, global_parameters, snapshot, ledger_dir, None).await?;
+    let cancellation = BootstrapCancellation::new();
+    import_snapshot_with_optional_nonces(network, global_parameters, snapshot, ledger_dir, None, &cancellation).await?;
     Ok(())
 }
 
@@ -699,12 +789,22 @@ async fn import_snapshot_with_optional_nonces(
     snapshot: &Path,
     ledger_dir: &Path,
     nonce_tail: Option<HeaderHash>,
-) -> anyhow::Result<ImportedSnapshot> {
+    cancellation: &BootstrapCancellation,
+) -> Result<ImportedSnapshot, BootstrapError> {
+    checkpoint(cancellation)?;
     if snapshot.is_file() && has_snapshot_archive_extension(snapshot) {
-        return import_node_snapshot_archive(network, global_parameters, snapshot, ledger_dir, nonce_tail).await;
+        return import_node_snapshot_archive(
+            network,
+            global_parameters,
+            snapshot,
+            ledger_dir,
+            nonce_tail,
+            cancellation,
+        )
+        .await;
     }
 
-    Err(ImportError::UnsupportedSnapshotPath(snapshot.to_path_buf()).into())
+    Err(anyhow::Error::from(ImportError::UnsupportedSnapshotPath(snapshot.to_path_buf())).into())
 }
 
 async fn import_node_snapshot_archive(
@@ -713,9 +813,11 @@ async fn import_node_snapshot_archive(
     snapshot_archive: &Path,
     ledger_dir: &Path,
     nonce_tail: Option<HeaderHash>,
-) -> anyhow::Result<ImportedSnapshot> {
+    cancellation: &BootstrapCancellation,
+) -> Result<ImportedSnapshot, BootstrapError> {
     info!(bootstrap::snapshot::IMPORT_ARCHIVE, path = snapshot_archive.display().to_string());
-    import_node_snapshot_source(network, global_parameters, snapshot_archive, ledger_dir, nonce_tail).await
+    import_node_snapshot_source(network, global_parameters, snapshot_archive, ledger_dir, nonce_tail, cancellation)
+        .await
 }
 
 async fn import_node_snapshot_source(
@@ -724,15 +826,18 @@ async fn import_node_snapshot_source(
     archive_path: &Path,
     ledger_dir: &Path,
     nonce_tail: Option<HeaderHash>,
-) -> anyhow::Result<ImportedSnapshot> {
+    cancellation: &BootstrapCancellation,
+) -> Result<ImportedSnapshot, BootstrapError> {
+    checkpoint(cancellation)?;
     fs::create_dir_all(ledger_dir)?;
 
     let previous_accounts = if fs::exists(ledger_dir.join("live"))? {
-        let live = ReadOnlyRocksDB::new(&RocksDbConfig::new(ledger_dir.to_path_buf()))?;
+        let live = ReadOnlyRocksDB::new(&RocksDbConfig::new(ledger_dir.to_path_buf())).map_err(anyhow::Error::from)?;
         let previous_accounts = live
-            .iter_accounts()?
+            .iter_accounts()
+            .map_err(anyhow::Error::from)?
             .map(|(credential, _)| credential)
-            .chain(live.iter_recently_unregistered_accounts()?)
+            .chain(live.iter_recently_unregistered_accounts().map_err(anyhow::Error::from)?)
             .collect();
 
         fs::remove_dir_all(ledger_dir.join("live"))?;
@@ -742,21 +847,42 @@ async fn import_node_snapshot_source(
         BTreeSet::new()
     };
 
-    let db = RocksDB::empty(&RocksDbConfig::new(ledger_dir.to_path_buf()))?;
-    let (epoch, _point, chain_state) = import_node_snapshot_archive_data(
-        archive_path,
-        &db,
-        network,
-        global_parameters,
-        nonce_tail,
-        previous_accounts,
-    )?;
+    let db = RocksDB::empty(&RocksDbConfig::new(ledger_dir.to_path_buf())).map_err(anyhow::Error::from)?;
+    let global_parameters = global_parameters.clone();
+    let archive_path = archive_path.to_path_buf();
+    let importer_control = cancellation.clone();
+    let import_thread = std::thread::Builder::new().stack_size(10_000_000).spawn(move || {
+        import_node_snapshot_archive_data(
+            &archive_path,
+            &db,
+            network,
+            &global_parameters,
+            nonce_tail,
+            previous_accounts,
+            &importer_control,
+        )
+        .map(|(epoch, _point, chain_state)| (db, epoch, chain_state))
+    })?;
 
-    db.next_snapshot(epoch)?;
+    let (db, epoch, chain_state) = await_import_thread(import_thread).await?;
 
-    db.with_transaction(|batch| batch.try_epoch_transition(None, Some(EpochTransitionProgress::SnapshotTaken)))?;
+    checkpoint(cancellation)?;
+    db.next_snapshot(epoch).map_err(anyhow::Error::from)?;
+
+    db.with_transaction(|batch| batch.try_epoch_transition(None, Some(EpochTransitionProgress::SnapshotTaken)))
+        .map_err(anyhow::Error::from)?;
+    checkpoint(cancellation)?;
 
     Ok(ImportedSnapshot { epoch, chain_state })
+}
+
+async fn await_import_thread<T: Send + 'static>(
+    import_thread: std::thread::JoinHandle<Result<T, BootstrapError>>,
+) -> Result<T, BootstrapError> {
+    let joined = tokio::task::spawn_blocking(move || import_thread.join())
+        .await
+        .map_err(|error| anyhow!("bootstrap import join task failed: {error}"))?;
+    joined.map_err(|_| anyhow!("bootstrap import task panicked"))?
 }
 
 fn import_node_snapshot_archive_data(
@@ -766,7 +892,9 @@ fn import_node_snapshot_archive_data(
     global_parameters: &GlobalParameters,
     nonce_tail: Option<HeaderHash>,
     previous_accounts: BTreeSet<Credential>,
-) -> anyhow::Result<(Epoch, Point, Option<ChainState>)> {
+    cancellation: &BootstrapCancellation,
+) -> Result<(Epoch, Point, Option<ChainState>), BootstrapError> {
+    checkpoint(cancellation)?;
     let archive_file = fs::File::open(archive_path)?;
     let mut archive = Archive::new(ZstdDecoder::new(archive_file)?);
 
@@ -774,21 +902,26 @@ fn import_node_snapshot_archive_data(
     let mut previous_accounts: Option<BTreeSet<Credential>> = Some(previous_accounts);
 
     for entry in archive.entries()? {
+        checkpoint(cancellation)?;
         let mut entry = entry?;
         let path = entry.path()?.into_owned();
 
         if snapshot_archive_entry_matches(&path, Path::new(SNAPSHOT_STATE_FILE_NAME)) {
-            imported_state = Some(import_state_from_tvar(
-                db,
-                &mut entry,
-                network,
-                global_parameters,
-                nonce_tail,
-                previous_accounts.take().ok_or_else(|| {
-                    anyhow!("multiple {SNAPSHOT_STATE_FILE_NAME} in archive {}?", archive_path.display())
-                })?,
-                &BootstrapProgressFactory,
-            )?);
+            imported_state = Some(
+                import_state_from_tvar(
+                    db,
+                    &mut entry,
+                    network,
+                    global_parameters,
+                    nonce_tail,
+                    previous_accounts.take().ok_or_else(|| {
+                        anyhow!("multiple {SNAPSHOT_STATE_FILE_NAME} in archive {}?", archive_path.display())
+                    })?,
+                    &BootstrapProgressFactory,
+                    cancellation,
+                )
+                .map_err(|error| controlled_snapshot_import_error(error, cancellation))?,
+            );
         } else if snapshot_archive_entry_matches(&path, Path::new(SNAPSHOT_UTXO_FILE_NAME)) {
             let (epoch, point, era_history, chain_state) = imported_state.take().ok_or_else(|| {
                 anyhow!(
@@ -796,14 +929,22 @@ fn import_node_snapshot_archive_data(
                     archive_path.display()
                 )
             })?;
-
-            import_utxo_from_tvar(&mut entry, db, &BootstrapProgressFactory, &point, &era_history, network)?;
+            import_utxo_from_tvar(
+                &mut entry,
+                db,
+                &BootstrapProgressFactory,
+                &point,
+                &era_history,
+                network,
+                cancellation,
+            )
+            .map_err(|error| controlled_snapshot_import_error(error, cancellation))?;
 
             return Ok((epoch, point, chain_state));
         }
     }
 
-    Err(anyhow!("snapshot archive {} does not contain {SNAPSHOT_UTXO_FILE_NAME}", archive_path.display()))
+    Err(anyhow!("snapshot archive {} does not contain {SNAPSHOT_UTXO_FILE_NAME}", archive_path.display()).into())
 }
 
 #[cfg(test)]
@@ -812,6 +953,10 @@ mod tests {
         fs,
         io::Cursor,
         path::{Path, PathBuf},
+        sync::{
+            Arc, Barrier,
+            atomic::{AtomicBool, Ordering},
+        },
         time::Duration,
     };
 
@@ -820,7 +965,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        Snapshot, read_snapshot_archive_entry, select_bootstrap_snapshots, should_download_snapshot,
+        BootstrapCancellation, BootstrapError, Snapshot, await_import_thread, checkpoint, operation_error,
+        read_snapshot_archive_entry, select_bootstrap_snapshots, should_download_snapshot,
         snapshot_archive_entry_matches, sort_snapshots_by_slot, validate_publishable_snapshot_archive,
         validate_snapshot_archive,
     };
@@ -853,6 +999,65 @@ mod tests {
         }
 
         archive.into_inner().unwrap().finish().unwrap();
+    }
+
+    #[test]
+    fn cancellation_is_reported() {
+        let cancellation = BootstrapCancellation::new();
+        assert!(checkpoint(&cancellation).is_ok());
+
+        cancellation.cancel();
+
+        assert!(matches!(checkpoint(&cancellation), Err(BootstrapError::Cancelled)));
+    }
+
+    #[test]
+    fn cancellation_takes_precedence_over_an_operation_error() {
+        let cancellation = BootstrapCancellation::new();
+        cancellation.cancel();
+
+        let error =
+            operation_error(&cancellation, || panic!("operation error must not be converted after cancellation"));
+
+        assert!(matches!(error, BootstrapError::Cancelled));
+    }
+
+    #[test]
+    fn cancellation_waits_for_the_import_thread_to_release_its_resources() {
+        struct Released(Arc<AtomicBool>);
+
+        impl Drop for Released {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let cancellation = BootstrapCancellation::new();
+        let importer_control = cancellation.clone();
+        let importer_ready = Arc::new(Barrier::new(2));
+        let importer_continue = Arc::new(Barrier::new(2));
+        let released = Arc::new(AtomicBool::new(false));
+        let import_thread = {
+            let importer_ready = Arc::clone(&importer_ready);
+            let importer_continue = Arc::clone(&importer_continue);
+            let released = Arc::clone(&released);
+            std::thread::spawn(move || -> Result<(), BootstrapError> {
+                let _released = Released(released);
+                importer_ready.wait();
+                importer_continue.wait();
+                checkpoint(&importer_control)?;
+                Ok(())
+            })
+        };
+
+        importer_ready.wait();
+        cancellation.cancel();
+        importer_continue.wait();
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        let error = runtime.block_on(await_import_thread(import_thread)).unwrap_err();
+
+        assert!(matches!(error, BootstrapError::Cancelled));
+        assert!(released.load(Ordering::SeqCst));
     }
 
     #[test]

--- a/crates/amaru-bootstrap/src/cardano_node/tvar.rs
+++ b/crates/amaru-bootstrap/src/cardano_node/tvar.rs
@@ -23,11 +23,13 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     io::Read,
     iter,
+    sync::Arc,
 };
 
 use amaru_kernel::{
     Credential, Epoch, EraHistory, GlobalParameters, Hash, HeaderHash, MemoizedTransactionOutput, NetworkName, Point,
-    TransactionInput, cbor, cbor::lazy::LazyDecoder,
+    TransactionInput, cbor,
+    cbor::lazy::{Checkpoint, LazyDecoder},
 };
 use amaru_ledger::{
     bootstrap::import_initial_snapshot_with_decoder,
@@ -38,7 +40,7 @@ use amaru_progress_bar::ProgressBarFactory;
 use anyhow::anyhow;
 
 use super::{extract_snapshot_chain_state_after_ledger, mempack, parse_state_snapshot_prefix};
-use crate::bootstrap::ChainState;
+use crate::bootstrap::{BootstrapCancellation, ChainState, checkpoint};
 
 #[expect(clippy::too_many_arguments)]
 pub fn import_snapshot_from_tvar<S, F, State, Utxo>(
@@ -57,6 +59,7 @@ where
     State: Read,
     Utxo: Read,
 {
+    let cancellation = BootstrapCancellation::new();
     let (epoch, point, era_history, chain_state) = import_state_from_tvar(
         db,
         state_file,
@@ -65,13 +68,15 @@ where
         nonce_tail,
         previous_accounts,
         &with_progress,
+        &cancellation,
     )?;
 
-    import_utxo_from_tvar(utxo_file, db, &with_progress, &point, &era_history, network)?;
+    import_utxo_from_tvar(utxo_file, db, &with_progress, &point, &era_history, network, &cancellation)?;
 
     Ok((epoch, point, chain_state))
 }
 
+#[expect(clippy::too_many_arguments)]
 pub(crate) fn import_state_from_tvar<S, State>(
     db: &S,
     state_file: &mut State,
@@ -80,12 +85,15 @@ pub(crate) fn import_state_from_tvar<S, State>(
     nonce_tail: Option<HeaderHash>,
     previous_accounts: BTreeSet<Credential>,
     with_progress: &impl ProgressBarFactory,
+    cancellation: &BootstrapCancellation,
 ) -> anyhow::Result<(Epoch, Point, EraHistory, Option<ChainState>)>
 where
     S: Store,
     State: Read,
 {
-    let mut decoder = LazyDecoder::new(state_file);
+    let decoder_control = cancellation.clone();
+    let checkpoint: Arc<Checkpoint> = Arc::new(move || checkpoint(&decoder_control).map_err(Into::into));
+    let mut decoder = LazyDecoder::with_checkpoint(state_file, checkpoint);
     let parsed_snapshot = decoder.with_decoder(|d| parse_state_snapshot_prefix(d, global_parameters))?;
     let point = Point::Specific(parsed_snapshot.slot.into(), parsed_snapshot.hash, parsed_snapshot.block_height);
 
@@ -115,12 +123,15 @@ pub(crate) fn import_utxo_from_tvar<S, Utxo>(
     point: &Point,
     era_history: &EraHistory,
     network: NetworkName,
+    cancellation: &BootstrapCancellation,
 ) -> anyhow::Result<()>
 where
     S: Store,
     Utxo: Read,
 {
-    let mut decoder = LazyDecoder::new(utxo_file);
+    let decoder_control = cancellation.clone();
+    let checkpoint: Arc<Checkpoint> = Arc::new(move || checkpoint(&decoder_control).map_err(Into::into));
+    let mut decoder = LazyDecoder::with_checkpoint(utxo_file, checkpoint);
     import_tvar_utxo(&mut decoder, db, with_progress, point, era_history, network)
 }
 
@@ -196,6 +207,7 @@ where
         actual_size += size;
 
         if !utxo.is_empty() {
+            decoder.checkpoint()?;
             db.with_transaction(|transaction| {
                 transaction.save(
                     era_history,
@@ -216,6 +228,7 @@ where
                     iter::empty(),
                 )
             })?;
+            decoder.checkpoint()?;
         }
 
         if done {

--- a/crates/amaru-bootstrap/src/cardano_node/tvar.rs
+++ b/crates/amaru-bootstrap/src/cardano_node/tvar.rs
@@ -207,7 +207,6 @@ where
         actual_size += size;
 
         if !utxo.is_empty() {
-            decoder.checkpoint()?;
             db.with_transaction(|transaction| {
                 transaction.save(
                     era_history,

--- a/crates/amaru-bootstrap/src/lib.rs
+++ b/crates/amaru-bootstrap/src/lib.rs
@@ -38,7 +38,7 @@
 //! ```ignore
 //! use std::path::PathBuf;
 //!
-//! use amaru_bootstrap::{S3Config, bootstrap, default_snapshots_dir};
+//! use amaru_bootstrap::{BootstrapCancellation, S3Config, bootstrap, default_snapshots_dir};
 //! use amaru_kernel::NetworkName;
 //! use amaru_node::{default_chain_dir, default_ledger_dir};
 //!
@@ -48,6 +48,8 @@
 //! let ledger_dir = PathBuf::from(default_ledger_dir(network));
 //! let chain_dir = PathBuf::from(default_chain_dir(network));
 //! let snapshots_dir = PathBuf::from(default_snapshots_dir(network));
+//! let cancellation = BootstrapCancellation::new();
+//! // Clone this handle into your application's shutdown path and call `cancel()` there.
 //!
 //! // Caller must ensure ledger_dir and chain_dir are empty or missing.
 //! bootstrap(
@@ -58,6 +60,7 @@
 //!     snapshots_dir,          // `snapshots/<network>/`; reuses archives already on disk
 //!     /* target_epoch */ None, // latest window available on the CDN
 //!     S3Config::default(),     // or override bucket / public_url
+//!     cancellation,
 //! )
 //! .await?;
 //!
@@ -132,8 +135,8 @@ pub use aws::{
     S3Client, S3Config, S3Snapshot,
 };
 pub use bootstrap::{
-    BOOTSTRAP_HEADERS_PER_POINT, BootstrapError, ChainState, ImportError, InitialNonces, bootstrap,
-    fetch_headers_from_points, import_headers, import_packaged_blocks, import_snapshots,
+    BOOTSTRAP_HEADERS_PER_POINT, BootstrapCancellation, BootstrapError, ChainState, ImportError, InitialNonces,
+    bootstrap, fetch_headers_from_points, import_headers, import_packaged_blocks, import_snapshots,
     import_snapshots_from_directory, store_chain_state, validate_publishable_snapshot_archive,
 };
 

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -17,7 +17,7 @@ use std::{
     io::Read,
     iter,
     rc::Rc,
-    sync::LazyLock,
+    sync::{Arc, LazyLock},
 };
 
 use amaru_kernel::{
@@ -27,7 +27,10 @@ use amaru_kernel::{
     Proposal, ProposalId, ProposalPointer, ProposalState, ProposalsRoots, ProposalsRootsRc, ProtocolParameters,
     ProtocolVersion, RatificationStatus, RationalNumber, Relay, Reward, RewardAccount, Slot, TransactionPointer, Vote,
     Voter,
-    cbor::{self, HasProtocolVersion, lazy::LazyDecoder},
+    cbor::{
+        self, HasProtocolVersion,
+        lazy::{Checkpoint, LazyDecoder},
+    },
     protocol_version, size,
     utils::cbor::{SerialisedAsArray, SerialisedAsSet},
 };
@@ -138,15 +141,18 @@ fn save_bootstrap_account_batches(
     db: &impl Store,
     mut rows: impl Iterator<Item = (accounts::Key, accounts::Row)>,
     mut on_batch: impl FnMut(usize),
-) -> Result<(), StoreError> {
+    checkpoint: Option<&Arc<Checkpoint>>,
+) -> anyhow::Result<()> {
     loop {
         let batch = rows.by_ref().take(BATCH_SIZE).collect::<Vec<_>>();
         if batch.is_empty() {
             return Ok(());
         }
 
+        checkpoint.map_or(Ok(()), |checkpoint| checkpoint())?;
         let size = batch.len();
         db.save_bootstrap_accounts(batch.into_iter())?;
+        checkpoint.map_or(Ok(()), |checkpoint| checkpoint())?;
         on_batch(size);
     }
 }
@@ -163,6 +169,7 @@ fn import_rewards(
     rewards_size: usize,
     with_progress: &impl ProgressBarFactory,
 ) -> anyhow::Result<u64> {
+    let checkpoint = decoder.checkpoint_handle();
     let (progress, unclaimed_rewards) = decoder.stream_map(
         |d| {
             let credential = d.decode()?;
@@ -182,11 +189,13 @@ fn import_rewards(
         },
         |(progress, unclaimed_rewards), entries| {
             for batch in entries.chunks(BATCH_SIZE) {
+                checkpoint.as_ref().map_or(Ok(()), |checkpoint| checkpoint())?;
                 let transaction = db.create_transaction();
                 for (credential, amount) in batch {
                     *unclaimed_rewards += transaction.refund(credential, *amount)?;
                 }
                 transaction.commit()?;
+                checkpoint.as_ref().map_or(Ok(()), |checkpoint| checkpoint())?;
                 progress.tick(batch.len());
             }
             Ok(())
@@ -211,6 +220,7 @@ fn import_accounts(
 
     decoder.begin_array()?;
 
+    let checkpoint = decoder.checkpoint_handle();
     let (progress, size, awaiting_default_deposit) = decoder.stream_map(
         |d| Ok((d.decode::<Credential>()?, d.decode::<NodeAccount>()?)),
         |length| {
@@ -243,7 +253,7 @@ fn import_accounts(
             awaiting_default_deposit.extend(awaiting);
 
             let ready = ready.into_iter().map(|(credential, account)| (credential, account.into_row(point, None)));
-            save_bootstrap_account_batches(db, ready, |_| {})?;
+            save_bootstrap_account_batches(db, ready, |_| {}, checkpoint.as_ref())?;
             Ok(())
         },
     )?;
@@ -261,8 +271,10 @@ fn import_recently_unregistered_accounts(
     era_history: &EraHistory,
     protocol_parameters: &ProtocolParameters,
     recently_unregistered_accounts: BTreeSet<Credential>,
+    checkpoint: Option<&Arc<Checkpoint>>,
 ) -> anyhow::Result<()> {
     if !recently_unregistered_accounts.is_empty() {
+        checkpoint.map_or(Ok(()), |checkpoint| checkpoint())?;
         db.with_transaction(|transaction| {
             transaction.save(
                 era_history,
@@ -283,6 +295,7 @@ fn import_recently_unregistered_accounts(
                 iter::empty(),
             )
         })?;
+        checkpoint.map_or(Ok(()), |checkpoint| checkpoint())?;
     }
 
     Ok(())
@@ -294,6 +307,7 @@ fn import_default_account_deposits(
     default_deposit: Lovelace,
     with_progress: &impl ProgressBarFactory,
     mut accounts: Vec<(Credential, NodeAccount)>,
+    checkpoint: Option<&Arc<Checkpoint>>,
 ) -> anyhow::Result<()> {
     if accounts.is_empty() {
         return Ok(());
@@ -308,7 +322,7 @@ fn import_default_account_deposits(
     let awaiting =
         accounts.drain(..).map(|(credential, account)| (credential, account.into_row(point, Some(default_deposit))));
 
-    save_bootstrap_account_batches(db, awaiting, |size| progress.tick(size))?;
+    save_bootstrap_account_batches(db, awaiting, |size| progress.tick(size), checkpoint)?;
 
     progress.finish();
     Ok(())
@@ -424,6 +438,7 @@ fn decode_initial_snapshot(
         protocol_parameters.stake_credential_deposit,
         with_progress,
         awaiting_default_deposit,
+        decoder.checkpoint_handle().as_ref(),
     )?;
 
     let (pools, pools_updates, pools_retirements) =
@@ -518,6 +533,7 @@ fn decode_initial_snapshot(
         era_history,
         &protocol_parameters,
         recently_unregistered_accounts,
+        decoder.checkpoint_handle().as_ref(),
     )?;
 
     Ok(InitialSnapshot {
@@ -620,21 +636,29 @@ pub fn import_initial_snapshot_with_decoder(
         with_progress,
     )?;
 
+    decoder.checkpoint()?;
     import_protocol_parameters(db, &protocol_parameters)?;
 
+    decoder.checkpoint()?;
     import_block_issuers(db, point, era_history, block_issuers)?;
 
+    decoder.checkpoint()?;
     import_stake_pools(db, point, era_history, pools, pools_updates, pools_retirements)
         .map_err(|err| anyhow!("import pool state: {err}"))?;
 
+    decoder.checkpoint()?;
     import_proposals_roots(db, &proposals_roots)?;
 
+    decoder.checkpoint()?;
     import_proposals(db, point, era_history, &protocol_parameters, &proposals)?;
 
+    decoder.checkpoint()?;
     import_recently_pruned_proposals(db, era_history, epoch, &proposals_roots, enacted_proposals, expired_proposals)?;
 
+    decoder.checkpoint()?;
     import_votes(db, point, era_history, &protocol_parameters, proposals)?;
 
+    decoder.checkpoint()?;
     import_pots(
         db,
         Pots {
@@ -657,13 +681,18 @@ pub fn import_initial_snapshot_with_decoder(
     //    accordingly on import.
     //
     // This may cause a few warnings on import, but they can be safely ignored.
+    decoder.checkpoint()?;
     import_dreps(db, point, era_history, &protocol_parameters, epoch, dreps)?;
 
+    decoder.checkpoint()?;
     import_constitution(db, constitution)?;
 
+    decoder.checkpoint()?;
     import_constitutional_committee(db, point, era_history, &protocol_parameters, cc_state, cc_members)?;
 
+    decoder.checkpoint()?;
     save_point(db, point, era_history, &protocol_parameters, governance_activity)?;
+    decoder.checkpoint()?;
 
     Ok(epoch)
 }

--- a/crates/amaru-ledger/src/bootstrap.rs
+++ b/crates/amaru-ledger/src/bootstrap.rs
@@ -149,7 +149,6 @@ fn save_bootstrap_account_batches(
             return Ok(());
         }
 
-        checkpoint.map_or(Ok(()), |checkpoint| checkpoint())?;
         let size = batch.len();
         db.save_bootstrap_accounts(batch.into_iter())?;
         checkpoint.map_or(Ok(()), |checkpoint| checkpoint())?;
@@ -189,7 +188,6 @@ fn import_rewards(
         },
         |(progress, unclaimed_rewards), entries| {
             for batch in entries.chunks(BATCH_SIZE) {
-                checkpoint.as_ref().map_or(Ok(()), |checkpoint| checkpoint())?;
                 let transaction = db.create_transaction();
                 for (credential, amount) in batch {
                     *unclaimed_rewards += transaction.refund(credential, *amount)?;
@@ -271,10 +269,8 @@ fn import_recently_unregistered_accounts(
     era_history: &EraHistory,
     protocol_parameters: &ProtocolParameters,
     recently_unregistered_accounts: BTreeSet<Credential>,
-    checkpoint: Option<&Arc<Checkpoint>>,
 ) -> anyhow::Result<()> {
     if !recently_unregistered_accounts.is_empty() {
-        checkpoint.map_or(Ok(()), |checkpoint| checkpoint())?;
         db.with_transaction(|transaction| {
             transaction.save(
                 era_history,
@@ -295,7 +291,6 @@ fn import_recently_unregistered_accounts(
                 iter::empty(),
             )
         })?;
-        checkpoint.map_or(Ok(()), |checkpoint| checkpoint())?;
     }
 
     Ok(())
@@ -533,7 +528,6 @@ fn decode_initial_snapshot(
         era_history,
         &protocol_parameters,
         recently_unregistered_accounts,
-        decoder.checkpoint_handle().as_ref(),
     )?;
 
     Ok(InitialSnapshot {
@@ -636,29 +630,23 @@ pub fn import_initial_snapshot_with_decoder(
         with_progress,
     )?;
 
-    decoder.checkpoint()?;
     import_protocol_parameters(db, &protocol_parameters)?;
 
-    decoder.checkpoint()?;
     import_block_issuers(db, point, era_history, block_issuers)?;
 
-    decoder.checkpoint()?;
     import_stake_pools(db, point, era_history, pools, pools_updates, pools_retirements)
         .map_err(|err| anyhow!("import pool state: {err}"))?;
-
     decoder.checkpoint()?;
+
     import_proposals_roots(db, &proposals_roots)?;
 
-    decoder.checkpoint()?;
     import_proposals(db, point, era_history, &protocol_parameters, &proposals)?;
 
-    decoder.checkpoint()?;
     import_recently_pruned_proposals(db, era_history, epoch, &proposals_roots, enacted_proposals, expired_proposals)?;
 
-    decoder.checkpoint()?;
     import_votes(db, point, era_history, &protocol_parameters, proposals)?;
-
     decoder.checkpoint()?;
+
     import_pots(
         db,
         Pots {
@@ -681,16 +669,13 @@ pub fn import_initial_snapshot_with_decoder(
     //    accordingly on import.
     //
     // This may cause a few warnings on import, but they can be safely ignored.
-    decoder.checkpoint()?;
     import_dreps(db, point, era_history, &protocol_parameters, epoch, dreps)?;
-
     decoder.checkpoint()?;
+
     import_constitution(db, constitution)?;
 
-    decoder.checkpoint()?;
     import_constitutional_committee(db, point, era_history, &protocol_parameters, cc_state, cc_members)?;
 
-    decoder.checkpoint()?;
     save_point(db, point, era_history, &protocol_parameters, governance_activity)?;
     decoder.checkpoint()?;
 

--- a/crates/amaru-minicbor-extra/src/decode/lazy.rs
+++ b/crates/amaru-minicbor-extra/src/decode/lazy.rs
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io::Read;
+use std::{io::Read, sync::Arc};
 
 use minicbor as cbor;
+
+/// Runtime-neutral callback used to stop incremental decoding at safe boundaries.
+pub type Checkpoint = dyn Fn() -> anyhow::Result<()> + Send + Sync;
 
 /// A decoder that only consumes bytes CHUNK_SIZE at a time. Useful to decode large files while
 /// maintaining memory usage low.
@@ -25,6 +28,7 @@ use minicbor as cbor;
 pub struct LazyDecoder<'a> {
     reader: &'a mut dyn Read,
     bytes: Vec<u8>,
+    checkpoint: Option<Arc<Checkpoint>>,
 }
 
 impl<'a> LazyDecoder<'a> {
@@ -32,7 +36,22 @@ impl<'a> LazyDecoder<'a> {
 
     /// Create a decoder that reads incrementally from `reader`.
     pub fn new(reader: &'a mut dyn Read) -> Self {
-        Self { reader, bytes: Vec::with_capacity(Self::CHUNK_SIZE) }
+        Self { reader, bytes: Vec::with_capacity(Self::CHUNK_SIZE), checkpoint: None }
+    }
+
+    /// Create a decoder which invokes `checkpoint` between bounded decode units.
+    pub fn with_checkpoint(reader: &'a mut dyn Read, checkpoint: Arc<Checkpoint>) -> Self {
+        Self { reader, bytes: Vec::with_capacity(Self::CHUNK_SIZE), checkpoint: Some(checkpoint) }
+    }
+
+    /// Invoke the configured checkpoint, if any.
+    pub fn checkpoint(&self) -> anyhow::Result<()> {
+        self.checkpoint.as_ref().map_or(Ok(()), |checkpoint| checkpoint())
+    }
+
+    /// Clone the configured checkpoint for database batch handlers associated with this decoder.
+    pub fn checkpoint_handle(&self) -> Option<Arc<Checkpoint>> {
+        self.checkpoint.clone()
     }
 
     /// Skip the next CBOR element.
@@ -70,6 +89,7 @@ impl<'a> LazyDecoder<'a> {
         skip_entry: impl Fn(&mut cbor::Decoder<'_>) -> Result<(), cbor::decode::Error>,
     ) -> anyhow::Result<()> {
         loop {
+            self.checkpoint()?;
             let (entries, complete) =
                 self.with_decoder(|d| decode_sequence_chunk(d, remaining, &skip_entry).map_err(Into::into))?;
             remaining = remaining.map(|count| count - entries.len() as u64);
@@ -105,6 +125,7 @@ impl<'a> LazyDecoder<'a> {
         let mut can_read_more = true;
         loop {
             if should_read_more {
+                self.checkpoint()?;
                 let offset = self.bytes.len();
                 self.bytes.resize(offset + Self::CHUNK_SIZE, 0);
                 let read = match self.reader.read(&mut self.bytes[offset..]) {
@@ -136,6 +157,7 @@ impl<'a> LazyDecoder<'a> {
                 }
                 Err(err) if can_read_more => match err.downcast::<cbor::decode::Error>() {
                     Ok(err) if err.is_end_of_input() => {
+                        self.checkpoint()?;
                         should_read_more = true;
                         continue;
                     }
@@ -166,11 +188,14 @@ impl<'a> LazyDecoder<'a> {
         let mut state = init(length);
 
         loop {
+            self.checkpoint()?;
             let (entries, complete) =
                 self.with_decoder(|d| decode_sequence_chunk(d, remaining, &decode_entry).map_err(Into::into))?;
 
             remaining = remaining.map(|count| count - entries.len() as u64);
+            self.checkpoint()?;
             handle_entries(&mut state, entries)?;
+            self.checkpoint()?;
 
             if complete {
                 return Ok(state);
@@ -225,7 +250,13 @@ fn decode_sequence_chunk<T>(
 
 #[cfg(test)]
 mod tests {
-    use std::io::{self, Read};
+    use std::{
+        io::{self, Read},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
 
     use minicbor as cbor;
 
@@ -253,6 +284,27 @@ mod tests {
         assert_eq!(entries, vec![(1, 10)]);
         assert!(!complete);
         assert_eq!(decoder.position(), 2);
+    }
+
+    #[test]
+    fn checkpoint_stops_before_retrying_an_incomplete_decode() {
+        let bytes = [0x18, 0x2a];
+        let mut reader = ChunkedReader { inner: bytes.as_slice(), chunk_size: 1 };
+        let checks = Arc::new(AtomicUsize::new(0));
+        let checks_for_decoder = Arc::clone(&checks);
+        let checkpoint = Arc::new(move || {
+            let check = checks_for_decoder.fetch_add(1, Ordering::SeqCst);
+            if check >= 1 {
+                anyhow::bail!("cancelled at checkpoint")
+            }
+            Ok(())
+        });
+        let mut decoder = LazyDecoder::with_checkpoint(&mut reader, checkpoint);
+
+        let error = decoder.decode::<u8>().expect_err("the second read must be cancelled");
+
+        assert!(error.to_string().contains("cancelled at checkpoint"));
+        assert_eq!(checks.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/crates/amaru-minicbor-extra/src/decode/lazy.rs
+++ b/crates/amaru-minicbor-extra/src/decode/lazy.rs
@@ -89,7 +89,6 @@ impl<'a> LazyDecoder<'a> {
         skip_entry: impl Fn(&mut cbor::Decoder<'_>) -> Result<(), cbor::decode::Error>,
     ) -> anyhow::Result<()> {
         loop {
-            self.checkpoint()?;
             let (entries, complete) =
                 self.with_decoder(|d| decode_sequence_chunk(d, remaining, &skip_entry).map_err(Into::into))?;
             remaining = remaining.map(|count| count - entries.len() as u64);
@@ -157,7 +156,6 @@ impl<'a> LazyDecoder<'a> {
                 }
                 Err(err) if can_read_more => match err.downcast::<cbor::decode::Error>() {
                     Ok(err) if err.is_end_of_input() => {
-                        self.checkpoint()?;
                         should_read_more = true;
                         continue;
                     }
@@ -188,14 +186,11 @@ impl<'a> LazyDecoder<'a> {
         let mut state = init(length);
 
         loop {
-            self.checkpoint()?;
             let (entries, complete) =
                 self.with_decoder(|d| decode_sequence_chunk(d, remaining, &decode_entry).map_err(Into::into))?;
 
             remaining = remaining.map(|count| count - entries.len() as u64);
-            self.checkpoint()?;
             handle_entries(&mut state, entries)?;
-            self.checkpoint()?;
 
             if complete {
                 return Ok(state);

--- a/crates/amaru-node/src/tests/world/fragment.rs
+++ b/crates/amaru-node/src/tests/world/fragment.rs
@@ -205,9 +205,18 @@ async fn populate_fragment_stores(root: &Path, meta: &FragmentMeta) -> anyhow::R
             snapshots_dir = %snapshots_dir.display(),
             "reusing workspace snapshot cache"
         );
-        bootstrap(network, &global, ledger, chain, snapshots_dir, None, S3Config::default())
-            .await
-            .map_err(|e| anyhow::anyhow!("bootstrap: {e}"))?;
+        bootstrap(
+            network,
+            &global,
+            ledger,
+            chain,
+            snapshots_dir,
+            None,
+            S3Config::default(),
+            amaru_bootstrap::BootstrapCancellation::new(),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("bootstrap: {e}"))?;
     } else {
         tracing::info!(target = "world_fragment", "bootstrap/ already populated; skipping snapshot download");
     }

--- a/crates/amaru/src/bin/amaru/cmd/node/bootstrap.rs
+++ b/crates/amaru/src/bin/amaru/cmd/node/bootstrap.rs
@@ -180,8 +180,11 @@ async fn run(args: Args) -> anyhow::Result<()> {
             region: args.s3_region,
             public_url: args.s3_public_url,
         },
+        amaru_bootstrap::BootstrapCancellation::new(),
     )
-    .await
+    .await?;
+
+    Ok(())
 }
 
 /// Whether `dir` holds anything. An empty directory is no more a database than a missing one, and


### PR DESCRIPTION
Allow the bootstrap process to be cancelled using a `tokio_util::sync::CancellationToken`.
Especially useful for 3rd party apps doing a bootstrap, as bootstrap process can take some significant time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to cancel an in-progress node bootstrap operation.
  - Bootstrap now checks for cancellation at safe processing points and reports when cancellation occurs.
  - Cancellation stops lengthy state, UTxO, snapshot, and packaged-block imports more responsively.
  - Import progress is checkpointed incrementally, improving resumability and resource cleanup.

- **Documentation**
  - Added guidance for creating and passing a bootstrap cancellation handle.
  - Updated OpenTelemetry configuration documentation, including optional signal selection and enabling all signals by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->