### PR TITLE
chore: no need for custom stack anymore

### DIFF
--- a/crates/amaru-bootstrap/src/bootstrap/mod.rs
+++ b/crates/amaru-bootstrap/src/bootstrap/mod.rs
@@ -718,7 +718,6 @@ async fn import_node_snapshot_archive(
     import_node_snapshot_source(network, global_parameters, snapshot_archive, ledger_dir, nonce_tail).await
 }
 
-#[expect(clippy::unwrap_used)]
 async fn import_node_snapshot_source(
     network: NetworkName,
     global_parameters: &GlobalParameters,
@@ -744,25 +743,14 @@ async fn import_node_snapshot_source(
     };
 
     let db = RocksDB::empty(&RocksDbConfig::new(ledger_dir.to_path_buf()))?;
-    let global_parameters = global_parameters.clone();
-    let archive_path = archive_path.to_path_buf();
-    let builder = std::thread::Builder::new().stack_size(10_000_000);
-
-    let (db, epoch, chain_state) = builder
-        .spawn(move || {
-            import_node_snapshot_archive_data(
-                &archive_path,
-                &db,
-                network,
-                &global_parameters,
-                nonce_tail,
-                previous_accounts,
-            )
-            .map(|(epoch, _point, chain_state)| (db, epoch, chain_state))
-        })
-        .unwrap()
-        .join()
-        .unwrap()?;
+    let (epoch, _point, chain_state) = import_node_snapshot_archive_data(
+        archive_path,
+        &db,
+        network,
+        global_parameters,
+        nonce_tail,
+        previous_accounts,
+    )?;
 
     db.next_snapshot(epoch)?;
 


### PR DESCRIPTION
Now that bootstrap is streamed, no more need for custom increased stack.

Skip-Changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Snapshot archive imports now run directly on the calling thread.
  * Removed the dedicated import thread and its associated overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->