### PR TITLE
fix: release should sign commit

### DIFF
--- a/.github/workflows/release-after.yml
+++ b/.github/workflows/release-after.yml
@@ -162,6 +162,7 @@ jobs:
           base: ${{ needs.release-metadata.outputs.base_branch }}
           branch: release-${{ needs.release-metadata.outputs.release_tag }}
           delete-branch: true
+          sign-commits: true
           signoff: true
           commit-message: "chore: update packages metadata for ${{ needs.release-metadata.outputs.release_tag }}"
           title: "Update packages metadata for ${{ needs.release-metadata.outputs.release_tag }}"


### PR DESCRIPTION
Make sure commits from the release PR are signed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Release packaging update pull requests now use GPG-signed commits for improved authenticity and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->