### PR TITLE
use inbound or outbound connection as desired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,14 @@ Other guiding principles:
 ### Changed
 
 - **amaru-consensus**: `BlockValidator` now runs the ledger on a dedicated thread that owns the ledger state exclusively; operations are requested through a bounded channel and answered via per-request reply channels, replacing the shared lock around the state. `BlockValidator` is no longer generic over the store types. ([#1094][])
+- **amaru-protocols**: handshake combines version data as in the node-to-node spec and the initiator checks that `MsgAcceptVersion` carries that agreed record. ([#884](https://github.com/pragma-org/amaru/issues/884))
+- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
+- **amaru-consensus**: after an outbound handshake, peer selection sends `SetLocalUse(Diffusion)` so fetch and share follow actual local use. Peer-sharing cadence is 300s then 900s (blueprint defaults).
+- **amaru-protocols**: `LocalUseApplied` is the source of `may_initiate`; fetch and share route only to connections whose local use is Diffusion.
+- **amaru-protocols**: `SetLocalUse` stops initiator groups with `MsgDone` (last-to-finish; 300s diffusion / 120s maintenance). Expected child death installs a mux done-trap; unexpected death still tears the bearer. Responders reset in place after `MsgDone`.
+- **amaru-protocols**: mux times SDU assembly and send: unbounded wait for the first header byte, then 10s during the first Handshake and 30s afterwards for the rest of that SDU. Overflow of that timer tears the bearer down.
+- **amaru-protocols**: Implement SDU send & receive timeouts in the muxer as per the network spec.
+- **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record. Outbound connections still offer initiator-only diffusion (duplex is not advertised until both halves run).
 - **amaru-protocols**: `NetworkOps::connect` takes a `Peer`. Outbound dialling no longer resolves names; that stays in peer selection.
 - **amaru-node**: add world test simulation, both with generated fake chain and with a real chain fragment from preprod.
 - **amaru-node**: `Telemetry::install` no longer reads `AMARU_OPEN_TELEMETRY_SIGNALS`; embedders that select OTLP signals must pass `TelemetryOptions` to `install_with_options`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ Other guiding principles:
 - **amaru**: the `mempool_max_bytes` startup trace field is now an IEC size such as `176 KiB` instead of a raw integer.
 - **amaru-protocols**: a connection is one established session whose local use is None, Maintenance, or Diffusion. The manager no longer redials when a session drops; peer selection fills outbound slots. ([#736](https://github.com/pragma-org/amaru/issues/736))
 - **amaru-protocols**: lowering local use sends `MsgDone` to the initiator mini-protocols and waits for them to finish (300s from Diffusion, 120s from Maintenance). Unexpected protocol death still tears the connection down.
+- **amaru-consensus**: after an outbound handshake, the node starts diffusion (ChainSync, BlockFetch, PeerSharing) on that connection. Peer-sharing asks every 300s at first, then every 900s.
+- **amaru-protocols**: BlockFetch and PeerSharing run only on connections whose local use is Diffusion.
 
 ### Fixed
 
@@ -80,14 +82,6 @@ Other guiding principles:
 ### Changed
 
 - **amaru-consensus**: `BlockValidator` now runs the ledger on a dedicated thread that owns the ledger state exclusively; operations are requested through a bounded channel and answered via per-request reply channels, replacing the shared lock around the state. `BlockValidator` is no longer generic over the store types. ([#1094][])
-- **amaru-protocols**: handshake combines version data as in the node-to-node spec and the initiator checks that `MsgAcceptVersion` carries that agreed record. ([#884](https://github.com/pragma-org/amaru/issues/884))
-- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
-- **amaru-consensus**: after an outbound handshake, peer selection sends `SetLocalUse(Diffusion)` so fetch and share follow actual local use. Peer-sharing cadence is 300s then 900s (blueprint defaults).
-- **amaru-protocols**: `LocalUseApplied` is the source of `may_initiate`; fetch and share route only to connections whose local use is Diffusion.
-- **amaru-protocols**: `SetLocalUse` stops initiator groups with `MsgDone` (last-to-finish; 300s diffusion / 120s maintenance). Expected child death installs a mux done-trap; unexpected death still tears the bearer. Responders reset in place after `MsgDone`.
-- **amaru-protocols**: mux times SDU assembly and send: unbounded wait for the first header byte, then 10s during the first Handshake and 30s afterwards for the rest of that SDU. Overflow of that timer tears the bearer down.
-- **amaru-protocols**: Implement SDU send & receive timeouts in the muxer as per the network spec.
-- **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record. Outbound connections still offer initiator-only diffusion (duplex is not advertised until both halves run).
 - **amaru-protocols**: `NetworkOps::connect` takes a `Peer`. Outbound dialling no longer resolves names; that stays in peer selection.
 - **amaru-node**: add world test simulation, both with generated fake chain and with a real chain fragment from preprod.
 - **amaru-node**: `Telemetry::install` no longer reads `AMARU_OPEN_TELEMETRY_SIGNALS`; embedders that select OTLP signals must pass `TelemetryOptions` to `install_with_options`.

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -23,6 +23,7 @@ use amaru_kernel::{BlockHeight, Peer, PeerCandidate};
 use amaru_observability::{Instrument, TraceContext, debug, debug_span, info, warn};
 use amaru_ouroboros::{ConnectionDirection, ConnectionId};
 use amaru_protocols::{
+    connection::LocalUse,
     manager::ManagerMessage,
     peer_sharing::{SharePeersReply, ShareResult},
 };
@@ -38,9 +39,9 @@ const STATIC_PEER_BAN_PERIOD: Duration = Duration::from_secs(10);
 /// Backoff after a failed Host/SRV lookup before that candidate may be picked again.
 const RESOLUTION_RETRY_DELAY: Duration = Duration::from_secs(30);
 /// Delay after outbound connect before the first peer-sharing request.
-pub const SHARE_REQUEST_INITIAL_DELAY: Duration = Duration::from_millis(100);
+pub const SHARE_REQUEST_INITIAL_DELAY: Duration = Duration::from_secs(300);
 /// Interval between subsequent peer-sharing requests on a live outbound connection.
-pub const SHARE_REQUEST_INTERVAL: Duration = Duration::from_secs(60 * 60);
+pub const SHARE_REQUEST_INTERVAL: Duration = Duration::from_secs(900);
 /// How many peers to request per share call (network-spec amount is `Word8`).
 pub const SHARE_REQUEST_AMOUNT: u8 = 20;
 
@@ -140,6 +141,7 @@ pub const SHARE_REQUEST_AMOUNT: u8 = 20;
 ///     connection for the same peer, sending `Disconnect` for the old one).
 ///   - `Outbound`: Inserts/updates as `PeerState::Connected(conn)`. If replacing
 ///     a prior `Connected` state, warns and sends `Disconnect` for the old conn.
+///     Sends `SetLocalUse(Diffusion)` so fetch/share follow actual local use.
 ///     When `advertisable`, starts peer-sharing on that connection
 ///     (`ManagerMessage::RequestSharePeers` with [`SHARE_REQUEST_INITIAL_DELAY`] /
 ///     [`SHARE_REQUEST_INTERVAL`]); the initiator owns the request cadence.
@@ -705,6 +707,11 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
             if let Some(old_id) = disconnect_old {
                 eff.send(&state.manager, ManagerMessage::Disconnect(peer, old_id)).await;
             }
+            eff.send(
+                &state.manager,
+                ManagerMessage::SetLocalUse { peer, conn_id: connection.id, local_use: LocalUse::Diffusion },
+            )
+            .await;
             // Only ask peers that advertised peer-sharing willingness (they run the server).
             // Cadence lives on the peer-sharing initiator until the connection ends.
             if advertisable {

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -247,6 +247,10 @@ pub struct PeerSelection {
     /// Contramap target for peer-sharing replies ([`ShareResult`] → [`PeerSelectionMsg::SharePeersResult`]).
     /// Ignored in [`PartialEq`] (lazily wired, test-unstable name).
     share_reply: StageRef<ShareResult>,
+    /// Delay after outbound connect before the first peer-sharing request.
+    share_request_initial_delay: Duration,
+    /// Interval between subsequent peer-sharing requests on a live outbound connection.
+    share_request_interval: Duration,
 }
 
 impl PartialEq for PeerSelection {
@@ -262,6 +266,8 @@ impl PartialEq for PeerSelection {
             && self.pending_resolve == other.pending_resolve
             && self.bound == other.bound
             && self.resolve_backoff == other.resolve_backoff
+            && self.share_request_initial_delay == other.share_request_initial_delay
+            && self.share_request_interval == other.share_request_interval
         // share_reply intentionally omitted
     }
 }
@@ -353,7 +359,16 @@ impl PeerSelection {
             bound: BTreeMap::new(),
             resolve_backoff: BTreeMap::new(),
             share_reply: StageRef::blackhole(),
+            share_request_initial_delay: SHARE_REQUEST_INITIAL_DELAY,
+            share_request_interval: SHARE_REQUEST_INTERVAL,
         }
+    }
+
+    /// Override the peer-sharing request cadence (production default is 300s then 900s).
+    pub fn with_share_request_delays(mut self, initial: Duration, interval: Duration) -> Self {
+        self.share_request_initial_delay = initial;
+        self.share_request_interval = interval;
+        self
     }
 }
 
@@ -514,8 +529,8 @@ impl PeerSelection {
             ManagerMessage::RequestSharePeers {
                 peer,
                 amount: SHARE_REQUEST_AMOUNT,
-                initial_delay: SHARE_REQUEST_INITIAL_DELAY,
-                interval: SHARE_REQUEST_INTERVAL,
+                initial_delay: self.share_request_initial_delay,
+                interval: self.share_request_interval,
                 reply_to: self.share_reply.clone(),
             },
         )

--- a/crates/amaru-consensus/src/stages/peer_selection/tests.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/tests.rs
@@ -14,7 +14,7 @@
 
 use amaru_observability::tracing::Level;
 use amaru_ouroboros::{ConnectionDirection, ConnectionId};
-use amaru_protocols::manager::ManagerMessage;
+use amaru_protocols::{connection::LocalUse, manager::ManagerMessage};
 use amaru_pure_stage::{
     simulation::Run,
     trace_match::{assert_trace_contains, assert_trace_does_not_contain, tm_send_match},
@@ -587,6 +587,15 @@ fn test_connected_outbound() {
             te_input("ps-1", &msg),
             te_clock_suspend("ps-1"),
             te_record_advertisability("ps-1", p, false, sim_t0()),
+            te_send(
+                "ps-1",
+                "manager",
+                ManagerMessage::SetLocalUse {
+                    peer: p,
+                    conn_id: ConnectionId::initial(),
+                    local_use: LocalUse::Diffusion,
+                },
+            ),
             te_state("ps-1", &after),
         ],
     );

--- a/crates/amaru-node/src/stages/build_stage_graph.rs
+++ b/crates/amaru-node/src/stages/build_stage_graph.rs
@@ -70,7 +70,8 @@ pub fn build_stage_graph(
             config.target_upstream_peers,
             config.target_downstream_peers,
             config.peer_removal_cooldown_secs,
-        ),
+        )
+        .with_share_request_delays(config.share_request_initial_delay, config.share_request_interval),
     );
 
     let peer_selection_notify = peer_selection_ref.contramap(|n: PeerSelectionNotify| match n {

--- a/crates/amaru-node/src/stages/config.rs
+++ b/crates/amaru-node/src/stages/config.rs
@@ -22,7 +22,10 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use amaru_consensus::performance::PeerMix;
+use amaru_consensus::{
+    performance::PeerMix,
+    stages::peer_selection::{SHARE_REQUEST_INITIAL_DELAY, SHARE_REQUEST_INTERVAL},
+};
 use amaru_kernel::{
     ConsensusParameters, EraHistory, GlobalParameters, NetworkMagic, NetworkName, PREPROD_ERA_HISTORY,
     PREPROD_GLOBAL_PARAMETERS, Peer, PeerCandidate,
@@ -81,6 +84,12 @@ pub struct Config {
 
     /// BlockFetch initiator pipeline depth. `1` is the lock-step instance; `N > 1` pipelines.
     pub blockfetch_pipeline_n: NonZeroU8,
+
+    /// Delay after outbound connect before the first peer-sharing request (production 300s).
+    pub share_request_initial_delay: Duration,
+
+    /// Interval between subsequent peer-sharing requests (production 900s).
+    pub share_request_interval: Duration,
 
     /// Optional embedder observers (adopted blocks, full stake summaries).
     pub observers: amaru_ledger::LedgerObservers,
@@ -160,6 +169,8 @@ impl Default for Config {
             mempool: MempoolConfig::default(),
             tx_submission_responder_params: ResponderParams::default(),
             blockfetch_pipeline_n: NonZeroU8::MIN,
+            share_request_initial_delay: SHARE_REQUEST_INITIAL_DELAY,
+            share_request_interval: SHARE_REQUEST_INTERVAL,
             observers: amaru_ledger::LedgerObservers::default(),
             meter: None,
             realign_chain_store: true,

--- a/crates/amaru-node/src/tests/configuration.rs
+++ b/crates/amaru-node/src/tests/configuration.rs
@@ -83,6 +83,8 @@ pub struct NodeTestConfig {
     pub peer_mix: Option<String>,
     /// BlockFetch initiator pipeline depth forwarded to [`Config::blockfetch_pipeline_n`].
     pub blockfetch_pipeline_n: NonZeroU8,
+    /// When set, overrides [`Config::share_request_initial_delay`] (production default 300s).
+    pub share_request_initial_delay: Option<Duration>,
     /// Keeps a dummy ledger tempdir alive until the last node graph holding it is dropped.
     dummy_ledger: Arc<Mutex<Option<Arc<tempfile::TempDir>>>>,
 }
@@ -113,6 +115,7 @@ impl Debug for NodeTestConfig {
             .field("keep_persisted_best_chain", &self.keep_persisted_best_chain)
             .field("peer_mix", &self.peer_mix)
             .field("blockfetch_pipeline_n", &self.blockfetch_pipeline_n)
+            .field("share_request_initial_delay", &self.share_request_initial_delay)
             .finish()
     }
 }
@@ -146,6 +149,7 @@ impl Default for NodeTestConfig {
             keep_persisted_best_chain: false,
             peer_mix: None,
             blockfetch_pipeline_n: NonZeroU8::MIN,
+            share_request_initial_delay: None,
             dummy_ledger: Arc::new(Mutex::new(None)),
         }
     }
@@ -310,6 +314,12 @@ impl NodeTestConfig {
         self
     }
 
+    /// First peer-sharing request this long after an outbound handshake (production 300s).
+    pub fn with_share_request_initial_delay(mut self, delay: Duration) -> Self {
+        self.share_request_initial_delay = Some(delay);
+        self
+    }
+
     /// Given a list of block headers:
     ///
     /// - Store them in the chain store.
@@ -366,6 +376,9 @@ impl NodeTestConfig {
             config.peer_mix = mix.parse().map_err(|e| anyhow::anyhow!("invalid peer-mix `{mix}`: {e}"))?;
         }
         config.blockfetch_pipeline_n = self.blockfetch_pipeline_n;
+        if let Some(delay) = self.share_request_initial_delay {
+            config.share_request_initial_delay = delay;
+        }
 
         if let Some(ledger_dir) = &self.ledger_dir {
             config.ledger_config.ledger_store = RocksDbConfig::new(ledger_dir.clone());

--- a/crates/amaru-node/src/tests/world/generated.rs
+++ b/crates/amaru-node/src/tests/world/generated.rs
@@ -21,7 +21,7 @@
 //!
 //! Every run prints `seed=0x…`. Replay with `AMARU_TEST_SEED=<that value>`.
 
-use std::{cmp::Ordering, env::var, net::SocketAddr, num::NonZeroU8, sync::Arc};
+use std::{cmp::Ordering, env::var, net::SocketAddr, num::NonZeroU8, sync::Arc, time::Duration};
 
 use amaru_consensus::{
     effects::{GenerateRandomSeed, ValidateBlockEffect, ValidateHeaderEffect},
@@ -269,9 +269,10 @@ fn injector_linear_store(n: usize, seed: u64) -> (Arc<InMemoryChainStore>, Vec<a
 /// fragment: the injector reveals the whole inventory up front (no live minting).
 ///
 /// Peer sharing must add connections beyond the initial chain. Delay and horizon are knobs.
-/// Seeded disconnects stay sparse relative to the fragment; their schedule is redrawn until
-/// at least one adjacent pair sits inside one reconnect delay. Each inventory hash is a
-/// world-heap Reveal, paced by the injector's default mailbox.
+/// Production share delay is 300s, longer than these horizons, so the nodes use
+/// [`P_JOIN_SHARE_INITIAL_DELAY`]. Seeded disconnects stay sparse relative to the fragment;
+/// their schedule is redrawn until at least one adjacent pair sits inside one reconnect delay.
+/// Each inventory hash is a world-heap Reveal, paced by the injector's default mailbox.
 const P_JOIN_NODES: usize = 5;
 const P_JOIN_FRAGMENT: usize = 100;
 /// Payload hop ~10ms ± 2ms. Handshake hops stay 1–5ms.
@@ -287,6 +288,9 @@ const P_JOIN_RECONNECT_DELAY_NANOS: u64 = 2_000_000_000;
 /// Leave the reconnect delay plus slack after the last drop.
 const P_JOIN_DISCONNECT_TAIL_NANOS: u64 = 2_500_000_000;
 const P_JOIN_RUNS: u32 = 50;
+/// First peer-sharing request after outbound handshake. Must be well below the horizon
+/// (production default is 300s).
+const P_JOIN_SHARE_INITIAL_DELAY: Duration = Duration::from_millis(100);
 
 /// Realistic link delay: finish catch-up quickly on a near-constant hop.
 #[test]
@@ -360,6 +364,7 @@ fn run_p_join_quiescent_chain(
             .with_upstream_peer(upstream)
             .with_listen_address(listen)
             .with_seed(derive_seed(seed, TAG_NODE + i as u64))
+            .with_share_request_initial_delay(P_JOIN_SHARE_INITIAL_DELAY)
             .with_trace_buffer(TraceBuffer::new_shared(20_000, 16_000_000))
             // Common ancestor so FindIntersect is not Origin-vs-a-parent-hash the node does not have.
             .with_validated_blocks(vec![headers[0].clone()]);

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -519,6 +519,7 @@ async fn do_handshake(
         );
     }
 
+    eff.send(manager, ManagerMessage::LocalUseApplied { peer, conn_id: *conn_id, local_use }).await;
     State::Established(established)
 }
 
@@ -530,13 +531,16 @@ async fn converge_use(mut s: Established, params: &Params, eff: &Effects<Connect
         begin_stop(s, params, eff).await
     } else if s.desired_use > s.actual_use && params.role == Role::Initiator {
         start_initiators(s, params, eff).await
-    } else {
+    } else if s.desired_use != s.actual_use {
         s.actual_use = s.desired_use;
+        notify_local_use(&s, params, eff).await;
+        s
+    } else {
         s
     }
 }
 
-async fn begin_stop(mut s: Established, _params: &Params, eff: &Effects<ConnectionMessage>) -> Established {
+async fn begin_stop(mut s: Established, params: &Params, eff: &Effects<ConnectionMessage>) -> Established {
     let drop_diffusion = s.actual_use >= LocalUse::Diffusion && s.desired_use < LocalUse::Diffusion;
     let drop_maintenance = s.actual_use >= LocalUse::Maintenance && s.desired_use < LocalUse::Maintenance;
 
@@ -567,6 +571,7 @@ async fn begin_stop(mut s: Established, _params: &Params, eff: &Effects<Connecti
 
     if s.stopping.is_empty() {
         s.actual_use = s.desired_use;
+        notify_local_use(&s, params, eff).await;
         return s;
     }
 
@@ -613,6 +618,7 @@ async fn on_expected_stop(
     if s.stopping.is_empty() {
         eff.clear_timeout_at(STOP_TIMEOUT_SLOT).await;
         s.actual_use = s.desired_use;
+        notify_local_use(&s, params, eff).await;
         if params.role == Role::Initiator && s.desired_use > LocalUse::None {
             return start_initiators(s, params, eff).await;
         }
@@ -689,7 +695,16 @@ async fn start_initiators(mut s: Established, params: &Params, eff: &Effects<Con
         }
     }
     s.actual_use = s.desired_use;
+    notify_local_use(&s, params, eff).await;
     s
+}
+
+async fn notify_local_use(s: &Established, params: &Params, eff: &Effects<ConnectionMessage>) {
+    eff.send(
+        &params.manager,
+        ManagerMessage::LocalUseApplied { peer: params.peer, conn_id: params.conn_id, local_use: s.actual_use },
+    )
+    .await;
 }
 
 pub fn register_deserializers() -> DeserializerGuards {

--- a/crates/amaru-protocols/src/keepalive/initiator.rs
+++ b/crates/amaru-protocols/src/keepalive/initiator.rs
@@ -199,7 +199,7 @@ pub mod tests {
         crate::keepalive::spec::<Initiator>().check(State::Idle, |msg| match msg {
             Message::KeepAlive(cookie) => Some(InitiatorAction::SendKeepAlive(*cookie)),
             Message::Done => Some(InitiatorAction::Done),
-            _ => None,
+            Message::ResponseKeepAlive(_) => None,
         });
     }
 }

--- a/crates/amaru-protocols/src/manager/mod.rs
+++ b/crates/amaru-protocols/src/manager/mod.rs
@@ -227,7 +227,8 @@ struct Connection {
     direction: ConnectionDirection,
     /// Whether we may initiate mini-protocols on this connection.
     ///
-    /// False until [`ManagerMessage::LocalUseApplied`] reports [`LocalUse::Diffusion`].
+    /// Outbound handshake already starts Diffusion initiators, so this is true from insert.
+    /// Inbound stays false until [`ManagerMessage::LocalUseApplied`] reports [`LocalUse::Diffusion`].
     may_initiate: bool,
     full_duplex_capable: bool,
 }
@@ -489,6 +490,10 @@ impl Manager {
             }
         };
         if accept_this {
+            // Outbound handshake starts Diffusion initiators in the same connection turn,
+            // so share/fetch must see `may_initiate` before `Connected` is processed.
+            let may_initiate = direction == ConnectionDirection::Outbound;
+            self.connections.insert(conn_id, Connection { stage, direction, full_duplex_capable, peer, may_initiate });
             eff.send(
                 &self.peer_selection,
                 PeerSelectionNotify::Connected {
@@ -501,8 +506,6 @@ impl Manager {
                 },
             )
             .await;
-            self.connections
-                .insert(conn_id, Connection { stage, direction, full_duplex_capable, peer, may_initiate: false });
         } else {
             info!(protocols::manager::peer::DUPLICATE_TERMINATED, peer, conn_id = conn_id.as_u64());
             eff.send(&stage, ConnectionMessage::Disconnect).await;

--- a/crates/amaru-protocols/src/manager/mod.rs
+++ b/crates/amaru-protocols/src/manager/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     accept::{self, PullAccept},
     blockfetch::Blocks,
     chainsync::ChainSyncInitiatorMsg,
-    connection::{self, ConnectionMessage},
+    connection::{self, ConnectionMessage, LocalUse},
     network_effects::{ConnectError, Network, NetworkOps},
     peer_sharing::{SharePeersReply, ShareResult},
     protocol::Role,
@@ -117,10 +117,10 @@ pub enum ManagerMessage {
         full_duplex: bool,
         advertisable: bool,
     },
-    /// Record the desired local use for a live connection.
-    ///
-    /// The connection stage does not currently reconcile `actual_use`.
-    SetLocalUse { peer: Peer, conn_id: ConnectionId, local_use: crate::connection::LocalUse },
+    /// Ask a live connection to converge toward this local use.
+    SetLocalUse { peer: Peer, conn_id: ConnectionId, local_use: LocalUse },
+    /// Connection finished converging; used to update `may_initiate`.
+    LocalUseApplied { peer: Peer, conn_id: ConnectionId, local_use: LocalUse },
 }
 
 impl ManagerMessage {
@@ -139,6 +139,7 @@ impl ManagerMessage {
             ManagerMessage::Accepted(..) => "Accepted",
             ManagerMessage::HandshakeComplete { .. } => "HandshakeComplete",
             ManagerMessage::SetLocalUse { .. } => "SetLocalUse",
+            ManagerMessage::LocalUseApplied { .. } => "LocalUseApplied",
         }
     }
 
@@ -226,8 +227,7 @@ struct Connection {
     direction: ConnectionDirection,
     /// Whether we may initiate mini-protocols on this connection.
     ///
-    /// This is false while the handshake is ongoing and may remain
-    /// false afterwards, e.g. if inbound and not full-duplex capable.
+    /// False until [`ManagerMessage::LocalUseApplied`] reports [`LocalUse::Diffusion`].
     may_initiate: bool,
     full_duplex_capable: bool,
 }
@@ -501,16 +501,8 @@ impl Manager {
                 },
             )
             .await;
-            self.connections.insert(
-                conn_id,
-                Connection {
-                    stage,
-                    direction,
-                    full_duplex_capable,
-                    peer,
-                    may_initiate: role == Role::Initiator || full_duplex,
-                },
-            );
+            self.connections
+                .insert(conn_id, Connection { stage, direction, full_duplex_capable, peer, may_initiate: false });
         } else {
             info!(protocols::manager::peer::DUPLICATE_TERMINATED, peer, conn_id = conn_id.as_u64());
             eff.send(&stage, ConnectionMessage::Disconnect).await;
@@ -760,6 +752,11 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
                         local_use = format!("{local_use:?}")
                     );
                     eff.send(&connection.stage, ConnectionMessage::SetLocalUse(local_use)).await;
+                }
+            }
+            ManagerMessage::LocalUseApplied { peer: _, conn_id, local_use } => {
+                if let Some(connection) = manager.connections.get_mut(&conn_id) {
+                    connection.may_initiate = local_use == LocalUse::Diffusion;
                 }
             }
         }

--- a/crates/amaru-protocols/src/tests/slow_manager_stage.rs
+++ b/crates/amaru-protocols/src/tests/slow_manager_stage.rs
@@ -43,6 +43,7 @@ pub async fn slow_manager_stage(manager: Manager, msg: ManagerMessage, eff: Effe
         ManagerMessage::ShareRequest { .. } => {}
         ManagerMessage::ConnectionResult(..) => {}
         ManagerMessage::SetLocalUse { .. } => {}
+        ManagerMessage::LocalUseApplied { .. } => {}
     }
     manager::stage(manager, msg, eff).await
 }


### PR DESCRIPTION
start / stop protocol handlers gracefully to switch between the different usage levels for a bearer

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changed**
  - Outbound connections now begin diffusion protocols after completing the handshake.
  - BlockFetch and peer sharing operate only on connections designated for diffusion.
  - Peer-sharing requests now begin after 5 minutes, then repeat every 15 minutes.

- **Bug Fixes**
  - Connection state and protocol availability now stay synchronized as local connection usage changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->