### PR TITLE
add a simulation test for the “peer behind NAT” situation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Other guiding principles:
 ### Added
 
 - **amaru-protocols**: BlockFetch times out after 60s if the peer stalls while serving a range. ([#1303](https://github.com/pragma-org/amaru/pull/1303))
+- **amaru-protocols**: `manager.peer.local_use_applied` is logged when a connection has finished changing local use (for example to Maintenance after an uninteresting demotion).
 
 ### Changed
 
@@ -62,6 +63,7 @@ Other guiding principles:
 - **amaru-protocols**: outbound handshake now offers duplex. When both sides agree, responders run on that bearer; promoting an inbound connection to Diffusion starts our initiators there too. ([#751](https://github.com/pragma-org/amaru/issues/751), [#660](https://github.com/pragma-org/amaru/issues/660))
 - **amaru-consensus**: peer selection prefers promoting a duplex inbound to Using instead of opening a second outbound connection; Using inbounds count toward the upstream target. ([#660](https://github.com/pragma-org/amaru/issues/660))
 - **amaru-protocols**: connection traces include `local_use`, `duplex`, and `stopping`.
+- **amaru-pure-stage**: a stage that stops on purpose is logged at debug. A stage that aborts because of an error still logs that error at info or above before exiting.
 
 ### Fixed
 

--- a/crates/amaru-consensus/src/stages/adopt_chain/tests.rs
+++ b/crates/amaru-consensus/src/stages/adopt_chain/tests.rs
@@ -57,7 +57,6 @@ fn test_incoming_tip_not_in_store() {
         ],
     );
     logs.assert_and_remove(Level::WARN, &["block.header_not_found", r#"role="incoming_tip""#])
-        .assert_and_remove(Level::INFO, &["terminated"])
         .assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
 }
 
@@ -84,7 +83,6 @@ fn test_current_best_not_loadable() {
         ],
     );
     logs.assert_and_remove(Level::WARN, &["block.header_not_found", r#"role="current_best""#])
-        .assert_and_remove(Level::INFO, &["terminated"])
         .assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
 }
 

--- a/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
+++ b/crates/amaru-consensus/src/stages/fetch_blocks/tests.rs
@@ -59,9 +59,12 @@ fn test_new_tip_load_header_fails() {
             te_terminated("fb-1", TerminationReason::Voluntary),
         ],
     );
-    logs.assert_and_remove(Level::ERROR, &["blocks.header_not_found"])
-        .assert_and_remove(Level::INFO, &["terminated"])
-        .assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
+    logs.assert_and_remove(Level::ERROR, &["blocks.header_not_found"]).assert_no_remaining_at([
+        Level::DEBUG,
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
 }
 
 #[test]
@@ -439,9 +442,12 @@ fn test_new_tip_find_missing_blocks_error() {
         ],
     );
 
-    logs.assert_and_remove(Level::ERROR, &["blocks.header_not_found"])
-        .assert_and_remove(Level::INFO, &["terminated"])
-        .assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
+    logs.assert_and_remove(Level::ERROR, &["blocks.header_not_found"]).assert_no_remaining_at([
+        Level::DEBUG,
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
 }
 
 #[test]

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -15,6 +15,7 @@
 use std::{
     cmp::Reverse,
     collections::{BTreeMap, BTreeSet, BinaryHeap, btree_map::Entry},
+    fmt::{self, Display},
     net::SocketAddr,
     time::Duration,
 };
@@ -157,7 +158,8 @@ fn churn_interval(seed: [u8; 32]) -> Duration {
 ///   - `Inbound`: If `inbound_peers.len() >= target_downstream_peers`, logs
 ///     `peer_selection.peer.add_skipped` with `reason="too_many_inbound"`, sends `ManagerMessage::Disconnect`,
 ///     and returns early (no insert). Otherwise inserts (or replaces a prior
-///     connection for the same peer, sending `Disconnect` for the old one).
+///     connection for the same peer, sending `Disconnect` for the old one),
+///     then `regulate_peers` so a duplex inbound can be promoted to Using.
 ///   - `Outbound`: Inserts/updates as `PeerState::Connected(conn)`. If replacing
 ///     a prior `Connected` state, warns and sends `Disconnect` for the old conn.
 ///     Sends `SetLocalUse(Diffusion)` so fetch/share follow actual local use.
@@ -293,8 +295,6 @@ impl PartialEq for PeerSelection {
             && self.share_request_initial_delay == other.share_request_initial_delay
             && self.share_request_interval == other.share_request_interval
             && self.demoted_until == other.demoted_until
-            && self.share_request_initial_delay == other.share_request_initial_delay
-            && self.share_request_interval == other.share_request_interval
         // share_reply and churn_timer intentionally omitted
     }
 }
@@ -321,6 +321,19 @@ impl Connection {
     pub fn with_local_use(mut self, local_use: LocalUse) -> Self {
         self.local_use = local_use;
         self
+    }
+}
+
+impl Display for Connection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Connection(id={}, duplex={}/{}, use={})",
+            self.id.as_u64(),
+            self.full_duplex_capable,
+            self.full_duplex,
+            self.local_use.as_str()
+        )
     }
 }
 
@@ -429,7 +442,7 @@ impl PeerSelection {
                 protocols::peer_selection::peer::REMOVED,
                 peer,
                 direction = "inbound",
-                peer_state = format!("{peer_state:?}"),
+                peer_state = peer_state.to_string(),
                 is_static
             );
             send_remove = true;
@@ -906,7 +919,10 @@ pub async fn stage(mut state: PeerSelection, msg: PeerSelectionMsg, eff: Effects
                 );
                 drop(span);
                 eff.send(&state.manager, ManagerMessage::Disconnect(peer, conn.id)).await;
+            } else {
+                drop(span);
             }
+            state.regulate_peers(&eff).await;
         }
         PeerSelectionMsg::Connected(peer, connection, ConnectionDirection::Outbound, advertisable) => {
             let now = eff.clock().await;

--- a/crates/amaru-consensus/src/stages/peer_selection/tests.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/tests.rs
@@ -529,15 +529,19 @@ fn test_connected_inbound_success() {
         s
     };
     let (running, _guards, mut logs) = setup(&prep, msg.clone());
-    assert_trace(
+    assert_trace_contains(
         &running,
         &[
-            te_state("ps-1", &state),
-            te_input("ps-1", &msg),
-            te_clock_suspend("ps-1"),
-            te_record_advertisability("ps-1", p, true, sim_t0()),
-            te_state("ps-1", &after),
+            te_input("ps-1", &msg).into(),
+            te_record_advertisability("ps-1", p, true, sim_t0()).into(),
+            te_state("ps-1", &after).into(),
         ],
+    );
+    assert_trace_does_not_contain(
+        &running,
+        &[tm_send_match::<ManagerMessage>("ps-1", "manager", |m| {
+            matches!(m, ManagerMessage::SetLocalUse { .. } | ManagerMessage::AddPeer(_))
+        })],
     );
     logs.assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
 }
@@ -1527,6 +1531,41 @@ fn test_churn_skips_static_peers() {
 
 fn duplex_conn() -> Connection {
     Connection::new(ConnectionId::initial(), true, true)
+}
+
+#[test]
+fn test_connected_inbound_duplex_promotes_to_using() {
+    let mut prep = test_prep(&[]);
+    prep.state.target_upstream_peers = 1;
+    let inbound = TestPrep::peer("8.8.8.8:8");
+    let msg = PeerSelectionMsg::Connected(inbound, duplex_conn(), ConnectionDirection::Inbound, true);
+    let after = {
+        let mut s = prep.state.clone();
+        s.inbound_peers.insert(inbound, duplex_conn().with_local_use(LocalUse::Diffusion));
+        s
+    };
+    let (running, _guards, mut logs) = setup(&prep, msg);
+    assert_trace_contains(
+        &running,
+        &[
+            te_send(
+                "ps-1",
+                "manager",
+                ManagerMessage::SetLocalUse {
+                    peer: inbound,
+                    conn_id: ConnectionId::initial(),
+                    local_use: LocalUse::Diffusion,
+                },
+            )
+            .into(),
+            te_state("ps-1", &after).into(),
+        ],
+    );
+    assert_trace_does_not_contain(
+        &running,
+        &[tm_send_match::<ManagerMessage>("ps-1", "manager", |m| matches!(m, ManagerMessage::AddPeer(_)))],
+    );
+    logs.assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
 }
 
 #[test]

--- a/crates/amaru-consensus/src/stages/select_chain/tests.rs
+++ b/crates/amaru-consensus/src/stages/select_chain/tests.rs
@@ -55,7 +55,6 @@ fn test_tip_not_found() {
         ],
     );
     logs.assert_and_remove(Level::ERROR, &["chain.select_from_tip", "chain.header_not_found", r#"role="tip""#])
-        .assert_and_remove(Level::INFO, &["terminated"])
         .assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
 }
 
@@ -670,7 +669,6 @@ fn test_block_validation_result_invalid_for_unknown_hash() {
         Level::ERROR,
         &["chain.select_from_block_validation", "chain.header_not_found", r#"role="validation_target""#],
     )
-    .assert_and_remove(Level::INFO, &["terminated"])
     .assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
 }
 
@@ -707,7 +705,6 @@ fn test_fault_set_block_valid_returns_err_failed_to_store_block_validation_resul
         Level::ERROR,
         &["chain.select_from_block_validation", "chain.store_validation_failed", "injected fault"],
     )
-    .assert_and_remove(Level::INFO, &["terminated", "stage=sc-1"])
     .assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
 }
 

--- a/crates/amaru-consensus/src/stages/test_utils.rs
+++ b/crates/amaru-consensus/src/stages/test_utils.rs
@@ -114,10 +114,12 @@ fn parse_target(line: &str) -> &str {
 
 /// Whether a captured line is worth asserting on.
 ///
-/// The simulation engine narrates every step it takes (`resuming stage`, `run effect`, ...) at
-/// DEBUG. Keeping that noise would make `assert_no_remaining_at` unusable at DEBUG, so engine
-/// chatter below INFO is discarded while its INFO and above (stage termination, dropped messages)
-/// is kept, since tests do rely on those.
+/// The simulation engine narrates every step it takes (`resuming stage`, `run effect`,
+/// voluntary `terminated`, ...) at DEBUG. Keeping that noise would make `assert_no_remaining_at`
+/// unusable at DEBUG, so engine chatter below INFO is discarded. INFO and above from the engine
+/// (dropped messages, unsupervised child termination) is kept, since tests do rely on those.
+/// A stage that aborts for an error still logs that error at INFO or above from the stage itself
+/// before calling `Terminate`.
 fn is_relevant(level: Level, target: &str) -> bool {
     level <= Level::INFO || !target.starts_with("amaru_pure_stage")
 }

--- a/crates/amaru-consensus/src/stages/validate_block/tests.rs
+++ b/crates/amaru-consensus/src/stages/validate_block/tests.rs
@@ -50,9 +50,12 @@ fn test_block_with_origin_parent_terminates() {
             te_terminated("vb-1", TerminationReason::Voluntary),
         ],
     );
-    logs.assert_and_remove(Level::ERROR, &["block.validate_from_genesis"])
-        .assert_and_remove(Level::INFO, &["terminated"])
-        .assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
+    logs.assert_and_remove(Level::ERROR, &["block.validate_from_genesis"]).assert_no_remaining_at([
+        Level::DEBUG,
+        Level::INFO,
+        Level::WARN,
+        Level::ERROR,
+    ]);
 }
 
 #[test]
@@ -194,7 +197,6 @@ fn test_ledger_failure_during_validation_terminates() {
         ],
     );
     logs.assert_and_remove(Level::WARN, &["block.apply_failed"])
-        .assert_and_remove(Level::INFO, &["terminated"])
         .assert_and_remove(Level::DEBUG, &["block.validate"])
         .assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
 }
@@ -442,7 +444,6 @@ fn test_ledger_failure_during_fork_switch_terminates() {
     );
     logs.assert_and_remove(Level::INFO, &["block.switch_fork"])
         .assert_and_remove(Level::WARN, &["block.apply_failed"])
-        .assert_and_remove(Level::INFO, &["terminated"])
         .assert_and_remove(Level::DEBUG, &["block.validate"])
         .assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
 }

--- a/crates/amaru-node/src/tests/world/generated.rs
+++ b/crates/amaru-node/src/tests/world/generated.rs
@@ -28,20 +28,24 @@ use amaru_consensus::{
     stages::select_chain::cmp_tip,
 };
 use amaru_kernel::{
-    BlockHeight, Hash, IsHeader, NetworkPoint, PREPROD_ERA_HISTORY, PREPROD_GLOBAL_PARAMETERS, Peer, Point, Slot,
-    any_headers_chain_with_root, cardano::network_block::make_encoded_block, utils::tests::run_strategy_with_seed,
+    BlockHeight, Hash, Header, IsHeader, NetworkPoint, PREPROD_ERA_HISTORY, PREPROD_GLOBAL_PARAMETERS, Peer, Point,
+    Slot, any_headers_chain_with_root, cardano::network_block::make_encoded_block,
+    utils::tests::run_strategy_with_seed,
 };
 use amaru_metrics::LedgerMetrics;
 use amaru_ouroboros::{
     BaseReadChainStore, ConnectionsResource, Nonces, WriteChainStore, in_memory_chain_store::InMemoryChainStore,
 };
 use amaru_protocols::store_effects::{ResourceHeaderStore, ResourceParameters};
-use amaru_pure_stage::{simulation::running::OverrideResult, trace_buffer::TraceBuffer};
-use tokio::runtime::Handle;
+use amaru_pure_stage::{
+    simulation::{SimulationRunning, running::OverrideResult},
+    trace_buffer::TraceBuffer,
+};
+use tokio::runtime::{Handle, Runtime};
 
 use super::{
-    HONEST_PAYLOAD_DELAY_MAX_NANOS, HeapLogEntry, HeapLogKind, WIRE_DELAY_MAX_NANOS, WorldConnectionProvider,
-    WorldLoop, build_injector, build_injector_peer, build_world_node,
+    HONEST_PAYLOAD_DELAY_MAX_NANOS, HeapLogEntry, HeapLogKind, InjectorShared, WIRE_DELAY_MAX_NANOS,
+    WorldConnectionProvider, WorldLoop, build_injector, build_injector_peer, build_world_node,
     support::{
         derive_seed, draw_test_seed, fragment_trace_guards, peer_saw_roll_forward, peer_trace, seed_bytes, test_seeds,
         tm_chainsync_roll_forward, tm_chainsync_roll_forward_of, tm_validate_header,
@@ -54,8 +58,223 @@ const TAG_INJECTOR: u64 = 100;
 const TAG_INJECTOR_PEER: u64 = 101;
 const TAG_PEER_SEL: u64 = 200;
 
+/// First node listen port is `base + NODE_PORT_OFFSET`.
+const NODE_PORT_OFFSET: u16 = 11;
+
+const BLOCKFETCH_FRAGMENT: usize = 6;
+const BLOCKFETCH_HORIZON_NANOS: u64 = 5_000_000_000;
+
 fn provider(seed: u64) -> Arc<WorldConnectionProvider> {
     Arc::new(WorldConnectionProvider::new(seed))
+}
+
+fn loopback(port: u16) -> SocketAddr {
+    SocketAddr::from(([127, 0, 0, 1], port))
+}
+
+fn node_listen(base: u16, index: usize) -> SocketAddr {
+    loopback(base + NODE_PORT_OFFSET + index as u16)
+}
+
+fn peer_at(addr: SocketAddr) -> Peer {
+    Peer::try_from(addr).expect("world tests use IPv4 loopback")
+}
+
+fn conway_root() -> NetworkPoint {
+    NetworkPoint::Specific(Slot::from(68_774_400), Hash::new([0u8; 32]))
+}
+
+fn generated_headers(n: usize, seed: u64) -> Vec<Header> {
+    run_strategy_with_seed(seed, any_headers_chain_with_root(n, conway_root().with_height(BlockHeight::from(0))))
+}
+
+fn injector_linear_store(n: usize, seed: u64) -> (Arc<InMemoryChainStore>, Vec<Header>) {
+    let headers = generated_headers(n, seed);
+    let store = Arc::new(InMemoryChainStore::new());
+    store.set_anchor_point(&headers[0].point()).unwrap();
+    for header in &headers {
+        store.store_header(header).unwrap();
+        store.store_block(&header.hash(), &make_encoded_block(header, &PREPROD_ERA_HISTORY)).unwrap();
+        store.roll_forward_chain(&header.point()).unwrap();
+    }
+    (store, headers)
+}
+
+fn stub_peer_selection_seed(sim: &mut SimulationRunning, seed: u64) {
+    let bytes = seed_bytes(seed);
+    sim.override_external_effect::<GenerateRandomSeed>(usize::MAX, move |_| OverrideResult::handled(bytes));
+}
+
+fn stub_generated_validation(sim: &mut SimulationRunning) {
+    sim.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| {
+        OverrideResult::handled(Ok(Nonces::for_tests()))
+    });
+    sim.override_external_effect::<ValidateBlockEffect>(usize::MAX, |_| {
+        OverrideResult::handled(Ok(Ok(LedgerMetrics::default())))
+    });
+}
+
+fn generated_node(seed: u64, index: usize, listen: SocketAddr) -> NodeTestConfig {
+    NodeTestConfig::default()
+        .with_listen_address(&listen.to_string())
+        .with_seed(derive_seed(seed, TAG_NODE + index as u64))
+        .with_trace_buffer(TraceBuffer::new_shared(10_000, 8_000_000))
+}
+
+fn with_ancestor(config: NodeTestConfig, ancestor: &Header) -> NodeTestConfig {
+    config.with_validated_blocks(vec![ancestor.clone()])
+}
+
+fn spawn_node(
+    config: NodeTestConfig,
+    connections: ConnectionsResource,
+    handle: &Handle,
+    seed: u64,
+    index: usize,
+    stub_validation: bool,
+) -> SimulationRunning {
+    let mut sim = build_world_node(&config, connections, handle).expect("production node");
+    if stub_validation {
+        stub_generated_validation(&mut sim);
+    }
+    stub_peer_selection_seed(&mut sim, derive_seed(seed, TAG_PEER_SEL + index as u64));
+    sim
+}
+
+fn spawn_injector(
+    store: Arc<InMemoryChainStore>,
+    connections: ConnectionsResource,
+    listen: SocketAddr,
+    seed: u64,
+    handle: &Handle,
+) -> (SimulationRunning, Arc<InjectorShared>) {
+    let source: Arc<dyn BaseReadChainStore> = store;
+    build_injector(source, connections, listen, derive_seed(seed, TAG_INJECTOR), handle).expect("injector")
+}
+
+fn world_with_injector(
+    provider: Arc<WorldConnectionProvider>,
+    injector: SimulationRunning,
+    shared: Arc<InjectorShared>,
+    nodes: Vec<SimulationRunning>,
+    headers: &[Header],
+) -> WorldLoop {
+    let mut graphs = Vec::with_capacity(1 + nodes.len());
+    graphs.push(injector);
+    graphs.extend(nodes);
+    let mut world = WorldLoop::new(provider, graphs).with_injector(0, shared);
+    world.schedule_reveals(headers.iter().map(IsHeader::hash));
+    world
+}
+
+/// Sync tests: production graphs may `Handle::block_on` DurationDist::Zero, which
+/// panics inside an existing Tokio context.
+struct SyncRun {
+    seed: u64,
+    handle: Handle,
+    provider: Arc<WorldConnectionProvider>,
+    _runtime: Runtime,
+    _guards: amaru_pure_stage::DeserializerGuards,
+}
+
+impl SyncRun {
+    fn new(label: &str) -> Self {
+        Self::with_provider(label, provider)
+    }
+
+    fn with_provider(label: &str, make: impl FnOnce(u64) -> Arc<WorldConnectionProvider>) -> Self {
+        let seed = draw_test_seed();
+        eprintln!("world {label} seed={seed:#x}");
+        let runtime = tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap();
+        let handle = runtime.handle().clone();
+        let provider = make(seed);
+        Self { seed, handle, provider, _runtime: runtime, _guards: fragment_trace_guards() }
+    }
+
+    fn connections(&self) -> ConnectionsResource {
+        self.provider.clone()
+    }
+
+    fn spawn_catch_up(&self, index: usize, config: NodeTestConfig) -> SimulationRunning {
+        spawn_node(config, self.connections(), &self.handle, self.seed, index, true)
+    }
+
+    fn spawn_live(&self, index: usize, config: NodeTestConfig) -> SimulationRunning {
+        spawn_node(config, self.connections(), &self.handle, self.seed, index, false)
+    }
+
+    fn spawn_injector(
+        &self,
+        store: Arc<InMemoryChainStore>,
+        listen: SocketAddr,
+    ) -> (SimulationRunning, Arc<InjectorShared>) {
+        spawn_injector(store, self.connections(), listen, self.seed, &self.handle)
+    }
+
+    fn injector_world(
+        &self,
+        injector: SimulationRunning,
+        shared: Arc<InjectorShared>,
+        nodes: Vec<SimulationRunning>,
+        headers: &[Header],
+    ) -> WorldLoop {
+        world_with_injector(self.provider.clone(), injector, shared, nodes, headers)
+    }
+}
+
+/// Serve-only injector graphs do not install [`ResourceParameters`].
+fn assert_production_k(graphs: &[SimulationRunning]) {
+    for graph in graphs {
+        let params = graph.resources().get::<ResourceParameters>().expect("production GlobalParameters");
+        assert_eq!(params.consensus_security_param, PREPROD_GLOBAL_PARAMETERS.consensus_security_param);
+        assert_eq!(params.consensus_security_param, 2160, "production k");
+    }
+}
+
+fn assert_dialed(log: &[HeapLogEntry], target: SocketAddr, seed: u64, what: &str) {
+    assert!(
+        log.iter().any(|e| matches!(e.kind, HeapLogKind::ConnectAttempt { target: t } if t == target)),
+        "{what}; seed={seed:#x} heap={log:?}"
+    );
+}
+
+fn assert_accepted_at(log: &[HeapLogEntry], listener: SocketAddr, seed: u64, what: &str) {
+    assert!(
+        log.iter().any(|e| matches!(e.kind, HeapLogKind::Accepted { listener: l, .. } if l == listener)),
+        "{what}; seed={seed:#x} heap={log:?}"
+    );
+}
+
+fn assert_not_dialed(log: &[HeapLogEntry], target: SocketAddr, seed: u64, what: &str) {
+    assert!(
+        !log.iter().any(|e| matches!(e.kind, HeapLogKind::ConnectAttempt { target: t } if t == target)),
+        "{what}; seed={seed:#x} heap={log:?}"
+    );
+}
+
+fn assert_adopted_head(world: &WorldLoop, graph: usize, head: &Header, seed: u64, who: &str) {
+    let store = world.graphs()[graph].resources().get::<ResourceHeaderStore>().expect("node chain store");
+    let tip = store.get_best_chain_tip();
+    let got =
+        store.load_header(&tip.hash()).unwrap_or_else(|| panic!("{who} best tip {tip} has no header; seed={seed:#x}"));
+    assert_eq!(
+        cmp_tip(Some(&got), Some(head)),
+        Ordering::Equal,
+        "{who} adopted tip {tip} must be cmp_tip-equal to HEAD {}; seed={seed:#x}",
+        head.point()
+    );
+    assert_eq!(tip, head.point(), "{who} best-chain pointer must be the generated HEAD; seed={seed:#x}");
+}
+
+fn assert_has_bodies(world: &WorldLoop, graph: usize, headers: &[Header], seed: u64, who: &str) {
+    let store = world.graphs()[graph].resources().get::<ResourceHeaderStore>().expect("node chain store");
+    for header in headers {
+        assert!(
+            store.has_block(&header.hash()).expect("has_block"),
+            "{who} must have fetched body for {}; seed={seed:#x}",
+            header.point()
+        );
+    }
 }
 
 /// Two production-shaped nodes (`build_node` × SimulationBuilder × SimulationRunning)
@@ -72,54 +291,22 @@ fn provider(seed: u64) -> Arc<WorldConnectionProvider> {
 /// That panics inside an existing Tokio context. WorldLoop is therefore synchronous.
 #[test]
 fn test_world_owns_production_nodes_boot_connect_exchange() {
-    let seed = draw_test_seed();
-    eprintln!("world boot_connect_exchange seed={seed:#x}");
-    let _guards = fragment_trace_guards();
-    let runtime = tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap();
-    let handle = runtime.handle().clone();
-    let provider = Arc::new(WorldConnectionProvider::with_long_tail_payload_delay(seed));
+    let run = SyncRun::with_provider("boot_connect_exchange", |seed| {
+        Arc::new(WorldConnectionProvider::with_long_tail_payload_delay(seed))
+    });
+    let headers = generated_headers(2, run.seed);
+    let listen_a = loopback(9311);
+    let listen_b = loopback(9310);
 
-    let conway_start_slot = Slot::from(68_774_400);
-    let root_point = NetworkPoint::Specific(conway_start_slot, Hash::new([0u8; 32]));
-    let headers =
-        run_strategy_with_seed(seed, any_headers_chain_with_root(2, root_point.with_height(BlockHeight::from(0))));
+    let node_a = generated_node(run.seed, 0, listen_a).with_no_upstream_peers().with_validated_blocks(headers);
+    let node_b = generated_node(run.seed, 1, listen_b).with_upstream_peer(peer_at(listen_a));
 
-    let listen_a = "127.0.0.1:9311";
-    let listen_b = "127.0.0.1:9310";
-    let peer_a = listen_a.parse().expect("listen_a is an IPv4 socket");
-
-    let node_a = NodeTestConfig::default()
-        .with_no_upstream_peers()
-        .with_listen_address(listen_a)
-        .with_seed(derive_seed(seed, TAG_NODE))
-        .with_trace_buffer(TraceBuffer::new_shared(10_000, 8_000_000))
-        .with_validated_blocks(headers);
-    let node_b = NodeTestConfig::default()
-        .with_upstream_peer(peer_a)
-        .with_listen_address(listen_b)
-        .with_seed(derive_seed(seed, TAG_NODE + 1))
-        .with_trace_buffer(TraceBuffer::new_shared(10_000, 8_000_000));
-
-    let connections: ConnectionsResource = provider.clone();
-    let mut sim_a = build_world_node(&node_a, connections.clone(), &handle).expect("node A");
-    let mut sim_b = build_world_node(&node_b, connections, &handle).expect("node B");
-    stub_peer_selection_seed(&mut sim_a, derive_seed(seed, TAG_PEER_SEL));
-    stub_peer_selection_seed(&mut sim_b, derive_seed(seed, TAG_PEER_SEL + 1));
-
-    let mut world = WorldLoop::new(provider, vec![sim_a, sim_b]);
-    // World coverage so a sampled long-tail Deliver can pop. Not a Praos deadline.
+    let mut world = WorldLoop::new(run.provider.clone(), vec![run.spawn_live(0, node_a), run.spawn_live(1, node_b)]);
     world.run_until_horizon(HONEST_PAYLOAD_DELAY_MAX_NANOS.saturating_add(WIRE_DELAY_MAX_NANOS));
 
-    for graph in world.graphs() {
-        let params = graph.resources().get::<ResourceParameters>().expect("production GlobalParameters");
-        assert_eq!(
-            params.consensus_security_param, PREPROD_GLOBAL_PARAMETERS.consensus_security_param,
-            "world nodes must keep production k"
-        );
-        assert_eq!(params.consensus_security_param, 2160);
-    }
-
+    assert_production_k(world.graphs());
     let log = world.heap_log();
+    let seed = run.seed;
     assert!(
         log.iter().any(|e| matches!(e.kind, HeapLogKind::ConnectAttempt { .. })),
         "nodes must connect; seed={seed:#x} heap={log:?}"
@@ -166,103 +353,70 @@ fn test_world_blockfetch_pipelined() {
     run_blockfetch_generated_chain(NonZeroU8::new(2).unwrap(), 9720);
 }
 
-const BLOCKFETCH_FRAGMENT: usize = 6;
-const BLOCKFETCH_HORIZON_NANOS: u64 = 5_000_000_000;
-
 fn run_blockfetch_generated_chain(n: NonZeroU8, base_port: u16) {
-    let seed = draw_test_seed();
-    eprintln!("world blockfetch n={} seed={seed:#x}", n.get());
-    let _guards = fragment_trace_guards();
-    let runtime = tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap();
-    let handle = runtime.handle().clone();
-    let provider = provider(seed);
-
-    let injector_addr: SocketAddr = format!("127.0.0.1:{base_port}").parse().unwrap();
-    let node_listen = format!("127.0.0.1:{}", base_port + 11);
-    let (store, headers) = injector_linear_store(BLOCKFETCH_FRAGMENT, seed);
+    let run = SyncRun::new(&format!("blockfetch n={}", n.get()));
+    let injector_addr = loopback(base_port);
+    let node_addr = node_listen(base_port, 0);
+    let (store, headers) = injector_linear_store(BLOCKFETCH_FRAGMENT, run.seed);
     let head = headers.last().expect("fragment HEAD").clone();
-    let source: Arc<dyn BaseReadChainStore> = store;
-    let connections: ConnectionsResource = provider.clone();
 
-    let (injector, shared) =
-        build_injector(source, connections.clone(), injector_addr, derive_seed(seed, TAG_INJECTOR), &handle)
-            .expect("injector");
-
-    let node = NodeTestConfig::default()
-        .with_upstream_peer(Peer::try_from(injector_addr).expect("injector is IPv4 loopback"))
-        .with_listen_address(&node_listen)
-        .with_seed(derive_seed(seed, TAG_NODE))
-        .with_trace_buffer(TraceBuffer::new_shared(10_000, 8_000_000))
-        .with_blockfetch_pipeline_n(n)
-        .with_validated_blocks(vec![headers[0].clone()]);
-    let mut sim = build_world_node(&node, connections, &handle).expect("production node");
-    sim.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| {
-        OverrideResult::handled(Ok(Nonces::for_tests()))
-    });
-    sim.override_external_effect::<ValidateBlockEffect>(usize::MAX, |_| {
-        OverrideResult::handled(Ok(Ok(LedgerMetrics::default())))
-    });
-    stub_peer_selection_seed(&mut sim, derive_seed(seed, TAG_PEER_SEL));
-
-    let mut world = WorldLoop::new(provider, vec![injector, sim]).with_injector(0, shared);
-    world.schedule_reveals(headers.iter().map(IsHeader::hash));
-    let head_point = head.point();
+    let (injector, shared) = run.spawn_injector(store, injector_addr);
+    let node = with_ancestor(
+        generated_node(run.seed, 0, node_addr).with_upstream_peer(peer_at(injector_addr)).with_blockfetch_pipeline_n(n),
+        &headers[0],
+    );
+    let mut world = run.injector_world(injector, shared, vec![run.spawn_catch_up(0, node)], &headers);
     world.run_until_horizon_on_best_chain_tip(BLOCKFETCH_HORIZON_NANOS, |_| {});
 
     let log = world.heap_log();
-    assert!(
-        log.iter().any(|e| matches!(e.kind, HeapLogKind::ConnectAttempt { .. })),
-        "node must connect; n={} seed={seed:#x} heap={log:?}",
-        n.get()
-    );
-    assert!(
-        log.iter().any(|e| matches!(e.kind, HeapLogKind::Accepted { .. })),
-        "injector must accept; n={} seed={seed:#x} heap={log:?}",
-        n.get()
-    );
-
-    let graph = &world.graphs()[1];
-    let store = graph.resources().get::<ResourceHeaderStore>().expect("node chain store");
-    let tip = store.get_best_chain_tip();
-    let got = store
-        .load_header(&tip.hash())
-        .unwrap_or_else(|| panic!("node best tip {tip} has no header; n={} seed={seed:#x}", n.get()));
-    assert_eq!(
-        cmp_tip(Some(&got), Some(&head)),
-        Ordering::Equal,
-        "node adopted tip {tip} must be cmp_tip-equal to HEAD {}; n={} seed={seed:#x}",
-        head.point(),
-        n.get()
-    );
-    assert_eq!(tip, head_point, "node best-chain pointer must be the generated HEAD; n={} seed={seed:#x}", n.get());
-    for header in &headers {
-        assert!(
-            store.has_block(&header.hash()).expect("has_block"),
-            "node must have fetched body for {}; n={} seed={seed:#x}",
-            header.point(),
-            n.get()
-        );
-    }
+    assert_dialed(&log, injector_addr, run.seed, "node must connect");
+    assert_accepted_at(&log, injector_addr, run.seed, "injector must accept");
+    assert_adopted_head(&world, 1, &head, run.seed, "node");
+    assert_has_bodies(&world, 1, &headers, run.seed, "node");
 }
 
-fn stub_peer_selection_seed(sim: &mut amaru_pure_stage::simulation::running::SimulationRunning, seed: u64) {
-    let bytes = seed_bytes(seed);
-    sim.override_external_effect::<GenerateRandomSeed>(usize::MAX, move |_| OverrideResult::handled(bytes));
-}
+/// Injector → A → B. A dials the injector and B (duplex handshake). B has no
+/// static upstreams; it must promote the inbound from A and fetch the fragment
+/// over that bearer.
+#[test]
+fn test_world_duplex_inbound_upstream_syncs_injector_chain() {
+    let run = SyncRun::new("duplex_inbound_upstream");
+    let injector_addr = loopback(9820);
+    let listen_a = node_listen(9820, 0);
+    let listen_b = node_listen(9820, 1);
+    let (store, headers) = injector_linear_store(BLOCKFETCH_FRAGMENT, run.seed);
+    let head = headers.last().expect("fragment HEAD").clone();
 
-fn injector_linear_store(n: usize, seed: u64) -> (Arc<InMemoryChainStore>, Vec<amaru_kernel::Header>) {
-    let conway_start_slot = Slot::from(68_774_400);
-    let root_point = NetworkPoint::Specific(conway_start_slot, Hash::new([0u8; 32]));
-    let headers =
-        run_strategy_with_seed(seed, any_headers_chain_with_root(n, root_point.with_height(BlockHeight::from(0))));
-    let store = Arc::new(InMemoryChainStore::new());
-    store.set_anchor_point(&headers[0].point()).unwrap();
-    for header in &headers {
-        store.store_header(header).unwrap();
-        store.store_block(&header.hash(), &make_encoded_block(header, &PREPROD_ERA_HISTORY)).unwrap();
-        store.roll_forward_chain(&header.point()).unwrap();
-    }
-    (store, headers)
+    let (injector, shared) = run.spawn_injector(store, injector_addr);
+    let node_a = with_ancestor(
+        generated_node(run.seed, 0, listen_a)
+            .with_upstream_peers(vec![peer_at(injector_addr), peer_at(listen_b)])
+            .with_target_upstream_peers(2)
+            .with_peer_mix("static~2"),
+        &headers[0],
+    );
+    let node_b = with_ancestor(
+        generated_node(run.seed, 1, listen_b)
+            .with_no_upstream_peers()
+            .with_target_upstream_peers(1)
+            .with_peer_mix("static~1"),
+        &headers[0],
+    );
+    let mut world = run.injector_world(
+        injector,
+        shared,
+        vec![run.spawn_catch_up(0, node_a), run.spawn_catch_up(1, node_b)],
+        &headers,
+    );
+    world.run_until_horizon_on_best_chain_tip(BLOCKFETCH_HORIZON_NANOS, |_| {});
+
+    let log = world.heap_log();
+    assert_dialed(&log, injector_addr, run.seed, "A must dial the injector");
+    assert_dialed(&log, listen_b, run.seed, "A must dial B");
+    assert_accepted_at(&log, listen_b, run.seed, "B must accept A");
+    assert_not_dialed(&log, listen_a, run.seed, "B must not dial A");
+    assert_adopted_head(&world, 2, &head, run.seed, "node B");
+    assert_has_bodies(&world, 2, &headers, run.seed, "node B");
 }
 
 /// Five production nodes in a line, head dialing the injector. P-join on a quiescent
@@ -341,49 +495,29 @@ fn run_p_join_quiescent_chain(
     seed: u64,
     handle: &Handle,
 ) {
-    use std::cmp::Ordering;
-
-    let injector_addr: SocketAddr = format!("127.0.0.1:{base_port}").parse().unwrap();
-    let node_addrs: Vec<String> =
-        (0..P_JOIN_NODES).map(|i| format!("127.0.0.1:{}", base_port + 11 + i as u16)).collect();
-
+    let injector_addr = loopback(base_port);
+    let node_addrs: Vec<SocketAddr> = (0..P_JOIN_NODES).map(|i| node_listen(base_port, i)).collect();
     let (store, headers) = injector_linear_store(P_JOIN_FRAGMENT, seed);
     let head = headers.last().expect("fragment HEAD").clone();
-    let source: Arc<dyn BaseReadChainStore> = store;
     let connections: ConnectionsResource = provider.clone();
 
-    let (injector, shared) =
-        build_injector(source, connections.clone(), injector_addr, derive_seed(seed, TAG_INJECTOR), handle)
-            .expect("injector");
-
-    let mut graphs = vec![injector];
-    for (i, listen) in node_addrs.iter().enumerate() {
-        let upstream = if i == 0 {
-            Peer::try_from(injector_addr).expect("injector is IPv4 loopback")
-        } else {
-            node_addrs[i - 1].parse().expect("node listen is an IPv4 socket")
-        };
-        let node = NodeTestConfig::default()
-            .with_upstream_peer(upstream)
-            .with_listen_address(listen)
-            .with_seed(derive_seed(seed, TAG_NODE + i as u64))
-            .with_target_upstream_peers(P_JOIN_NODES)
-            .with_share_request_initial_delay(P_JOIN_SHARE_INITIAL_DELAY)
-            .with_trace_buffer(TraceBuffer::new_shared(20_000, 16_000_000))
-            .with_share_request_initial_delay(P_JOIN_SHARE_INITIAL_DELAY)
-            // Common ancestor so FindIntersect is not Origin-vs-a-parent-hash the node does not have.
-            .with_validated_blocks(vec![headers[0].clone()]);
-        let mut sim = build_world_node(&node, connections.clone(), handle).expect("production node");
-        // Generated chain: stub validation (EDR-011).
-        sim.override_external_effect::<ValidateHeaderEffect>(usize::MAX, |_| {
-            OverrideResult::handled(Ok(Nonces::for_tests()))
-        });
-        sim.override_external_effect::<ValidateBlockEffect>(usize::MAX, |_| {
-            OverrideResult::handled(Ok(Ok(LedgerMetrics::default())))
-        });
-        stub_peer_selection_seed(&mut sim, derive_seed(seed, TAG_PEER_SEL + i as u64));
-        graphs.push(sim);
-    }
+    let (injector, shared) = spawn_injector(store, connections.clone(), injector_addr, seed, handle);
+    let nodes: Vec<_> = node_addrs
+        .iter()
+        .enumerate()
+        .map(|(i, listen)| {
+            let upstream = if i == 0 { peer_at(injector_addr) } else { peer_at(node_addrs[i - 1]) };
+            let node = with_ancestor(
+                generated_node(seed, i, *listen)
+                    .with_upstream_peer(upstream)
+                    .with_target_upstream_peers(P_JOIN_NODES)
+                    .with_share_request_initial_delay(P_JOIN_SHARE_INITIAL_DELAY)
+                    .with_trace_buffer(TraceBuffer::new_shared(20_000, 16_000_000)),
+                &headers[0],
+            );
+            spawn_node(node, connections.clone(), handle, seed, i, true)
+        })
+        .collect();
 
     let disconnect_latest =
         horizon_nanos.saturating_sub(P_JOIN_DISCONNECT_TAIL_NANOS).max(P_JOIN_DISCONNECT_EARLIEST_NANOS);
@@ -394,8 +528,7 @@ fn run_p_join_quiescent_chain(
         Some(P_JOIN_RECONNECT_DELAY_NANOS),
     );
 
-    let mut world = WorldLoop::new(provider, graphs).with_injector(0, shared);
-    world.schedule_reveals(headers.iter().map(IsHeader::hash));
+    let mut world = world_with_injector(provider, injector, shared, nodes, &headers);
     let head_point = head.point();
     let mut adopted_at = None;
     world.run_until_horizon_on_best_chain_tip(horizon_nanos, |world| {
@@ -408,11 +541,7 @@ fn run_p_join_quiescent_chain(
     });
     print_p_join_summary(label, seed, horizon_nanos, adopted_at, world.heap_log_ref());
 
-    for graph in world.graphs().iter().skip(1) {
-        let params = graph.resources().get::<ResourceParameters>().expect("production GlobalParameters");
-        assert_eq!(params.consensus_security_param, PREPROD_GLOBAL_PARAMETERS.consensus_security_param);
-        assert_eq!(params.consensus_security_param, 2160, "production k");
-    }
+    assert_production_k(&world.graphs()[1..]);
 
     let log = world.heap_log();
     let chain_connects = P_JOIN_NODES;
@@ -444,19 +573,8 @@ fn run_p_join_quiescent_chain(
         "injected disconnects must close a live pair; seed={seed:#x}"
     );
 
-    for (i, graph) in world.graphs().iter().enumerate().skip(1) {
-        let store = graph.resources().get::<ResourceHeaderStore>().expect("node chain store");
-        let tip = store.get_best_chain_tip();
-        let got = store
-            .load_header(&tip.hash())
-            .unwrap_or_else(|| panic!("node {i} best tip {tip} has no header after {horizon_nanos}ns; seed={seed:#x}"));
-        assert_eq!(
-            cmp_tip(Some(&got), Some(&head)),
-            Ordering::Equal,
-            "node {i} adopted tip {tip} must be cmp_tip-equal to the quiescent HEAD {}; seed={seed:#x}",
-            head.point()
-        );
-        assert_eq!(tip, head.point(), "node {i} best-chain pointer must be the quiescent HEAD; seed={seed:#x}");
+    for i in 1..=P_JOIN_NODES {
+        assert_adopted_head(&world, i, &head, seed, &format!("node {i}"));
     }
     world.stop();
 }
@@ -524,20 +642,24 @@ fn print_p_join_summary(
     );
 }
 
+fn tokio_injector_world(
+    seed: u64,
+    store: Arc<InMemoryChainStore>,
+    listen: SocketAddr,
+    handle: &Handle,
+) -> (WorldLoop, Arc<WorldConnectionProvider>) {
+    let provider = provider(seed);
+    let (sim, shared) = spawn_injector(store, provider.clone(), listen, seed, handle);
+    (WorldLoop::new(provider.clone(), vec![sim]).with_injector(0, shared), provider)
+}
+
 #[tokio::test]
 async fn test_injector_inventory_reaches_world_loop() {
     let seed = draw_test_seed();
     eprintln!("world injector_inventory seed={seed:#x}");
     let handle = tokio::runtime::Handle::current();
-    let provider = provider(seed);
     let (store, _) = injector_linear_store(3, seed);
-    let listen: SocketAddr = "127.0.0.1:9400".parse().unwrap();
-    let source: Arc<dyn BaseReadChainStore> = store;
-    let connections: ConnectionsResource = provider.clone();
-    let (sim, shared) =
-        build_injector(source, connections, listen, derive_seed(seed, TAG_INJECTOR), &handle).expect("injector");
-
-    let mut world = WorldLoop::new(provider, vec![sim]).with_injector(0, shared);
+    let (mut world, _) = tokio_injector_world(seed, store, loopback(9400), &handle);
     assert_eq!(world.inventory_len(), 3, "inventory is scanned at injector construction");
     world.run_until_horizon(0);
     world.assert_serving_accept(0);
@@ -548,15 +670,7 @@ async fn test_injector_empty_store_inventory_is_empty() {
     let seed = draw_test_seed();
     eprintln!("world injector_empty_store seed={seed:#x}");
     let handle = tokio::runtime::Handle::current();
-    let provider = provider(seed);
-    let store = Arc::new(InMemoryChainStore::new());
-    let listen: SocketAddr = "127.0.0.1:9401".parse().unwrap();
-    let source: Arc<dyn BaseReadChainStore> = store;
-    let connections: ConnectionsResource = provider.clone();
-    let (sim, shared) =
-        build_injector(source, connections, listen, derive_seed(seed, TAG_INJECTOR), &handle).expect("injector");
-
-    let mut world = WorldLoop::new(provider, vec![sim]).with_injector(0, shared);
+    let (mut world, _) = tokio_injector_world(seed, Arc::new(InMemoryChainStore::new()), loopback(9401), &handle);
     assert_eq!(world.inventory_len(), 0);
     world.run_until_horizon(0);
     world.assert_serving_accept(0);
@@ -570,16 +684,12 @@ async fn test_injector_reveal_gates_chainsync() {
     eprintln!("world injector_reveal_gates seed={seed:#x}");
     let _guards = fragment_trace_guards();
     let handle = tokio::runtime::Handle::current();
-    let provider = provider(seed);
     let (store, headers) = injector_linear_store(2, seed);
-    let listen: SocketAddr = "127.0.0.1:9402".parse().unwrap();
-    let source: Arc<dyn BaseReadChainStore> = store;
-    let connections: ConnectionsResource = provider.clone();
-    let (injector, shared) =
-        build_injector(source, connections.clone(), listen, derive_seed(seed, TAG_INJECTOR), &handle)
-            .expect("injector");
-    let peer =
-        build_injector_peer(connections, listen, derive_seed(seed, TAG_INJECTOR_PEER), &handle).expect("injector peer");
+    let listen = loopback(9402);
+    let provider = provider(seed);
+    let (injector, shared) = spawn_injector(store, provider.clone(), listen, seed, &handle);
+    let peer = build_injector_peer(provider.clone(), listen, derive_seed(seed, TAG_INJECTOR_PEER), &handle)
+        .expect("injector peer");
 
     let mut world = WorldLoop::new(provider, vec![injector, peer]).with_injector(0, shared);
     // Handshake hops are 1–5ms; a few mux frames finish well before 200ms.

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -2011,8 +2011,14 @@ define_schemas! {
                         required peer: %amaru_kernel::Peer
                         required error: String
                     }
-                    /// Local use of a connection was changed
+                    /// A change of local use was requested on a connection
                     public SET_LOCAL_USE {
+                        required peer: %amaru_kernel::Peer
+                        required conn_id: u64
+                        required local_use: String
+                    }
+                    /// The connection finished converging to this local use
+                    public LOCAL_USE_APPLIED {
                         required peer: %amaru_kernel::Peer
                         required conn_id: u64
                         required local_use: String
@@ -2499,7 +2505,7 @@ define_schemas! {
                     }
                 }
                 /// The muxer failed while moving data between a protocol and the network.
-                /// Operation ∈ {send, recv_header, decode_header, recv_data, muxing}.
+                /// Operation ∈ {send, recv_header, decode_header, recv_data, muxing, after_done}.
                 public FAILED {
                     required role: String
                     required peer: %amaru_kernel::Peer

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -2177,7 +2177,7 @@ define_schemas! {
                     }
                     /// Sample stored points to propose as chain intersections
                     INTERSECT_POINTS {
-                        optional points: String
+                        optional points: Option<&[amaru_kernel::Point]>
                     }
                     /// A rollback target announced by the peer is not in the chain store
                     public ROLLBACK_POINT_NOT_FOUND {

--- a/crates/amaru-ouroboros-traits/src/stores/chain_store/types.rs
+++ b/crates/amaru-ouroboros-traits/src/stores/chain_store/types.rs
@@ -44,6 +44,15 @@ pub enum SampleAncestorPointsResult {
     Found(Vec<Point>),
 }
 
+impl SampleAncestorPointsResult {
+    pub fn as_slice(&self) -> Option<&[Point]> {
+        match self {
+            SampleAncestorPointsResult::Found(points) => Some(points.as_slice()),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Error, PartialEq, Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum StoreError {
     WriteError { error: String },

--- a/crates/amaru-protocols/src/chainsync/initiator.rs
+++ b/crates/amaru-protocols/src/chainsync/initiator.rs
@@ -189,7 +189,7 @@ async fn intersect_points(eff: &Effects<Inputs<InitiatorMessage>>) -> anyhow::Re
     let span = debug_span!(protocols::chainsync::initiator::INTERSECT_POINTS);
     async {
         let points = eff.external(StoreEffect::sample_ancestor_points()).await?;
-        debug_record!(protocols::chainsync::initiator::INTERSECT_POINTS, points = format!("{points:?}"));
+        debug_record!(protocols::chainsync::initiator::INTERSECT_POINTS, points = points.as_slice());
         Ok(points)
     }
     .instrument(span)

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -587,27 +587,58 @@ async fn on_expected_stop(
     match child {
         ChildId::ChainSync => {
             s.chainsync_initiator = None;
-            mux::install_done_trap(&s.muxer, PROTO_N2N_CHAIN_SYNC.erase(), eff, ConnectionMessage::ChildDied(child))
-                .await;
+            mux::install_done_trap(
+                &s.muxer,
+                PROTO_N2N_CHAIN_SYNC.erase(),
+                params.peer,
+                eff,
+                ConnectionMessage::ChildDied(child),
+            )
+            .await;
         }
         ChildId::BlockFetch => {
             s.blockfetch_initiator = None;
-            mux::install_done_trap(&s.muxer, PROTO_N2N_BLOCK_FETCH.erase(), eff, ConnectionMessage::ChildDied(child))
-                .await;
+            mux::install_done_trap(
+                &s.muxer,
+                PROTO_N2N_BLOCK_FETCH.erase(),
+                params.peer,
+                eff,
+                ConnectionMessage::ChildDied(child),
+            )
+            .await;
         }
         ChildId::TxSubmission => {
             s.tx_submission_initiator = None;
-            mux::install_done_trap(&s.muxer, PROTO_N2N_TX_SUB.erase(), eff, ConnectionMessage::ChildDied(child)).await;
+            mux::install_done_trap(
+                &s.muxer,
+                PROTO_N2N_TX_SUB.erase(),
+                params.peer,
+                eff,
+                ConnectionMessage::ChildDied(child),
+            )
+            .await;
         }
         ChildId::KeepAlive => {
             s.keepalive_initiator = None;
-            mux::install_done_trap(&s.muxer, PROTO_N2N_KEEP_ALIVE.erase(), eff, ConnectionMessage::ChildDied(child))
-                .await;
+            mux::install_done_trap(
+                &s.muxer,
+                PROTO_N2N_KEEP_ALIVE.erase(),
+                params.peer,
+                eff,
+                ConnectionMessage::ChildDied(child),
+            )
+            .await;
         }
         ChildId::PeerSharing => {
             s.peer_sharing_initiator = None;
-            mux::install_done_trap(&s.muxer, PROTO_N2N_PEER_SHARE.erase(), eff, ConnectionMessage::ChildDied(child))
-                .await;
+            mux::install_done_trap(
+                &s.muxer,
+                PROTO_N2N_PEER_SHARE.erase(),
+                params.peer,
+                eff,
+                ConnectionMessage::ChildDied(child),
+            )
+            .await;
         }
         ChildId::Mux | ChildId::Handshake | ChildId::Responder => {}
     }

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::BTreeSet, sync::Arc};
+use std::{collections::BTreeSet, fmt, sync::Arc};
 
 use amaru_kernel::{EraHistory, NetworkMagic, Peer, Point};
 use amaru_observability::{Instrument, TraceContext, debug_span, error, info};
@@ -98,7 +98,7 @@ impl LocalUse {
         }
     }
 
-    fn as_str(self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::None => "none",
             Self::Maintenance => "maintenance",
@@ -146,6 +146,12 @@ pub enum ChildId {
     PeerSharing,
     /// Any eager responder instance. Death is always unexpected (reset in place, do not stop).
     Responder,
+}
+
+impl fmt::Display for ChildId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -220,7 +226,7 @@ pub async fn stage(
                     protocols::connection::CHILD_STOPPED,
                     peer = &params.peer,
                     conn_id = conn_id.as_u64(),
-                    child = format!("{child:?}")
+                    child = child.to_string()
                 );
                 State::Established(on_expected_stop(s, child, &params, &eff).await)
             }
@@ -229,7 +235,7 @@ pub async fn stage(
                     protocols::connection::CHILD_DIED,
                     peer = &params.peer,
                     conn_id = conn_id.as_u64(),
-                    child = format!("{child:?}")
+                    child = child.to_string()
                 );
                 return teardown(state, &params, &eff).await;
             }

--- a/crates/amaru-protocols/src/manager/mod.rs
+++ b/crates/amaru-protocols/src/manager/mod.rs
@@ -763,7 +763,13 @@ pub async fn stage(mut manager: Manager, msg: ManagerMessage, eff: Effects<Manag
                     eff.send(&connection.stage, ConnectionMessage::SetLocalUse(local_use)).await;
                 }
             }
-            ManagerMessage::LocalUseApplied { peer: _, conn_id, local_use } => {
+            ManagerMessage::LocalUseApplied { peer, conn_id, local_use } => {
+                info!(
+                    protocols::manager::peer::LOCAL_USE_APPLIED,
+                    peer,
+                    conn_id = conn_id.as_u64(),
+                    local_use = local_use.as_str(),
+                );
                 if let Some(connection) = manager.connections.get_mut(&conn_id) {
                     connection.may_initiate = local_use == LocalUse::Diffusion;
                 }

--- a/crates/amaru-protocols/src/mux.rs
+++ b/crates/amaru-protocols/src/mux.rs
@@ -122,22 +122,32 @@ pub enum HandlerMessage {
 }
 
 /// Mux citizen after an initiator has sent `MsgDone`. Any further frame is a protocol error.
-async fn done_trap(_: (), msg: HandlerMessage, eff: Effects<HandlerMessage>) -> () {
+async fn done_trap(peer: Peer, msg: HandlerMessage, eff: Effects<HandlerMessage>) -> Peer {
     match msg {
-        HandlerMessage::Registered(_) => {}
-        HandlerMessage::FromNetwork(_) => return eff.terminate().await,
+        HandlerMessage::Registered(_) => peer,
+        HandlerMessage::FromNetwork(_) => {
+            error!(
+                protocols::mux::FAILED,
+                peer,
+                role = "trap",
+                operation = "after_done",
+                error = "frame after MsgDone"
+            );
+            return eff.terminate().await;
+        }
     }
 }
 
 pub async fn install_done_trap<M: SendData>(
     muxer: &StageRef<MuxMessage>,
     protocol: ProtocolId<Erased>,
+    peer: Peer,
     eff: &Effects<M>,
     tombstone: M,
 ) {
     let trap = eff.stage("done-trap", done_trap).await;
     let trap = eff.supervise(trap, tombstone);
-    let trap = eff.wire_up(trap, ()).await;
+    let trap = eff.wire_up(trap, peer).await;
     eff.send(muxer, MuxMessage::Register { protocol, frame: Frame::OneCborItem, handler: trap, max_buffer: 5760 })
         .await;
 }

--- a/crates/amaru-pure-stage/src/simulation/running/mod.rs
+++ b/crates/amaru-pure-stage/src/simulation/running/mod.rs
@@ -1263,7 +1263,7 @@ impl SimulationRunning {
             },
             Effect::Detach { at_stage, effect } => return self.handle_detach(at_stage, effect),
             Effect::Terminate { at_stage } => {
-                tracing::info!(stage = %at_stage, "terminated");
+                tracing::debug!(stage = %at_stage, "terminated");
                 let (supervised_by, msg) = self.terminate_stage(at_stage.clone(), TerminationReason::Voluntary)?;
                 if supervised_by == *BLACKHOLE_NAME {
                     // top-level stage terminated, terminate the simulation

--- a/crates/amaru-pure-stage/src/tokio.rs
+++ b/crates/amaru-pure-stage/src/tokio.rs
@@ -407,7 +407,7 @@ fn run_stage_boxed(
                 match result {
                     Some(st) => state = st,
                     None => {
-                        tracing::info!(%stage_name, "terminated");
+                        tracing::debug!(%stage_name, "terminated");
                         tb.lock().push_terminated_voluntary(&stage_name);
                         break 'outer;
                     }
@@ -592,7 +592,7 @@ async fn interpreter(
                 StageResponse::ExternalResponse(Box::new(()))
             }
             StageEffect::Terminate => {
-                tracing::warn!("stage `{name}` terminated");
+                tracing::debug!("stage `{name}` terminated");
                 return None;
             }
             StageEffect::AddStage(name) => {

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -2616,8 +2616,9 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | `disconnecting` | `TRACE` | public | A connection is being closed on request. Direction ∈ {inbound, outbound}. | peer, conn_id, direction |  |
 | `duplicate_terminated` | `TRACE` | public | A duplicate connection is terminated after its handshake completed | peer, conn_id |  |
 | `handshake_completed` | `TRACE` | public | The handshake completed on a connection | peer, conn_id, full_duplex_capable, full_duplex, advertisable |  |
+| `local_use_applied` | `TRACE` | public | The connection finished converging to this local use | peer, conn_id, local_use |  |
 | `remove` | `TRACE` | public | A peer was removed from the manager | peer |  |
-| `set_local_use` | `TRACE` | public | Local use of a connection was changed | peer, conn_id, local_use |  |
+| `set_local_use` | `TRACE` | public | A change of local use was requested on a connection | peer, conn_id, local_use |  |
 
 <details><summary>span: `accepted`</summary>
 
@@ -2748,6 +2749,16 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 </details>
 
+<details><summary>span: `local_use_applied`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `peer` | `string` | ✓ |
+| `conn_id` | `integer` | ✓ |
+| `local_use` | `string` | ✓ |
+
+</details>
+
 <details><summary>span: `remove`</summary>
 
 | field | type | required |
@@ -2771,7 +2782,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
 | `empty_segment` | `TRACE` | public | A segment header announcing an empty payload was received | role, peer |  |
-| `failed` | `TRACE` | public | The muxer failed while moving data between a protocol and the network. Operation ∈ {send, recv_header, decode_header, recv_data, muxing}. | role, peer, operation, error |  |
+| `failed` | `TRACE` | public | The muxer failed while moving data between a protocol and the network. Operation ∈ {send, recv_header, decode_header, recv_data, muxing, after_done}. | role, peer, operation, error |  |
 
 <details><summary>span: `empty_segment`</summary>
 

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -7162,6 +7162,32 @@
       "description": "The handshake completed on a connection",
       "public": true
     },
+    "amaru::protocols::manager::peer::LOCAL_USE_APPLIED": {
+      "type": "object",
+      "properties": {
+        "peer": {
+          "type": "string"
+        },
+        "conn_id": {
+          "type": "integer"
+        },
+        "local_use": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "peer",
+        "conn_id",
+        "local_use"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "local_use_applied",
+      "level": "TRACE",
+      "target": "amaru::protocols::manager::peer",
+      "description": "The connection finished converging to this local use",
+      "public": true
+    },
     "amaru::protocols::manager::peer::REMOVE": {
       "type": "object",
       "properties": {
@@ -7203,7 +7229,7 @@
       "name": "set_local_use",
       "level": "TRACE",
       "target": "amaru::protocols::manager::peer",
-      "description": "Local use of a connection was changed",
+      "description": "A change of local use was requested on a connection",
       "public": true
     },
     "amaru::protocols::mux::EMPTY_SEGMENT": {
@@ -7255,7 +7281,7 @@
       "name": "failed",
       "level": "TRACE",
       "target": "amaru::protocols::mux",
-      "description": "The muxer failed while moving data between a protocol and the network. Operation ∈ {send, recv_header, decode_header, recv_data, muxing}.",
+      "description": "The muxer failed while moving data between a protocol and the network. Operation ∈ {send, recv_header, decode_header, recv_data, muxing, after_done}.",
       "public": true
     },
     "amaru::protocols::mux::protocol::BUFFER_EXCEEDED": {


### PR DESCRIPTION
to check that we can receive headers and blocks from a node we cannot dial

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added observability when a connection finishes applying its local-use setting.
  - Improved inbound duplex connection promotion to diffusion.
  - Added error reporting when a protocol stage fails after completion.

- **Bug Fixes**
  - Ensured peer regulation runs consistently after inbound reconnections.
  - Improved connection and child identifiers in logs.

- **Documentation**
  - Updated trace documentation and schemas for local-use changes, connection failures, and intersection points.

- **Refactor**
  - Centralized shared test setup and assertions for networking scenarios.

- **Style**
  - Reduced routine stage-termination messages to debug-level logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->