### PR TITLE
improve observability of new peer management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ Other guiding principles:
 - **amaru-consensus**: ChainSync `IntersectNotFound` treats the peer as uninteresting as an upstream (retry after 120s), not as adversarial.
 - **amaru-protocols**: outbound handshake now offers duplex. When both sides agree, responders run on that bearer; promoting an inbound connection to Diffusion starts our initiators there too. ([#751](https://github.com/pragma-org/amaru/issues/751), [#660](https://github.com/pragma-org/amaru/issues/660))
 - **amaru-consensus**: peer selection prefers promoting a duplex inbound to Using instead of opening a second outbound connection; Using inbounds count toward the upstream target. ([#660](https://github.com/pragma-org/amaru/issues/660))
+- **amaru-protocols**: outbound handshake now offers duplex. When both sides agree, responders run on that bearer; promoting an inbound connection to Diffusion starts our initiators there too.
+- **amaru-consensus**: peer selection prefers promoting a duplex inbound to Using instead of opening a second outbound connection; Using inbounds count toward the upstream target.
+- **amaru-protocols**: connection traces include `local_use`, `duplex`, and `stopping`.
 
 ### Fixed
 
@@ -71,6 +74,7 @@ Other guiding principles:
 - **amaru-tui**: the log scrollbar can be clicked and dragged to jump through the buffer. `|` focuses it for large keyboard steps (`↑↓`, page, home/end), and `@` jumps to a UTC time (`HH:MM[:SS]` or `YYYY-MM-DD[ HH:MM[:SS]]`). Log `↑`/`↓`/page/wheel now follow that same older/newer direction.
 - **amaru-tui**: `w` or the log `[ WRAP ]` control turns off wrapping so `←`/`→` (and shift-wheel / horizontal wheel) pan long lines; the column offset is kept while scrolling vertically. Pane focus on a tab moved to `Ctrl-←`/`Ctrl-→`.
 - **amaru-tui**: switching the log pane to DEBUG no longer panics when the retained debug stream is larger than ratatui’s `u16` paragraph scroll; the pane renders a visible window around the tail instead of the whole buffer.
+- **amaru-protocols**: the first peer-share request after an outbound handshake is no longer dropped.
 
 ## [v10.11.20260903](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260903)
 
@@ -86,20 +90,6 @@ Other guiding principles:
 ### Changed
 
 - **amaru-consensus**: `BlockValidator` now runs the ledger on a dedicated thread that owns the ledger state exclusively; operations are requested through a bounded channel and answered via per-request reply channels, replacing the shared lock around the state. `BlockValidator` is no longer generic over the store types. ([#1094][])
-- **amaru-protocols**: handshake combines version data as in the node-to-node spec and the initiator checks that `MsgAcceptVersion` carries that agreed record. ([#884](https://github.com/pragma-org/amaru/issues/884))
-- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
-- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
-- **amaru-protocols**: group stop bounds live on `ManagerConfig` (`diffusion_stop_timeout` 300s, `maintenance_stop_timeout` 120s). Connection message spans include `local_use`, `duplex`, and `stopping`.
-- **amaru-protocols**: outbound handshake offers duplex (`initiator_only = false`). Agreed duplex registers eager responders on the same bearer; inbound `SetLocalUse(Diffusion)` starts our initiators there.
-- **amaru-consensus**: peer selection prefers promoting a duplex inbound to Using instead of a second dial; Using inbound counts toward the upstream target.
-- **amaru-consensus**: peer selection churns ~20%/h of Using peers (worst first, skip static) with `SetLocalUse(Maintenance)` and does not increment malus. ChainSync `IntersectNotFound` is uninteresting-as-upstream (retry after 120s), not adversarial.
-- **amaru-consensus**: after an outbound handshake, peer selection sends `SetLocalUse(Diffusion)` so fetch and share follow actual local use. Peer-sharing cadence is 300s then 900s (blueprint defaults), overridable on `PeerSelection` / `Config` so world tests can form overlay links inside a short horizon.
-- **amaru-protocols**: `LocalUseApplied` is the source of `may_initiate`; fetch and share route only to connections whose local use is Diffusion. Outbound handshake inserts the connection as initiating before notifying peer selection, so the first `RequestSharePeers` is not dropped.
-- **amaru-protocols**: `SetLocalUse` stops initiator groups with `MsgDone` (last-to-finish; 300s diffusion / 120s maintenance). Expected child death installs a mux done-trap; unexpected death still tears the bearer. Responders reset in place after `MsgDone`.
-- **amaru-protocols**: mux times SDU assembly and send: unbounded wait for the first header byte, then 10s during the first Handshake and 30s afterwards for the rest of that SDU. Overflow of that timer tears the bearer down.
-- **amaru-protocols**: Implement SDU send & receive timeouts in the muxer as per the network spec.
-- **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record. Outbound connections still offer initiator-only diffusion (duplex is not advertised until both halves run).
-- **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record.
 - **amaru-protocols**: `NetworkOps::connect` takes a `Peer`. Outbound dialling no longer resolves names; that stays in peer selection.
 - **amaru-node**: add world test simulation, both with generated fake chain and with a real chain fragment from preprod.
 - **amaru-node**: `Telemetry::install` no longer reads `AMARU_OPEN_TELEMETRY_SIGNALS`; embedders that select OTLP signals must pass `TelemetryOptions` to `install_with_options`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,20 @@ Other guiding principles:
 ### Changed
 
 - **amaru-consensus**: `BlockValidator` now runs the ledger on a dedicated thread that owns the ledger state exclusively; operations are requested through a bounded channel and answered via per-request reply channels, replacing the shared lock around the state. `BlockValidator` is no longer generic over the store types. ([#1094][])
+- **amaru-protocols**: handshake combines version data as in the node-to-node spec and the initiator checks that `MsgAcceptVersion` carries that agreed record. ([#884](https://github.com/pragma-org/amaru/issues/884))
+- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
+- **amaru-protocols**: connection stage is one Established session with `LocalUse` (None / Maintenance / Diffusion). The manager no longer redials on drop; peer selection refills outbound slots. `SetLocalUse` is recorded (group stop/start lands next).
+- **amaru-protocols**: group stop bounds live on `ManagerConfig` (`diffusion_stop_timeout` 300s, `maintenance_stop_timeout` 120s). Connection message spans include `local_use`, `duplex`, and `stopping`.
+- **amaru-protocols**: outbound handshake offers duplex (`initiator_only = false`). Agreed duplex registers eager responders on the same bearer; inbound `SetLocalUse(Diffusion)` starts our initiators there.
+- **amaru-consensus**: peer selection prefers promoting a duplex inbound to Using instead of a second dial; Using inbound counts toward the upstream target.
+- **amaru-consensus**: peer selection churns ~20%/h of Using peers (worst first, skip static) with `SetLocalUse(Maintenance)` and does not increment malus. ChainSync `IntersectNotFound` is uninteresting-as-upstream (retry after 120s), not adversarial.
+- **amaru-consensus**: after an outbound handshake, peer selection sends `SetLocalUse(Diffusion)` so fetch and share follow actual local use. Peer-sharing cadence is 300s then 900s (blueprint defaults).
+- **amaru-protocols**: `LocalUseApplied` is the source of `may_initiate`; fetch and share route only to connections whose local use is Diffusion.
+- **amaru-protocols**: `SetLocalUse` stops initiator groups with `MsgDone` (last-to-finish; 300s diffusion / 120s maintenance). Expected child death installs a mux done-trap; unexpected death still tears the bearer. Responders reset in place after `MsgDone`.
+- **amaru-protocols**: mux times SDU assembly and send: unbounded wait for the first header byte, then 10s during the first Handshake and 30s afterwards for the rest of that SDU. Overflow of that timer tears the bearer down.
+- **amaru-protocols**: Implement SDU send & receive timeouts in the muxer as per the network spec.
+- **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record. Outbound connections still offer initiator-only diffusion (duplex is not advertised until both halves run).
+- **amaru-protocols**: handshake combines version data as in the node-to-node spec: network magics must match, `initiatorOnlyDiffusionMode` and `query` are OR, `peerSharing` is AND. The initiator checks that `MsgAcceptVersion` carries that agreed record.
 - **amaru-protocols**: `NetworkOps::connect` takes a `Peer`. Outbound dialling no longer resolves names; that stays in peer selection.
 - **amaru-node**: add world test simulation, both with generated fake chain and with a real chain fragment from preprod.
 - **amaru-node**: `Telemetry::install` no longer reads `AMARU_OPEN_TELEMETRY_SIGNALS`; embedders that select OTLP signals must pass `TelemetryOptions` to `install_with_options`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,8 +93,8 @@ Other guiding principles:
 - **amaru-protocols**: outbound handshake offers duplex (`initiator_only = false`). Agreed duplex registers eager responders on the same bearer; inbound `SetLocalUse(Diffusion)` starts our initiators there.
 - **amaru-consensus**: peer selection prefers promoting a duplex inbound to Using instead of a second dial; Using inbound counts toward the upstream target.
 - **amaru-consensus**: peer selection churns ~20%/h of Using peers (worst first, skip static) with `SetLocalUse(Maintenance)` and does not increment malus. ChainSync `IntersectNotFound` is uninteresting-as-upstream (retry after 120s), not adversarial.
-- **amaru-consensus**: after an outbound handshake, peer selection sends `SetLocalUse(Diffusion)` so fetch and share follow actual local use. Peer-sharing cadence is 300s then 900s (blueprint defaults).
-- **amaru-protocols**: `LocalUseApplied` is the source of `may_initiate`; fetch and share route only to connections whose local use is Diffusion.
+- **amaru-consensus**: after an outbound handshake, peer selection sends `SetLocalUse(Diffusion)` so fetch and share follow actual local use. Peer-sharing cadence is 300s then 900s (blueprint defaults), overridable on `PeerSelection` / `Config` so world tests can form overlay links inside a short horizon.
+- **amaru-protocols**: `LocalUseApplied` is the source of `may_initiate`; fetch and share route only to connections whose local use is Diffusion. Outbound handshake inserts the connection as initiating before notifying peer selection, so the first `RequestSharePeers` is not dropped.
 - **amaru-protocols**: `SetLocalUse` stops initiator groups with `MsgDone` (last-to-finish; 300s diffusion / 120s maintenance). Expected child death installs a mux done-trap; unexpected death still tears the bearer. Responders reset in place after `MsgDone`.
 - **amaru-protocols**: mux times SDU assembly and send: unbounded wait for the first header byte, then 10s during the first Handshake and 30s afterwards for the rest of that SDU. Overflow of that timer tears the bearer down.
 - **amaru-protocols**: Implement SDU send & receive timeouts in the muxer as per the network spec.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,6 @@ Other guiding principles:
 - **amaru-consensus**: ChainSync `IntersectNotFound` treats the peer as uninteresting as an upstream (retry after 120s), not as adversarial.
 - **amaru-protocols**: outbound handshake now offers duplex. When both sides agree, responders run on that bearer; promoting an inbound connection to Diffusion starts our initiators there too. ([#751](https://github.com/pragma-org/amaru/issues/751), [#660](https://github.com/pragma-org/amaru/issues/660))
 - **amaru-consensus**: peer selection prefers promoting a duplex inbound to Using instead of opening a second outbound connection; Using inbounds count toward the upstream target. ([#660](https://github.com/pragma-org/amaru/issues/660))
-- **amaru-protocols**: outbound handshake now offers duplex. When both sides agree, responders run on that bearer; promoting an inbound connection to Diffusion starts our initiators there too.
-- **amaru-consensus**: peer selection prefers promoting a duplex inbound to Using instead of opening a second outbound connection; Using inbounds count toward the upstream target.
 - **amaru-protocols**: connection traces include `local_use`, `duplex`, and `stopping`.
 
 ### Fixed

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -402,8 +402,6 @@ impl PeerSelection {
             share_request_interval: SHARE_REQUEST_INTERVAL,
             churn_timer: None,
             demoted_until: BTreeMap::new(),
-            share_request_initial_delay: SHARE_REQUEST_INITIAL_DELAY,
-            share_request_interval: SHARE_REQUEST_INTERVAL,
         }
     }
 

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -293,6 +293,8 @@ impl PartialEq for PeerSelection {
             && self.share_request_initial_delay == other.share_request_initial_delay
             && self.share_request_interval == other.share_request_interval
             && self.demoted_until == other.demoted_until
+            && self.share_request_initial_delay == other.share_request_initial_delay
+            && self.share_request_interval == other.share_request_interval
         // share_reply and churn_timer intentionally omitted
     }
 }
@@ -400,6 +402,8 @@ impl PeerSelection {
             share_request_interval: SHARE_REQUEST_INTERVAL,
             churn_timer: None,
             demoted_until: BTreeMap::new(),
+            share_request_initial_delay: SHARE_REQUEST_INITIAL_DELAY,
+            share_request_interval: SHARE_REQUEST_INTERVAL,
         }
     }
 

--- a/crates/amaru-node/src/tests/world/generated.rs
+++ b/crates/amaru-node/src/tests/world/generated.rs
@@ -370,6 +370,7 @@ fn run_p_join_quiescent_chain(
             .with_target_upstream_peers(P_JOIN_NODES)
             .with_share_request_initial_delay(P_JOIN_SHARE_INITIAL_DELAY)
             .with_trace_buffer(TraceBuffer::new_shared(20_000, 16_000_000))
+            .with_share_request_initial_delay(P_JOIN_SHARE_INITIAL_DELAY)
             // Common ancestor so FindIntersect is not Origin-vs-a-parent-hash the node does not have.
             .with_validated_blocks(vec![headers[0].clone()]);
         let mut sim = build_world_node(&node, connections.clone(), handle).expect("production node");

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -1888,6 +1888,9 @@ define_schemas! {
                         required conn_id: u64
                         required peer: %amaru_kernel::Peer
                         required role: String
+                        required local_use: String
+                        required duplex: bool
+                        required stopping: u64
                     }
                 }
                 /// A mini-protocol stage running on a connection died

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeSet, sync::Arc, time::Duration};
+use std::{collections::BTreeSet, sync::Arc};
 
 use amaru_kernel::{EraHistory, NetworkMagic, Peer, Point};
 use amaru_observability::{Instrument, TraceContext, debug_span, error, info};
@@ -41,8 +41,6 @@ use crate::{
     tx_submission::{self, register_tx_submission},
 };
 
-const DIFFUSION_STOP_TIMEOUT: Duration = Duration::from_secs(300);
-const MAINTENANCE_STOP_TIMEOUT: Duration = Duration::from_secs(120);
 const STOP_TIMEOUT_SLOT: u64 = 1;
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -97,6 +95,14 @@ impl LocalUse {
         match role {
             Role::Initiator => Self::Diffusion,
             Role::Responder => Self::None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Maintenance => "maintenance",
+            Self::Diffusion => "diffusion",
         }
     }
 }
@@ -199,6 +205,10 @@ pub async fn stage(
     let message_type = msg.message_type().to_string();
     let Params { conn_id, role, .. } = params;
     let peer = params.peer;
+    let (local_use, duplex, stopping) = match &state {
+        State::Established(s) => (s.actual_use.as_str(), s.duplex, s.stopping.len() as u64),
+        State::Initial | State::Handshake { .. } => ("negotiating", false, 0),
+    };
 
     async move {
         let state = match (state, msg) {
@@ -296,6 +306,9 @@ pub async fn stage(
         conn_id = conn_id.as_u64(),
         peer,
         role = role.to_string(),
+        local_use,
+        duplex,
+        stopping,
     ))
     .await
 }
@@ -552,7 +565,8 @@ async fn begin_stop(mut s: Established, params: &Params, eff: &Effects<Connectio
         return s;
     }
 
-    let timeout = if drop_diffusion { DIFFUSION_STOP_TIMEOUT } else { MAINTENANCE_STOP_TIMEOUT };
+    let timeout =
+        if drop_diffusion { params.config.diffusion_stop_timeout } else { params.config.maintenance_stop_timeout };
     eff.set_timeout_at(STOP_TIMEOUT_SLOT, timeout, ConnectionMessage::StopTimeout).await;
     s
 }

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -98,7 +98,7 @@ impl LocalUse {
         }
     }
 
-    pub fn as_str(self) -> &'static str {
+    fn as_str(self) -> &'static str {
         match self {
             Self::None => "none",
             Self::Maintenance => "maintenance",

--- a/crates/amaru-protocols/src/manager/mod.rs
+++ b/crates/amaru-protocols/src/manager/mod.rs
@@ -271,6 +271,10 @@ pub struct ManagerConfig {
     /// BlockFetch initiator pipeline depth. `1` drives the lock-step typestate
     /// instance; values greater than 1 wrap N instances in the CIP-0164 pipeliner.
     pub blockfetch_pipeline_n: NonZeroU8,
+    /// Last-to-finish bound when stopping the diffusion initiator group.
+    pub diffusion_stop_timeout: Duration,
+    /// Last-to-finish bound when stopping the maintenance initiator group.
+    pub maintenance_stop_timeout: Duration,
 }
 
 impl ManagerConfig {
@@ -314,6 +318,8 @@ impl Default for ManagerConfig {
             accept_interval: Duration::from_millis(100),
             tx_submission_params: ResponderParams::default(),
             blockfetch_pipeline_n: NonZeroU8::MIN,
+            diffusion_stop_timeout: Duration::from_secs(300),
+            maintenance_stop_timeout: Duration::from_secs(120),
         }
     }
 }


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changed**
  - Connection traces now include local usage, duplex status, and stopping time information.
  - Peer-sharing request timing can be configured, including the initial delay and recurring interval.
  - Connection stop timeouts are now configurable.

- **Bug Fixes**
  - Fixed an issue where the first peer-sharing request after an outbound handshake could be dropped.
  - Outbound connections now correctly begin their initiation process after handshakes complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->