### PR TITLE
correctly implement bearer lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ Other guiding principles:
 ### Changed
 
 - **amaru-consensus**: `BlockValidator` now runs the ledger on a dedicated thread that owns the ledger state exclusively; operations are requested through a bounded channel and answered via per-request reply channels, replacing the shared lock around the state. `BlockValidator` is no longer generic over the store types. ([#1094][])
+- **amaru-protocols**: handshake combines version data as in the node-to-node spec and the initiator checks that `MsgAcceptVersion` carries that agreed record. ([#884](https://github.com/pragma-org/amaru/issues/884))
+- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
+- **amaru-protocols**: mux times SDU assembly and send: unbounded wait for the first header byte, then 10s during the first Handshake and 30s afterwards for the rest of that SDU. Overflow of that timer tears the bearer down.
+- **amaru-protocols**: Implement SDU send & receive timeouts in the muxer as per the network spec.
+- **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record. Outbound connections still offer initiator-only diffusion (duplex is not advertised until both halves run).
 - **amaru-protocols**: `NetworkOps::connect` takes a `Peer`. Outbound dialling no longer resolves names; that stays in peer selection.
 - **amaru-node**: add world test simulation, both with generated fake chain and with a real chain fragment from preprod.
 - **amaru-node**: `Telemetry::install` no longer reads `AMARU_OPEN_TELEMETRY_SIGNALS`; embedders that select OTLP signals must pass `TelemetryOptions` to `install_with_options`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Other guiding principles:
 - **amaru-protocols**: handshake agrees version data per the node-to-node spec: network magics must match, initiator-only and query are OR, peer-sharing is AND. The initiator drops the connection if `MsgAcceptVersion` does not carry that record. ([#884](https://github.com/pragma-org/amaru/issues/884))
 - **amaru-protocols**: mux SDU assembly waits indefinitely for the first header byte, then 10s for the rest of the first Handshake message and 30s afterwards. Exceeding that limit tears the connection down.
 - **amaru**: the `mempool_max_bytes` startup trace field is now an IEC size such as `176 KiB` instead of a raw integer.
+- **amaru-protocols**: a connection is one established session whose local use is None, Maintenance, or Diffusion. The manager no longer redials when a session drops; peer selection fills outbound slots.
 
 ### Fixed
 
@@ -78,11 +79,6 @@ Other guiding principles:
 ### Changed
 
 - **amaru-consensus**: `BlockValidator` now runs the ledger on a dedicated thread that owns the ledger state exclusively; operations are requested through a bounded channel and answered via per-request reply channels, replacing the shared lock around the state. `BlockValidator` is no longer generic over the store types. ([#1094][])
-- **amaru-protocols**: handshake combines version data as in the node-to-node spec and the initiator checks that `MsgAcceptVersion` carries that agreed record. ([#884](https://github.com/pragma-org/amaru/issues/884))
-- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
-- **amaru-protocols**: mux times SDU assembly and send: unbounded wait for the first header byte, then 10s during the first Handshake and 30s afterwards for the rest of that SDU. Overflow of that timer tears the bearer down.
-- **amaru-protocols**: Implement SDU send & receive timeouts in the muxer as per the network spec.
-- **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record. Outbound connections still offer initiator-only diffusion (duplex is not advertised until both halves run).
 - **amaru-protocols**: `NetworkOps::connect` takes a `Peer`. Outbound dialling no longer resolves names; that stays in peer selection.
 - **amaru-node**: add world test simulation, both with generated fake chain and with a real chain fragment from preprod.
 - **amaru-node**: `Telemetry::install` no longer reads `AMARU_OPEN_TELEMETRY_SIGNALS`; embedders that select OTLP signals must pass `TelemetryOptions` to `install_with_options`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,6 @@ Other guiding principles:
 - **amaru-protocols**: handshake agrees version data per the node-to-node spec: network magics must match, initiator-only and query are OR, peer-sharing is AND. The initiator drops the connection if `MsgAcceptVersion` does not carry that record. ([#884](https://github.com/pragma-org/amaru/issues/884))
 - **amaru-protocols**: mux SDU assembly waits indefinitely for the first header byte, then 10s for the rest of the first Handshake message and 30s afterwards. Exceeding that limit tears the connection down.
 - **amaru**: the `mempool_max_bytes` startup trace field is now an IEC size such as `176 KiB` instead of a raw integer.
-- **amaru-protocols**: a connection is one established session whose local use is None, Maintenance, or Diffusion. The manager no longer redials when a session drops; peer selection fills outbound slots.
 - **amaru-protocols**: a connection is one established session whose local use is None, Maintenance, or Diffusion. The manager no longer redials when a session drops; peer selection fills outbound slots. ([#736](https://github.com/pragma-org/amaru/issues/736))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Other guiding principles:
 - **amaru-protocols**: mux SDU assembly waits indefinitely for the first header byte, then 10s for the rest of the first Handshake message and 30s afterwards. Exceeding that limit tears the connection down.
 - **amaru**: the `mempool_max_bytes` startup trace field is now an IEC size such as `176 KiB` instead of a raw integer.
 - **amaru-protocols**: a connection is one established session whose local use is None, Maintenance, or Diffusion. The manager no longer redials when a session drops; peer selection fills outbound slots.
+- **amaru-protocols**: a connection is one established session whose local use is None, Maintenance, or Diffusion. The manager no longer redials when a session drops; peer selection fills outbound slots. ([#736](https://github.com/pragma-org/amaru/issues/736))
 
 ### Fixed
 

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -146,12 +146,9 @@ pub const SHARE_REQUEST_AMOUNT: u8 = 20;
 ///
 /// - **Disconnected**:
 ///   - `Inbound`: Removes from `inbound_peers` only on exact `ConnectionId` match
-///     (via `Entry::Occupied` guard).
-///   - `Outbound` + `will_retry == true`: If present as `PeerState::Connected` with
-///     matching id, replaces it with `Connecting` so a reconnect handshake does
-///     not race a stale live entry; then clears availability if nothing remains.
-///   - `Outbound` + `will_retry == false`: Removes only if present as exactly
-///     `PeerState::Connected` with matching id; then `regulate_peers`.
+///     (via `Entry::Occupied` guard), then clears availability if nothing remains.
+///   - `Outbound`: Removes only if present as `PeerState::Connected` with matching
+///     id (`Connecting` is ignored); then clears availability and `regulate_peers`.
 ///     (Share-request timers die with the connection's peer-sharing stage.)
 ///
 /// - **ConnectFailed**: Records a connection failure on Performance, removes the peer from

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -307,7 +307,7 @@ pub enum PeerSelectionMsg {
     /// `advertisable` is the remote handshake peer-sharing willingness (latest wins in Performance).
     Connected(Peer, Connection, ConnectionDirection, bool),
     /// A peer has disconnected and the peer_selection stage can stop tracking it.
-    Disconnected(Peer, ConnectionId, ConnectionDirection, bool),
+    Disconnected(Peer, ConnectionId, ConnectionDirection),
     /// A (re)connection attempt has failed, the Manager has removed this peer.
     ConnectFailed(Peer),
     /// Ask the stage to refill outbound slots (no payload).
@@ -714,7 +714,7 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
                 state.start_peer_sharing(peer, &eff).await;
             }
         }
-        PeerSelectionMsg::Disconnected(peer, conn_id, ConnectionDirection::Inbound, _) => {
+        PeerSelectionMsg::Disconnected(peer, conn_id, ConnectionDirection::Inbound) => {
             {
                 let _span = debug_span!(
                     amaru::protocols::peer_selection::peer::DISCONNECTED,
@@ -731,23 +731,7 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
             }
             state.clear_availability_if_gone(&peer, &eff).await;
         }
-        PeerSelectionMsg::Disconnected(peer, conn_id, ConnectionDirection::Outbound, true) => {
-            if let Entry::Occupied(mut entry) = state.outbound_peers.entry(peer)
-                && let PeerState::Connected(conn) = entry.get()
-                && conn.id == conn_id
-            {
-                let _span = debug_span!(
-                    amaru::protocols::peer_selection::peer::DISCONNECTED,
-                    peer,
-                    conn_id = conn_id.as_u64(),
-                    direction = ConnectionDirection::Outbound,
-                )
-                .entered();
-                entry.insert(PeerState::Connecting);
-            }
-            state.clear_availability_if_gone(&peer, &eff).await;
-        }
-        PeerSelectionMsg::Disconnected(peer, conn_id, ConnectionDirection::Outbound, _) => {
+        PeerSelectionMsg::Disconnected(peer, conn_id, ConnectionDirection::Outbound) => {
             if let Entry::Occupied(entry) = state.outbound_peers.entry(peer)
                 && let PeerState::Connected(conn) = entry.get()
                 && conn.id == conn_id

--- a/crates/amaru-consensus/src/stages/peer_selection/tests.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/tests.rs
@@ -683,7 +683,7 @@ fn test_disconnected_inbound() {
     let state = prep.state.clone();
     let mut state_with_peer = state.clone();
     state_with_peer.inbound_peers.insert(p, conn());
-    let msg = PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Inbound, false);
+    let msg = PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Inbound);
     let after = {
         let mut s = state_with_peer.clone();
         s.inbound_peers.remove(&p);
@@ -709,7 +709,7 @@ fn test_disconnected_outbound_connecting_schedules_cooldown() {
     let state = prep.state.clone();
     let mut state_conn = state.clone();
     state_conn.outbound_peers.insert(p, PeerState::Connecting);
-    let msg = PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Outbound, true);
+    let msg = PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Outbound);
     let (running, _guards, mut logs) = setup_preload(&prep, [msg.clone()]);
     // will_retry == true: no cool-down, no regulation; still clear availability claims.
     assert_trace(
@@ -747,7 +747,7 @@ fn test_outbound_retry_drops_dead_conn_before_reconnect() {
         s
     };
 
-    let died = PeerSelectionMsg::Disconnected(p, id0, ConnectionDirection::Outbound, true);
+    let died = PeerSelectionMsg::Disconnected(p, id0, ConnectionDirection::Outbound);
     let connected = PeerSelectionMsg::Connected(p, conn1, ConnectionDirection::Outbound, false);
     let (running, _guards, mut logs) = setup_preload(&prep, [died.clone(), connected.clone()]);
 
@@ -980,7 +980,7 @@ fn test_disconnected_outbound_connected_normal() {
     };
 
     let (running, _guards, mut logs) =
-        setup(&prep, PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Outbound, false));
+        setup(&prep, PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Outbound));
 
     // te_input + final state (normal outbound Connected disconnect removes the peer, no short ban)
     assert_trace_contains(
@@ -988,7 +988,7 @@ fn test_disconnected_outbound_connected_normal() {
         &[
             te_input(
                 "ps-1",
-                &PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Outbound, false),
+                &PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Outbound),
             )
             .into(),
             tm_state(
@@ -1086,7 +1086,7 @@ fn test_disconnected_outbound_peer_also_in_inbound() {
     prep.state.outbound_peers.insert(p, PeerState::Connected(conn()));
 
     let (running, _guards, mut logs) =
-        setup(&prep, PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Outbound, false));
+        setup(&prep, PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Outbound));
 
     // te_input + final state (no RemovePeer expected for the inbound side)
     assert_trace_contains(
@@ -1094,7 +1094,7 @@ fn test_disconnected_outbound_peer_also_in_inbound() {
         &[
             te_input(
                 "ps-1",
-                &PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Outbound, false),
+                &PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Outbound),
             )
             .into(),
             tm_state(

--- a/crates/amaru-consensus/src/stages/peer_selection/tests.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/tests.rs
@@ -724,8 +724,8 @@ fn test_disconnected_inbound_ignores_stale_conn_id() {
     let mut prep = test_prep(&[]);
     let p = TestPrep::peer("1.1.1.2:1");
     let mut ids = ConnectionId::initial();
-    let live = ids.get_and_increment();
     let stale = ids.get_and_increment();
+    let live = ids.get_and_increment();
     prep.state.inbound_peers.insert(p, Connection::new(live, true, false));
     let state = prep.state.clone();
     let msg = PeerSelectionMsg::Disconnected(p, stale, ConnectionDirection::Inbound);

--- a/crates/amaru-consensus/src/stages/peer_selection/tests.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/tests.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Many tests in this file were simplified to only check logs; the variables for
-// trace assertions are intentionally left for future use or documentation.
-
 use amaru_observability::tracing::Level;
 use amaru_ouroboros::{ConnectionDirection, ConnectionId};
 use amaru_protocols::manager::ManagerMessage;
@@ -396,13 +393,20 @@ fn test_add_peer_during_cooldown_cancels_timer() {
 
 #[test]
 fn test_adversarial_outbound_connected() {
-    let prep = test_prep(&[]);
+    let mut prep = test_prep(&[]);
     let p = TestPrep::peer("7.7.7.7:7");
+    prep.state.outbound_peers.insert(p, PeerState::Connected(conn()));
     let state = prep.state.clone();
     let sid = first_schedule_id();
-    let after = {
+    let after_ban = {
         let mut s = state.clone();
+        s.outbound_peers.remove(&p);
         with_single_cooldown(&mut s, p, sid);
+        s
+    };
+    let idle = {
+        let mut s = state.clone();
+        s.outbound_peers.remove(&p);
         s
     };
     let (running, _guards, mut logs) = setup(&prep, PeerSelectionMsg::adversarial(p));
@@ -412,19 +416,31 @@ fn test_adversarial_outbound_connected() {
             te_state("ps-1", &state).into(),
             te_input("ps-1", &PeerSelectionMsg::adversarial(p)).into(),
             te_is_static_peer("ps-1", p).into(),
+            te_send("ps-1", "manager", ManagerMessage::RemovePeer(p)).into(),
             te_clock_suspend("ps-1").into(),
             te_peer_adversarial("ps-1", p).into(),
             te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, sid).into(),
-            te_state("ps-1", &after).into(),
+            te_random_seed("ps-1").into(),
+            te_state("ps-1", &after_ban).into(),
             te_clock(cooldown_instant()).into(),
             te_input("ps-1", &PeerSelectionMsg::CheckCooldowns).into(),
             te_cancel_schedule("ps-1", sid).into(),
             te_clock_suspend("ps-1").into(),
             te_random_seed("ps-1").into(),
-            te_state("ps-1", &state).into(),
+            te_state("ps-1", &idle).into(),
         ],
     );
     logs.assert_and_remove(Level::DEBUG, &["peer_selection.peer.adversarial", r#"peer="7.7.7.7:7""#])
+        .assert_and_remove(
+            Level::WARN,
+            &[
+                "peer.ban",
+                "peer_selection.peer.removed",
+                r#"peer="7.7.7.7:7""#,
+                r#"direction="outbound""#,
+                "is_static=false",
+            ],
+        )
         .assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
 }
 
@@ -623,6 +639,7 @@ fn test_share_peers_result_records_shared_peers() {
 
     let p = TestPrep::peer("7.7.7.7:7");
     let learned = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(9, 9, 9, 9), 3001));
+    let learned_peer = TestPrep::peer("9.9.9.9:3001");
     let mut prep = test_prep(&[]);
     prep.state.outbound_peers.insert(p, PeerState::Connected(conn()));
     let reply = PeerSelectionMsg::SharePeersResult { peer: p, peers: vec![learned] };
@@ -633,9 +650,10 @@ fn test_share_peers_result_records_shared_peers() {
             te_input("ps-1", &reply).into(),
             tm_state(
                 "ps-1",
-                // shared pool is in Performance; stage only regulates when added > 0
-                move |s: &PeerSelection| s.outbound_peers.len() <= 3,
-                "shared peer recorded",
+                move |s: &PeerSelection| {
+                    s.outbound_peers.contains_key(&p) && s.outbound_peers.contains_key(&learned_peer)
+                },
+                "shared peer recorded and dialed",
             ),
         ],
     );
@@ -678,18 +696,17 @@ fn test_connect_failed_records_failure() {
 
 #[test]
 fn test_disconnected_inbound() {
-    let prep = test_prep(&[]);
+    let mut prep = test_prep(&[]);
     let p = TestPrep::peer("1.1.1.1:1");
+    prep.state.inbound_peers.insert(p, conn());
     let state = prep.state.clone();
-    let mut state_with_peer = state.clone();
-    state_with_peer.inbound_peers.insert(p, conn());
     let msg = PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Inbound);
     let after = {
-        let mut s = state_with_peer.clone();
+        let mut s = state.clone();
         s.inbound_peers.remove(&p);
         s
     };
-    let (running, _guards, mut logs) = setup_preload(&prep, [msg.clone()]);
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
     assert_trace(
         &running,
         &[
@@ -703,22 +720,38 @@ fn test_disconnected_inbound() {
 }
 
 #[test]
-fn test_disconnected_outbound_connecting_schedules_cooldown() {
-    let prep = test_prep(&[]);
-    let p = TestPrep::peer("0.0.0.0:0");
+fn test_disconnected_inbound_ignores_stale_conn_id() {
+    let mut prep = test_prep(&[]);
+    let p = TestPrep::peer("1.1.1.2:1");
+    let mut ids = ConnectionId::initial();
+    let live = ids.get_and_increment();
+    let stale = ids.get_and_increment();
+    prep.state.inbound_peers.insert(p, Connection::new(live, true, false));
     let state = prep.state.clone();
-    let mut state_conn = state.clone();
-    state_conn.outbound_peers.insert(p, PeerState::Connecting);
+    let msg = PeerSelectionMsg::Disconnected(p, stale, ConnectionDirection::Inbound);
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    // Live inbound remains, so availability claims must not be cleared.
+    assert_trace(&running, &[te_state("ps-1", &state), te_input("ps-1", &msg), te_state("ps-1", &state)]);
+    assert_trace_does_not_contain(&running, &[te_clear_peer_availability("ps-1", p).into()]);
+    logs.assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_disconnected_outbound_connecting_is_noop() {
+    let mut prep = test_prep(&[]);
+    let p = TestPrep::peer("0.0.0.0:0");
+    prep.state.outbound_peers.insert(p, PeerState::Connecting);
+    let state = prep.state.clone();
     let msg = PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Outbound);
-    let (running, _guards, mut logs) = setup_preload(&prep, [msg.clone()]);
-    // will_retry == true: no cool-down, no regulation; still clear availability claims.
-    assert_trace(
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    // Outbound disconnect only applies to a matching Connected session.
+    assert_trace(&running, &[te_state("ps-1", &state), te_input("ps-1", &msg), te_state("ps-1", &state)]);
+    assert_trace_does_not_contain(
         &running,
         &[
-            te_state("ps-1", &state),
-            te_input("ps-1", &msg),
-            te_clear_peer_availability("ps-1", p),
-            te_state("ps-1", &state),
+            te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, first_schedule_id()).into(),
+            te_clear_peer_availability("ps-1", p).into(),
+            te_random_seed("ps-1").into(),
         ],
     );
     logs.assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
@@ -738,7 +771,7 @@ fn test_outbound_retry_drops_dead_conn_before_reconnect() {
     let start = prep.state.clone();
     let after_death = {
         let mut s = start.clone();
-        s.outbound_peers.insert(p, PeerState::Connecting);
+        s.outbound_peers.remove(&p);
         s
     };
     let after_reconnect = {
@@ -968,35 +1001,31 @@ fn test_adversarial_inbound_only() {
 
 #[test]
 fn test_disconnected_outbound_connected_normal() {
-    let prep = test_prep(&[]);
+    let mut prep = test_prep(&[]);
     let p = TestPrep::peer("8.8.8.8:8");
-    let mut state = prep.state.clone();
-    state.outbound_peers.insert(p, PeerState::Connected(conn()));
-
-    let _after = {
+    prep.state.outbound_peers.insert(p, PeerState::Connected(conn()));
+    let state = prep.state.clone();
+    let after = {
         let mut s = state.clone();
         s.outbound_peers.remove(&p);
         s
     };
+    let msg = PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Outbound);
+    let (running, _guards, mut logs) = setup(&prep, msg.clone());
 
-    let (running, _guards, mut logs) =
-        setup(&prep, PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Outbound));
-
-    // te_input + final state (normal outbound Connected disconnect removes the peer, no short ban)
     assert_trace_contains(
         &running,
         &[
-            te_input(
-                "ps-1",
-                &PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Outbound),
-            )
-            .into(),
-            tm_state(
-                "ps-1",
-                |s: &PeerSelection| !s.outbound_peers.contains_key(&p),
-                "final state: peer removed from outbound",
-            ),
+            te_state("ps-1", &state).into(),
+            te_input("ps-1", &msg).into(),
+            te_clear_peer_availability("ps-1", p).into(),
+            te_random_seed("ps-1").into(),
+            te_state("ps-1", &after).into(),
         ],
+    );
+    assert_trace_does_not_contain(
+        &running,
+        &[te_schedule("ps-1", PeerSelectionMsg::CheckCooldowns, first_schedule_id()).into()],
     );
 
     logs.assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);

--- a/crates/amaru-node/src/stages/build_stage_graph.rs
+++ b/crates/amaru-node/src/stages/build_stage_graph.rs
@@ -82,8 +82,8 @@ pub fn build_stage_graph(
                 advertisable,
             )
         }
-        PeerSelectionNotify::Disconnected { peer, conn_id, direction, will_retry } => {
-            PeerSelectionMsg::Disconnected(peer, conn_id, direction, will_retry)
+        PeerSelectionNotify::Disconnected { peer, conn_id, direction } => {
+            PeerSelectionMsg::Disconnected(peer, conn_id, direction)
         }
         PeerSelectionNotify::ConnectFailed { peer } => PeerSelectionMsg::ConnectFailed(peer),
         PeerSelectionNotify::ShareRequest { peer, amount, reply_to } => {

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -2002,6 +2002,12 @@ define_schemas! {
                         required peer: %amaru_kernel::Peer
                         required error: String
                     }
+                    /// Local use of a connection was changed
+                    public SET_LOCAL_USE {
+                        required peer: %amaru_kernel::Peer
+                        required conn_id: u64
+                        required local_use: String
+                    }
                 }
                 listen {
                     tags: setup

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -152,7 +152,9 @@ pub enum ConnectionMessage {
     NewTip(Point, TraceContext),
     /// A supervised mini-protocol or mux stage terminated.
     ChildDied(ChildId),
-    /// Peer selection (or default after handshake) wants this local use.
+    /// Record the desired local use for a live connection.
+    ///
+    /// The connection stage does not currently reconcile `actual_use`.
     SetLocalUse(LocalUse),
 }
 
@@ -224,6 +226,7 @@ pub async fn stage(
                 State::Established(s)
             }
             (State::Established(mut s), ConnectionMessage::SetLocalUse(desired)) => {
+                // Record only; `actual_use` is not reconciled here.
                 s.desired_use = desired;
                 State::Established(s)
             }

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -86,7 +86,7 @@ pub enum LocalUse {
 }
 
 impl LocalUse {
-    pub fn default_for_role(role: Role) -> Self {
+    fn default_for_role(role: Role) -> Self {
         match role {
             Role::Initiator => Self::Diffusion,
             Role::Responder => Self::None,
@@ -225,8 +225,6 @@ pub async fn stage(
             }
             (State::Established(mut s), ConnectionMessage::SetLocalUse(desired)) => {
                 s.desired_use = desired;
-                // Starting extra groups on a duplex bearer is a later PR. Stopping is MsgDone.
-                // This commit only records the intent so later commits can converge actual_use.
                 State::Established(s)
             }
             (state @ (State::Initial | State::Handshake { .. }), msg @ ConnectionMessage::FetchBlocks { .. }) => {

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -77,36 +77,46 @@ struct Params {
     manager: StageRef<ManagerMessage>,
 }
 
+/// Local use of a bearer: which initiator groups we intend to run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
+pub enum LocalUse {
+    None,
+    Maintenance,
+    Diffusion,
+}
+
+impl LocalUse {
+    pub fn default_for_role(role: Role) -> Self {
+        match role {
+            Role::Initiator => Self::Diffusion,
+            Role::Responder => Self::None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 enum State {
     Initial,
     Handshake { muxer: StageRef<MuxMessage>, handshake: StageRef<Inputs<Void>> },
-    Initiator(StateInitiator),
-    Responder(StateResponder),
+    Established(Established),
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-struct StateInitiator {
-    chainsync_initiator: StageRef<chainsync::InitiatorMessage>,
-    blockfetch_initiator: StageRef<blockfetch::BlockFetchMessage>,
-    peer_sharing_initiator: StageRef<PeerSharingMessage>,
+struct Established {
+    desired_use: LocalUse,
+    actual_use: LocalUse,
     version_number: VersionNumber,
     version_data: VersionData,
     muxer: StageRef<MuxMessage>,
     handshake: StageRef<Inputs<Void>>,
     keepalive: StageRef<HandlerMessage>,
     tx_submission: StageRef<HandlerMessage>,
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-struct StateResponder {
-    chainsync_responder: StageRef<chainsync::ResponderMessage>,
-    muxer: StageRef<MuxMessage>,
-    handshake: StageRef<Inputs<Void>>,
-    keepalive: StageRef<HandlerMessage>,
-    tx_submission: StageRef<HandlerMessage>,
-    blockfetch_responder: StageRef<Void>,
-    peer_sharing_responder: StageRef<crate::peer_sharing::ResponderMessage>,
+    chainsync_initiator: Option<StageRef<chainsync::InitiatorMessage>>,
+    blockfetch_initiator: Option<StageRef<blockfetch::BlockFetchMessage>>,
+    peer_sharing_initiator: Option<StageRef<PeerSharingMessage>>,
+    chainsync_responder: Option<StageRef<chainsync::ResponderMessage>>,
+    blockfetch_responder: Option<StageRef<Void>>,
+    peer_sharing_responder: Option<StageRef<crate::peer_sharing::ResponderMessage>>,
 }
 
 /// Identity of a supervised child stage of a connection.
@@ -142,6 +152,8 @@ pub enum ConnectionMessage {
     NewTip(Point, TraceContext),
     /// A supervised mini-protocol or mux stage terminated.
     ChildDied(ChildId),
+    /// Peer selection (or default after handshake) wants this local use.
+    SetLocalUse(LocalUse),
 }
 
 impl ConnectionMessage {
@@ -154,6 +166,7 @@ impl ConnectionMessage {
             ConnectionMessage::RequestSharePeers { .. } => "RequestSharePeers",
             ConnectionMessage::NewTip(_, _) => "NewTip",
             ConnectionMessage::ChildDied(_) => "ChildDied",
+            ConnectionMessage::SetLocalUse(_) => "SetLocalUse",
         }
     }
 
@@ -189,28 +202,32 @@ pub async fn stage(
             (State::Handshake { muxer, handshake }, ConnectionMessage::Handshake(handshake_result)) => {
                 do_handshake(&params, muxer, params.pipeline.clone(), handshake, handshake_result, eff).await
             }
-            (State::Initiator(s), ConnectionMessage::FetchBlocks { from, through, id, cr }) => {
-                eff.send(&s.blockfetch_initiator, BlockFetchMessage::RequestRange { from, through, id, cr }).await;
-                State::Initiator(s)
+            (State::Established(s), ConnectionMessage::FetchBlocks { from, through, id, cr }) => {
+                if let Some(blockfetch) = &s.blockfetch_initiator {
+                    eff.send(blockfetch, BlockFetchMessage::RequestRange { from, through, id, cr }).await;
+                }
+                State::Established(s)
             }
             (
-                State::Initiator(s),
+                State::Established(s),
                 ConnectionMessage::RequestSharePeers { amount, initial_delay, interval, reply_to },
             ) => {
-                eff.send(
-                    &s.peer_sharing_initiator,
-                    PeerSharingMessage::Start { amount, initial_delay, interval, reply_to },
-                )
-                .await;
-                State::Initiator(s)
+                if let Some(ps) = &s.peer_sharing_initiator {
+                    eff.send(ps, PeerSharingMessage::Start { amount, initial_delay, interval, reply_to }).await;
+                }
+                State::Established(s)
             }
-            (State::Responder(s), ConnectionMessage::NewTip(tip, trace_context)) => {
-                eff.send(&s.chainsync_responder, chainsync::ResponderMessage::NewTip(tip, trace_context)).await;
-                State::Responder(s)
+            (State::Established(s), ConnectionMessage::NewTip(tip, trace_context)) => {
+                if let Some(cs) = &s.chainsync_responder {
+                    eff.send(cs, chainsync::ResponderMessage::NewTip(tip, trace_context)).await;
+                }
+                State::Established(s)
             }
-            (State::Initiator(s), ConnectionMessage::NewTip(_, _)) => {
-                // don't propagate new tip messages when using the initiator side of a connection.
-                State::Initiator(s)
+            (State::Established(mut s), ConnectionMessage::SetLocalUse(desired)) => {
+                s.desired_use = desired;
+                // Starting extra groups on a duplex bearer is a later PR. Stopping is MsgDone.
+                // This commit only records the intent so later commits can converge actual_use.
+                State::Established(s)
             }
             (state @ (State::Initial | State::Handshake { .. }), msg @ ConnectionMessage::FetchBlocks { .. }) => {
                 // The peer might be still connecting. In that case we reschedule the message
@@ -226,6 +243,10 @@ pub async fn stage(
             }
             (state @ (State::Initial | State::Handshake { .. }), msg @ ConnectionMessage::NewTip(_, _)) => {
                 // The peer might be still connecting. Reschedule the NewTip message.
+                eff.schedule_after(msg, params.config.reconnect_delay).await;
+                state
+            }
+            (state @ (State::Initial | State::Handshake { .. }), msg @ ConnectionMessage::SetLocalUse(_)) => {
                 eff.schedule_after(msg, params.config.reconnect_delay).await;
                 state
             }
@@ -249,10 +270,10 @@ pub async fn stage(
 /// purge signal must be sent explicitly here whenever an initiator session may have been started.
 async fn teardown(state: State, params: &Params, eff: &Effects<ConnectionMessage>) -> Connection {
     match state {
-        State::Initiator(..) => {
+        State::Established(s) if s.chainsync_initiator.is_some() => {
             notify_chainsync_terminated(params, eff).await;
         }
-        State::Initial | State::Handshake { .. } | State::Responder(_) => {}
+        State::Initial | State::Handshake { .. } | State::Established(_) => {}
     }
     eff.terminate().await
 }
@@ -385,76 +406,86 @@ async fn do_handshake(
     )
     .await;
 
+    let local_use = LocalUse::default_for_role(*role);
+    let mut established = Established {
+        desired_use: local_use,
+        actual_use: local_use,
+        version_number,
+        version_data,
+        muxer: muxer.clone(),
+        handshake,
+        keepalive,
+        tx_submission,
+        chainsync_initiator: None,
+        blockfetch_initiator: None,
+        peer_sharing_initiator: None,
+        chainsync_responder: None,
+        blockfetch_responder: None,
+        peer_sharing_responder: None,
+    };
+
     if *role == Role::Initiator {
-        let chainsync_initiator = register_chainsync_initiator(
-            &muxer,
-            peer,
-            *conn_id,
-            pipeline_ref,
-            &eff,
-            ConnectionMessage::ChildDied(ChildId::ChainSync),
-        )
-        .await;
-        let blockfetch_initiator = register_blockfetch_initiator(
-            &muxer,
-            peer,
-            config.blockfetch_pipeline_n,
-            &eff,
-            ConnectionMessage::ChildDied(ChildId::BlockFetch),
-        )
-        .await;
-        let peer_sharing_initiator = register_peer_sharing_initiator(
-            &muxer,
-            peer,
-            *conn_id,
-            &eff,
-            ConnectionMessage::ChildDied(ChildId::PeerSharing),
-        )
-        .await;
-        State::Initiator(StateInitiator {
-            chainsync_initiator,
-            blockfetch_initiator,
-            peer_sharing_initiator,
-            version_number,
-            version_data,
-            muxer,
-            handshake,
-            keepalive,
-            tx_submission,
-        })
+        established.chainsync_initiator = Some(
+            register_chainsync_initiator(
+                &muxer,
+                peer,
+                *conn_id,
+                pipeline_ref,
+                &eff,
+                ConnectionMessage::ChildDied(ChildId::ChainSync),
+            )
+            .await,
+        );
+        established.blockfetch_initiator = Some(
+            register_blockfetch_initiator(
+                &muxer,
+                peer,
+                config.blockfetch_pipeline_n,
+                &eff,
+                ConnectionMessage::ChildDied(ChildId::BlockFetch),
+            )
+            .await,
+        );
+        established.peer_sharing_initiator = Some(
+            register_peer_sharing_initiator(
+                &muxer,
+                peer,
+                *conn_id,
+                &eff,
+                ConnectionMessage::ChildDied(ChildId::PeerSharing),
+            )
+            .await,
+        );
     } else {
         let store = Store::new(eff.clone());
         let upstream = store.get_best_chain_tip().await;
-        let chainsync_responder = register_chainsync_responder(
-            &muxer,
-            upstream,
-            peer,
-            *conn_id,
-            &eff,
-            ConnectionMessage::ChildDied(ChildId::ChainSync),
-        )
-        .await;
-        let blockfetch_responder =
-            register_blockfetch_responder(&muxer, peer, &eff, ConnectionMessage::ChildDied(ChildId::BlockFetch)).await;
-        let peer_sharing_responder = register_peer_sharing_responder(
-            &muxer,
-            peer,
-            manager.clone(),
-            &eff,
-            ConnectionMessage::ChildDied(ChildId::PeerSharing),
-        )
-        .await;
-
-        State::Responder(StateResponder {
-            chainsync_responder,
-            blockfetch_responder,
-            peer_sharing_responder,
-            muxer,
-            handshake,
-            keepalive,
-            tx_submission,
-        })
+        established.chainsync_responder = Some(
+            register_chainsync_responder(
+                &muxer,
+                upstream,
+                peer,
+                *conn_id,
+                &eff,
+                ConnectionMessage::ChildDied(ChildId::ChainSync),
+            )
+            .await,
+        );
+        established.blockfetch_responder = Some(
+            register_blockfetch_responder(&muxer, peer, &eff, ConnectionMessage::ChildDied(ChildId::BlockFetch)).await,
+        );
+        established.peer_sharing_responder = Some(
+            register_peer_sharing_responder(
+                &muxer,
+                peer,
+                manager.clone(),
+                &eff,
+                ConnectionMessage::ChildDied(ChildId::PeerSharing),
+            )
+            .await,
+        );
     }
+
+    State::Established(established)
 }
 
 pub fn register_deserializers() -> DeserializerGuards {

--- a/crates/amaru-protocols/src/manager/mod.rs
+++ b/crates/amaru-protocols/src/manager/mod.rs
@@ -52,9 +52,8 @@ pub enum PeerSelectionNotify {
     /// A connection has been terminated (graceful disconnect, error, handshake refusal,
     /// or network error).
     ///
-    /// If the connection was outbound then it may be retried, leading to either
-    /// `ConnectFailed` or `Connected`.
-    Disconnected { peer: Peer, conn_id: ConnectionId, direction: ConnectionDirection, will_retry: bool },
+    /// The connection is gone. peer-selection owns redial via `Dial` message.
+    Disconnected { peer: Peer, conn_id: ConnectionId, direction: ConnectionDirection },
 
     /// An outbound connection attempt has failed (e.g. connection timeout, handshake refusal, network error)
     /// for a number of tries, see [`ManagerConfig::connect_retries`].
@@ -68,7 +67,7 @@ pub enum PeerSelectionNotify {
 pub enum ManagerMessage {
     /// Start outgoing connection attempts to the given peer until successful or retries exhausted.
     ///
-    /// If the connection succeeds then future disconnection will first lead to retries before giving up.
+    /// After a successful session dies, peer selection issues a new `Dial`; the manager does not redial.
     AddPeer(Peer),
     /// Remove a peer and terminate all of its connections.
     RemovePeer(Peer),
@@ -527,12 +526,7 @@ impl Manager {
             let connection = self.connections.remove(&conn_id).expect("PeerState implies Connection");
             eff.send(
                 &self.peer_selection,
-                PeerSelectionNotify::Disconnected {
-                    peer,
-                    conn_id,
-                    direction: ConnectionDirection::Inbound,
-                    will_retry: false,
-                },
+                PeerSelectionNotify::Disconnected { peer, conn_id, direction: ConnectionDirection::Inbound },
             )
             .await;
             eff.send(&connection.stage, ConnectionMessage::Disconnect).await;
@@ -542,12 +536,7 @@ impl Manager {
             let connection = self.connections.remove(&conn_id).expect("PeerState implies Connection");
             eff.send(
                 &self.peer_selection,
-                PeerSelectionNotify::Disconnected {
-                    peer,
-                    conn_id,
-                    direction: ConnectionDirection::Outbound,
-                    will_retry: false,
-                },
+                PeerSelectionNotify::Disconnected { peer, conn_id, direction: ConnectionDirection::Outbound },
             )
             .await;
             eff.send(&connection.stage, ConnectionMessage::Disconnect).await;
@@ -577,19 +566,16 @@ impl Manager {
                 ConnectionDirection::Outbound => {
                     assert_eq!(peer_state.outbound, OutboundState::Connected { conn_id });
                     assert_eq!(role, Role::Initiator);
-                    info!(protocols::manager::peer::CONNECTION_DIED_HANDLED, peer, outcome = "peer_selection_redial");
                     if peer_state.inbound.is_none() {
+                        info!(protocols::manager::peer::CONNECTION_DIED_HANDLED, peer, outcome = "peer_removed");
                         self.peers.remove(&peer);
                     } else {
+                        info!(protocols::manager::peer::CONNECTION_DIED_HANDLED, peer, outcome = "kept_for_inbound");
                         peer_state.outbound = OutboundState::None;
                     }
                 }
             }
-            eff.send(
-                &self.peer_selection,
-                PeerSelectionNotify::Disconnected { peer, conn_id, direction, will_retry: false },
-            )
-            .await;
+            eff.send(&self.peer_selection, PeerSelectionNotify::Disconnected { peer, conn_id, direction }).await;
         } else {
             // pre-handshake death (no entry was inserted to connections, and no Connected notify was sent)
             debug!(
@@ -763,8 +749,14 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
             ManagerMessage::ConnectionResult(peer, conn_id) => {
                 manager.connection_result(peer, conn_id, &eff).await;
             }
-            ManagerMessage::SetLocalUse { peer: _, conn_id, local_use } => {
+            ManagerMessage::SetLocalUse { peer, conn_id, local_use } => {
                 if let Some(connection) = manager.connections.get(&conn_id) {
+                    info!(
+                        protocols::manager::peer::SET_LOCAL_USE,
+                        peer,
+                        conn_id = conn_id.as_u64(),
+                        local_use = format!("{local_use:?}")
+                    );
                     eff.send(&connection.stage, ConnectionMessage::SetLocalUse(local_use)).await;
                 }
             }

--- a/crates/amaru-protocols/src/manager/mod.rs
+++ b/crates/amaru-protocols/src/manager/mod.rs
@@ -117,7 +117,9 @@ pub enum ManagerMessage {
         full_duplex: bool,
         advertisable: bool,
     },
-    /// Ask a live connection to converge toward this local use.
+    /// Record the desired local use for a live connection.
+    ///
+    /// The connection stage does not currently reconcile `actual_use`.
     SetLocalUse { peer: Peer, conn_id: ConnectionId, local_use: crate::connection::LocalUse },
 }
 

--- a/crates/amaru-protocols/src/manager/mod.rs
+++ b/crates/amaru-protocols/src/manager/mod.rs
@@ -118,6 +118,8 @@ pub enum ManagerMessage {
         full_duplex: bool,
         advertisable: bool,
     },
+    /// Ask a live connection to converge toward this local use.
+    SetLocalUse { peer: Peer, conn_id: ConnectionId, local_use: crate::connection::LocalUse },
 }
 
 impl ManagerMessage {
@@ -135,6 +137,7 @@ impl ManagerMessage {
             ManagerMessage::ConnectionDied(..) => "ConnectionDied",
             ManagerMessage::Accepted(..) => "Accepted",
             ManagerMessage::HandshakeComplete { .. } => "HandshakeComplete",
+            ManagerMessage::SetLocalUse { .. } => "SetLocalUse",
         }
     }
 
@@ -171,9 +174,8 @@ impl ManagerMessage {
 /// An outbound connection is initiated by sending `ManagerMessage::AddPeer`. The manager will
 /// then try to connect to that peer until successful or retries exhausted. After a successful
 /// connection and handshake, the manager notifies `peer_selection` about the new connection.
-/// When the connection dies, the manager will inform `peer_selection` about the disconnection
-/// and then try to reconnect until successful or retries exhausted unless connections to this
-/// peer have died thrice within [`ManagerConfig::three_strike_window`].
+/// When the connection dies, the manager notifies `peer_selection` and does **not** redial.
+/// Peer selection decides whether to `AddPeer` again.
 ///
 /// ## Behavioural contracts
 ///
@@ -210,13 +212,10 @@ enum OutboundState {
     },
 }
 
-const MAX_OUTBOUND_DEATHS_TRACKED: usize = 2;
-
 #[derive(Default, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 struct PeerState {
     outbound: OutboundState,
     inbound: Option<ConnectionId>,
-    outbound_death_times: [Option<Instant>; MAX_OUTBOUND_DEATHS_TRACKED],
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -266,7 +265,6 @@ pub struct ManagerConfig {
     pub reconnect_delay: Duration,
     pub connect_retries: u16,
     pub accept_interval: Duration,
-    pub three_strike_window: Duration,
     pub tx_submission_params: ResponderParams,
     /// BlockFetch initiator pipeline depth. `1` drives the lock-step typestate
     /// instance; values greater than 1 wrap N instances in the CIP-0164 pipeliner.
@@ -312,7 +310,6 @@ impl Default for ManagerConfig {
             reconnect_delay: Duration::from_secs(2),
             connect_retries: 3,
             accept_interval: Duration::from_millis(100),
-            three_strike_window: Duration::from_secs(60),
             tx_submission_params: ResponderParams::default(),
             blockfetch_pipeline_n: NonZeroU8::MIN,
         }
@@ -580,30 +577,17 @@ impl Manager {
                 ConnectionDirection::Outbound => {
                     assert_eq!(peer_state.outbound, OutboundState::Connected { conn_id });
                     assert_eq!(role, Role::Initiator);
-                    let now = eff.clock().await;
-                    let times = &mut peer_state.outbound_death_times;
-                    // rotate to the left, so the oldest is in last position, then replace last with current time
-                    times.rotate_left(1);
-                    if let Some(oldest) = times[const { MAX_OUTBOUND_DEATHS_TRACKED - 1 }].replace(now)
-                        && now.saturating_since(oldest) < self.config.three_strike_window
-                    {
-                        info!(protocols::manager::peer::CONNECTION_DIED_HANDLED, peer, outcome = "retries_suppressed");
-                        if peer_state.inbound.is_none() {
-                            self.peers.remove(&peer);
-                        } else {
-                            peer_state.outbound = OutboundState::None;
-                        }
-                        eff.send(&self.peer_selection, PeerSelectionNotify::ConnectFailed { peer }).await;
+                    info!(protocols::manager::peer::CONNECTION_DIED_HANDLED, peer, outcome = "peer_selection_redial");
+                    if peer_state.inbound.is_none() {
+                        self.peers.remove(&peer);
                     } else {
-                        info!(protocols::manager::peer::CONNECTION_DIED_HANDLED, peer, outcome = "reconnect_scheduled");
-                        peer_state.outbound = OutboundState::Scheduled { retries: self.config.connect_retries };
-                        self.connect(peer, false, eff).await;
+                        peer_state.outbound = OutboundState::None;
                     }
                 }
             }
             eff.send(
                 &self.peer_selection,
-                PeerSelectionNotify::Disconnected { peer, conn_id, direction, will_retry: role == Role::Initiator },
+                PeerSelectionNotify::Disconnected { peer, conn_id, direction, will_retry: false },
             )
             .await;
         } else {
@@ -615,7 +599,13 @@ impl Manager {
                 conn_id = conn_id.as_u64()
             );
             if role == Role::Initiator {
-                self.connect(peer, false, eff).await;
+                if let Some(state) = self.peers.get_mut(&peer) {
+                    state.outbound = OutboundState::None;
+                    if state.inbound.is_none() {
+                        self.peers.remove(&peer);
+                    }
+                }
+                eff.send(&self.peer_selection, PeerSelectionNotify::ConnectFailed { peer }).await;
             }
             // inbound pre-HS deaths require no further action (peer entry is only created on HS success)
         }
@@ -772,6 +762,11 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
             }
             ManagerMessage::ConnectionResult(peer, conn_id) => {
                 manager.connection_result(peer, conn_id, &eff).await;
+            }
+            ManagerMessage::SetLocalUse { peer: _, conn_id, local_use } => {
+                if let Some(connection) = manager.connections.get(&conn_id) {
+                    eff.send(&connection.stage, ConnectionMessage::SetLocalUse(local_use)).await;
+                }
             }
         }
         manager

--- a/crates/amaru-protocols/src/tests/slow_manager_stage.rs
+++ b/crates/amaru-protocols/src/tests/slow_manager_stage.rs
@@ -42,6 +42,7 @@ pub async fn slow_manager_stage(manager: Manager, msg: ManagerMessage, eff: Effe
         ManagerMessage::RequestSharePeers { .. } => {}
         ManagerMessage::ShareRequest { .. } => {}
         ManagerMessage::ConnectionResult(..) => {}
+        ManagerMessage::SetLocalUse { .. } => {}
     }
     manager::stage(manager, msg, eff).await
 }

--- a/crates/amaru-protocols/src/tests/test_cases.rs
+++ b/crates/amaru-protocols/src/tests/test_cases.rs
@@ -51,7 +51,7 @@ use crate::{
 async fn test_connect_initiator_responder() -> anyhow::Result<()> {
     setup_logging();
     let (responder, addr, responder_done) = start_responder().await?;
-    let (initiator, initiator_done) = start_initiator_at(addr).await?;
+    let (initiator, initiator_done, _) = start_initiator_at(addr).await?;
 
     wait_for_termination(responder_done, initiator_done).await?;
     check_state(initiator, responder)?;
@@ -63,7 +63,7 @@ async fn test_connect_initiator_reconnection() -> anyhow::Result<()> {
     setup_logging();
     let addr = ephemeral_localhost_addr()?;
     tracing::info!("starting test at address {}", addr);
-    let (initiator, initiator_done) = start_initiator_with_configuration(
+    let (initiator, initiator_done, _) = start_initiator_with_configuration(
         Configuration::initiator().with_addr(addr).with_reconnect_delay(Duration::from_millis(500)),
     )
     .await?;
@@ -83,7 +83,7 @@ async fn test_connect_initiator_reconnection_on_responder_restart() -> anyhow::R
     // the initiator doesn't start synchronizing right away
     let (responder, addr, _) =
         start_responder_with_configuration(Configuration::responder().with_slow_manager()).await?;
-    let (initiator, initiator_done) = start_initiator_with_configuration(
+    let (initiator, initiator_done, initiator_sender) = start_initiator_with_configuration(
         Configuration::initiator()
             .with_addr(addr)
             .with_reconnect_delay(Duration::from_millis(1000))
@@ -102,6 +102,8 @@ async fn test_connect_initiator_reconnection_on_responder_restart() -> anyhow::R
     tracing::info!("restart the responder at address {}", addr);
     let responder_configuration = Configuration::responder().with_addr(addr);
     let (responder, _, responder_done) = start_responder_with_configuration(responder_configuration).await?;
+    let peer = Peer::try_from(addr).expect("test listen address is a peer");
+    initiator_sender.send(ManagerMessage::AddPeer(peer)).await.unwrap();
 
     // Both the initiator and the responder should eventually terminate with the same state
     tracing::info!("wait for termination");
@@ -128,7 +130,7 @@ async fn test_accept_stage_supervised_restart() -> anyhow::Result<()> {
         start_responder_with_failing_accept(Configuration::responder(), 1, 1).await?;
 
     // Start an initiator that will connect to the responder
-    let (initiator, initiator_done) = start_initiator_with_configuration(
+    let (initiator, initiator_done, _) = start_initiator_with_configuration(
         Configuration::initiator()
             .with_addr(addr)
             .with_reconnect_delay(Duration::from_millis(500))
@@ -195,7 +197,9 @@ async fn start_responder_with_configuration(
 
 /// Create and start an initiator node that connects to the given port.
 /// ChainSync events are sent to a stage that stores them in the in-memory store without further processing.
-async fn start_initiator_at(addr: impl Into<Option<SocketAddr>>) -> anyhow::Result<(TokioRunning, Arc<Notify>)> {
+async fn start_initiator_at(
+    addr: impl Into<Option<SocketAddr>>,
+) -> anyhow::Result<(TokioRunning, Arc<Notify>, amaru_pure_stage::Sender<ManagerMessage>)> {
     let addr = addr.into().unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 3000)));
     start_initiator_with_configuration(Configuration::initiator().with_addr(addr)).await
 }
@@ -204,7 +208,7 @@ async fn start_initiator_at(addr: impl Into<Option<SocketAddr>>) -> anyhow::Resu
 /// ChainSync events are sent to a stage that stores them in the in-memory store without further processing.
 async fn start_initiator_with_configuration(
     configuration: Configuration,
-) -> anyhow::Result<(TokioRunning, Arc<Notify>)> {
+) -> anyhow::Result<(TokioRunning, Arc<Notify>, amaru_pure_stage::Sender<ManagerMessage>)> {
     tracing::info!("Creating the initiator");
     let addr = configuration.addr;
     let peer = Peer::try_from(addr).expect("test listen address is a peer");
@@ -241,7 +245,7 @@ async fn start_initiator_with_configuration(
     let running_initiator = initiator_network.run(Handle::current());
     initiator_sender.send(ManagerMessage::AddPeer(peer)).await.unwrap();
 
-    Ok((running_initiator, notify))
+    Ok((running_initiator, notify, initiator_sender))
 }
 
 /// Create and start a responder node that uses the manager's supervised accept stage.

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -2606,6 +2606,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | `duplicate_terminated` | `TRACE` | public | A duplicate connection is terminated after its handshake completed | peer, conn_id |  |
 | `handshake_completed` | `TRACE` | public | The handshake completed on a connection | peer, conn_id, full_duplex_capable, full_duplex, advertisable |  |
 | `remove` | `TRACE` | public | A peer was removed from the manager | peer |  |
+| `set_local_use` | `TRACE` | public | Local use of a connection was changed | peer, conn_id, local_use |  |
 
 <details><summary>span: `accepted`</summary>
 
@@ -2741,6 +2742,16 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | field | type | required |
 | --- | --- | --- |
 | `peer` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `set_local_use`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `peer` | `string` | ✓ |
+| `conn_id` | `integer` | ✓ |
+| `local_use` | `string` | ✓ |
 
 </details>
 

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -7154,6 +7154,32 @@
       "description": "A peer was removed from the manager",
       "public": true
     },
+    "amaru::protocols::manager::peer::SET_LOCAL_USE": {
+      "type": "object",
+      "properties": {
+        "peer": {
+          "type": "string"
+        },
+        "conn_id": {
+          "type": "integer"
+        },
+        "local_use": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "peer",
+        "conn_id",
+        "local_use"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "set_local_use",
+      "level": "TRACE",
+      "target": "amaru::protocols::manager::peer",
+      "description": "Local use of a connection was changed",
+      "public": true
+    },
     "amaru::protocols::mux::EMPTY_SEGMENT": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
- model local use for maintenance or diffusion
- tear down based on error or selection decision

fixes #736

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Connections now use a unified session model with local-use states: None, Maintenance, or Diffusion.
  * The connection manager no longer automatically redials after a session drops; peer selection manages available outbound connections.
* **Observability**
  * Connection local-use changes are now recorded with peer, connection, and usage details.
* **Documentation**
  * Added documentation for the new connection local-use trace event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->