### PR TITLE
use full-duplex peer connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Other guiding principles:
 - **amaru-protocols**: BlockFetch and PeerSharing run only on connections whose local use is Diffusion.
 - **amaru-consensus**: peer selection churns about 20% of Using peers per hour (worst first, never static bootstrap peers) by demoting them to Maintenance, without incrementing malus.
 - **amaru-consensus**: ChainSync `IntersectNotFound` treats the peer as uninteresting as an upstream (retry after 120s), not as adversarial.
+- **amaru-protocols**: outbound handshake now offers duplex. When both sides agree, responders run on that bearer; promoting an inbound connection to Diffusion starts our initiators there too.
+- **amaru-consensus**: peer selection prefers promoting a duplex inbound to Using instead of opening a second outbound connection; Using inbounds count toward the upstream target.
 
 ### Fixed
 
@@ -84,18 +86,6 @@ Other guiding principles:
 ### Changed
 
 - **amaru-consensus**: `BlockValidator` now runs the ledger on a dedicated thread that owns the ledger state exclusively; operations are requested through a bounded channel and answered via per-request reply channels, replacing the shared lock around the state. `BlockValidator` is no longer generic over the store types. ([#1094][])
-- **amaru-protocols**: handshake combines version data as in the node-to-node spec and the initiator checks that `MsgAcceptVersion` carries that agreed record. ([#884](https://github.com/pragma-org/amaru/issues/884))
-- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
-- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
-- **amaru-protocols**: outbound handshake offers duplex (`initiator_only = false`). Agreed duplex registers eager responders on the same bearer; inbound `SetLocalUse(Diffusion)` starts our initiators there.
-- **amaru-consensus**: peer selection prefers promoting a duplex inbound to Using instead of a second dial; Using inbound counts toward the upstream target.
-- **amaru-consensus**: peer selection churns ~20%/h of Using peers (worst first, skip static) with `SetLocalUse(Maintenance)` and does not increment malus. ChainSync `IntersectNotFound` is uninteresting-as-upstream (retry after 120s), not adversarial.
-- **amaru-consensus**: after an outbound handshake, peer selection sends `SetLocalUse(Diffusion)` so fetch and share follow actual local use. Peer-sharing cadence is 300s then 900s (blueprint defaults).
-- **amaru-protocols**: `LocalUseApplied` is the source of `may_initiate`; fetch and share route only to connections whose local use is Diffusion.
-- **amaru-protocols**: `SetLocalUse` stops initiator groups with `MsgDone` (last-to-finish; 300s diffusion / 120s maintenance). Expected child death installs a mux done-trap; unexpected death still tears the bearer. Responders reset in place after `MsgDone`.
-- **amaru-protocols**: mux times SDU assembly and send: unbounded wait for the first header byte, then 10s during the first Handshake and 30s afterwards for the rest of that SDU. Overflow of that timer tears the bearer down.
-- **amaru-protocols**: Implement SDU send & receive timeouts in the muxer as per the network spec.
-- **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record. Outbound connections still offer initiator-only diffusion (duplex is not advertised until both halves run).
 - **amaru-protocols**: `NetworkOps::connect` takes a `Peer`. Outbound dialling no longer resolves names; that stays in peer selection.
 - **amaru-node**: add world test simulation, both with generated fake chain and with a real chain fragment from preprod.
 - **amaru-node**: `Telemetry::install` no longer reads `AMARU_OPEN_TELEMETRY_SIGNALS`; embedders that select OTLP signals must pass `TelemetryOptions` to `install_with_options`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,18 @@ Other guiding principles:
 ### Changed
 
 - **amaru-consensus**: `BlockValidator` now runs the ledger on a dedicated thread that owns the ledger state exclusively; operations are requested through a bounded channel and answered via per-request reply channels, replacing the shared lock around the state. `BlockValidator` is no longer generic over the store types. ([#1094][])
+- **amaru-protocols**: handshake combines version data as in the node-to-node spec and the initiator checks that `MsgAcceptVersion` carries that agreed record. ([#884](https://github.com/pragma-org/amaru/issues/884))
+- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
+- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
+- **amaru-protocols**: outbound handshake offers duplex (`initiator_only = false`). Agreed duplex registers eager responders on the same bearer; inbound `SetLocalUse(Diffusion)` starts our initiators there.
+- **amaru-consensus**: peer selection prefers promoting a duplex inbound to Using instead of a second dial; Using inbound counts toward the upstream target.
+- **amaru-consensus**: peer selection churns ~20%/h of Using peers (worst first, skip static) with `SetLocalUse(Maintenance)` and does not increment malus. ChainSync `IntersectNotFound` is uninteresting-as-upstream (retry after 120s), not adversarial.
+- **amaru-consensus**: after an outbound handshake, peer selection sends `SetLocalUse(Diffusion)` so fetch and share follow actual local use. Peer-sharing cadence is 300s then 900s (blueprint defaults).
+- **amaru-protocols**: `LocalUseApplied` is the source of `may_initiate`; fetch and share route only to connections whose local use is Diffusion.
+- **amaru-protocols**: `SetLocalUse` stops initiator groups with `MsgDone` (last-to-finish; 300s diffusion / 120s maintenance). Expected child death installs a mux done-trap; unexpected death still tears the bearer. Responders reset in place after `MsgDone`.
+- **amaru-protocols**: mux times SDU assembly and send: unbounded wait for the first header byte, then 10s during the first Handshake and 30s afterwards for the rest of that SDU. Overflow of that timer tears the bearer down.
+- **amaru-protocols**: Implement SDU send & receive timeouts in the muxer as per the network spec.
+- **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record. Outbound connections still offer initiator-only diffusion (duplex is not advertised until both halves run).
 - **amaru-protocols**: `NetworkOps::connect` takes a `Peer`. Outbound dialling no longer resolves names; that stays in peer selection.
 - **amaru-node**: add world test simulation, both with generated fake chain and with a real chain fragment from preprod.
 - **amaru-node**: `Telemetry::install` no longer reads `AMARU_OPEN_TELEMETRY_SIGNALS`; embedders that select OTLP signals must pass `TelemetryOptions` to `install_with_options`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,8 @@ Other guiding principles:
 - **amaru-protocols**: BlockFetch and PeerSharing run only on connections whose local use is Diffusion.
 - **amaru-consensus**: peer selection churns about 20% of Using peers per hour (worst first, never static bootstrap peers) by demoting them to Maintenance, without incrementing malus.
 - **amaru-consensus**: ChainSync `IntersectNotFound` treats the peer as uninteresting as an upstream (retry after 120s), not as adversarial.
-- **amaru-protocols**: outbound handshake now offers duplex. When both sides agree, responders run on that bearer; promoting an inbound connection to Diffusion starts our initiators there too.
-- **amaru-consensus**: peer selection prefers promoting a duplex inbound to Using instead of opening a second outbound connection; Using inbounds count toward the upstream target.
+- **amaru-protocols**: outbound handshake now offers duplex. When both sides agree, responders run on that bearer; promoting an inbound connection to Diffusion starts our initiators there too. ([#751](https://github.com/pragma-org/amaru/issues/751), [#660](https://github.com/pragma-org/amaru/issues/660))
+- **amaru-consensus**: peer selection prefers promoting a duplex inbound to Using instead of opening a second outbound connection; Using inbounds count toward the upstream target. ([#660](https://github.com/pragma-org/amaru/issues/660))
 
 ### Fixed
 

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -527,6 +527,7 @@ impl PeerSelection {
                     PeerState::Connected(conn) => conn.local_use == LocalUse::Diffusion,
                 })
                 .count()
+            + self.inbound_peers.values().filter(|conn| conn.local_use == LocalUse::Diffusion).count()
     }
 
     fn using_peers(&self) -> Vec<Peer> {
@@ -545,6 +546,20 @@ impl PeerSelection {
         self.churn_timer = Some(id);
     }
 
+    fn connection_mut(&mut self, peer: Peer, conn_id: ConnectionId) -> Option<&mut Connection> {
+        if let Some(PeerState::Connected(conn)) = self.outbound_peers.get_mut(&peer)
+            && conn.id == conn_id
+        {
+            return Some(conn);
+        }
+        if let Some(conn) = self.inbound_peers.get_mut(&peer)
+            && conn.id == conn_id
+        {
+            return Some(conn);
+        }
+        None
+    }
+
     async fn demote_to_maintenance(
         &mut self,
         peer: Peer,
@@ -553,10 +568,10 @@ impl PeerSelection {
         until: Instant,
         eff: &Effects<PeerSelectionMsg>,
     ) -> bool {
-        let Some(PeerState::Connected(conn)) = self.outbound_peers.get_mut(&peer) else {
+        let Some(conn) = self.connection_mut(peer, conn_id) else {
             return false;
         };
-        if conn.id != conn_id || conn.local_use != LocalUse::Diffusion {
+        if conn.local_use != LocalUse::Diffusion {
             return false;
         }
         conn.local_use = LocalUse::Maintenance;
@@ -575,10 +590,10 @@ impl PeerSelection {
         if self.using_occupancy() >= self.target_upstream_peers {
             return;
         }
-        let Some(PeerState::Connected(conn)) = self.outbound_peers.get_mut(&peer) else {
+        let Some(conn) = self.connection_mut(peer, conn_id) else {
             return;
         };
-        if conn.id != conn_id || conn.local_use != LocalUse::Maintenance {
+        if conn.local_use == LocalUse::Diffusion {
             return;
         }
         conn.local_use = LocalUse::Diffusion;
@@ -617,6 +632,30 @@ impl PeerSelection {
         }
     }
 
+    async fn promote_duplex_inbounds(&mut self, now: Instant, eff: &Effects<PeerSelectionMsg>) {
+        let candidates: Vec<(Peer, ConnectionId)> = self
+            .inbound_peers
+            .iter()
+            .filter_map(|(peer, conn)| {
+                if conn.full_duplex
+                    && conn.local_use != LocalUse::Diffusion
+                    && !self.demoted_until.get(peer).is_some_and(|until| *until > now)
+                    && !self.cooldowns.is_cooling(peer)
+                {
+                    Some((*peer, conn.id))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for (peer, conn_id) in candidates {
+            if self.using_occupancy() >= self.target_upstream_peers {
+                break;
+            }
+            self.try_promote(peer, conn_id, now, eff).await;
+        }
+    }
+
     async fn promote_eligible_maintenance(&mut self, now: Instant, eff: &Effects<PeerSelectionMsg>) {
         let candidates: Vec<(Peer, ConnectionId)> = self
             .outbound_peers
@@ -641,6 +680,8 @@ impl PeerSelection {
 
     async fn regulate_peers(&mut self, eff: &Effects<PeerSelectionMsg>) {
         let now = eff.clock().await;
+        // TODO: this is for testing the feature, should use peer mix quota and metrics ranking
+        self.promote_duplex_inbounds(now, eff).await;
         self.promote_eligible_maintenance(now, eff).await;
         let target_upstream_peers = self.target_upstream_peers;
         let outbound = self.using_occupancy();
@@ -653,6 +694,12 @@ impl PeerSelection {
         let now = eff.clock().await;
         let mut excluded: BTreeSet<PeerCandidate> =
             self.outbound_peers.keys().copied().map(PeerCandidate::from).collect();
+        excluded.extend(
+            self.inbound_peers
+                .iter()
+                .filter(|(_, conn)| conn.local_use == LocalUse::Diffusion)
+                .map(|(peer, _)| PeerCandidate::from(*peer)),
+        );
         for p in self.cooldowns.cooling_peers() {
             excluded.insert(PeerCandidate::from(p));
         }

--- a/crates/amaru-consensus/src/stages/peer_selection/tests.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/tests.rs
@@ -1524,3 +1524,62 @@ fn test_churn_skips_static_peers() {
     );
     logs.assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
 }
+
+fn duplex_conn() -> Connection {
+    Connection::new(ConnectionId::initial(), true, true)
+}
+
+#[test]
+fn test_regulate_promotes_duplex_inbound_instead_of_dial() {
+    let mut prep = test_prep(&["10.0.0.1:1"]);
+    prep.state.target_upstream_peers = 1;
+    let inbound = TestPrep::peer("8.8.8.8:8");
+    prep.state.inbound_peers.insert(inbound, duplex_conn());
+    let after = {
+        let mut s = prep.state.clone();
+        s.inbound_peers.insert(inbound, duplex_conn().with_local_use(LocalUse::Diffusion));
+        s
+    };
+
+    let (running, _guards, mut logs) = setup(&prep, PeerSelectionMsg::Regulate);
+    assert_trace_contains(
+        &running,
+        &[
+            te_send(
+                "ps-1",
+                "manager",
+                ManagerMessage::SetLocalUse {
+                    peer: inbound,
+                    conn_id: ConnectionId::initial(),
+                    local_use: LocalUse::Diffusion,
+                },
+            )
+            .into(),
+            te_state("ps-1", &after).into(),
+        ],
+    );
+    assert_trace_does_not_contain(
+        &running,
+        &[tm_send_match::<ManagerMessage>("ps-1", "manager", |m| matches!(m, ManagerMessage::AddPeer(_)))],
+    );
+    logs.assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_using_inbound_counts_toward_upstream_target() {
+    let mut prep = test_prep(&["10.0.0.1:1"]);
+    prep.state.target_upstream_peers = 1;
+    let inbound = TestPrep::peer("8.8.8.8:8");
+    prep.state.inbound_peers.insert(inbound, duplex_conn().with_local_use(LocalUse::Diffusion));
+    let start = prep.state.clone();
+
+    let (running, _guards, mut logs) = setup(&prep, PeerSelectionMsg::Regulate);
+    assert_trace_contains(&running, &[te_state("ps-1", &start).into(), te_state("ps-1", &start).into()]);
+    assert_trace_does_not_contain(
+        &running,
+        &[tm_send_match::<ManagerMessage>("ps-1", "manager", |m| {
+            matches!(m, ManagerMessage::AddPeer(_) | ManagerMessage::SetLocalUse { .. })
+        })],
+    );
+    logs.assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
+}

--- a/crates/amaru-node/src/tests/world/generated.rs
+++ b/crates/amaru-node/src/tests/world/generated.rs
@@ -270,9 +270,12 @@ fn injector_linear_store(n: usize, seed: u64) -> (Arc<InMemoryChainStore>, Vec<a
 ///
 /// Peer sharing must add connections beyond the initial chain. Delay and horizon are knobs.
 /// Production share delay is 300s, longer than these horizons, so the nodes use
-/// [`P_JOIN_SHARE_INITIAL_DELAY`]. Seeded disconnects stay sparse relative to the fragment;
-/// their schedule is redrawn until at least one adjacent pair sits inside one reconnect delay.
-/// Each inventory hash is a world-heap Reveal, paced by the injector's default mailbox.
+/// [`P_JOIN_SHARE_INITIAL_DELAY`]. Duplex inbound Using plus skip-links among the line can
+/// fill the production upstream target of 3 before a share reply names the injector, so
+/// each node targets [`P_JOIN_NODES`] Using slots (one left for the injector). Seeded
+/// disconnects stay sparse relative to the fragment; their schedule is redrawn until at
+/// least one adjacent pair sits inside one reconnect delay. Each inventory hash is a
+/// world-heap Reveal, paced by the injector's default mailbox.
 const P_JOIN_NODES: usize = 5;
 const P_JOIN_FRAGMENT: usize = 100;
 /// Payload hop ~10ms ± 2ms. Handshake hops stay 1–5ms.
@@ -364,6 +367,7 @@ fn run_p_join_quiescent_chain(
             .with_upstream_peer(upstream)
             .with_listen_address(listen)
             .with_seed(derive_seed(seed, TAG_NODE + i as u64))
+            .with_target_upstream_peers(P_JOIN_NODES)
             .with_share_request_initial_delay(P_JOIN_SHARE_INITIAL_DELAY)
             .with_trace_buffer(TraceBuffer::new_shared(20_000, 16_000_000))
             // Common ancestor so FindIntersect is not Origin-vs-a-parent-hash the node does not have.

--- a/crates/amaru-protocols/src/blockfetch/responder.rs
+++ b/crates/amaru-protocols/src/blockfetch/responder.rs
@@ -267,7 +267,7 @@ pub async fn register_blockfetch_responder<M: amaru_pure_stage::SendData>(
     tombstone: M,
 ) -> StageRef<Void> {
     let mux = MuxClient::new(muxer.clone(), PROTO_N2N_BLOCK_FETCH.responder().erase());
-    let blockfetch = eff.stage("blockfetch", instance).await;
+    let blockfetch = eff.stage("blockfetch-responder", instance).await;
     let blockfetch = eff.supervise(blockfetch, tombstone);
     let blockfetch = eff.wire_up(blockfetch, Instance::new(mux, peer)).await;
     eff.send(

--- a/crates/amaru-protocols/src/chainsync/mod.rs
+++ b/crates/amaru-protocols/src/chainsync/mod.rs
@@ -81,7 +81,7 @@ mod register {
         eff: &Effects<ConnectionMessage>,
         tombstone: ConnectionMessage,
     ) -> StageRef<ResponderMessage> {
-        let chainsync = eff.stage("chainsync", responder()).await;
+        let chainsync = eff.stage("chainsync-responder", responder()).await;
         let chainsync = eff.supervise(chainsync, tombstone);
         let chainsync = eff.wire_up(chainsync, ChainSyncResponder::new(upstream, peer, conn_id, muxer.clone())).await;
         eff.send(

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -112,6 +112,7 @@ enum State {
 struct Established {
     desired_use: LocalUse,
     actual_use: LocalUse,
+    duplex: bool,
     version_number: VersionNumber,
     version_data: VersionData,
     muxer: StageRef<MuxMessage>,
@@ -137,6 +138,8 @@ pub enum ChildId {
     ChainSync,
     BlockFetch,
     PeerSharing,
+    /// Any eager responder instance. Death is always unexpected (reset in place, do not stop).
+    Responder,
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -229,7 +232,7 @@ pub async fn stage(
             }
             (State::Initial, ConnectionMessage::Initialize) => do_initialize(&params, eff).await,
             (State::Handshake { muxer, handshake }, ConnectionMessage::Handshake(handshake_result)) => {
-                do_handshake(&params, muxer, params.pipeline.clone(), handshake, handshake_result, eff).await
+                do_handshake(&params, muxer, handshake, handshake_result, eff).await
             }
             (State::Established(s), ConnectionMessage::FetchBlocks { from, through, id, cr }) => {
                 if !s.stopping.contains(&ChildId::BlockFetch)
@@ -341,7 +344,7 @@ async fn do_initialize(Params { conn_id, role, magic, peer, .. }: &Params, eff: 
                 handshake::HandshakeInitiator::new(
                     muxer.clone(),
                     handshake_result,
-                    VersionTable::v11_and_above(*magic, true, true),
+                    VersionTable::v11_and_above(*magic, false, true),
                 ),
             )
             .await
@@ -376,13 +379,13 @@ async fn do_initialize(Params { conn_id, role, magic, peer, .. }: &Params, eff: 
 }
 
 async fn do_handshake(
-    Params { role, peer, conn_id, manager, era_history, mempool_stage, config, .. }: &Params,
+    params: &Params,
     muxer: StageRef<MuxMessage>,
-    pipeline_ref: StageRef<ChainSyncInitiatorMsg>,
     handshake: StageRef<Inputs<Void>>,
     handshake_result: HandshakeResult,
     eff: Effects<ConnectionMessage>,
 ) -> State {
+    let Params { role, peer, conn_id, manager, .. } = params;
     let peer = *peer;
     let (version_number, version_data) = match handshake_result {
         HandshakeResult::Accepted(version_number, version_data) => (version_number, version_data),
@@ -397,8 +400,7 @@ async fn do_handshake(
     };
 
     let full_duplex_capable = version_data.is_full_duplex_capable();
-    // TODO: this needs to change once we actually start supporting full duplex mode
-    let full_duplex = false;
+    let full_duplex = full_duplex_capable;
     let advertisable = version_data.is_advertisable();
 
     eff.send(
@@ -417,38 +419,19 @@ async fn do_handshake(
 
     eff.send(&muxer, mux::MuxMessage::SetSduTimeout(mux::SDU_TIMEOUT_ESTABLISHED)).await;
 
-    let keepalive_initiator = register_keepalive(
-        *role,
-        peer,
-        *conn_id,
-        muxer.clone(),
-        &eff,
-        ConnectionMessage::ChildDied(ChildId::KeepAlive),
-    )
-    .await;
-    let tx_submission_initiator = register_tx_submission(
-        *role,
-        peer,
-        muxer.clone(),
-        &eff,
-        TxOrigin::Remote(peer),
-        mempool_stage.clone(),
-        config.tx_submission_params,
-        era_history.clone(),
-        ConnectionMessage::ChildDied(ChildId::TxSubmission),
-    )
-    .await;
-
     let local_use = LocalUse::default_for_role(*role);
+    let run_initiators = *role == Role::Initiator || full_duplex;
+    let run_responders = *role == Role::Responder || full_duplex;
     let mut established = Established {
         desired_use: local_use,
-        actual_use: local_use,
+        actual_use: LocalUse::None,
+        duplex: full_duplex,
         version_number,
         version_data,
         muxer: muxer.clone(),
         handshake,
-        keepalive_initiator,
-        tx_submission_initiator,
+        keepalive_initiator: None,
+        tx_submission_initiator: None,
         chainsync_initiator: None,
         blockfetch_initiator: None,
         peer_sharing_initiator: None,
@@ -458,69 +441,63 @@ async fn do_handshake(
         stopping: BTreeSet::new(),
     };
 
-    if *role == Role::Initiator {
-        established.chainsync_initiator = Some(
-            register_chainsync_initiator(
-                &muxer,
-                peer,
-                *conn_id,
-                pipeline_ref,
-                &eff,
-                ConnectionMessage::ChildDied(ChildId::ChainSync),
-            )
-            .await,
-        );
-        established.blockfetch_initiator = Some(
-            register_blockfetch_initiator(
-                &muxer,
-                peer,
-                config.blockfetch_pipeline_n,
-                &eff,
-                ConnectionMessage::ChildDied(ChildId::BlockFetch),
-            )
-            .await,
-        );
-        established.peer_sharing_initiator = Some(
-            register_peer_sharing_initiator(
-                &muxer,
-                peer,
-                *conn_id,
-                &eff,
-                ConnectionMessage::ChildDied(ChildId::PeerSharing),
-            )
-            .await,
-        );
+    if run_responders {
+        established = register_responders(established, params, &eff).await;
+    }
+    if run_initiators && local_use > LocalUse::None {
+        established = start_initiators(established, params, &eff).await;
     } else {
-        let store = Store::new(eff.clone());
-        let upstream = store.get_best_chain_tip().await;
-        established.chainsync_responder = Some(
-            register_chainsync_responder(
-                &muxer,
-                upstream,
-                peer,
-                *conn_id,
-                &eff,
-                ConnectionMessage::ChildDied(ChildId::ChainSync),
-            )
-            .await,
-        );
-        established.blockfetch_responder = Some(
-            register_blockfetch_responder(&muxer, peer, &eff, ConnectionMessage::ChildDied(ChildId::BlockFetch)).await,
-        );
-        established.peer_sharing_responder = Some(
+        established.actual_use = local_use;
+        notify_local_use(&established, params, &eff).await;
+    }
+    State::Established(established)
+}
+
+async fn register_responders(mut s: Established, params: &Params, eff: &Effects<ConnectionMessage>) -> Established {
+    let Params { peer, conn_id, manager, era_history, mempool_stage, config, .. } = params;
+    let died = ConnectionMessage::ChildDied(ChildId::Responder);
+    let _ = register_keepalive(Role::Responder, *peer, *conn_id, s.muxer.clone(), eff, died).await;
+    let _ = register_tx_submission(
+        Role::Responder,
+        *peer,
+        s.muxer.clone(),
+        eff,
+        TxOrigin::Remote(*peer),
+        mempool_stage.clone(),
+        config.tx_submission_params,
+        era_history.clone(),
+        ConnectionMessage::ChildDied(ChildId::Responder),
+    )
+    .await;
+    let store = Store::new(eff.clone());
+    let upstream = store.get_best_chain_tip().await;
+    s.chainsync_responder = Some(
+        register_chainsync_responder(
+            &s.muxer,
+            upstream,
+            *peer,
+            *conn_id,
+            eff,
+            ConnectionMessage::ChildDied(ChildId::Responder),
+        )
+        .await,
+    );
+    s.blockfetch_responder = Some(
+        register_blockfetch_responder(&s.muxer, *peer, eff, ConnectionMessage::ChildDied(ChildId::Responder)).await,
+    );
+    if s.version_data.is_advertisable() {
+        s.peer_sharing_responder = Some(
             register_peer_sharing_responder(
-                &muxer,
-                peer,
+                &s.muxer,
+                *peer,
                 manager.clone(),
-                &eff,
-                ConnectionMessage::ChildDied(ChildId::PeerSharing),
+                eff,
+                ConnectionMessage::ChildDied(ChildId::Responder),
             )
             .await,
         );
     }
-
-    eff.send(manager, ManagerMessage::LocalUseApplied { peer, conn_id: *conn_id, local_use }).await;
-    State::Established(established)
+    s
 }
 
 async fn converge_use(mut s: Established, params: &Params, eff: &Effects<ConnectionMessage>) -> Established {
@@ -529,7 +506,7 @@ async fn converge_use(mut s: Established, params: &Params, eff: &Effects<Connect
     }
     if s.desired_use < s.actual_use {
         begin_stop(s, params, eff).await
-    } else if s.desired_use > s.actual_use && params.role == Role::Initiator {
+    } else if s.desired_use > s.actual_use && (params.role == Role::Initiator || s.duplex) {
         start_initiators(s, params, eff).await
     } else if s.desired_use != s.actual_use {
         s.actual_use = s.desired_use;
@@ -612,14 +589,14 @@ async fn on_expected_stop(
             mux::install_done_trap(&s.muxer, PROTO_N2N_PEER_SHARE.erase(), eff, ConnectionMessage::ChildDied(child))
                 .await;
         }
-        ChildId::Mux | ChildId::Handshake => {}
+        ChildId::Mux | ChildId::Handshake | ChildId::Responder => {}
     }
 
     if s.stopping.is_empty() {
         eff.clear_timeout_at(STOP_TIMEOUT_SLOT).await;
         s.actual_use = s.desired_use;
         notify_local_use(&s, params, eff).await;
-        if params.role == Role::Initiator && s.desired_use > LocalUse::None {
+        if s.desired_use > LocalUse::None && (params.role == Role::Initiator || s.duplex) {
             return start_initiators(s, params, eff).await;
         }
     }

--- a/crates/amaru-protocols/src/handshake/mod.rs
+++ b/crates/amaru-protocols/src/handshake/mod.rs
@@ -225,10 +225,10 @@ mod negotiation_tests {
     }
 
     #[test]
-    fn outbound_offer_remains_initiator_only() {
-        let table = VersionTable::v11_and_above(NetworkMagic::PREPROD, true, true);
+    fn outbound_offer_is_duplex() {
+        let table = VersionTable::v11_and_above(NetworkMagic::PREPROD, false, true);
         for data in table.values.values() {
-            assert!(data.initiator_only_diffusion_mode());
+            assert!(!data.initiator_only_diffusion_mode());
         }
     }
 

--- a/crates/amaru-protocols/src/keepalive/mod.rs
+++ b/crates/amaru-protocols/src/keepalive/mod.rs
@@ -83,7 +83,7 @@ pub async fn register_keepalive(
         )
     } else {
         let (state, stage) = responder::KeepAliveResponder::new(muxer.clone());
-        let keepalive = eff.stage("keepalive", responder::responder()).await;
+        let keepalive = eff.stage("keepalive-responder", responder::responder()).await;
         let keepalive = eff.supervise(keepalive, tombstone);
         let keepalive = eff.wire_up(keepalive, (state, stage)).await;
         (keepalive.contramap(Inputs::<Void>::Network), None)

--- a/crates/amaru-protocols/src/peer_sharing/responder.rs
+++ b/crates/amaru-protocols/src/peer_sharing/responder.rs
@@ -61,7 +61,7 @@ pub async fn register_peer_sharing_responder<M: amaru_pure_stage::SendData>(
     use crate::{mux::Frame, peer_sharing::MAX_MESSAGE_BYTES};
 
     let (state, stage) = PeerSharingResponder::new(muxer.clone(), peer, manager);
-    let ps = eff.stage("peer_sharing", responder()).await;
+    let ps = eff.stage("peer_sharing-responder", responder()).await;
     let ps = eff.supervise(ps, tombstone);
     let ps = eff.wire_up(ps, (state, stage)).await;
     eff.send(

--- a/crates/amaru-protocols/src/tx_submission/mod.rs
+++ b/crates/amaru-protocols/src/tx_submission/mod.rs
@@ -100,7 +100,7 @@ pub async fn register_tx_submission(
     } else {
         let (state, stage) =
             responder::TxSubmissionResponder::new(peer, muxer.clone(), params, origin, mempool_stage, era_history);
-        let tx_submission = eff.stage("tx_submission", responder::responder()).await;
+        let tx_submission = eff.stage("tx_submission-responder", responder::responder()).await;
         let tx_submission = eff.supervise(tx_submission, tombstone);
         let tx_submission = eff.wire_up(tx_submission, (state, stage)).await;
         (tx_submission.contramap(Inputs::<ResponderLocalIn>::Network), None)


### PR DESCRIPTION
actually promote inbound connections to upstream peers without opening a second connection; also demote them when uninteresting without tearing down the bearer

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for full-duplex connections, allowing inbound and outbound protocol activity to share a single connection when both peers support it.
  - Improved peer selection to promote eligible inbound duplex connections for use before opening additional outbound connections.
  - Inbound connections already available for diffusion now count toward upstream connection targets.

- **Bug Fixes**
  - Improved connection lifecycle handling so initiator services restart appropriately on full-duplex connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->