### PR TITLE
properly terminate protocol handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,12 @@ Other guiding principles:
 ### Changed
 
 - **amaru-consensus**: `BlockValidator` now runs the ledger on a dedicated thread that owns the ledger state exclusively; operations are requested through a bounded channel and answered via per-request reply channels, replacing the shared lock around the state. `BlockValidator` is no longer generic over the store types. ([#1094][])
+- **amaru-protocols**: handshake combines version data as in the node-to-node spec and the initiator checks that `MsgAcceptVersion` carries that agreed record. ([#884](https://github.com/pragma-org/amaru/issues/884))
+- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
+- **amaru-protocols**: `SetLocalUse` stops initiator groups with `MsgDone` (last-to-finish; 300s diffusion / 120s maintenance). Expected child death installs a mux done-trap; unexpected death still tears the bearer. Responders reset in place after `MsgDone`.
+- **amaru-protocols**: mux times SDU assembly and send: unbounded wait for the first header byte, then 10s during the first Handshake and 30s afterwards for the rest of that SDU. Overflow of that timer tears the bearer down.
+- **amaru-protocols**: Implement SDU send & receive timeouts in the muxer as per the network spec.
+- **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record. Outbound connections still offer initiator-only diffusion (duplex is not advertised until both halves run).
 - **amaru-protocols**: `NetworkOps::connect` takes a `Peer`. Outbound dialling no longer resolves names; that stays in peer selection.
 - **amaru-node**: add world test simulation, both with generated fake chain and with a real chain fragment from preprod.
 - **amaru-node**: `Telemetry::install` no longer reads `AMARU_OPEN_TELEMETRY_SIGNALS`; embedders that select OTLP signals must pass `TelemetryOptions` to `install_with_options`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,6 @@ Other guiding principles:
 - **amaru-protocols**: mux SDU assembly waits indefinitely for the first header byte, then 10s for the rest of the first Handshake message and 30s afterwards. Exceeding that limit tears the connection down.
 - **amaru**: the `mempool_max_bytes` startup trace field is now an IEC size such as `176 KiB` instead of a raw integer.
 - **amaru-protocols**: a connection is one established session whose local use is None, Maintenance, or Diffusion. The manager no longer redials when a session drops; peer selection fills outbound slots. ([#736](https://github.com/pragma-org/amaru/issues/736))
-- **amaru-protocols**: a connection is one established session whose local use is None, Maintenance, or Diffusion. The manager no longer redials when a session drops; peer selection fills outbound slots.
 - **amaru-protocols**: lowering local use sends `MsgDone` to the initiator mini-protocols and waits for them to finish (300s from Diffusion, 120s from Maintenance). Unexpected protocol death still tears the connection down.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ Other guiding principles:
 - **amaru-protocols**: mux SDU assembly waits indefinitely for the first header byte, then 10s for the rest of the first Handshake message and 30s afterwards. Exceeding that limit tears the connection down.
 - **amaru**: the `mempool_max_bytes` startup trace field is now an IEC size such as `176 KiB` instead of a raw integer.
 - **amaru-protocols**: a connection is one established session whose local use is None, Maintenance, or Diffusion. The manager no longer redials when a session drops; peer selection fills outbound slots. ([#736](https://github.com/pragma-org/amaru/issues/736))
+- **amaru-protocols**: a connection is one established session whose local use is None, Maintenance, or Diffusion. The manager no longer redials when a session drops; peer selection fills outbound slots.
+- **amaru-protocols**: lowering local use sends `MsgDone` to the initiator mini-protocols and waits for them to finish (300s from Diffusion, 120s from Maintenance). Unexpected protocol death still tears the connection down.
 
 ### Fixed
 
@@ -79,12 +81,6 @@ Other guiding principles:
 ### Changed
 
 - **amaru-consensus**: `BlockValidator` now runs the ledger on a dedicated thread that owns the ledger state exclusively; operations are requested through a bounded channel and answered via per-request reply channels, replacing the shared lock around the state. `BlockValidator` is no longer generic over the store types. ([#1094][])
-- **amaru-protocols**: handshake combines version data as in the node-to-node spec and the initiator checks that `MsgAcceptVersion` carries that agreed record. ([#884](https://github.com/pragma-org/amaru/issues/884))
-- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
-- **amaru-protocols**: `SetLocalUse` stops initiator groups with `MsgDone` (last-to-finish; 300s diffusion / 120s maintenance). Expected child death installs a mux done-trap; unexpected death still tears the bearer. Responders reset in place after `MsgDone`.
-- **amaru-protocols**: mux times SDU assembly and send: unbounded wait for the first header byte, then 10s during the first Handshake and 30s afterwards for the rest of that SDU. Overflow of that timer tears the bearer down.
-- **amaru-protocols**: Implement SDU send & receive timeouts in the muxer as per the network spec.
-- **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record. Outbound connections still offer initiator-only diffusion (duplex is not advertised until both halves run).
 - **amaru-protocols**: `NetworkOps::connect` takes a `Peer`. Outbound dialling no longer resolves names; that stays in peer selection.
 - **amaru-node**: add world test simulation, both with generated fake chain and with a real chain fragment from preprod.
 - **amaru-node**: `Telemetry::install` no longer reads `AMARU_OPEN_TELEMETRY_SIGNALS`; embedders that select OTLP signals must pass `TelemetryOptions` to `install_with_options`.

--- a/crates/amaru-consensus/src/stages/peer_selection/tests.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/tests.rs
@@ -744,7 +744,7 @@ fn test_disconnected_outbound_connecting_is_noop() {
     let state = prep.state.clone();
     let msg = PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Outbound);
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
-    // Outbound disconnect only applies to a matching Connected session.
+    // Outbound disconnect only applies to a matching Connected session; Connecting is a no-op.
     assert_trace(&running, &[te_state("ps-1", &state), te_input("ps-1", &msg), te_state("ps-1", &state)]);
     assert_trace_does_not_contain(
         &running,

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -1896,6 +1896,12 @@ define_schemas! {
                     required conn_id: u64
                     required child: String
                 }
+                /// A mini-protocol stage running on a connection stopped upon request
+                public CHILD_STOPPED {
+                    required peer: %amaru_kernel::Peer
+                    required conn_id: u64
+                    required child: String
+                }
                 /// The peer refused our proposed protocol versions
                 public HANDSHAKE_REFUSED {
                     required reason: String

--- a/crates/amaru-protocols/src/blockfetch/responder.rs
+++ b/crates/amaru-protocols/src/blockfetch/responder.rs
@@ -50,7 +50,7 @@ on_receive!(Idle as ServerIdleIn {
         Call<ToInitiator, StartBatch>, Repeat<Call<ToInitiator, Block>>, Call<ToInitiator, BatchDone>, Send<ToMux, WantNext> => Idle
         | Call<ToInitiator, NoBlocks>, Send<ToMux, WantNext> => Idle
     }
-    ClientDone => { Done }
+    ClientDone => { Send<ToMux, WantNext> => Idle }
 });
 
 /// Range of points to fetch, newest first, at least one point.
@@ -235,7 +235,7 @@ async fn instance(inst: Instance, mail: Mail, eff: Effects<Mail>) -> Instance {
                     Err(err) => return invalid(peer, idle.name(), err, eff).await,
                 }
             }
-            Ok(ServerIdleIn::ClientDone(done)) => idle.receive(done, eff).finish().into(),
+            Ok(ServerIdleIn::ClientDone(done)) => idle.receive(done, eff).send(&mux, WantNext).await.finish().into(),
             Err(Inputs::Internal(Internal::Timeout)) => idle.into(),
             Err(mail) => return invalid(peer, idle.name(), mail, eff).await,
         },
@@ -344,7 +344,7 @@ pub mod tests {
                 send_desc::<ToMux, WantNext>()
             )
         );
-        assert_eq!(remaining::<Idle, ClientDone>(), "=> Done");
+        assert_eq!(remaining::<Idle, ClientDone>(), format!("{} => Idle", send_desc::<ToMux, WantNext>()));
     }
 
     #[test]
@@ -615,7 +615,7 @@ pub mod tests {
     }
 
     #[test]
-    fn close_idle_goes_done() {
+    fn close_idle_resets() {
         let mut network = SimulationBuilder::default();
         let mux = network.stage("mux", mux_step);
         let mux_ref = mux.sender();
@@ -627,8 +627,8 @@ pub mod tests {
         running.run(Run::skip_wakeups()).assert_idle();
         let log = running.get_state(&mux).cloned().unwrap();
         assert!(log.sends.is_empty());
-        assert_eq!(log.wants, 1);
-        assert!(matches!(running.get_state(&handler).unwrap().proto, Proto::Done(_)));
+        assert_eq!(log.wants, 2);
+        assert!(matches!(running.get_state(&handler).unwrap().proto, Proto::Idle(_)));
     }
 
     #[test]

--- a/crates/amaru-protocols/src/chainsync/initiator.rs
+++ b/crates/amaru-protocols/src/chainsync/initiator.rs
@@ -90,6 +90,7 @@ pub struct ChainSyncInitiator {
     muxer: StageRef<MuxMessage>,
     pipeline: StageRef<ChainSyncInitiatorMsg>,
     me: StageRef<InitiatorMessage>,
+    pending_close: bool,
 }
 
 impl ChainSyncInitiator {
@@ -99,7 +100,10 @@ impl ChainSyncInitiator {
         muxer: StageRef<MuxMessage>,
         pipeline: StageRef<ChainSyncInitiatorMsg>,
     ) -> (InitiatorState, Self) {
-        (InitiatorState::Idle, Self { upstream: None, peer, conn_id, muxer, pipeline, me: StageRef::blackhole() })
+        (
+            InitiatorState::Idle,
+            Self { upstream: None, peer, conn_id, muxer, pipeline, me: StageRef::blackhole(), pending_close: false },
+        )
     }
 }
 
@@ -107,7 +111,7 @@ impl StageState<InitiatorState, Initiator> for ChainSyncInitiator {
     type LocalIn = InitiatorMessage;
 
     async fn local(
-        self,
+        mut self,
         proto: &InitiatorState,
         input: Self::LocalIn,
         _eff: &Effects<Inputs<Self::LocalIn>>,
@@ -115,16 +119,22 @@ impl StageState<InitiatorState, Initiator> for ChainSyncInitiator {
         use InitiatorState::*;
 
         Ok(match (proto, input) {
-            (Idle, InitiatorMessage::RequestNext) => (Some(InitiatorAction::RequestNext), self),
-            (CanAwait(_) | MustReply(_), InitiatorMessage::RequestNext) => (Some(InitiatorAction::RequestNext), self),
+            (Idle, InitiatorMessage::RequestNext) if !self.pending_close => (Some(InitiatorAction::RequestNext), self),
+            (CanAwait(_) | MustReply(_), InitiatorMessage::RequestNext) if !self.pending_close => {
+                (Some(InitiatorAction::RequestNext), self)
+            }
             (Idle, InitiatorMessage::Done) => (Some(InitiatorAction::Done), self),
+            (CanAwait(_) | MustReply(_) | Intersect, InitiatorMessage::Done) => {
+                self.pending_close = true;
+                (None, self)
+            }
             (this, input) => anyhow::bail!("invalid state: {:?} <- {:?}", this, input),
         })
     }
 
     async fn network(
         mut self,
-        _proto: &InitiatorState,
+        proto: &InitiatorState,
         input: <InitiatorState as ProtocolState<Initiator>>::Out,
         eff: &Effects<Inputs<Self::LocalIn>>,
     ) -> anyhow::Result<(Option<<InitiatorState as ProtocolState<Initiator>>::Action>, Self)> {
@@ -159,6 +169,9 @@ impl StageState<InitiatorState, Initiator> for ChainSyncInitiator {
                 ChainSyncInitiatorMsg { peer: self.peer, conn_id: self.conn_id, handler: self.me.clone(), msg: input },
             )
             .await;
+            if self.pending_close && matches!(proto, InitiatorState::Idle) {
+                return Ok((Some(InitiatorAction::Done), self));
+            }
             Ok((action, self))
         }
         .instrument(debug_span!(protocols::chainsync::initiator::CHAINSYNC_INITIATOR_STAGE, message_type))
@@ -332,7 +345,7 @@ impl ProtocolState<Initiator> for InitiatorState {
             (MustReply(n), InitiatorAction::RequestNext) => {
                 (outcome().send(Message::RequestNext(1)).want_next(), MustReply(*n + 1))
             }
-            (Idle, InitiatorAction::Done) => (outcome().send(Message::Done), Done),
+            (Idle, InitiatorAction::Done) => (outcome().send(Message::Done).finish(), Done),
             (this, input) => anyhow::bail!("invalid state: {:?} <- {:?}", this, input),
         })
     }

--- a/crates/amaru-protocols/src/chainsync/initiator.rs
+++ b/crates/amaru-protocols/src/chainsync/initiator.rs
@@ -128,7 +128,9 @@ impl StageState<InitiatorState, Initiator> for ChainSyncInitiator {
                 self.pending_close = true;
                 (None, self)
             }
-            (this, input) => anyhow::bail!("invalid state: {:?} <- {:?}", this, input),
+            (this, input) => {
+                anyhow::bail!("invalid state: {:?} <- {:?} (pending_close={})", this, input, self.pending_close)
+            }
         })
     }
 

--- a/crates/amaru-protocols/src/chainsync/responder.rs
+++ b/crates/amaru-protocols/src/chainsync/responder.rs
@@ -248,7 +248,7 @@ impl ProtocolState<Responder> for ResponderState {
             (Idle { send_rollback }, Message::RequestNext(1)) => {
                 (outcome().result(ResponderResult::RequestNext), CanAwait { send_rollback: *send_rollback })
             }
-            (Idle { .. }, Message::Done) => (outcome().result(ResponderResult::Done), Done),
+            (Idle { .. }, Message::Done) => (outcome().want_next(), Idle { send_rollback: false }),
             (this, input) => anyhow::bail!("invalid state: {:?} <- {:?}", this, input),
         })
     }
@@ -287,7 +287,7 @@ impl ProtocolState<Responder> for ResponderState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{chainsync::initiator::InitiatorState, protocol::ProtoSpec};
+    use crate::protocol::ProtoSpec;
 
     #[expect(clippy::wildcard_enum_match_arm)]
     #[test]
@@ -295,7 +295,7 @@ mod tests {
         use Message::{
             AwaitReply, FindIntersect, IntersectFound, IntersectNotFound, RequestNext, RollBackward, RollForward,
         };
-        use ResponderState::{CanAwait, Done, Idle, Intersect, MustReply};
+        use ResponderState::{CanAwait, Idle, Intersect, MustReply};
 
         // canonical states and messages
         let idle = |send_rollback: bool| Idle { send_rollback };
@@ -311,8 +311,8 @@ mod tests {
         spec.init(idle(true), find_intersect(), Intersect);
         spec.init(idle(false), RequestNext(1), can_await(false));
         spec.init(idle(true), RequestNext(1), can_await(true));
-        spec.init(idle(false), Message::Done, Done);
-        spec.init(idle(true), Message::Done, Done);
+        spec.init(idle(false), Message::Done, idle(false));
+        spec.init(idle(true), Message::Done, idle(false));
         spec.resp(Intersect, intersect_found(), idle(true));
         spec.resp(Intersect, intersect_not_found(), idle(false));
         spec.resp(can_await(false), AwaitReply, MustReply);
@@ -337,12 +337,7 @@ mod tests {
             _ => None,
         });
 
-        spec.assert_refines(&super::super::initiator::tests::spec(), |state| match state {
-            Idle { .. } => InitiatorState::Idle,
-            CanAwait { .. } => InitiatorState::CanAwait(0),
-            MustReply => InitiatorState::MustReply(0),
-            Intersect => InitiatorState::Intersect,
-            Done => InitiatorState::Done,
-        });
+        // MsgDone restarts this responder in Idle. That does not refine the initiator
+        // graph, where Done is terminal.
     }
 }

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
 
 use amaru_kernel::{EraHistory, NetworkMagic, Peer, Point};
 use amaru_observability::{Instrument, TraceContext, debug_span, error, info};
@@ -25,18 +25,25 @@ use crate::{
         self, ChainSyncInitiatorMsg, InitiatorResult, register_chainsync_initiator, register_chainsync_responder,
     },
     handshake,
-    keepalive::register_keepalive,
+    keepalive::{self, register_keepalive},
     manager::{ManagerConfig, ManagerMessage},
-    mux::{self, HandlerMessage, MuxMessage},
+    mux::{self, MuxMessage},
     peer_sharing::{PeerSharingMessage, ShareResult, register_peer_sharing_initiator, register_peer_sharing_responder},
-    protocol::{Inputs, PROTO_HANDSHAKE, Role},
+    protocol::{
+        Inputs, PROTO_HANDSHAKE, PROTO_N2N_BLOCK_FETCH, PROTO_N2N_CHAIN_SYNC, PROTO_N2N_KEEP_ALIVE,
+        PROTO_N2N_PEER_SHARE, PROTO_N2N_TX_SUB, Role,
+    },
     protocol_messages::{
         handshake::HandshakeResult, version_data::VersionData, version_number::VersionNumber,
         version_table::VersionTable,
     },
     store_effects::Store,
-    tx_submission::register_tx_submission,
+    tx_submission::{self, register_tx_submission},
 };
+
+const DIFFUSION_STOP_TIMEOUT: Duration = Duration::from_secs(300);
+const MAINTENANCE_STOP_TIMEOUT: Duration = Duration::from_secs(120);
+const STOP_TIMEOUT_SLOT: u64 = 1;
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Connection {
@@ -109,18 +116,19 @@ struct Established {
     version_data: VersionData,
     muxer: StageRef<MuxMessage>,
     handshake: StageRef<Inputs<Void>>,
-    keepalive: StageRef<HandlerMessage>,
-    tx_submission: StageRef<HandlerMessage>,
+    keepalive_initiator: Option<StageRef<keepalive::InitiatorMessage>>,
+    tx_submission_initiator: Option<StageRef<tx_submission::InitiatorLocalIn>>,
     chainsync_initiator: Option<StageRef<chainsync::InitiatorMessage>>,
     blockfetch_initiator: Option<StageRef<blockfetch::BlockFetchMessage>>,
     peer_sharing_initiator: Option<StageRef<PeerSharingMessage>>,
     chainsync_responder: Option<StageRef<chainsync::ResponderMessage>>,
     blockfetch_responder: Option<StageRef<Void>>,
     peer_sharing_responder: Option<StageRef<crate::peer_sharing::ResponderMessage>>,
+    stopping: BTreeSet<ChildId>,
 }
 
 /// Identity of a supervised child stage of a connection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 pub enum ChildId {
     Mux,
     Handshake,
@@ -156,6 +164,8 @@ pub enum ConnectionMessage {
     ///
     /// The connection stage does not currently reconcile `actual_use`.
     SetLocalUse(LocalUse),
+    /// Last-to-finish group stop exceeded its bound.
+    StopTimeout,
 }
 
 impl ConnectionMessage {
@@ -169,6 +179,7 @@ impl ConnectionMessage {
             ConnectionMessage::NewTip(_, _) => "NewTip",
             ConnectionMessage::ChildDied(_) => "ChildDied",
             ConnectionMessage::SetLocalUse(_) => "SetLocalUse",
+            ConnectionMessage::StopTimeout => "StopTimeout",
         }
     }
 
@@ -191,6 +202,15 @@ pub async fn stage(
             (state, ConnectionMessage::Disconnect) => {
                 return teardown(state, &params, &eff).await;
             }
+            (State::Established(s), ConnectionMessage::ChildDied(child)) if s.stopping.contains(&child) => {
+                info!(
+                    protocols::connection::CHILD_DIED,
+                    peer = &params.peer,
+                    conn_id = conn_id.as_u64(),
+                    child = format!("{child:?}")
+                );
+                State::Established(on_expected_stop(s, child, &params, &eff).await)
+            }
             (state, ConnectionMessage::ChildDied(child)) => {
                 info!(
                     protocols::connection::CHILD_DIED,
@@ -200,12 +220,21 @@ pub async fn stage(
                 );
                 return teardown(state, &params, &eff).await;
             }
+            (State::Established(s), ConnectionMessage::StopTimeout) => {
+                if s.stopping.is_empty() {
+                    State::Established(s)
+                } else {
+                    return teardown(State::Established(s), &params, &eff).await;
+                }
+            }
             (State::Initial, ConnectionMessage::Initialize) => do_initialize(&params, eff).await,
             (State::Handshake { muxer, handshake }, ConnectionMessage::Handshake(handshake_result)) => {
                 do_handshake(&params, muxer, params.pipeline.clone(), handshake, handshake_result, eff).await
             }
             (State::Established(s), ConnectionMessage::FetchBlocks { from, through, id, cr }) => {
-                if let Some(blockfetch) = &s.blockfetch_initiator {
+                if !s.stopping.contains(&ChildId::BlockFetch)
+                    && let Some(blockfetch) = &s.blockfetch_initiator
+                {
                     eff.send(blockfetch, BlockFetchMessage::RequestRange { from, through, id, cr }).await;
                 }
                 State::Established(s)
@@ -214,7 +243,9 @@ pub async fn stage(
                 State::Established(s),
                 ConnectionMessage::RequestSharePeers { amount, initial_delay, interval, reply_to },
             ) => {
-                if let Some(ps) = &s.peer_sharing_initiator {
+                if !s.stopping.contains(&ChildId::PeerSharing)
+                    && let Some(ps) = &s.peer_sharing_initiator
+                {
                     eff.send(ps, PeerSharingMessage::Start { amount, initial_delay, interval, reply_to }).await;
                 }
                 State::Established(s)
@@ -228,7 +259,7 @@ pub async fn stage(
             (State::Established(mut s), ConnectionMessage::SetLocalUse(desired)) => {
                 // Record only; `actual_use` is not reconciled here.
                 s.desired_use = desired;
-                State::Established(s)
+                State::Established(converge_use(s, &params, &eff).await)
             }
             (state @ (State::Initial | State::Handshake { .. }), msg @ ConnectionMessage::FetchBlocks { .. }) => {
                 // The peer might be still connecting. In that case we reschedule the message
@@ -251,6 +282,7 @@ pub async fn stage(
                 eff.schedule_after(msg, params.config.reconnect_delay).await;
                 state
             }
+            (state @ (State::Initial | State::Handshake { .. }), ConnectionMessage::StopTimeout) => state,
             x => unimplemented!("{x:?}"),
         };
         Connection { params, state }
@@ -385,7 +417,7 @@ async fn do_handshake(
 
     eff.send(&muxer, mux::MuxMessage::SetSduTimeout(mux::SDU_TIMEOUT_ESTABLISHED)).await;
 
-    let keepalive = register_keepalive(
+    let keepalive_initiator = register_keepalive(
         *role,
         peer,
         *conn_id,
@@ -394,7 +426,7 @@ async fn do_handshake(
         ConnectionMessage::ChildDied(ChildId::KeepAlive),
     )
     .await;
-    let tx_submission = register_tx_submission(
+    let tx_submission_initiator = register_tx_submission(
         *role,
         peer,
         muxer.clone(),
@@ -415,14 +447,15 @@ async fn do_handshake(
         version_data,
         muxer: muxer.clone(),
         handshake,
-        keepalive,
-        tx_submission,
+        keepalive_initiator,
+        tx_submission_initiator,
         chainsync_initiator: None,
         blockfetch_initiator: None,
         peer_sharing_initiator: None,
         chainsync_responder: None,
         blockfetch_responder: None,
         peer_sharing_responder: None,
+        stopping: BTreeSet::new(),
     };
 
     if *role == Role::Initiator {
@@ -487,6 +520,176 @@ async fn do_handshake(
     }
 
     State::Established(established)
+}
+
+async fn converge_use(mut s: Established, params: &Params, eff: &Effects<ConnectionMessage>) -> Established {
+    if !s.stopping.is_empty() {
+        return s;
+    }
+    if s.desired_use < s.actual_use {
+        begin_stop(s, params, eff).await
+    } else if s.desired_use > s.actual_use && params.role == Role::Initiator {
+        start_initiators(s, params, eff).await
+    } else {
+        s.actual_use = s.desired_use;
+        s
+    }
+}
+
+async fn begin_stop(mut s: Established, _params: &Params, eff: &Effects<ConnectionMessage>) -> Established {
+    let drop_diffusion = s.actual_use == LocalUse::Diffusion && s.desired_use <= LocalUse::Maintenance;
+    let drop_maintenance = s.desired_use == LocalUse::None;
+
+    if drop_diffusion {
+        if let Some(cs) = &s.chainsync_initiator {
+            s.stopping.insert(ChildId::ChainSync);
+            eff.send(cs, chainsync::InitiatorMessage::Done).await;
+        }
+        if let Some(bf) = &s.blockfetch_initiator {
+            s.stopping.insert(ChildId::BlockFetch);
+            eff.send(bf, BlockFetchMessage::Close).await;
+        }
+        if let Some(tx) = &s.tx_submission_initiator {
+            s.stopping.insert(ChildId::TxSubmission);
+            eff.send(tx, tx_submission::InitiatorLocalIn::Close).await;
+        }
+    }
+    if drop_maintenance {
+        if let Some(ka) = &s.keepalive_initiator {
+            s.stopping.insert(ChildId::KeepAlive);
+            eff.send(ka, keepalive::InitiatorMessage::Close).await;
+        }
+        if let Some(ps) = &s.peer_sharing_initiator {
+            s.stopping.insert(ChildId::PeerSharing);
+            eff.send(ps, PeerSharingMessage::Close).await;
+        }
+    }
+
+    if s.stopping.is_empty() {
+        s.actual_use = s.desired_use;
+        return s;
+    }
+
+    let timeout = if drop_diffusion { DIFFUSION_STOP_TIMEOUT } else { MAINTENANCE_STOP_TIMEOUT };
+    eff.set_timeout_at(STOP_TIMEOUT_SLOT, timeout, ConnectionMessage::StopTimeout).await;
+    s
+}
+
+async fn on_expected_stop(
+    mut s: Established,
+    child: ChildId,
+    params: &Params,
+    eff: &Effects<ConnectionMessage>,
+) -> Established {
+    s.stopping.remove(&child);
+    match child {
+        ChildId::ChainSync => {
+            s.chainsync_initiator = None;
+            mux::install_done_trap(&s.muxer, PROTO_N2N_CHAIN_SYNC.erase(), eff, ConnectionMessage::ChildDied(child))
+                .await;
+        }
+        ChildId::BlockFetch => {
+            s.blockfetch_initiator = None;
+            mux::install_done_trap(&s.muxer, PROTO_N2N_BLOCK_FETCH.erase(), eff, ConnectionMessage::ChildDied(child))
+                .await;
+        }
+        ChildId::TxSubmission => {
+            s.tx_submission_initiator = None;
+            mux::install_done_trap(&s.muxer, PROTO_N2N_TX_SUB.erase(), eff, ConnectionMessage::ChildDied(child)).await;
+        }
+        ChildId::KeepAlive => {
+            s.keepalive_initiator = None;
+            mux::install_done_trap(&s.muxer, PROTO_N2N_KEEP_ALIVE.erase(), eff, ConnectionMessage::ChildDied(child))
+                .await;
+        }
+        ChildId::PeerSharing => {
+            s.peer_sharing_initiator = None;
+            mux::install_done_trap(&s.muxer, PROTO_N2N_PEER_SHARE.erase(), eff, ConnectionMessage::ChildDied(child))
+                .await;
+        }
+        ChildId::Mux | ChildId::Handshake => {}
+    }
+
+    if s.stopping.is_empty() {
+        eff.clear_timeout_at(STOP_TIMEOUT_SLOT).await;
+        s.actual_use = s.desired_use;
+        if params.role == Role::Initiator && s.desired_use > LocalUse::None {
+            return start_initiators(s, params, eff).await;
+        }
+    }
+    s
+}
+
+async fn start_initiators(mut s: Established, params: &Params, eff: &Effects<ConnectionMessage>) -> Established {
+    let Params { peer, conn_id, config, pipeline, mempool_stage, era_history, .. } = params;
+    if s.desired_use >= LocalUse::Maintenance {
+        if s.keepalive_initiator.is_none() {
+            s.keepalive_initiator = register_keepalive(
+                Role::Initiator,
+                *peer,
+                *conn_id,
+                s.muxer.clone(),
+                eff,
+                ConnectionMessage::ChildDied(ChildId::KeepAlive),
+            )
+            .await;
+        }
+        if s.peer_sharing_initiator.is_none() {
+            s.peer_sharing_initiator = Some(
+                register_peer_sharing_initiator(
+                    &s.muxer,
+                    *peer,
+                    *conn_id,
+                    eff,
+                    ConnectionMessage::ChildDied(ChildId::PeerSharing),
+                )
+                .await,
+            );
+        }
+    }
+    if s.desired_use == LocalUse::Diffusion {
+        if s.chainsync_initiator.is_none() {
+            s.chainsync_initiator = Some(
+                register_chainsync_initiator(
+                    &s.muxer,
+                    *peer,
+                    *conn_id,
+                    pipeline.clone(),
+                    eff,
+                    ConnectionMessage::ChildDied(ChildId::ChainSync),
+                )
+                .await,
+            );
+        }
+        if s.blockfetch_initiator.is_none() {
+            s.blockfetch_initiator = Some(
+                register_blockfetch_initiator(
+                    &s.muxer,
+                    *peer,
+                    config.blockfetch_pipeline_n,
+                    eff,
+                    ConnectionMessage::ChildDied(ChildId::BlockFetch),
+                )
+                .await,
+            );
+        }
+        if s.tx_submission_initiator.is_none() {
+            s.tx_submission_initiator = register_tx_submission(
+                Role::Initiator,
+                *peer,
+                s.muxer.clone(),
+                eff,
+                TxOrigin::Remote(*peer),
+                mempool_stage.clone(),
+                config.tx_submission_params,
+                era_history.clone(),
+                ConnectionMessage::ChildDied(ChildId::TxSubmission),
+            )
+            .await;
+        }
+    }
+    s.actual_use = s.desired_use;
+    s
 }
 
 pub fn register_deserializers() -> DeserializerGuards {

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -204,7 +204,7 @@ pub async fn stage(
             }
             (State::Established(s), ConnectionMessage::ChildDied(child)) if s.stopping.contains(&child) => {
                 info!(
-                    protocols::connection::CHILD_DIED,
+                    protocols::connection::CHILD_STOPPED,
                     peer = &params.peer,
                     conn_id = conn_id.as_u64(),
                     child = format!("{child:?}")
@@ -537,8 +537,8 @@ async fn converge_use(mut s: Established, params: &Params, eff: &Effects<Connect
 }
 
 async fn begin_stop(mut s: Established, _params: &Params, eff: &Effects<ConnectionMessage>) -> Established {
-    let drop_diffusion = s.actual_use == LocalUse::Diffusion && s.desired_use <= LocalUse::Maintenance;
-    let drop_maintenance = s.desired_use == LocalUse::None;
+    let drop_diffusion = s.actual_use >= LocalUse::Diffusion && s.desired_use < LocalUse::Diffusion;
+    let drop_maintenance = s.actual_use >= LocalUse::Maintenance && s.desired_use < LocalUse::Maintenance;
 
     if drop_diffusion {
         if let Some(cs) = &s.chainsync_initiator {

--- a/crates/amaru-protocols/src/keepalive/initiator.rs
+++ b/crates/amaru-protocols/src/keepalive/initiator.rs
@@ -47,6 +47,7 @@ pub fn initiator() -> Miniprotocol<State, KeepAliveInitiator, Initiator> {
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum InitiatorMessage {
     SendKeepAlive,
+    Close,
 }
 
 /// Message sent from the handler (for future use, e.g., RTT reporting)
@@ -62,11 +63,12 @@ pub struct KeepAliveInitiator {
     conn_id: ConnectionId,
     sent_at: Option<(Cookie, Instant)>,
     muxer: StageRef<MuxMessage>,
+    pending_close: bool,
 }
 
 impl KeepAliveInitiator {
     pub fn new(peer: Peer, conn_id: ConnectionId, muxer: StageRef<MuxMessage>) -> (State, Self) {
-        (State::Idle, Self { cookie: Cookie::new(), peer, conn_id, sent_at: None, muxer })
+        (State::Idle, Self { cookie: Cookie::new(), peer, conn_id, sent_at: None, muxer, pending_close: false })
     }
 }
 
@@ -82,9 +84,15 @@ impl StageState<State, Initiator> for KeepAliveInitiator {
         use State::*;
 
         match (proto, input) {
-            (Idle, InitiatorMessage::SendKeepAlive) => {
+            (Idle, InitiatorMessage::SendKeepAlive) if !self.pending_close => {
                 self.sent_at = Some((self.cookie, eff.clock().await));
                 Ok((Some(InitiatorAction::SendKeepAlive(self.cookie)), self))
+            }
+            (Idle, InitiatorMessage::SendKeepAlive) => Ok((Some(InitiatorAction::Done), self)),
+            (Idle, InitiatorMessage::Close) => Ok((Some(InitiatorAction::Done), self)),
+            (Waiting, InitiatorMessage::Close) => {
+                self.pending_close = true;
+                Ok((None, self))
             }
             (this, input) => anyhow::bail!("invalid state: {:?} <- {:?}", this, input),
         }
@@ -113,6 +121,9 @@ impl StageState<State, Initiator> for KeepAliveInitiator {
                 );
             }
             self.cookie = input.cookie.next();
+            if self.pending_close {
+                return Ok((Some(InitiatorAction::Done), self));
+            }
             let delay = if u16::from(input.cookie) == 0 {
                 // this is only for the very first keep-alive message, which the Haskell node expects within the first
                 // five seconds
@@ -164,6 +175,7 @@ impl ProtocolState<Initiator> for State {
             (Idle, InitiatorAction::SendKeepAlive(cookie)) => {
                 (outcome().send(Message::KeepAlive(cookie)).want_next(), Waiting)
             }
+            (Idle, InitiatorAction::Done) => (outcome().send(Message::Done).finish(), Done),
             (this, input) => anyhow::bail!("invalid state: {:?} <- {:?}", this, input),
         })
     }
@@ -172,10 +184,10 @@ impl ProtocolState<Initiator> for State {
 #[derive(Debug)]
 pub enum InitiatorAction {
     SendKeepAlive(Cookie),
+    Done,
 }
 
 #[cfg(test)]
-#[expect(clippy::wildcard_enum_match_arm)]
 pub mod tests {
     use crate::{
         keepalive::{State, initiator::InitiatorAction, messages::Message},
@@ -186,6 +198,7 @@ pub mod tests {
     fn test_initiator_protocol() {
         crate::keepalive::spec::<Initiator>().check(State::Idle, |msg| match msg {
             Message::KeepAlive(cookie) => Some(InitiatorAction::SendKeepAlive(*cookie)),
+            Message::Done => Some(InitiatorAction::Done),
             _ => None,
         });
     }

--- a/crates/amaru-protocols/src/keepalive/mod.rs
+++ b/crates/amaru-protocols/src/keepalive/mod.rs
@@ -21,6 +21,7 @@ mod tests;
 use amaru_kernel::Peer;
 use amaru_ouroboros::ConnectionId;
 use amaru_pure_stage::{Effects, StageRef, Void};
+pub use initiator::InitiatorMessage;
 pub use messages::{Cookie, Message};
 
 use crate::{
@@ -37,6 +38,7 @@ pub fn register_deserializers() -> amaru_pure_stage::DeserializerGuards {
 pub enum State {
     Idle,
     Waiting,
+    Done,
 }
 
 pub fn spec<R: crate::protocol::RoleT>() -> crate::protocol::ProtoSpec<State, Message, R>
@@ -47,8 +49,15 @@ where
     let keep_alive = || Message::KeepAlive(Cookie::new());
     let response_keep_alive = || Message::ResponseKeepAlive(Cookie::new());
 
+    let done = || Message::Done;
+
     // Initiator sends KeepAlive from Idle, transitions to Waiting
     spec.init(State::Idle, keep_alive(), State::Waiting);
+    if R::ROLE == Some(crate::protocol::Role::Initiator) {
+        spec.init(State::Idle, done(), State::Done);
+    } else {
+        spec.init(State::Idle, done(), State::Idle);
+    }
     // Initiator receives ResponseKeepAlive in Waiting, transitions to Idle
     spec.resp(State::Waiting, response_keep_alive(), State::Idle);
 
@@ -62,19 +71,22 @@ pub async fn register_keepalive(
     muxer: StageRef<crate::mux::MuxMessage>,
     eff: &Effects<ConnectionMessage>,
     tombstone: ConnectionMessage,
-) -> StageRef<crate::mux::HandlerMessage> {
-    let keepalive = if role == crate::protocol::Role::Initiator {
+) -> Option<StageRef<initiator::InitiatorMessage>> {
+    let (handler, close) = if role == crate::protocol::Role::Initiator {
         let (state, stage) = initiator::KeepAliveInitiator::new(peer, conn_id, muxer.clone());
         let keepalive = eff.stage("keepalive", initiator::initiator()).await;
         let keepalive = eff.supervise(keepalive, tombstone);
         let keepalive = eff.wire_up(keepalive, (state, stage)).await;
-        keepalive.contramap(Inputs::<initiator::InitiatorMessage>::Network)
+        (
+            keepalive.contramap(Inputs::<initiator::InitiatorMessage>::Network),
+            Some(keepalive.contramap(Inputs::<initiator::InitiatorMessage>::Local)),
+        )
     } else {
         let (state, stage) = responder::KeepAliveResponder::new(muxer.clone());
         let keepalive = eff.stage("keepalive", responder::responder()).await;
         let keepalive = eff.supervise(keepalive, tombstone);
         let keepalive = eff.wire_up(keepalive, (state, stage)).await;
-        keepalive.contramap(Inputs::<Void>::Network)
+        (keepalive.contramap(Inputs::<Void>::Network), None)
     };
 
     eff.send(
@@ -82,11 +94,11 @@ pub async fn register_keepalive(
         crate::mux::MuxMessage::Register {
             protocol: PROTO_N2N_KEEP_ALIVE.for_role(role).erase(),
             frame: mux::Frame::OneCborItem,
-            handler: keepalive.clone(),
+            handler,
             max_buffer: 65535,
         },
     )
     .await;
 
-    keepalive
+    close
 }

--- a/crates/amaru-protocols/src/keepalive/responder.rs
+++ b/crates/amaru-protocols/src/keepalive/responder.rs
@@ -99,6 +99,7 @@ impl ProtocolState<Responder> for State {
 
         Ok(match (self, input) {
             (Idle, Message::KeepAlive(cookie)) => (outcome().result(ResponderResult { cookie }), Waiting),
+            (Idle, Message::Done) => (outcome().want_next(), Idle),
             (this, input) => anyhow::bail!("invalid state: {:?} <- {:?}", this, input),
         })
     }

--- a/crates/amaru-protocols/src/mux.rs
+++ b/crates/amaru-protocols/src/mux.rs
@@ -24,7 +24,7 @@ use std::{
 use amaru_kernel::{NonEmptyBytes, Peer};
 use amaru_observability::{Instrument, debug, debug_span, error, info, trace, warn};
 use amaru_ouroboros::ConnectionId;
-use amaru_pure_stage::{Effects, Instant, OrTerminateWith, StageRef, TryInStage, Void};
+use amaru_pure_stage::{Effects, Instant, OrTerminateWith, SendData, StageRef, TryInStage, Void};
 use anyhow::Context;
 use bytes::{Buf, BufMut, Bytes, BytesMut, TryGetError};
 use cbor_data::{Cbor, ErrorKind, ParseError};
@@ -119,6 +119,27 @@ impl Frame {
 pub enum HandlerMessage {
     Registered(ProtocolId<Erased>),
     FromNetwork(NonEmptyBytes),
+}
+
+/// Mux citizen after an initiator has sent `MsgDone`. Any further frame is a protocol error.
+pub async fn done_trap(_: (), msg: HandlerMessage, eff: Effects<HandlerMessage>) -> () {
+    match msg {
+        HandlerMessage::Registered(_) => {}
+        HandlerMessage::FromNetwork(_) => return eff.terminate().await,
+    }
+}
+
+pub async fn install_done_trap<M: SendData>(
+    muxer: &StageRef<MuxMessage>,
+    protocol: ProtocolId<Erased>,
+    eff: &Effects<M>,
+    tombstone: M,
+) {
+    let trap = eff.stage("done-trap", done_trap).await;
+    let trap = eff.supervise(trap, tombstone);
+    let trap = eff.wire_up(trap, ()).await;
+    eff.send(muxer, MuxMessage::Register { protocol, frame: Frame::OneCborItem, handler: trap, max_buffer: 5760 })
+        .await;
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/crates/amaru-protocols/src/mux.rs
+++ b/crates/amaru-protocols/src/mux.rs
@@ -122,7 +122,7 @@ pub enum HandlerMessage {
 }
 
 /// Mux citizen after an initiator has sent `MsgDone`. Any further frame is a protocol error.
-pub async fn done_trap(_: (), msg: HandlerMessage, eff: Effects<HandlerMessage>) -> () {
+async fn done_trap(_: (), msg: HandlerMessage, eff: Effects<HandlerMessage>) -> () {
     match msg {
         HandlerMessage::Registered(_) => {}
         HandlerMessage::FromNetwork(_) => return eff.terminate().await,

--- a/crates/amaru-protocols/src/peer_sharing/initiator.rs
+++ b/crates/amaru-protocols/src/peer_sharing/initiator.rs
@@ -58,6 +58,8 @@ pub enum PeerSharingMessage {
     Start { amount: u8, initial_delay: Duration, interval: Duration, reply_to: StageRef<ShareResult> },
     /// Internal timer: send the next share request if idle.
     Tick,
+    /// Clean shutdown: `MsgDone` when Idle, otherwise wait for the in-flight reply.
+    Close,
 }
 
 /// Reply delivered to the requester after `MsgSharePeers`.
@@ -147,6 +149,14 @@ impl StageState<State, Initiator> for PeerSharingInitiator {
                     State::Done => Ok((None, self)),
                 }
             }
+            PeerSharingMessage::Close => match proto {
+                State::Idle if !self.in_flight => Ok((Some(InitiatorAction::Done), self)),
+                State::Busy | State::Idle => {
+                    self.reply_to = None;
+                    Ok((None, self))
+                }
+                State::Done => Ok((None, self)),
+            },
         }
     }
 
@@ -167,6 +177,10 @@ impl StageState<State, Initiator> for PeerSharingInitiator {
                     if !self.in_flight {
                         warn!(protocols::peer_sharing::initiator::PROTOCOL_VIOLATION, reason = "no_request_in_flight");
                         return eff.terminate().await;
+                    }
+                    if self.reply_to.is_none() {
+                        self.in_flight = false;
+                        return Ok((Some(InitiatorAction::Done), self));
                     }
                     if peers.len() > self.amount as usize {
                         warn!(
@@ -228,7 +242,7 @@ impl ProtocolState<Initiator> for State {
             (Idle, InitiatorAction::ShareRequest { amount }) => {
                 (outcome().send(Message::ShareRequest { amount }).want_next(), Busy)
             }
-            (Idle, InitiatorAction::Done) => (outcome().send(Message::Done), Done),
+            (Idle, InitiatorAction::Done) => (outcome().send(Message::Done).finish(), Done),
             (this, input) => anyhow::bail!("invalid state: {:?} <- {:?}", this, input),
         })
     }

--- a/crates/amaru-protocols/src/peer_sharing/mod.rs
+++ b/crates/amaru-protocols/src/peer_sharing/mod.rs
@@ -68,7 +68,11 @@ where
     // Client sends ShareRequest from Idle → Busy
     spec.init(State::Idle, share_request(), State::Busy);
     // Client may send Done from Idle → Done
-    spec.init(State::Idle, done(), State::Done);
+    if R::ROLE == Some(crate::protocol::Role::Initiator) {
+        spec.init(State::Idle, done(), State::Done);
+    } else {
+        spec.init(State::Idle, done(), State::Idle);
+    }
     // Server replies SharePeers from Busy → Idle
     spec.resp(State::Busy, share_peers(), State::Idle);
 

--- a/crates/amaru-protocols/src/peer_sharing/responder.rs
+++ b/crates/amaru-protocols/src/peer_sharing/responder.rs
@@ -183,7 +183,7 @@ impl ProtocolState<Responder> for State {
             (Idle, Message::ShareRequest { amount }) => {
                 (outcome().result(ResponderResult::ShareRequest { amount }), Busy)
             }
-            (Idle, Message::Done) => (outcome().result(ResponderResult::Done), Done),
+            (Idle, Message::Done) => (outcome().want_next(), Idle),
             (this, input) => anyhow::bail!("invalid state: {:?} <- {:?}", this, input),
         })
     }

--- a/crates/amaru-protocols/src/protocol/miniprotocol.rs
+++ b/crates/amaru-protocols/src/protocol/miniprotocol.rs
@@ -97,53 +97,23 @@ pub struct Outcome<S, R, E> {
 
 impl<S, R, E> Outcome<S, R, E> {
     pub fn send(self, send: S) -> Self {
-        Self {
-            send: Some(send),
-            result: self.result,
-            terminate_with: self.terminate_with,
-            want_next: self.want_next,
-            finished: self.finished,
-        }
+        Self { send: Some(send), ..self }
     }
 
     pub fn result(self, done: R) -> Self {
-        Self {
-            send: self.send,
-            result: Some(done),
-            terminate_with: self.terminate_with,
-            want_next: self.want_next,
-            finished: self.finished,
-        }
+        Self { result: Some(done), ..self }
     }
 
     pub fn want_next(self) -> Self {
-        Self {
-            send: self.send,
-            result: self.result,
-            terminate_with: self.terminate_with,
-            want_next: true,
-            finished: self.finished,
-        }
+        Self { want_next: true, ..self }
     }
 
     pub fn terminate_with(self, e: E) -> Self {
-        Self {
-            send: self.send,
-            result: self.result,
-            terminate_with: Some(e),
-            want_next: self.want_next,
-            finished: self.finished,
-        }
+        Self { terminate_with: Some(e), ..self }
     }
 
     pub fn finish(self) -> Self {
-        Self {
-            send: self.send,
-            result: self.result,
-            terminate_with: self.terminate_with,
-            want_next: self.want_next,
-            finished: true,
-        }
+        Self { finished: true, ..self }
     }
 
     pub fn without_result(self) -> Outcome<S, Void, E> {

--- a/crates/amaru-protocols/src/protocol/miniprotocol.rs
+++ b/crates/amaru-protocols/src/protocol/miniprotocol.rs
@@ -91,32 +91,74 @@ pub struct Outcome<S, R, E> {
     pub result: Option<R>,
     pub terminate_with: Option<E>,
     pub want_next: bool,
+    /// After sending, terminate this handler (clean `MsgDone`, not a protocol error).
+    pub finished: bool,
 }
 
 impl<S, R, E> Outcome<S, R, E> {
     pub fn send(self, send: S) -> Self {
-        Self { send: Some(send), result: self.result, terminate_with: self.terminate_with, want_next: self.want_next }
+        Self {
+            send: Some(send),
+            result: self.result,
+            terminate_with: self.terminate_with,
+            want_next: self.want_next,
+            finished: self.finished,
+        }
     }
 
     pub fn result(self, done: R) -> Self {
-        Self { send: self.send, result: Some(done), terminate_with: self.terminate_with, want_next: self.want_next }
+        Self {
+            send: self.send,
+            result: Some(done),
+            terminate_with: self.terminate_with,
+            want_next: self.want_next,
+            finished: self.finished,
+        }
     }
 
     pub fn want_next(self) -> Self {
-        Self { send: self.send, result: self.result, terminate_with: self.terminate_with, want_next: true }
+        Self {
+            send: self.send,
+            result: self.result,
+            terminate_with: self.terminate_with,
+            want_next: true,
+            finished: self.finished,
+        }
     }
 
     pub fn terminate_with(self, e: E) -> Self {
-        Self { send: self.send, result: self.result, terminate_with: Some(e), want_next: self.want_next }
+        Self {
+            send: self.send,
+            result: self.result,
+            terminate_with: Some(e),
+            want_next: self.want_next,
+            finished: self.finished,
+        }
+    }
+
+    pub fn finish(self) -> Self {
+        Self {
+            send: self.send,
+            result: self.result,
+            terminate_with: self.terminate_with,
+            want_next: self.want_next,
+            finished: true,
+        }
     }
 
     pub fn without_result(self) -> Outcome<S, Void, E> {
-        Outcome { send: self.send, result: None, terminate_with: self.terminate_with, want_next: self.want_next }
+        Outcome {
+            send: self.send,
+            result: None,
+            terminate_with: self.terminate_with,
+            want_next: self.want_next,
+            finished: self.finished,
+        }
     }
 }
 
 pub fn outcome<S, R, E>() -> Outcome<S, R, E> {
-    Outcome { send: None, result: None, terminate_with: None, want_next: false }
+    Outcome { send: None, result: None, terminate_with: None, want_next: false, finished: false }
 }
 
 /// This tracks only the network protocol state, reacting to local decisions
@@ -253,6 +295,9 @@ where
                         MuxMessage::Send(proto_id.erase(), msg, cr)
                     })
                     .await;
+                }
+                if outcome.finished {
+                    return eff.terminate().await;
                 }
             }
 

--- a/crates/amaru-protocols/src/tx_submission/initiator.rs
+++ b/crates/amaru-protocols/src/tx_submission/initiator.rs
@@ -90,7 +90,7 @@ impl StageState<State, Initiator> for TxSubmissionInitiator {
 
     async fn local(
         mut self,
-        _proto: &State,
+        proto: &State,
         input: Self::LocalIn,
         eff: &Effects<Inputs<Self::LocalIn>>,
     ) -> anyhow::Result<(Option<InitiatorAction>, Self)> {
@@ -111,6 +111,14 @@ impl StageState<State, Initiator> for TxSubmissionInitiator {
                 }
                 action
             }
+            InitiatorLocalIn::Close => {
+                if matches!(proto, crate::tx_submission::State::TxIdsBlocking) {
+                    Some(InitiatorAction::Done)
+                } else {
+                    self.pending_close = true;
+                    None
+                }
+            }
         };
         Ok((action, self))
     }
@@ -128,6 +136,9 @@ impl StageState<State, Initiator> for TxSubmissionInitiator {
             let mempool = MemoryPool::new(eff.clone());
 
             let action = match input {
+                InitiatorResult::RequestTxIds { blocking: Blocking::Yes, .. } if self.pending_close => {
+                    Some(InitiatorAction::Done)
+                }
                 InitiatorResult::RequestTxIds { ack, req, blocking: Blocking::Yes } => {
                     self.request_tx_ids_blocking(eff, ack, req).await?
                 }
@@ -207,7 +218,7 @@ impl ProtocolState<Initiator> for State {
             (State::Txs, InitiatorAction::SendReplyTxs(txs)) => {
                 (outcome().send(Message::ReplyTxs(txs)).want_next(), State::Idle)
             }
-            (State::TxIdsBlocking, InitiatorAction::Done) => (outcome().send(Message::Done), State::Done),
+            (State::TxIdsBlocking, InitiatorAction::Done) => (outcome().send(Message::Done).finish(), State::Done),
             (_, InitiatorAction::Error(e)) => (outcome().terminate_with(e), State::Done),
             (this, input) => anyhow::bail!("invalid state: {:?} <- {:?}", this, input),
         })
@@ -284,6 +295,7 @@ pub struct TxSubmissionInitiator {
     muxer: StageRef<MuxMessage>,
     /// Era history used to derive the current era tag for outgoing wire messages.
     era_history: Arc<EraHistory>,
+    pending_close: bool,
 }
 
 impl TxSubmissionInitiator {
@@ -304,6 +316,7 @@ impl TxSubmissionInitiator {
                 wait_for_at_least_callback: StageRef::blackhole(),
                 muxer,
                 era_history,
+                pending_close: false,
             },
         )
     }
@@ -536,6 +549,7 @@ impl TxSubmissionInitiator {
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum InitiatorLocalIn {
     WaitForAtLeastReached,
+    Close,
 }
 
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/crates/amaru-protocols/src/tx_submission/mod.rs
+++ b/crates/amaru-protocols/src/tx_submission/mod.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
 use amaru_kernel::{EraHistory, Peer};
 use amaru_ouroboros::{MempoolMsg, TxOrigin};
 use amaru_pure_stage::{Effects, StageRef};
-pub use initiator::initiator;
+pub use initiator::{InitiatorLocalIn, initiator};
 pub use responder::{ResponderLocalIn, ResponderResult, TxSubmissionMsg, responder};
 #[cfg(test)]
 pub use tests::*;
@@ -64,7 +64,11 @@ where
     spec.init(TxIdsBlocking, reply_tx_ids(), Idle);
     spec.init(TxIdsNonBlocking, reply_tx_ids(), Idle);
     spec.init(Txs, reply_txs(), Idle);
-    spec.init(TxIdsBlocking, Message::Done, State::Done);
+    if R::ROLE == Some(crate::protocol::Role::Initiator) {
+        spec.init(TxIdsBlocking, Message::Done, State::Done);
+    } else {
+        spec.init(TxIdsBlocking, Message::Done, State::Init);
+    }
     spec.resp(Idle, request_tx_ids_blocking(), TxIdsBlocking);
     spec.resp(Idle, request_tx_ids_non_blocking(), TxIdsNonBlocking);
     spec.resp(Idle, request_txs(), Txs);
@@ -82,21 +86,24 @@ pub async fn register_tx_submission(
     params: ResponderParams,
     era_history: Arc<EraHistory>,
     tombstone: ConnectionMessage,
-) -> StageRef<mux::HandlerMessage> {
-    let tx_submission = if role == Role::Initiator {
+) -> Option<StageRef<initiator::InitiatorLocalIn>> {
+    let (handler, close) = if role == Role::Initiator {
         let (state, stage) =
             initiator::TxSubmissionInitiator::new(peer, muxer.clone(), mempool_stage.clone(), era_history);
         let tx_submission = eff.stage("tx_submission", initiator::initiator()).await;
         let tx_submission = eff.supervise(tx_submission, tombstone);
         let tx_submission = eff.wire_up(tx_submission, (state, stage)).await;
-        tx_submission.contramap(Inputs::<initiator::InitiatorLocalIn>::Network)
+        (
+            tx_submission.contramap(Inputs::<initiator::InitiatorLocalIn>::Network),
+            Some(tx_submission.contramap(Inputs::<initiator::InitiatorLocalIn>::Local)),
+        )
     } else {
         let (state, stage) =
             responder::TxSubmissionResponder::new(peer, muxer.clone(), params, origin, mempool_stage, era_history);
         let tx_submission = eff.stage("tx_submission", responder::responder()).await;
         let tx_submission = eff.supervise(tx_submission, tombstone);
         let tx_submission = eff.wire_up(tx_submission, (state, stage)).await;
-        tx_submission.contramap(Inputs::<ResponderLocalIn>::Network)
+        (tx_submission.contramap(Inputs::<ResponderLocalIn>::Network), None)
     };
 
     eff.send(
@@ -104,13 +111,13 @@ pub async fn register_tx_submission(
         mux::MuxMessage::Register {
             protocol: PROTO_N2N_TX_SUB.for_role(role).erase(),
             frame: mux::Frame::OneCborItem,
-            handler: tx_submission.clone(),
+            handler,
             max_buffer: 2_500_000,
         },
     )
     .await;
 
-    tx_submission
+    close
 }
 
 /// The state of the tx submission protocol as a whole.

--- a/crates/amaru-protocols/src/tx_submission/responder.rs
+++ b/crates/amaru-protocols/src/tx_submission/responder.rs
@@ -146,7 +146,7 @@ impl ProtocolState<Responder> for State {
                 let txs = tagged_txs.into_iter().map(|t| t.tx).collect();
                 (outcome().result(ResponderResult::ReplyTxs(txs)), State::Idle)
             }
-            (State::TxIdsBlocking, Message::Done) => (outcome().result(ResponderResult::Done), State::Done),
+            (State::TxIdsBlocking, Message::Done) => (outcome().want_next(), State::Init),
             (this, input) => anyhow::bail!("invalid state: {:?} <- {:?}", this, input),
         })
     }

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -2481,6 +2481,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | --- | --- | --- | --- | --- | --- |
 | `accept_failed` | `TRACE` | public | An inbound connection could not be accepted. Reason ∈ {aborted, error}. | reason | error |
 | `child_died` | `TRACE` | public | A mini-protocol stage running on a connection died | peer, conn_id, child |  |
+| `child_stopped` | `TRACE` | public | A mini-protocol stage running on a connection stopped upon request | peer, conn_id, child |  |
 | `handshake_query_reply` | `TRACE` | public | The peer answered a version query instead of negotiating | version_table |  |
 | `handshake_refused` | `TRACE` | public | The peer refused our proposed protocol versions | reason |  |
 
@@ -2494,6 +2495,16 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 </details>
 
 <details><summary>span: `child_died`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `peer` | `string` | ✓ |
+| `conn_id` | `integer` | ✓ |
+| `child` | `string` | ✓ |
+
+</details>
+
+<details><summary>span: `child_stopped`</summary>
 
 | field | type | required |
 | --- | --- | --- |

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -6677,6 +6677,32 @@
       "description": "A mini-protocol stage running on a connection died",
       "public": true
     },
+    "amaru::protocols::connection::CHILD_STOPPED": {
+      "type": "object",
+      "properties": {
+        "peer": {
+          "type": "string"
+        },
+        "conn_id": {
+          "type": "integer"
+        },
+        "child": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "peer",
+        "conn_id",
+        "child"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "child_stopped",
+      "level": "TRACE",
+      "target": "amaru::protocols::connection",
+      "description": "A mini-protocol stage running on a connection stopped upon request",
+      "public": true
+    },
     "amaru::protocols::connection::HANDSHAKE_QUERY_REPLY": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
Bearer termination is only adequate in case of peer misbehaviour, protocols can be shut down in a graceful fashion.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connections now shut down mini-protocols gracefully, waiting for completion before closing.
  * Added timeout safeguards during shutdown: 300 seconds for Diffusion and 120 seconds for Maintenance.
  * Keep-alive, chain-sync, peer-sharing, transaction-submission, and block-fetch protocols can restart or continue operating after a peer sends `Done`.
  * Added tracing for mini-protocols stopped at connection shutdown.

* **Bug Fixes**
  * Improved peer reconnection handling and preserved availability when disconnecting peers that are still connecting.
  * Unexpected protocol termination still closes the connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->