### PR TITLE
implement peer churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Other guiding principles:
 - **amaru-protocols**: lowering local use sends `MsgDone` to the initiator mini-protocols and waits for them to finish (300s from Diffusion, 120s from Maintenance). Unexpected protocol death still tears the connection down.
 - **amaru-consensus**: after an outbound handshake, the node starts diffusion (ChainSync, BlockFetch, PeerSharing) on that connection. Peer-sharing asks every 300s at first, then every 900s.
 - **amaru-protocols**: BlockFetch and PeerSharing run only on connections whose local use is Diffusion.
+- **amaru-consensus**: peer selection churns about 20% of Using peers per hour (worst first, never static bootstrap peers) by demoting them to Maintenance, without incrementing malus.
+- **amaru-consensus**: ChainSync `IntersectNotFound` treats the peer as uninteresting as an upstream (retry after 120s), not as adversarial.
 
 ### Fixed
 
@@ -82,16 +84,6 @@ Other guiding principles:
 ### Changed
 
 - **amaru-consensus**: `BlockValidator` now runs the ledger on a dedicated thread that owns the ledger state exclusively; operations are requested through a bounded channel and answered via per-request reply channels, replacing the shared lock around the state. `BlockValidator` is no longer generic over the store types. ([#1094][])
-- **amaru-protocols**: handshake combines version data as in the node-to-node spec and the initiator checks that `MsgAcceptVersion` carries that agreed record. ([#884](https://github.com/pragma-org/amaru/issues/884))
-- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
-- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
-- **amaru-consensus**: peer selection churns ~20%/h of Using peers (worst first, skip static) with `SetLocalUse(Maintenance)` and does not increment malus. ChainSync `IntersectNotFound` is uninteresting-as-upstream (retry after 120s), not adversarial.
-- **amaru-consensus**: after an outbound handshake, peer selection sends `SetLocalUse(Diffusion)` so fetch and share follow actual local use. Peer-sharing cadence is 300s then 900s (blueprint defaults).
-- **amaru-protocols**: `LocalUseApplied` is the source of `may_initiate`; fetch and share route only to connections whose local use is Diffusion.
-- **amaru-protocols**: `SetLocalUse` stops initiator groups with `MsgDone` (last-to-finish; 300s diffusion / 120s maintenance). Expected child death installs a mux done-trap; unexpected death still tears the bearer. Responders reset in place after `MsgDone`.
-- **amaru-protocols**: mux times SDU assembly and send: unbounded wait for the first header byte, then 10s during the first Handshake and 30s afterwards for the rest of that SDU. Overflow of that timer tears the bearer down.
-- **amaru-protocols**: Implement SDU send & receive timeouts in the muxer as per the network spec.
-- **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record. Outbound connections still offer initiator-only diffusion (duplex is not advertised until both halves run).
 - **amaru-protocols**: `NetworkOps::connect` takes a `Peer`. Outbound dialling no longer resolves names; that stays in peer selection.
 - **amaru-node**: add world test simulation, both with generated fake chain and with a real chain fragment from preprod.
 - **amaru-node**: `Telemetry::install` no longer reads `AMARU_OPEN_TELEMETRY_SIGNALS`; embedders that select OTLP signals must pass `TelemetryOptions` to `install_with_options`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,16 @@ Other guiding principles:
 ### Changed
 
 - **amaru-consensus**: `BlockValidator` now runs the ledger on a dedicated thread that owns the ledger state exclusively; operations are requested through a bounded channel and answered via per-request reply channels, replacing the shared lock around the state. `BlockValidator` is no longer generic over the store types. ([#1094][])
+- **amaru-protocols**: handshake combines version data as in the node-to-node spec and the initiator checks that `MsgAcceptVersion` carries that agreed record. ([#884](https://github.com/pragma-org/amaru/issues/884))
+- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
+- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
+- **amaru-consensus**: peer selection churns ~20%/h of Using peers (worst first, skip static) with `SetLocalUse(Maintenance)` and does not increment malus. ChainSync `IntersectNotFound` is uninteresting-as-upstream (retry after 120s), not adversarial.
+- **amaru-consensus**: after an outbound handshake, peer selection sends `SetLocalUse(Diffusion)` so fetch and share follow actual local use. Peer-sharing cadence is 300s then 900s (blueprint defaults).
+- **amaru-protocols**: `LocalUseApplied` is the source of `may_initiate`; fetch and share route only to connections whose local use is Diffusion.
+- **amaru-protocols**: `SetLocalUse` stops initiator groups with `MsgDone` (last-to-finish; 300s diffusion / 120s maintenance). Expected child death installs a mux done-trap; unexpected death still tears the bearer. Responders reset in place after `MsgDone`.
+- **amaru-protocols**: mux times SDU assembly and send: unbounded wait for the first header byte, then 10s during the first Handshake and 30s afterwards for the rest of that SDU. Overflow of that timer tears the bearer down.
+- **amaru-protocols**: Implement SDU send & receive timeouts in the muxer as per the network spec.
+- **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record. Outbound connections still offer initiator-only diffusion (duplex is not advertised until both halves run).
 - **amaru-protocols**: `NetworkOps::connect` takes a `Peer`. Outbound dialling no longer resolves names; that stays in peer selection.
 - **amaru-node**: add world test simulation, both with generated fake chain and with a real chain fragment from preprod.
 - **amaru-node**: `Telemetry::install` no longer reads `AMARU_OPEN_TELEMETRY_SIGNALS`; embedders that select OTLP signals must pass `TelemetryOptions` to `install_with_options`.

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -44,6 +44,25 @@ pub const SHARE_REQUEST_INITIAL_DELAY: Duration = Duration::from_secs(300);
 pub const SHARE_REQUEST_INTERVAL: Duration = Duration::from_secs(900);
 /// How many peers to request per share call (network-spec amount is `Word8`).
 pub const SHARE_REQUEST_AMOUNT: u8 = 20;
+/// Caught-up churn interval before fuzz (Haskell default).
+pub const CHURN_INTERVAL_BASE: Duration = Duration::from_secs(3300);
+/// Extra delay drawn uniformly from `0..=CHURN_INTERVAL_FUZZ`.
+pub const CHURN_INTERVAL_FUZZ: Duration = Duration::from_secs(600);
+/// Fraction of Using peers to demote each cycle (at least one).
+pub const CHURN_FRACTION_PERCENT: usize = 20;
+/// After clean churn, the bearer stays; do not re-promote for this long.
+pub const CHURN_REPROMOTE_DELAY: Duration = Duration::from_secs(10);
+/// Retry Using after no intersection (not hostility).
+pub const UNINTERESTING_RETRY: Duration = Duration::from_secs(120);
+/// Retry Using after a rollback past the intersection.
+pub const UNINTERESTING_RETRY_AFTER_ROLLBACK: Duration = Duration::from_secs(180);
+
+fn churn_interval(seed: [u8; 32]) -> Duration {
+    let mut bytes = [0u8; 8];
+    bytes.copy_from_slice(&seed[0..8]);
+    let fuzz_secs = u64::from_le_bytes(bytes) % (CHURN_INTERVAL_FUZZ.as_secs() + 1);
+    CHURN_INTERVAL_BASE + Duration::from_secs(fuzz_secs)
+}
 
 /// Peer selection stage for the Amaru consensus node.
 ///
@@ -187,9 +206,10 @@ pub const SHARE_REQUEST_AMOUNT: u8 = 20;
 /// ## Regulation, Schedules, and Effects
 ///
 /// `regulate_peers` (called from `CheckCooldowns`, outbound non-retry disconnect,
-/// `ConnectFailed`, `Regulate`, and outbound removal inside `ban_peer` after the
-/// ban is recorded)
-/// early-returns if `outbound_peers.len() >= target_upstream_peers`. Otherwise it
+/// `ConnectFailed`, `Regulate`, churn/uninteresting demotion, and outbound removal
+/// inside `ban_peer` after the ban is recorded)
+/// early-returns if Using occupancy (`Diffusion` outbound + in-flight dials) is at
+/// `target_upstream_peers`. Eligible Maintenance outbound is promoted first. Otherwise it
 /// obtains a seed via `eff.external(GenerateRandomSeed)` and asks Performance to
 /// select [`PeerCandidate`]s (mix + quality-weighted sample within each source;
 /// hard exclude outbound + cool-down + in-flight resolve). Socket candidates are
@@ -251,6 +271,10 @@ pub struct PeerSelection {
     share_request_initial_delay: Duration,
     /// Interval between subsequent peer-sharing requests on a live outbound connection.
     share_request_interval: Duration,
+    /// Next regular churn wake. Ignored in [`PartialEq`] (schedule id is test-unstable).
+    churn_timer: Option<ScheduleId>,
+    /// Peers demoted from Using that must not be re-promoted until this instant.
+    demoted_until: BTreeMap<Peer, Instant>,
 }
 
 impl PartialEq for PeerSelection {
@@ -268,7 +292,8 @@ impl PartialEq for PeerSelection {
             && self.resolve_backoff == other.resolve_backoff
             && self.share_request_initial_delay == other.share_request_initial_delay
             && self.share_request_interval == other.share_request_interval
-        // share_reply intentionally omitted
+            && self.demoted_until == other.demoted_until
+        // share_reply and churn_timer intentionally omitted
     }
 }
 
@@ -283,11 +308,17 @@ pub struct Connection {
     id: ConnectionId,
     full_duplex_capable: bool,
     full_duplex: bool,
+    local_use: LocalUse,
 }
 
 impl Connection {
     pub fn new(id: ConnectionId, full_duplex_capable: bool, full_duplex: bool) -> Self {
-        Self { id, full_duplex_capable, full_duplex }
+        Self { id, full_duplex_capable, full_duplex, local_use: LocalUse::None }
+    }
+
+    pub fn with_local_use(mut self, local_use: LocalUse) -> Self {
+        self.local_use = local_use;
+        self
     }
 }
 
@@ -319,6 +350,12 @@ pub enum PeerSelectionMsg {
     ///
     /// Used by the ledger-check child after it has already written candidates into Performance.
     Regulate,
+    /// Periodic Using-set churn: demote the worst non-static fraction, then refill.
+    Churn,
+    /// ChainSync found no usable intersection (or rolled back past it). Stop diffusion, keep the bearer.
+    Uninteresting { peer: Peer, conn_id: ConnectionId, after_rollback: bool },
+    /// Reconsider a previously demoted outbound bearer as Using.
+    Promote { peer: Peer, conn_id: ConnectionId },
     /// Reply from the peer-sharing initiator (one result per request cycle).
     SharePeersResult { peer: Peer, peers: Vec<SocketAddr> },
     /// Server-side peer-sharing: select addresses to advertise to `peer` and reply on `reply_to`.
@@ -361,6 +398,8 @@ impl PeerSelection {
             share_reply: StageRef::blackhole(),
             share_request_initial_delay: SHARE_REQUEST_INITIAL_DELAY,
             share_request_interval: SHARE_REQUEST_INTERVAL,
+            churn_timer: None,
+            demoted_until: BTreeMap::new(),
         }
     }
 
@@ -405,6 +444,7 @@ impl PeerSelection {
             send_remove = true;
             refill_outbound = true;
             self.unbind_peer(&peer);
+            self.demoted_until.remove(&peer);
         }
 
         if send_remove {
@@ -477,9 +517,134 @@ impl PeerSelection {
         self.outbound_peers.insert(peer, PeerState::Connecting);
     }
 
+    fn using_occupancy(&self) -> usize {
+        self.pending_resolve.len()
+            + self
+                .outbound_peers
+                .values()
+                .filter(|state| match state {
+                    PeerState::Connecting => true,
+                    PeerState::Connected(conn) => conn.local_use == LocalUse::Diffusion,
+                })
+                .count()
+    }
+
+    fn using_peers(&self) -> Vec<Peer> {
+        self.outbound_peers
+            .iter()
+            .filter_map(|(peer, state)| match state {
+                PeerState::Connected(conn) if conn.local_use == LocalUse::Diffusion => Some(*peer),
+                PeerState::Connecting | PeerState::Connected(_) => None,
+            })
+            .collect()
+    }
+
+    async fn arm_churn(&mut self, eff: &Effects<PeerSelectionMsg>) {
+        let seed: [u8; 32] = eff.external(GenerateRandomSeed).await;
+        let now = eff.clock().await;
+        let id = eff.schedule_at(PeerSelectionMsg::Churn, now + churn_interval(seed)).await;
+        self.churn_timer = Some(id);
+    }
+
+    async fn demote_to_maintenance(
+        &mut self,
+        peer: Peer,
+        conn_id: ConnectionId,
+        reason: &'static str,
+        until: Instant,
+        eff: &Effects<PeerSelectionMsg>,
+    ) -> bool {
+        let Some(PeerState::Connected(conn)) = self.outbound_peers.get_mut(&peer) else {
+            return false;
+        };
+        if conn.id != conn_id || conn.local_use != LocalUse::Diffusion {
+            return false;
+        }
+        conn.local_use = LocalUse::Maintenance;
+        self.demoted_until.insert(peer, until);
+        info!(protocols::peer_selection::peer::DEMOTED, peer, conn_id = conn_id.as_u64(), reason);
+        eff.send(&self.manager, ManagerMessage::SetLocalUse { peer, conn_id, local_use: LocalUse::Maintenance }).await;
+        let _promote = eff.schedule_at(PeerSelectionMsg::Promote { peer, conn_id }, until).await;
+        true
+    }
+
+    async fn try_promote(&mut self, peer: Peer, conn_id: ConnectionId, now: Instant, eff: &Effects<PeerSelectionMsg>) {
+        if self.demoted_until.get(&peer).is_some_and(|until| *until > now) {
+            return;
+        }
+        self.demoted_until.remove(&peer);
+        if self.using_occupancy() >= self.target_upstream_peers {
+            return;
+        }
+        let Some(PeerState::Connected(conn)) = self.outbound_peers.get_mut(&peer) else {
+            return;
+        };
+        if conn.id != conn_id || conn.local_use != LocalUse::Maintenance {
+            return;
+        }
+        conn.local_use = LocalUse::Diffusion;
+        eff.send(&self.manager, ManagerMessage::SetLocalUse { peer, conn_id, local_use: LocalUse::Diffusion }).await;
+    }
+
+    async fn churn(&mut self, eff: &Effects<PeerSelectionMsg>) {
+        let using = self.using_peers();
+        if using.is_empty() {
+            return;
+        }
+        let want = (using.len() * CHURN_FRACTION_PERCENT / 100).max(1).min(using.len());
+        let now = eff.clock().await;
+        let ranked = eff.external(Performance::rank_peers_for_churn(using, now)).await;
+        let mut demoted = 0;
+        for (peer, _) in ranked {
+            if demoted >= want {
+                break;
+            }
+            if eff.external(Performance::is_static_peer(peer)).await {
+                continue;
+            }
+            let Some(PeerState::Connected(conn)) = self.outbound_peers.get(&peer) else {
+                continue;
+            };
+            if conn.local_use != LocalUse::Diffusion {
+                continue;
+            }
+            let conn_id = conn.id;
+            if self.demote_to_maintenance(peer, conn_id, "churn", now + CHURN_REPROMOTE_DELAY, eff).await {
+                demoted += 1;
+            }
+        }
+        if demoted > 0 {
+            self.regulate_peers(eff).await;
+        }
+    }
+
+    async fn promote_eligible_maintenance(&mut self, now: Instant, eff: &Effects<PeerSelectionMsg>) {
+        let candidates: Vec<(Peer, ConnectionId)> = self
+            .outbound_peers
+            .iter()
+            .filter_map(|(peer, state)| match state {
+                PeerState::Connected(conn)
+                    if conn.local_use == LocalUse::Maintenance
+                        && !self.demoted_until.get(peer).is_some_and(|until| *until > now) =>
+                {
+                    Some((*peer, conn.id))
+                }
+                PeerState::Connecting | PeerState::Connected(_) => None,
+            })
+            .collect();
+        for (peer, conn_id) in candidates {
+            if self.using_occupancy() >= self.target_upstream_peers {
+                break;
+            }
+            self.try_promote(peer, conn_id, now, eff).await;
+        }
+    }
+
     async fn regulate_peers(&mut self, eff: &Effects<PeerSelectionMsg>) {
+        let now = eff.clock().await;
+        self.promote_eligible_maintenance(now, eff).await;
         let target_upstream_peers = self.target_upstream_peers;
-        let outbound = self.outbound_peers.len() + self.pending_resolve.len();
+        let outbound = self.using_occupancy();
         if outbound >= target_upstream_peers {
             return;
         }
@@ -626,6 +791,7 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
             // Mix includes static sockets and names; Host/SRV are resolved just before dialling
             // and stay in their pool so a later pick re-resolves.
             state.regulate_peers(&eff).await;
+            state.arm_churn(&eff).await;
             // NOTE: no supervision, failure in ledger-check shall tear down the node.
             let ledger_check = eff
                 .wire_up(
@@ -706,6 +872,8 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
                 full_duplex = connection.full_duplex,
             )
             .entered();
+            let mut connection = connection;
+            connection.local_use = LocalUse::Diffusion;
             let old = state.outbound_peers.insert(peer, PeerState::Connected(connection));
             let disconnect_old = if let Some(PeerState::Connected(conn)) = old {
                 warn!(
@@ -765,6 +933,7 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
                 entry.remove();
                 drop(span);
                 state.unbind_peer(&peer);
+                state.demoted_until.remove(&peer);
                 state.clear_availability_if_gone(&peer, &eff).await;
                 state.regulate_peers(&eff).await;
             }
@@ -774,6 +943,7 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
             eff.external(Performance::record_connection_failure(peer, now)).await;
             state.outbound_peers.remove(&peer);
             state.unbind_peer(&peer);
+            state.demoted_until.remove(&peer);
             state.clear_availability_if_gone(&peer, &eff).await;
             state.regulate_peers(&eff).await;
         }
@@ -803,7 +973,7 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
                 let now = eff.clock().await;
                 state.resolve_backoff.insert(candidate, now + RESOLUTION_RETRY_DELAY);
                 state.regulate_peers(&eff).await;
-                if state.outbound_peers.len() + state.pending_resolve.len() < state.target_upstream_peers {
+                if state.using_occupancy() < state.target_upstream_peers {
                     eff.schedule_at(PeerSelectionMsg::Regulate, now + RESOLUTION_RETRY_DELAY).await;
                 }
                 return state;
@@ -823,6 +993,24 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
             }
             state.start_dial(candidate, origin, peer, &eff).await;
             state.regulate_peers(&eff).await;
+        }
+        PeerSelectionMsg::Churn => {
+            if let Some(id) = state.churn_timer.take() {
+                eff.cancel_schedule(id).await;
+            }
+            state.churn(&eff).await;
+            state.arm_churn(&eff).await;
+        }
+        PeerSelectionMsg::Uninteresting { peer, conn_id, after_rollback } => {
+            let now = eff.clock().await;
+            let delay = if after_rollback { UNINTERESTING_RETRY_AFTER_ROLLBACK } else { UNINTERESTING_RETRY };
+            if state.demote_to_maintenance(peer, conn_id, "uninteresting", now + delay, &eff).await {
+                state.regulate_peers(&eff).await;
+            }
+        }
+        PeerSelectionMsg::Promote { peer, conn_id } => {
+            let now = eff.clock().await;
+            state.try_promote(peer, conn_id, now, &eff).await;
         }
     }
     state

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -45,17 +45,17 @@ pub const SHARE_REQUEST_INTERVAL: Duration = Duration::from_secs(900);
 /// How many peers to request per share call (network-spec amount is `Word8`).
 pub const SHARE_REQUEST_AMOUNT: u8 = 20;
 /// Caught-up churn interval before fuzz (Haskell default).
-pub const CHURN_INTERVAL_BASE: Duration = Duration::from_secs(3300);
+const CHURN_INTERVAL_BASE: Duration = Duration::from_secs(3300);
 /// Extra delay drawn uniformly from `0..=CHURN_INTERVAL_FUZZ`.
-pub const CHURN_INTERVAL_FUZZ: Duration = Duration::from_secs(600);
+const CHURN_INTERVAL_FUZZ: Duration = Duration::from_secs(600);
 /// Fraction of Using peers to demote each cycle (at least one).
-pub const CHURN_FRACTION_PERCENT: usize = 20;
+const CHURN_FRACTION_PERCENT: usize = 20;
 /// After clean churn, the bearer stays; do not re-promote for this long.
-pub const CHURN_REPROMOTE_DELAY: Duration = Duration::from_secs(10);
+pub(crate) const CHURN_REPROMOTE_DELAY: Duration = Duration::from_secs(10);
 /// Retry Using after no intersection (not hostility).
-pub const UNINTERESTING_RETRY: Duration = Duration::from_secs(120);
+pub(crate) const UNINTERESTING_RETRY: Duration = Duration::from_secs(120);
 /// Retry Using after a rollback past the intersection.
-pub const UNINTERESTING_RETRY_AFTER_ROLLBACK: Duration = Duration::from_secs(180);
+const UNINTERESTING_RETRY_AFTER_ROLLBACK: Duration = Duration::from_secs(180);
 
 fn churn_interval(seed: [u8; 32]) -> Duration {
     let mut bytes = [0u8; 8];
@@ -541,8 +541,7 @@ impl PeerSelection {
 
     async fn arm_churn(&mut self, eff: &Effects<PeerSelectionMsg>) {
         let seed: [u8; 32] = eff.external(GenerateRandomSeed).await;
-        let now = eff.clock().await;
-        let id = eff.schedule_at(PeerSelectionMsg::Churn, now + churn_interval(seed)).await;
+        let id = eff.schedule_after(PeerSelectionMsg::Churn, churn_interval(seed)).await;
         self.churn_timer = Some(id);
     }
 

--- a/crates/amaru-consensus/src/stages/peer_selection/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/test_setup.rs
@@ -161,6 +161,7 @@ pub fn register_guards() -> DeserializerGuards {
         amaru_pure_stage::register_effect_deserializer::<crate::performance::PeerAdversarialEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordAdvertisabilityEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::RecordConnectionFailureEffect>().boxed(),
+        amaru_pure_stage::register_effect_deserializer::<crate::performance::RankPeersForChurnEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::OkForSharingEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::SelectOutboundEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::SelectSharePeersEffect>().boxed(),
@@ -190,6 +191,13 @@ pub fn te_peer_adversarial(at_stage: &str, peer: Peer) -> TraceEntry {
 
 pub fn te_is_static_peer(at_stage: &str, peer: Peer) -> TraceEntry {
     TraceEntry::suspend(Effect::external(at_stage, Box::new(crate::performance::Performance::is_static_peer(peer))))
+}
+
+pub fn te_rank_peers_for_churn(at_stage: &str, candidates: Vec<Peer>, at: Instant) -> TraceEntry {
+    TraceEntry::suspend(Effect::external(
+        at_stage,
+        Box::new(crate::performance::Performance::rank_peers_for_churn(candidates, at)),
+    ))
 }
 
 pub fn te_clear_peer_availability(at_stage: &str, peer: Peer) -> TraceEntry {

--- a/crates/amaru-consensus/src/stages/peer_selection/tests.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/tests.rs
@@ -26,7 +26,7 @@ use crate::stages::{
         TestPrep, cooldown_duration, cooldown_instant, first_schedule_id, first_static_schedule_id,
         peer_selection_stage, second_schedule_id_at, setup, setup_preload, setup_preload_until_sleeping, sim_at,
         sim_t0, static_cooldown_instant, te_cancel_schedule, te_clear_peer_availability, te_clock, te_clock_suspend,
-        te_is_static_peer, te_peer_adversarial, te_random_seed, te_record_advertisability,
+        te_is_static_peer, te_peer_adversarial, te_random_seed, te_rank_peers_for_churn, te_record_advertisability,
         te_record_connection_failure, te_schedule, te_send, test_prep, test_prep_with_snapshot,
         tm_add_stage_starts_with, with_single_cooldown,
     },
@@ -35,6 +35,10 @@ use crate::stages::{
 
 fn conn() -> Connection {
     Connection::new(ConnectionId::initial(), true, false)
+}
+
+fn using_conn() -> Connection {
+    conn().with_local_use(LocalUse::Diffusion)
 }
 
 // ---------------------------------------------------------------------------
@@ -46,7 +50,7 @@ fn test_initialize_empty_static() {
     let prep = test_prep(&[]);
     let state = prep.state.clone();
     let msg = PeerSelectionMsg::Initialize;
-    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    let (running, _guards, mut logs) = setup_preload_until_sleeping(&prep, [msg.clone()]);
 
     // On Initialize we create the "peer-selection/ledger-check" child.
     // We assert the key observable effects + the INFO log.
@@ -80,7 +84,7 @@ fn test_initialize_adds_static_peers() {
     state.outbound_peers.insert(p1, PeerState::Connecting);
     state.outbound_peers.insert(p2, PeerState::Connecting);
 
-    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    let (running, _guards, mut logs) = setup_preload_until_sleeping(&prep, [msg.clone()]);
 
     // target_upstream_peers is 3 and only 2 static peers exist, so regulate draws a seed
     // but finds no further candidates.
@@ -119,7 +123,7 @@ fn test_initialize_resolves_static_hostname() {
     state.outbound_peers.insert(resolved, PeerState::Connecting);
     state.bound.insert(candidate.clone(), resolved);
     let msg = PeerSelectionMsg::Initialize;
-    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    let (running, _guards, mut logs) = setup_preload_until_sleeping(&prep, [msg.clone()]);
 
     assert_trace_contains(
         &running,
@@ -163,7 +167,7 @@ fn test_initialize_resolves_static_srv() {
     state.outbound_peers.insert(resolved, PeerState::Connecting);
     state.bound.insert(candidate.clone(), resolved);
     let msg = PeerSelectionMsg::Initialize;
-    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    let (running, _guards, mut logs) = setup_preload_until_sleeping(&prep, [msg.clone()]);
 
     assert_trace_contains(
         &running,
@@ -227,7 +231,7 @@ fn test_initialize_resolve_failure_does_not_dial() {
 fn test_initialize_fills_from_snapshot() {
     let prep = test_prep_with_snapshot(&[], &["10.0.2.1:1", "10.0.2.2:2", "10.0.2.3:3"]);
     let msg = PeerSelectionMsg::Initialize;
-    let (running, _guards, mut logs) = setup(&prep, msg.clone());
+    let (running, _guards, mut logs) = setup_preload_until_sleeping(&prep, [msg.clone()]);
 
     assert_trace_contains(
         &running,
@@ -576,7 +580,7 @@ fn test_connected_outbound() {
     let msg = PeerSelectionMsg::Connected(p, conn(), ConnectionDirection::Outbound, false);
     let after = {
         let mut s = state.clone();
-        s.outbound_peers.insert(p, PeerState::Connected(conn()));
+        s.outbound_peers.insert(p, PeerState::Connected(using_conn()));
         s
     };
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
@@ -610,7 +614,7 @@ fn test_connected_outbound_starts_peer_sharing() {
     let msg = PeerSelectionMsg::Connected(p, conn(), ConnectionDirection::Outbound, true);
     let after = {
         let mut s = state.clone();
-        s.outbound_peers.insert(p, PeerState::Connected(conn()));
+        s.outbound_peers.insert(p, PeerState::Connected(using_conn()));
         s
     };
     let p_send = p;
@@ -650,7 +654,7 @@ fn test_share_peers_result_records_shared_peers() {
     let learned = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(9, 9, 9, 9), 3001));
     let learned_peer = TestPrep::peer("9.9.9.9:3001");
     let mut prep = test_prep(&[]);
-    prep.state.outbound_peers.insert(p, PeerState::Connected(conn()));
+    prep.state.outbound_peers.insert(p, PeerState::Connected(using_conn()));
     let reply = PeerSelectionMsg::SharePeersResult { peer: p, peers: vec![learned] };
     let (running, _guards, mut logs) = setup(&prep, reply.clone());
     assert_trace_contains(
@@ -773,8 +777,8 @@ fn test_outbound_retry_drops_dead_conn_before_reconnect() {
     let mut ids = ConnectionId::initial();
     let id0 = ids.get_and_increment();
     let id1 = ids.get_and_increment();
-    let conn0 = Connection::new(id0, true, false);
-    let conn1 = Connection::new(id1, true, false);
+    let conn0 = Connection::new(id0, true, false).with_local_use(LocalUse::Diffusion);
+    let conn1 = Connection::new(id1, true, false).with_local_use(LocalUse::Diffusion);
 
     prep.state.outbound_peers.insert(p, PeerState::Connected(conn0));
     let start = prep.state.clone();
@@ -820,7 +824,7 @@ fn test_outbound_retry_drops_dead_conn_before_reconnect() {
 fn test_adversarial_static_outbound_does_not_readd_while_connected() {
     let mut prep = test_prep(&["10.0.9.1:1"]);
     let p = TestPrep::peer("10.0.9.1:1");
-    prep.state.outbound_peers.insert(p, PeerState::Connected(conn()));
+    prep.state.outbound_peers.insert(p, PeerState::Connected(using_conn()));
     let start = prep.state.clone();
     let sid = first_static_schedule_id();
     let after_ban = {
@@ -1012,7 +1016,7 @@ fn test_adversarial_inbound_only() {
 fn test_disconnected_outbound_connected_normal() {
     let mut prep = test_prep(&[]);
     let p = TestPrep::peer("8.8.8.8:8");
-    prep.state.outbound_peers.insert(p, PeerState::Connected(conn()));
+    prep.state.outbound_peers.insert(p, PeerState::Connected(using_conn()));
     let state = prep.state.clone();
     let after = {
         let mut s = state.clone();
@@ -1121,7 +1125,7 @@ fn test_disconnected_outbound_peer_also_in_inbound() {
     let mut prep = test_prep(&[]);
     let p = TestPrep::peer("7.7.7.7:7");
     prep.state.inbound_peers.insert(p, conn());
-    prep.state.outbound_peers.insert(p, PeerState::Connected(conn()));
+    prep.state.outbound_peers.insert(p, PeerState::Connected(using_conn()));
 
     let (running, _guards, mut logs) =
         setup(&prep, PeerSelectionMsg::Disconnected(p, ConnectionId::initial(), ConnectionDirection::Outbound));
@@ -1342,8 +1346,8 @@ fn test_share_request_replies_with_selected_peers() {
     let static_a_s = static_a.to_string();
     let static_b_s = static_b.to_string();
     let mut prep = test_prep(&[static_a_s.as_str(), static_b_s.as_str()]);
-    prep.state.outbound_peers.insert(static_a, PeerState::Connected(conn()));
-    prep.state.outbound_peers.insert(static_b, PeerState::Connected(conn()));
+    prep.state.outbound_peers.insert(static_a, PeerState::Connected(using_conn()));
+    prep.state.outbound_peers.insert(static_b, PeerState::Connected(using_conn()));
 
     let reply_to: StageRef<SharePeersReply> = StageRef::named_for_tests("share_reply");
     let msg = PeerSelectionMsg::ShareRequest { peer: requester, amount: 10, reply_to: reply_to.clone() };
@@ -1377,7 +1381,7 @@ fn test_share_request_excludes_requester_and_respects_amount() {
     let name_refs: Vec<&str> = names.iter().map(String::as_str).collect();
     let mut prep = test_prep(&name_refs);
     for p in &peers {
-        prep.state.outbound_peers.insert(*p, PeerState::Connected(conn()));
+        prep.state.outbound_peers.insert(*p, PeerState::Connected(using_conn()));
     }
     let requester = peers[0];
     let reply_to: StageRef<SharePeersReply> = StageRef::named_for_tests("share_reply");
@@ -1398,4 +1402,125 @@ fn test_share_request_excludes_requester_and_respects_amount() {
         &["peer_selection.sharing.sent", r#"peer="10.0.0.1:3001""#, "requested=2", "count=2"],
     )
     .assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_churn_demotes_worst_non_static_without_malus() {
+    // UntilSleeping: Churn re-arms a ~3300s timer; UntilBlocked would follow it forever.
+    let mut prep = test_prep(&[]);
+    let a = TestPrep::peer("1.1.1.1:1");
+    let b = TestPrep::peer("2.2.2.2:2");
+    let c = TestPrep::peer("3.3.3.3:3");
+    for p in [a, b, c] {
+        prep.state.outbound_peers.insert(p, PeerState::Connected(using_conn()));
+    }
+    let start = prep.state.clone();
+    let after = {
+        let mut s = start.clone();
+        s.outbound_peers.insert(a, PeerState::Connected(using_conn().with_local_use(LocalUse::Maintenance)));
+        s.demoted_until.insert(a, sim_t0() + CHURN_REPROMOTE_DELAY);
+        s
+    };
+
+    let (running, _guards, mut logs) = setup_preload_until_sleeping(&prep, [PeerSelectionMsg::Churn]);
+    assert_trace_contains(
+        &running,
+        &[
+            te_state("ps-1", &start).into(),
+            te_input("ps-1", &PeerSelectionMsg::Churn).into(),
+            te_clock_suspend("ps-1").into(),
+            te_rank_peers_for_churn("ps-1", vec![a, b, c], sim_t0()).into(),
+            te_is_static_peer("ps-1", a).into(),
+            te_send(
+                "ps-1",
+                "manager",
+                ManagerMessage::SetLocalUse {
+                    peer: a,
+                    conn_id: ConnectionId::initial(),
+                    local_use: LocalUse::Maintenance,
+                },
+            )
+            .into(),
+            te_state("ps-1", &after).into(),
+        ],
+    );
+    assert_trace_does_not_contain(&running, &[te_record_connection_failure("ps-1", a, sim_t0()).into()]);
+    logs.assert_and_remove(Level::INFO, &["peer_selection.peer.demoted", r#"peer="1.1.1.1:1""#, r#"reason="churn""#])
+        .assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_uninteresting_demotes_without_malus() {
+    let mut prep = test_prep(&[]);
+    let p = TestPrep::peer("8.8.8.8:8");
+    prep.state.outbound_peers.insert(p, PeerState::Connected(using_conn()));
+    let start = prep.state.clone();
+    let after = {
+        let mut s = start.clone();
+        s.outbound_peers.insert(p, PeerState::Connected(using_conn().with_local_use(LocalUse::Maintenance)));
+        s.demoted_until.insert(p, sim_t0() + UNINTERESTING_RETRY);
+        s
+    };
+    let msg = PeerSelectionMsg::Uninteresting { peer: p, conn_id: ConnectionId::initial(), after_rollback: false };
+
+    let (running, _guards, mut logs) = setup_preload_until_sleeping(&prep, [msg.clone()]);
+    assert_trace_contains(
+        &running,
+        &[
+            te_state("ps-1", &start).into(),
+            te_input("ps-1", &msg).into(),
+            te_clock_suspend("ps-1").into(),
+            te_send(
+                "ps-1",
+                "manager",
+                ManagerMessage::SetLocalUse {
+                    peer: p,
+                    conn_id: ConnectionId::initial(),
+                    local_use: LocalUse::Maintenance,
+                },
+            )
+            .into(),
+            te_state("ps-1", &after).into(),
+        ],
+    );
+    assert_trace_does_not_contain(&running, &[te_record_connection_failure("ps-1", p, sim_t0()).into()]);
+    logs.assert_and_remove(
+        Level::INFO,
+        &["peer_selection.peer.demoted", r#"peer="8.8.8.8:8""#, r#"reason="uninteresting""#],
+    )
+    .assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_churn_skips_static_peers() {
+    // UntilSleeping: Churn re-arms a ~3300s timer; UntilBlocked would follow it forever.
+    let mut prep = test_prep(&["10.0.0.1:1"]);
+    let static_p = TestPrep::peer("10.0.0.1:1");
+    prep.state.outbound_peers.insert(static_p, PeerState::Connected(using_conn()));
+    let start = prep.state.clone();
+
+    let (running, _guards, mut logs) = setup_preload_until_sleeping(&prep, [PeerSelectionMsg::Churn]);
+    assert_trace_contains(
+        &running,
+        &[
+            te_state("ps-1", &start).into(),
+            te_input("ps-1", &PeerSelectionMsg::Churn).into(),
+            te_is_static_peer("ps-1", static_p).into(),
+            te_state("ps-1", &start).into(),
+        ],
+    );
+    assert_trace_does_not_contain(
+        &running,
+        &[te_send(
+            "ps-1",
+            "manager",
+            ManagerMessage::SetLocalUse {
+                peer: static_p,
+                conn_id: ConnectionId::initial(),
+                local_use: LocalUse::Maintenance,
+            },
+        )
+        .into()],
+    );
+    logs.assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
 }

--- a/crates/amaru-consensus/src/stages/track_peers/mod.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/mod.rs
@@ -832,7 +832,13 @@ impl TrackPeers {
             }
             IntersectNotFound(tip) => {
                 info!(consensus::chainsync::INTERSECT_NOT_FOUND, peer, highest = tip);
-                eff.send(&handler, chainsync::InitiatorMessage::Done).await;
+                let _ = handler;
+                // Not hostility: stop diffusion via peer selection, keep the bearer.
+                eff.send(
+                    &self.peer_selection,
+                    PeerSelectionMsg::Uninteresting { peer, conn_id, after_rollback: false },
+                )
+                .await;
                 self.purge_connection(conn_id);
                 self.clear_availability_if_gone(&peer, &eff).await;
             }

--- a/crates/amaru-consensus/src/stages/track_peers/tests.rs
+++ b/crates/amaru-consensus/src/stages/track_peers/tests.rs
@@ -325,12 +325,14 @@ fn test_reconnect_intersect_then_roll_forward() {
 }
 
 #[test]
-fn test_intersect_not_found_untracked_sends_done() {
+fn test_intersect_not_found_untracked_notifies_uninteresting() {
     let prep = test_prep();
     let state = prep.state.clone();
+    let peer = Peer::for_test(3001);
+    let conn_id = prep.conn_id;
     let msg = TrackPeersMsg::FromUpstream(ChainSyncInitiatorMsg {
-        peer: Peer::for_test(3001),
-        conn_id: prep.conn_id,
+        peer,
+        conn_id,
         handler: prep.handler.clone(),
         msg: chainsync::InitiatorResult::IntersectNotFound(Point::Origin),
     });
@@ -341,7 +343,8 @@ fn test_intersect_not_found_untracked_sends_done() {
         &[
             te_state("tp-1", &state).into(),
             te_input("tp-1", &msg).into(),
-            te_send("tp-1", &prep.handler, chainsync::InitiatorMessage::Done).into(),
+            te_send("tp-1", "peer_selection", PeerSelectionMsg::Uninteresting { peer, conn_id, after_rollback: false })
+                .into(),
             te_state("tp-1", &state).into(),
         ],
     );
@@ -373,7 +376,12 @@ fn test_intersect_not_found_removes_peer() {
         &[
             te_state("tp-1", &state).into(),
             te_input("tp-1", &msg).into(),
-            te_send("tp-1", &prep.handler, chainsync::InitiatorMessage::Done).into(),
+            te_send(
+                "tp-1",
+                "peer_selection",
+                PeerSelectionMsg::Uninteresting { peer, conn_id: prep.conn_id, after_rollback: false },
+            )
+            .into(),
             te_state("tp-1", &expected).into(),
         ],
     );

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -2114,6 +2114,12 @@ define_schemas! {
                     ADVERSARIAL {
                         required peer: %amaru_kernel::Peer
                     }
+                    /// Local use dropped to Maintenance. Reason ∈ {churn, uninteresting}.
+                    public DEMOTED {
+                        required peer: %amaru_kernel::Peer
+                        required conn_id: u64
+                        required reason: String
+                    }
                 }
                 ledger {
                     /// Look for peer candidates registered as relays in the ledger

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -2855,6 +2855,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | `added` | `TRACE` | public | A peer was added to the outbound set | peer, was_banned |  |
 | `address_rejected` | `TRACE` | public | A candidate address was rejected and will not be used as a Peer. | address, reason |  |
 | `connected` | `TRACE` | public | A connection has been established and the handshake completed successfully. | peer, conn_id, direction, full_duplex_capable, full_duplex |  |
+| `demoted` | `TRACE` | public | Local use dropped to Maintenance. Reason ∈ {churn, uninteresting}. | peer, conn_id, reason |  |
 | `disconnected` | `TRACE` | public | A connection has been terminated (graceful disconnect, error, handshake refusal, or network error). | peer, conn_id, direction | reason |
 | `reconnected` | `TRACE` | public | A peer reconnected while a previous connection was still registered; the older connection is dropped. Direction ∈ {inbound, outbound}. | peer, direction, conn_id |  |
 | `removed` | `TRACE` | public | A peer was removed after behaving adversarially | peer, direction, peer_state, is_static |  |
@@ -2897,6 +2898,16 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | `direction` | `string` | ✓ |
 | `full_duplex_capable` | `boolean` | ✓ |
 | `full_duplex` | `boolean` | ✓ |
+
+</details>
+
+<details><summary>span: `demoted`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `peer` | `string` | ✓ |
+| `conn_id` | `integer` | ✓ |
+| `reason` | `string` | ✓ |
 
 </details>
 

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -7442,6 +7442,32 @@
       "description": "A connection has been established and the handshake completed successfully.",
       "public": true
     },
+    "amaru::protocols::peer_selection::peer::DEMOTED": {
+      "type": "object",
+      "properties": {
+        "peer": {
+          "type": "string"
+        },
+        "conn_id": {
+          "type": "integer"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "peer",
+        "conn_id",
+        "reason"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "demoted",
+      "level": "TRACE",
+      "target": "amaru::protocols::peer_selection::peer",
+      "description": "Local use dropped to Maintenance. Reason ∈ {churn, uninteresting}.",
+      "public": true
+    },
     "amaru::protocols::peer_selection::peer::DISCONNECTED": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
gracefully remove upstreams as per the Cardano churn schedule (20% every hour with some timing jitter); the metrics this is based on are still not refined, just the mechanism is implemented properly

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changed**
  - Peer selection now periodically rotates approximately 20% of active peers, prioritizing the least preferred peers while preserving static bootstrap peers.
  - Rotated peers move to maintenance and may be promoted again after a delay.
  - Peers with unsuccessful chain-sync intersections are marked uninteresting and retried after 120 seconds instead of being treated as adversarial.
  - Connection occupancy now reflects active diffusion peers and pending connection attempts.

- **Observability**
  - Added tracing for peers demoted to maintenance, including the reason for demotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->