### PR TITLE
feat: allow 3rd party dev to have full PR run

### DIFF
--- a/.github/workflows/ci-build-and-test.yml
+++ b/.github/workflows/ci-build-and-test.yml
@@ -95,11 +95,8 @@ jobs:
   snapshots:
     name: Compare ledger epoch snapshots
     uses: ./.github/workflows/template-ledger-epoch-snapshots.yml
-    secrets:
-      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-      S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
-      CARDANO_NODE_BUCKET_NAME: ${{ secrets.CARDANO_NODE_BUCKET_NAME }}
+    with:
+      CARDANO_NODE_DB_URL: ${{ vars.CARDANO_NODE_DB_URL }}
 
   benches:
     name: Bench

--- a/.github/workflows/ci-transaction-submission.yml
+++ b/.github/workflows/ci-transaction-submission.yml
@@ -27,6 +27,7 @@ jobs:
       AMARU_UPSTREAM_PEERS: 1
       BUILD_PROFILE: test
       CARGO_BUILD_TARGET: x86_64-unknown-linux-gnu
+      CARDANO_NODE_DB_URL: ${{ vars.CARDANO_NODE_DB_URL }}
       E2E_TX_WORK_DIR: ${{ github.workspace }}/e2e-tx-submission-output
       RUST_BACKTRACE: 1
 
@@ -66,16 +67,13 @@ jobs:
 
       - name: Download cardano-node database
         shell: bash
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-          ENDPOINT: ${{ secrets.S3_ENDPOINT }}
-          OBJECT: "s3://${{ secrets.CARDANO_NODE_BUCKET_NAME }}/preprod.tar.zstd"
         run: |
           set -euo pipefail
+          : "${CARDANO_NODE_DB_URL:?CARDANO_NODE_DB_URL is not configured}"
           mkdir -p "$CARDANO_NODE_DB" "$(dirname "$CARDANO_NODE_SOCKET_FILE")"
-          aws s3 cp "$OBJECT" - --endpoint-url "$ENDPOINT" | tar --zstd -xf - -C "$CARDANO_NODE_DB"
+          archive_url="${CARDANO_NODE_DB_URL%/}/preprod.tar.zstd"
+          curl --fail --location "$archive_url" \
+            | tar --zstd -xf - -C "$CARDANO_NODE_DB"
           touch "$CARDANO_NODE_DB/clean"
 
       - name: Spawn cardano-node

--- a/.github/workflows/nightly-synchronization.yml
+++ b/.github/workflows/nightly-synchronization.yml
@@ -22,21 +22,20 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: auto
-      ENDPOINT: ${{ secrets.S3_ENDPOINT }}
-      OBJECT: "s3://${{ secrets.CARDANO_NODE_BUCKET_NAME }}/${{ matrix.network }}.tar.zstd"
+      CARDANO_NODE_DB_URL: ${{ vars.CARDANO_NODE_DB_URL }}
       OGMIOS_VERSION: v7.0.0
       CARDANO_NODE_VERSION: 11.0.1
 
     steps:
-      - name: 📥 Download R2 Object
+      - name: 📥 Download cardano-node database
         shell: bash
         run: |
           set -euo pipefail
+          : "${CARDANO_NODE_DB_URL:?CARDANO_NODE_DB_URL is not configured}"
           mkdir -p "${{ runner.temp }}/db"
-          aws s3 cp "$OBJECT" - --endpoint-url "$ENDPOINT" | tar --zstd -xf - -C "${{ runner.temp }}/db"
+          archive_url="${CARDANO_NODE_DB_URL%/}/${{ matrix.network }}.tar.zstd"
+          curl --fail --location "$archive_url" \
+            | tar --zstd -xf - -C "${{ runner.temp }}/db"
           touch ${{ runner.temp }}/db/clean
 
       - name: ⚙️ Synchronize with ${{ matrix.network }}
@@ -52,8 +51,14 @@ jobs:
           # compatible with protocol version 12.
           synchronization-level: ${{ inputs.synchronization-level || (matrix.network == 'preview' && 0.99 || 1) }}
 
-      - name: 📥 Upload R2 Object
+      - name: 📤 Upload cardano-node database
         shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+          OBJECT: "s3://${{ secrets.CARDANO_NODE_BUCKET_NAME }}/${{ matrix.network }}.tar.zstd"
         run: |
           set -euo pipefail
           tar --zstd -cf - -C "${{ runner.temp }}/db" . | aws s3 cp - "$OBJECT" --endpoint-url "$ENDPOINT"

--- a/.github/workflows/template-ledger-epoch-snapshots.yml
+++ b/.github/workflows/template-ledger-epoch-snapshots.yml
@@ -8,14 +8,9 @@ on:
         type: string
         required: false
         default: ""
-    secrets:
-      R2_ACCESS_KEY_ID:
-        required: true
-      R2_SECRET_ACCESS_KEY:
-        required: true
-      S3_ENDPOINT:
-        required: true
-      CARDANO_NODE_BUCKET_NAME:
+      CARDANO_NODE_DB_URL:
+        description: "Public HTTPS base URL containing preprod.tar.zstd and preview.tar.zstd"
+        type: string
         required: true
 
 env:
@@ -53,11 +48,7 @@ jobs:
       AMARU_UPSTREAM_PEERS: 1
       BUILD_PROFILE: test
       CARGO_BUILD_TARGET: x86_64-unknown-linux-gnu
-      AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: auto
-      ENDPOINT: ${{ secrets.S3_ENDPOINT }}
-      OBJECT: "s3://${{ secrets.CARDANO_NODE_BUCKET_NAME }}/${{ matrix.network.name }}.tar.zstd"
+      CARDANO_NODE_DB_URL: ${{ inputs.CARDANO_NODE_DB_URL }}
       TRACE_CONTRACT: data/${{ matrix.network.name }}/run-until-trace-contract.json
       TRACE_COMPARE_LOG: trace-compare.log
       AMARU_WITH_OPEN_TELEMETRY: "true"
@@ -90,8 +81,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          : "${CARDANO_NODE_DB_URL:?CARDANO_NODE_DB_URL is not configured}"
           mkdir -p "$CARDANO_NODE_DB" "$(dirname "$CARDANO_NODE_SOCKET_FILE")"
-          aws s3 cp "$OBJECT" - --endpoint-url "$ENDPOINT" | tar --zstd -xf - -C "$CARDANO_NODE_DB"
+          archive_url="${CARDANO_NODE_DB_URL%/}/${{ matrix.network.name }}.tar.zstd"
+          curl --fail --location "$archive_url" \
+            | tar --zstd -xf - -C "$CARDANO_NODE_DB"
           touch "$CARDANO_NODE_DB/clean"
 
       - name: Spawn Haskell Node

--- a/scripts/configure-github-secrets
+++ b/scripts/configure-github-secrets
@@ -9,18 +9,23 @@ usage() {
 Usage:
   scripts/configure-github-secrets [--repo OWNER/REPO]
   scripts/configure-github-secrets [--repo OWNER/REPO] --set-base64-file SECRET FILE
+  scripts/configure-github-secrets [--repo OWNER/REPO] --set-variable VARIABLE VALUE
 
-Interactively show GitHub Actions secrets referenced by this repository and
-set or update repository-level values without exposing them in command-line
-arguments.
+Interactively show GitHub Actions secrets and variables referenced by this
+repository and set or update their repository-level values. Secret values are
+never exposed in command-line arguments.
 
 With --set-base64-file, base64-encode FILE and set SECRET without prompting.
+With --set-variable, set the public configuration VARIABLE to VALUE without
+prompting.
 EOF
 }
 
 repo="${GH_REPO:-}"
 base64_secret_name=""
 base64_file_path=""
+variable_name=""
+variable_value=""
 while (($# > 0)); do
   case "$1" in
     --repo)
@@ -35,6 +40,13 @@ while (($# > 0)); do
       base64_file_path="$3"
       shift 3
       ;;
+    --set-variable)
+      [[ $# -ge 3 ]] || { usage >&2; exit 2; }
+      [[ -z "$variable_name" ]] || { echo "error: --set-variable may only be specified once" >&2; exit 2; }
+      variable_name="$2"
+      variable_value="$3"
+      shift 3
+      ;;
     -h | --help)
       usage
       exit 0
@@ -46,6 +58,11 @@ while (($# > 0)); do
       ;;
   esac
 done
+
+if [[ -n "$base64_secret_name" && -n "$variable_name" ]]; then
+  echo "error: --set-base64-file and --set-variable cannot be used together" >&2
+  exit 2
+fi
 
 require_command() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -80,12 +97,24 @@ done < <(
     | sort -u
 )
 
-((${#required_secrets[@]} > 0)) || {
-  echo "error: no GitHub Actions secret references found" >&2
+required_variables=()
+while IFS= read -r required_variable_name; do
+  [[ -n "$required_variable_name" ]] || continue
+  required_variables+=("$required_variable_name")
+done < <(
+  LC_ALL=C grep -RhoE 'vars\.[A-Za-z_][A-Za-z0-9_]*' \
+    "$ROOT_DIR/.github/workflows" "$ROOT_DIR/.github/actions" 2>/dev/null \
+    | sed 's/^vars\.//' \
+    | sort -u
+)
+
+((${#required_secrets[@]} > 0 || ${#required_variables[@]} > 0)) || {
+  echo "error: no GitHub Actions secret or variable references found" >&2
   exit 1
 }
 
 configured_secrets=()
+configured_variables=()
 refresh_configured_secrets() {
   local secret_list
   if ! secret_list="$(gh secret list --repo "$repo" --json name --jq '.[].name')"; then
@@ -99,6 +128,24 @@ refresh_configured_secrets() {
   return 0
 }
 
+refresh_configured_variables() {
+  local variable_list
+  if ! variable_list="$(gh variable list --repo "$repo" --json name --jq '.[].name')"; then
+    echo "error: unable to list GitHub Actions variables for $repo" >&2
+    return 1
+  fi
+  configured_variables=()
+  while IFS= read -r configured_variable_name; do
+    [[ -n "$configured_variable_name" ]] && configured_variables+=("$configured_variable_name")
+  done <<<"$variable_list"
+  return 0
+}
+
+refresh_configuration() {
+  refresh_configured_secrets
+  refresh_configured_variables
+}
+
 secret_is_configured() {
   local expected="$1" configured
   ((${#configured_secrets[@]} > 0)) || return 1
@@ -108,21 +155,43 @@ secret_is_configured() {
   return 1
 }
 
+variable_is_configured() {
+  local expected="$1" configured
+  ((${#configured_variables[@]} > 0)) || return 1
+  for configured in "${configured_variables[@]}"; do
+    [[ "$configured" == "$expected" ]] && return 0
+  done
+  return 1
+}
+
 show_status() {
-  local index secret_name status missing=0
-  printf '\nGitHub Actions repository secrets for %s\n' "$repo"
-  printf 'Status only includes repository-level secrets visible to your GitHub account.\n\n'
+  local index secret_name required_variable_name status missing_secrets=0 missing_variables=0
+  printf '\nGitHub Actions repository configuration for %s\n' "$repo"
+  printf 'Status only includes repository-level values visible to your GitHub account.\n\n'
+  printf 'Secrets:\n'
   for index in "${!required_secrets[@]}"; do
     secret_name="${required_secrets[$index]}"
     if secret_is_configured "$secret_name"; then
       status="configured"
     else
       status="MISSING"
-      missing=$((missing + 1))
+      missing_secrets=$((missing_secrets + 1))
     fi
-    printf '  %2d) %-42s %s\n' "$((index + 1))" "$secret_name" "$status"
+    printf '  %-4s %-42s %s\n' "s$((index + 1)))" "$secret_name" "$status"
   done
-  printf '\n%d of %d referenced secrets missing at repository level.\n' "$missing" "${#required_secrets[@]}"
+  printf '\nVariables (public configuration):\n'
+  for index in "${!required_variables[@]}"; do
+    required_variable_name="${required_variables[$index]}"
+    if variable_is_configured "$required_variable_name"; then
+      status="configured"
+    else
+      status="MISSING"
+      missing_variables=$((missing_variables + 1))
+    fi
+    printf '  %-4s %-42s %s\n' "v$((index + 1)))" "$required_variable_name" "$status"
+  done
+  printf '\n%d of %d referenced secrets and %d of %d referenced variables missing at repository level.\n' \
+    "$missing_secrets" "${#required_secrets[@]}" "$missing_variables" "${#required_variables[@]}"
 }
 
 set_from_hidden_prompt() {
@@ -175,6 +244,14 @@ secret_is_required() {
   return 1
 }
 
+variable_is_required() {
+  local expected="$1" required
+  for required in "${required_variables[@]}"; do
+    [[ "$required" == "$expected" ]] && return 0
+  done
+  return 1
+}
+
 configure_secret() {
   local secret_name="$1" choice
   while true; do
@@ -195,6 +272,16 @@ configure_secret() {
   done
 }
 
+set_variable() {
+  local name="$1" value="${2:-}"
+  if [[ -z "$value" ]]; then
+    printf 'Enter public value for %s: ' "$name"
+    IFS= read -r value
+  fi
+  [[ -n "$value" ]] || { echo "error: refusing to set an empty variable" >&2; return 1; }
+  gh variable set "$name" --repo "$repo" --body "$value"
+}
+
 if [[ -n "$base64_secret_name" ]]; then
   secret_is_required "$base64_secret_name" || {
     echo "error: secret is not referenced by this repository: $base64_secret_name" >&2
@@ -205,27 +292,54 @@ if [[ -n "$base64_secret_name" ]]; then
   exit 0
 fi
 
-refresh_configured_secrets
+if [[ -n "$variable_name" ]]; then
+  variable_is_required "$variable_name" || {
+    echo "error: variable is not referenced by this repository: $variable_name" >&2
+    exit 1
+  }
+  set_variable "$variable_name" "$variable_value"
+  printf 'Set repository variable %s.\n' "$variable_name"
+  exit 0
+fi
+
+refresh_configuration
 while true; do
   show_status
-  printf '\nChoose a secret number to set/update, r to refresh, or q to quit: '
+  printf '\nChoose sN or vN to set/update a secret or variable, r to refresh, or q to quit: '
   IFS= read -r choice || exit 0
   case "$choice" in
     q | Q) exit 0 ;;
     r | R)
-      refresh_configured_secrets
+      refresh_configuration
       ;;
-    *[!0-9]* | '')
-      echo "error: enter a listed number, r, or q" >&2
-      ;;
-    *)
-      choice_number=$((10#$choice))
+    s* | [0-9]*)
+      choice_number_text="${choice#s}"
+      if [[ -z "$choice_number_text" || "$choice_number_text" == *[!0-9]* ]]; then
+        echo "error: enter a listed sN or vN value, r, or q" >&2
+        continue
+      fi
+      choice_number=$((10#$choice_number_text))
       if ((choice_number < 1 || choice_number > ${#required_secrets[@]})); then
         echo "error: secret number is out of range" >&2
         continue
       fi
       configure_secret "${required_secrets[$((choice_number - 1))]}"
-      refresh_configured_secrets
+      refresh_configuration
       ;;
+    v*)
+      choice_number_text="${choice#v}"
+      if [[ -z "$choice_number_text" || "$choice_number_text" == *[!0-9]* ]]; then
+        echo "error: enter a listed sN or vN value, r, or q" >&2
+        continue
+      fi
+      choice_number=$((10#$choice_number_text))
+      if ((choice_number < 1 || choice_number > ${#required_variables[@]})); then
+        echo "error: variable number is out of range" >&2
+        continue
+      fi
+      set_variable "${required_variables[$((choice_number - 1))]}"
+      refresh_configuration
+      ;;
+    *) echo "error: enter a listed sN or vN value, r, or q" >&2 ;;
   esac
 done


### PR DESCRIPTION
**There might be a reason not to do this, comment if that's the case**

Make sure external contributors PR can run fully so that anyone can get good DX.


This requires publishing publicly cardano dbs and defining GH var `CARDANO_NODE_DB_URL`.

```shell
scripts/configure-github-secrets \
  --repo pragma-org/amaru \
  --set-variable CARDANO_NODE_DB_URL \
  'https://<public-r2-domain>'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflows now retrieve Cardano node databases from a configured repository variable and public HTTPS URL.
  * Added support for managing GitHub Actions repository variables through the configuration tool.
  * Interactive configuration now displays and supports both secrets and variables.

* **Changes**
  * Updated reusable workflows to accept the Cardano node database URL as a required input.
  * Improved workflow validation when the database URL is not configured.
  * Existing object-upload credentials are now scoped only to the upload step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->