### PR TITLE
baby steps towards more readable typestate errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Other guiding principles:
 - **amaru-protocols**: handshake agrees version data per the node-to-node spec: network magics must match, initiator-only and query are OR, peer-sharing is AND. The initiator drops the connection if `MsgAcceptVersion` does not carry that record. ([#884](https://github.com/pragma-org/amaru/issues/884))
 - **amaru-protocols**: mux SDU assembly waits indefinitely for the first header byte, then 10s for the rest of the first Handshake message and 30s afterwards. Exceeding that limit tears the connection down.
 - **amaru**: the `mempool_max_bytes` startup trace field is now an IEC size such as `176 KiB` instead of a raw integer.
-- **amaru-pure-stage**: typestate remainders are `Choice` / `Par` / `Repeat` wrapping tuples of length at most 10, so rustc prints `Choice<(Then<Par<((Send<Role, T>, Wait),)>, Idle>,)>` instead of a Cons encoding. `Session::remainder()` returns the surface syntax as `&'static str` (`"Send<Role, T> => Idle"`). `send_any` is always in scope; a missing `SendAny` fails at `.await` (`IntoFuture`) instead of “no method named send_any”. Other protocol steps live on `SessionOps` (prelude) with `Take` / `FinishIn` bounds.
+- **amaru-pure-stage**: typestate remainders are `Choice` / `Par` / `Repeat` wrapping tuples of length at most 10, so rustc prints `Choice<(Then<Par<((Send<Role, T>, Wait),)>, Idle>,)>` instead of a Cons encoding. `reveal_remainder!(session)` is a compile-time dump of the surface syntax (`error[E0080]: evaluation panicked: Send<Role, T> => Idle`). `send_any` is always in scope; a missing `SendAny` fails at `.await` (`IntoFuture`) instead of “no method named send_any”. Other protocol steps live on `SessionOps` (prelude) with `Take` / `FinishIn` bounds.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Other guiding principles:
 - **amaru-protocols**: handshake agrees version data per the node-to-node spec: network magics must match, initiator-only and query are OR, peer-sharing is AND. The initiator drops the connection if `MsgAcceptVersion` does not carry that record. ([#884](https://github.com/pragma-org/amaru/issues/884))
 - **amaru-protocols**: mux SDU assembly waits indefinitely for the first header byte, then 10s for the rest of the first Handshake message and 30s afterwards. Exceeding that limit tears the connection down.
 - **amaru**: the `mempool_max_bytes` startup trace field is now an IEC size such as `176 KiB` instead of a raw integer.
-- **amaru-pure-stage**: typestate remainders are `Choice` / `Par` / `Repeat` wrapping tuples of length at most 10, so rustc prints `Choice<(Then<Par<((Send<Role, T>, Wait),)>, Idle>,)>` instead of a Cons encoding. `send_any` is always in scope; a missing `SendAny` fails at `.await` (`IntoFuture`) instead of “no method named send_any”. Other protocol steps live on `SessionOps` (prelude) with `Take` / `FinishIn` bounds.
+- **amaru-pure-stage**: typestate remainders are `Choice` / `Par` / `Repeat` wrapping tuples of length at most 10, so rustc prints `Choice<(Then<Par<((Send<Role, T>, Wait),)>, Idle>,)>` instead of a Cons encoding. `Session::remainder()` returns the surface syntax as `&'static str` (`"Send<Role, T> => Idle"`). `send_any` is always in scope; a missing `SendAny` fails at `.await` (`IntoFuture`) instead of “no method named send_any”. Other protocol steps live on `SessionOps` (prelude) with `Take` / `FinishIn` bounds.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Other guiding principles:
 - **amaru-protocols**: handshake agrees version data per the node-to-node spec: network magics must match, initiator-only and query are OR, peer-sharing is AND. The initiator drops the connection if `MsgAcceptVersion` does not carry that record. ([#884](https://github.com/pragma-org/amaru/issues/884))
 - **amaru-protocols**: mux SDU assembly waits indefinitely for the first header byte, then 10s for the rest of the first Handshake message and 30s afterwards. Exceeding that limit tears the connection down.
 - **amaru**: the `mempool_max_bytes` startup trace field is now an IEC size such as `176 KiB` instead of a raw integer.
+- **amaru-pure-stage**: typestate remainders are right-nested pairs (`Cons<H, T>` = `(H, T)`, `Nil` = `()`), so rustc prints `(Send<Role, T>, (Wait, ()))` instead of a Cons encoding. `send_any` is always in scope; a missing `SendAny` fails at `.await` (`IntoFuture`) instead of “no method named send_any”. Other protocol steps live on `SessionOps` (prelude) with `Take` / `FinishIn` bounds.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Other guiding principles:
 - **amaru-protocols**: handshake agrees version data per the node-to-node spec: network magics must match, initiator-only and query are OR, peer-sharing is AND. The initiator drops the connection if `MsgAcceptVersion` does not carry that record. ([#884](https://github.com/pragma-org/amaru/issues/884))
 - **amaru-protocols**: mux SDU assembly waits indefinitely for the first header byte, then 10s for the rest of the first Handshake message and 30s afterwards. Exceeding that limit tears the connection down.
 - **amaru**: the `mempool_max_bytes` startup trace field is now an IEC size such as `176 KiB` instead of a raw integer.
-- **amaru-pure-stage**: typestate remainders are right-nested pairs (`Cons<H, T>` = `(H, T)`, `Nil` = `()`), so rustc prints `(Send<Role, T>, (Wait, ()))` instead of a Cons encoding. `send_any` is always in scope; a missing `SendAny` fails at `.await` (`IntoFuture`) instead of “no method named send_any”. Other protocol steps live on `SessionOps` (prelude) with `Take` / `FinishIn` bounds.
+- **amaru-pure-stage**: typestate remainders are `Choice` / `Par` / `Repeat` wrapping tuples of length at most 10, so rustc prints `Choice<(Then<Par<((Send<Role, T>, Wait),)>, Idle>,)>` instead of a Cons encoding. `send_any` is always in scope; a missing `SendAny` fails at `.await` (`IntoFuture`) instead of “no method named send_any”. Other protocol steps live on `SessionOps` (prelude) with `Take` / `FinishIn` bounds.
 
 ### Fixed
 

--- a/crates/amaru-protocols/src/lib.rs
+++ b/crates/amaru-protocols/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(type_alias_impl_trait)]
+#![feature(type_alias_impl_trait, generic_const_exprs)]
 
 #[cfg(all(not(target_family = "wasm"), not(target_arch = "riscv32")))]
 const _: () = amaru_deps::AMARU_DEPS_USED;

--- a/crates/amaru-pure-stage/src/lib.rs
+++ b/crates/amaru-pure-stage/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(generic_const_exprs, const_type_name)]
+#![feature(generic_const_exprs, const_type_name, unsized_const_params, adt_const_params)]
 #![allow(incomplete_features)]
 #![deny(clippy::future_not_send)]
 

--- a/crates/amaru-pure-stage/src/typestate.rs
+++ b/crates/amaru-pure-stage/src/typestate.rs
@@ -30,6 +30,11 @@
 //! star. Use [`Session::discard_repeat`](session::Session::discard_repeat)
 //! after the last iteration.
 //!
+//! Hover a failing `send` still shows the encoding. Bind
+//! [`Session::remainder`](session::Session::remainder) for the surface syntax
+//! (`"Send<Role, T> => Idle"`): rust-analyzer may show the string; otherwise
+//! comment out the bad call and print or `assert_eq!` the binding.
+//!
 //! **Limits:** sequences, parallel branches, and choice alternatives are tuples
 //! of length at most 10 ([`Choice`] / [`Par`] / [`Repeat`] wrap those tuples).
 //! Sequences are ordered. When several parallel heads match, the **leftmost**
@@ -39,6 +44,7 @@
 //! required remainders for agency timers (`Effects::set_timeout`). Existing
 //! stages keep using [`Effects`](crate::Effects).
 
+mod describe;
 mod effect;
 mod list;
 mod macros;
@@ -46,6 +52,7 @@ mod occupancy;
 mod role;
 mod session;
 
+pub use describe::{ConstDesc, Remainder};
 pub use effect::{
     AddStage, Call, CancelSchedule, ClearTimeout, Clock, Effect, External, Receive, Repeat, Schedule, Send, SendAny,
     SetTimeout, Terminate, Wait,
@@ -61,8 +68,8 @@ pub use session::{
 pub mod prelude {
     pub use super::{
         AddStage, Call, CancelSchedule, Choice, ClearTimeout, Clock, External, ExtractInput, FromMailbox, IntoRoleCall,
-        IntoRoleMail, Occupancy, OccupancyOf, OnReceive, Par, Receive, Repeat, Role, RoleTag, Schedule, Send, SendAny,
-        Session, SessionOps, SetTimeout, State, Terminate, To, Wait, initial_state,
+        IntoRoleMail, Occupancy, OccupancyOf, OnReceive, Par, Receive, Remainder, Repeat, Role, RoleTag, Schedule,
+        Send, SendAny, Session, SessionOps, SetTimeout, State, Terminate, To, Wait, initial_state,
     };
     pub use crate::{define_mailbox, define_messages, define_role, define_role_tag, make_states, on_receive, star};
 }

--- a/crates/amaru-pure-stage/src/typestate.rs
+++ b/crates/amaru-pure-stage/src/typestate.rs
@@ -30,7 +30,8 @@
 //! star. Use [`Session::discard_repeat`](session::Session::discard_repeat)
 //! after the last iteration.
 //!
-//! **Limits:** parallel and choice are right-nested pair lists (not tree-associative).
+//! **Limits:** sequences, parallel branches, and choice alternatives are tuples
+//! of length at most 10 ([`Choice`] / [`Par`] / [`Repeat`] wrap those tuples).
 //! Sequences are ordered. When several parallel heads match, the **leftmost**
 //! wins. Two choice alternatives with the same head are ambiguous (payload
 //! inference would otherwise stick to the first alternative). `finish` strips
@@ -49,7 +50,7 @@ pub use effect::{
     AddStage, Call, CancelSchedule, ClearTimeout, Clock, Effect, External, Receive, Repeat, Schedule, Send, SendAny,
     SetTimeout, Terminate, Wait,
 };
-pub use list::{CanFinish, Clean, Cons, DiscardRepeat, FinishIn, FmtPar, Here, Nil, Select, Take, Then};
+pub use list::{CanFinish, Choice, Clean, DiscardRepeat, FinishIn, FmtPar, Here, Par, Select, Take, Then};
 pub use occupancy::{Occupancy, OccupancyOf};
 pub use role::{IntoRoleCall, IntoRoleMail, Role, RoleTag};
 pub use session::{
@@ -59,8 +60,8 @@ pub use session::{
 
 pub mod prelude {
     pub use super::{
-        AddStage, Call, CancelSchedule, ClearTimeout, Clock, Cons, External, ExtractInput, FromMailbox, IntoRoleCall,
-        IntoRoleMail, Nil, Occupancy, OccupancyOf, OnReceive, Receive, Repeat, Role, RoleTag, Schedule, Send, SendAny,
+        AddStage, Call, CancelSchedule, Choice, ClearTimeout, Clock, External, ExtractInput, FromMailbox, IntoRoleCall,
+        IntoRoleMail, Occupancy, OccupancyOf, OnReceive, Par, Receive, Repeat, Role, RoleTag, Schedule, Send, SendAny,
         Session, SessionOps, SetTimeout, State, Terminate, To, Wait, initial_state,
     };
     pub use crate::{define_mailbox, define_messages, define_role, define_role_tag, make_states, on_receive, star};

--- a/crates/amaru-pure-stage/src/typestate.rs
+++ b/crates/amaru-pure-stage/src/typestate.rs
@@ -30,7 +30,7 @@
 //! star. Use [`Session::discard_repeat`](session::Session::discard_repeat)
 //! after the last iteration.
 //!
-//! **Limits:** parallel and choice are flat `Cons` lists (not tree-associative).
+//! **Limits:** parallel and choice are right-nested pair lists (not tree-associative).
 //! Sequences are ordered. When several parallel heads match, the **leftmost**
 //! wins. Two choice alternatives with the same head are ambiguous (payload
 //! inference would otherwise stick to the first alternative). `finish` strips
@@ -49,18 +49,19 @@ pub use effect::{
     AddStage, Call, CancelSchedule, ClearTimeout, Clock, Effect, External, Receive, Repeat, Schedule, Send, SendAny,
     SetTimeout, Terminate, Wait,
 };
-pub use list::{CanFinish, Clean, Cons, DiscardRepeat, FmtPar, Here, Nil, Select, Then};
+pub use list::{CanFinish, Clean, Cons, DiscardRepeat, FinishIn, FmtPar, Here, Nil, Select, Take, Then};
 pub use occupancy::{Occupancy, OccupancyOf};
 pub use role::{IntoRoleCall, IntoRoleMail, Role, RoleTag};
 pub use session::{
-    ExtractInput, FromMailbox, InitialState, Marker, NotInitialState, OnReceive, Session, State, To, initial_state,
+    ExtractInput, FromMailbox, InitialState, Marker, NotInitialState, OnReceive, SendAnyOp, Session, SessionOps, State,
+    To, initial_state,
 };
 
 pub mod prelude {
     pub use super::{
         AddStage, Call, CancelSchedule, ClearTimeout, Clock, Cons, External, ExtractInput, FromMailbox, IntoRoleCall,
         IntoRoleMail, Nil, Occupancy, OccupancyOf, OnReceive, Receive, Repeat, Role, RoleTag, Schedule, Send, SendAny,
-        Session, SetTimeout, State, Terminate, To, Wait, initial_state,
+        Session, SessionOps, SetTimeout, State, Terminate, To, Wait, initial_state,
     };
     pub use crate::{define_mailbox, define_messages, define_role, define_role_tag, make_states, on_receive, star};
 }

--- a/crates/amaru-pure-stage/src/typestate.rs
+++ b/crates/amaru-pure-stage/src/typestate.rs
@@ -30,10 +30,10 @@
 //! star. Use [`Session::discard_repeat`](session::Session::discard_repeat)
 //! after the last iteration.
 //!
-//! Hover a failing `send` still shows the encoding. Bind
-//! [`Session::remainder`](session::Session::remainder) for the surface syntax
-//! (`"Send<Role, T> => Idle"`): rust-analyzer may show the string; otherwise
-//! comment out the bad call and print or `assert_eq!` the binding.
+//! Hover a failing `send` still shows the encoding. Dump the surface syntax
+//! (`"Send<Role, T> => Idle"`) with [`reveal_remainder`](crate::reveal_remainder)
+//! (`reveal_remainder!(streaming)` → E0080 with that string). [`Session::remainder`](session::Session::remainder)
+//! returns the same `&str` at runtime.
 //!
 //! **Limits:** sequences, parallel branches, and choice alternatives are tuples
 //! of length at most 10 ([`Choice`] / [`Par`] / [`Repeat`] wrap those tuples).
@@ -52,7 +52,7 @@ mod occupancy;
 mod role;
 mod session;
 
-pub use describe::{ConstDesc, Remainder};
+pub use describe::{ConstDesc, Remainder, remainder_ctfe_panic};
 pub use effect::{
     AddStage, Call, CancelSchedule, ClearTimeout, Clock, Effect, External, Receive, Repeat, Schedule, Send, SendAny,
     SetTimeout, Terminate, Wait,
@@ -71,7 +71,9 @@ pub mod prelude {
         IntoRoleMail, Occupancy, OccupancyOf, OnReceive, Par, Receive, Remainder, Repeat, Role, RoleTag, Schedule,
         Send, SendAny, Session, SessionOps, SetTimeout, State, Terminate, To, Wait, initial_state,
     };
-    pub use crate::{define_mailbox, define_messages, define_role, define_role_tag, make_states, on_receive, star};
+    pub use crate::{
+        define_mailbox, define_messages, define_role, define_role_tag, make_states, on_receive, reveal_remainder, star,
+    };
 }
 
 #[cfg(test)]

--- a/crates/amaru-pure-stage/src/typestate/describe.rs
+++ b/crates/amaru-pure-stage/src/typestate/describe.rs
@@ -1,0 +1,315 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Const pretty-print of a remainder so rustc / rust-analyzer can put the
+//! surface syntax in a type (`Remainder<"Send<Role, T> => Idle">`).
+
+use std::{any::type_name, fmt, marker::PhantomData};
+
+use super::{
+    State,
+    effect::{
+        AddStage, Call, CancelSchedule, ClearTimeout, Clock, External, Receive, Repeat, Schedule, Send, SendAny,
+        SetTimeout, Terminate, Wait,
+    },
+    list::{Choice, Par, Then, Uncons},
+};
+
+/// Const `&'static str` form of a remainder or effect (`Send<Role, T> => Idle`).
+pub trait ConstDesc {
+    const TEXT: &'static str;
+}
+
+/// ZST whose const parameter is the pretty remainder. Hover a binding of this
+/// type (or ascribe a guess) to read the session at that point.
+pub struct Remainder<const TEXT: &'static str>;
+
+impl<const TEXT: &'static str> Remainder<TEXT> {
+    /// The pretty remainder string (same as [`TEXT`](Self::TEXT) the type carries).
+    pub const TEXT: &'static str = TEXT;
+}
+
+impl<const TEXT: &'static str> fmt::Debug for Remainder<TEXT> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(TEXT)
+    }
+}
+
+impl<const TEXT: &'static str> fmt::Display for Remainder<TEXT> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(TEXT)
+    }
+}
+
+const fn write_str(buf: &mut [u8], mut pos: usize, s: &str) -> usize {
+    let b = s.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        buf[pos] = b[i];
+        pos += 1;
+        i += 1;
+    }
+    pos
+}
+
+const fn join_len(a: &str, sep: &str, b: &str) -> usize {
+    a.len() + sep.len() + b.len()
+}
+
+const fn wrap_len(pre: &str, inner: &str, suf: &str) -> usize {
+    pre.len() + inner.len() + suf.len()
+}
+
+const fn angle2_len<R, T>(name: &str) -> usize {
+    name.len() + 1 + type_name::<R>().len() + 2 + type_name::<T>().len() + 1
+}
+
+const fn angle1_len<R>(name: &str) -> usize {
+    name.len() + 1 + type_name::<R>().len() + 1
+}
+
+const fn str_from_bytes(bytes: &[u8]) -> &str {
+    // Only `write_str` of UTF-8 literals and `type_name` output fills these buffers.
+    unsafe { core::str::from_utf8_unchecked(bytes) }
+}
+
+struct Angle2<R, T, const NAME: &'static str, const N: usize>(PhantomData<(R, T)>);
+impl<R, T, const NAME: &'static str, const N: usize> Angle2<R, T, NAME, N> {
+    const BYTES: [u8; N] = {
+        let mut buf = [0u8; N];
+        let mut pos = 0;
+        pos = write_str(&mut buf, pos, NAME);
+        pos = write_str(&mut buf, pos, "<");
+        pos = write_str(&mut buf, pos, type_name::<R>());
+        pos = write_str(&mut buf, pos, ", ");
+        pos = write_str(&mut buf, pos, type_name::<T>());
+        let _ = write_str(&mut buf, pos, ">");
+        buf
+    };
+    const TEXT: &'static str = str_from_bytes(&Self::BYTES);
+}
+
+struct Angle1<R, const NAME: &'static str, const N: usize>(PhantomData<R>);
+impl<R, const NAME: &'static str, const N: usize> Angle1<R, NAME, N> {
+    const BYTES: [u8; N] = {
+        let mut buf = [0u8; N];
+        let mut pos = 0;
+        pos = write_str(&mut buf, pos, NAME);
+        pos = write_str(&mut buf, pos, "<");
+        pos = write_str(&mut buf, pos, type_name::<R>());
+        let _ = write_str(&mut buf, pos, ">");
+        buf
+    };
+    const TEXT: &'static str = str_from_bytes(&Self::BYTES);
+}
+
+struct JoinBuf<A, B, const SEP: &'static str, const N: usize>(PhantomData<(A, B)>);
+impl<A: ConstDesc, B: ConstDesc, const SEP: &'static str, const N: usize> JoinBuf<A, B, SEP, N> {
+    const BYTES: [u8; N] = {
+        let mut buf = [0u8; N];
+        let mut pos = 0;
+        pos = write_str(&mut buf, pos, A::TEXT);
+        pos = write_str(&mut buf, pos, SEP);
+        let _ = write_str(&mut buf, pos, B::TEXT);
+        buf
+    };
+    const TEXT: &'static str = str_from_bytes(&Self::BYTES);
+}
+
+struct WrapBuf<T, const PRE: &'static str, const SUF: &'static str, const N: usize>(PhantomData<T>);
+impl<T: ConstDesc, const PRE: &'static str, const SUF: &'static str, const N: usize> WrapBuf<T, PRE, SUF, N> {
+    const BYTES: [u8; N] = {
+        let mut buf = [0u8; N];
+        let mut pos = 0;
+        pos = write_str(&mut buf, pos, PRE);
+        pos = write_str(&mut buf, pos, T::TEXT);
+        let _ = write_str(&mut buf, pos, SUF);
+        buf
+    };
+    const TEXT: &'static str = str_from_bytes(&Self::BYTES);
+}
+
+struct ThenBuf<P, S, const N: usize>(PhantomData<(P, S)>);
+impl<P: ConstDesc, S: State, const N: usize> ThenBuf<P, S, N> {
+    const BYTES: [u8; N] = {
+        let mut buf = [0u8; N];
+        let mut pos = 0;
+        pos = write_str(&mut buf, pos, P::TEXT);
+        pos = write_str(&mut buf, pos, " => ");
+        let _ = write_str(&mut buf, pos, S::NAME);
+        buf
+    };
+    const TEXT: &'static str = str_from_bytes(&Self::BYTES);
+}
+
+struct EmptyThenBuf<S: State, const N: usize>(PhantomData<S>);
+impl<S: State, const N: usize> EmptyThenBuf<S, N> {
+    const BYTES: [u8; N] = {
+        let mut buf = [0u8; N];
+        let mut pos = 0;
+        pos = write_str(&mut buf, pos, "=> ");
+        let _ = write_str(&mut buf, pos, S::NAME);
+        buf
+    };
+    const TEXT: &'static str = str_from_bytes(&Self::BYTES);
+}
+
+macro_rules! const_lit {
+    ($ty:ty, $text:expr) => {
+        impl ConstDesc for $ty {
+            const TEXT: &'static str = $text;
+        }
+    };
+}
+
+const_lit!(Wait, "Wait");
+const_lit!(Clock, "Clock");
+const_lit!(Terminate, "Terminate");
+const_lit!(CancelSchedule, "CancelSchedule");
+const_lit!(SetTimeout, "SetTimeout");
+const_lit!(ClearTimeout, "ClearTimeout");
+const_lit!(AddStage, "AddStage");
+
+impl<R, T> ConstDesc for Send<R, T>
+where
+    [(); angle2_len::<R, T>("Send")]:,
+{
+    const TEXT: &'static str = Angle2::<R, T, "Send", { angle2_len::<R, T>("Send") }>::TEXT;
+}
+
+impl<R, T> ConstDesc for Call<R, T>
+where
+    [(); angle2_len::<R, T>("Call")]:,
+{
+    const TEXT: &'static str = Angle2::<R, T, "Call", { angle2_len::<R, T>("Call") }>::TEXT;
+}
+
+impl<R> ConstDesc for SendAny<R>
+where
+    [(); angle1_len::<R>("SendAny")]:,
+{
+    const TEXT: &'static str = Angle1::<R, "SendAny", { angle1_len::<R>("SendAny") }>::TEXT;
+}
+
+impl<T> ConstDesc for Receive<T>
+where
+    [(); angle1_len::<T>("Receive")]:,
+{
+    const TEXT: &'static str = Angle1::<T, "Receive", { angle1_len::<T>("Receive") }>::TEXT;
+}
+
+impl<T> ConstDesc for Schedule<T>
+where
+    [(); angle1_len::<T>("Schedule")]:,
+{
+    const TEXT: &'static str = Angle1::<T, "Schedule", { angle1_len::<T>("Schedule") }>::TEXT;
+}
+
+impl<E: crate::ExternalEffect> ConstDesc for External<E>
+where
+    [(); angle1_len::<E>("External")]:,
+{
+    const TEXT: &'static str = Angle1::<E, "External", { angle1_len::<E>("External") }>::TEXT;
+}
+
+impl<E: ConstDesc> ConstDesc for Repeat<E>
+where
+    [(); wrap_len("Repeat<", E::TEXT, ">")]:,
+{
+    const TEXT: &'static str = WrapBuf::<E, "Repeat<", ">", { wrap_len("Repeat<", E::TEXT, ">") }>::TEXT;
+}
+
+macro_rules! impl_const_seq {
+    ($H:ident) => {
+        impl<$H: ConstDesc> ConstDesc for ($H,) {
+            const TEXT: &'static str = $H::TEXT;
+        }
+    };
+    ($H:ident, $($T:ident),+) => {
+        impl<$H: ConstDesc, $($T: ConstDesc),+> ConstDesc for ($H, $($T,)+)
+        where
+            ($($T,)+): ConstDesc,
+            [(); $H::TEXT.len() $(+ 2 + $T::TEXT.len())*]:,
+        {
+            const TEXT: &'static str = JoinBuf::<
+                $H,
+                ($($T,)+),
+                ", ",
+                { $H::TEXT.len() $(+ 2 + $T::TEXT.len())* },
+            >::TEXT;
+        }
+        impl_const_seq!($($T),+);
+    };
+}
+
+macro_rules! impl_const_par {
+    ($H:ident) => {
+        impl<$H: ConstDesc> ConstDesc for Par<($H,)> {
+            const TEXT: &'static str = $H::TEXT;
+        }
+        impl<$H: ConstDesc> ConstDesc for Choice<($H,)> {
+            const TEXT: &'static str = $H::TEXT;
+        }
+    };
+    ($H:ident, $($T:ident),+) => {
+        impl<$H: ConstDesc, $($T: ConstDesc),+> ConstDesc for Par<($H, $($T,)+)>
+        where
+            Par<($($T,)+)>: ConstDesc,
+            [(); $H::TEXT.len() $(+ 3 + $T::TEXT.len())*]:,
+        {
+            const TEXT: &'static str = JoinBuf::<
+                $H,
+                Par<($($T,)+)>,
+                " | ",
+                { $H::TEXT.len() $(+ 3 + $T::TEXT.len())* },
+            >::TEXT;
+        }
+        impl<$H: ConstDesc, $($T: ConstDesc),+> ConstDesc for Choice<($H, $($T,)+)>
+        where
+            Choice<($($T,)+)>: ConstDesc,
+            [(); $H::TEXT.len() $(+ 3 + $T::TEXT.len())*]:,
+        {
+            const TEXT: &'static str = JoinBuf::<
+                $H,
+                Choice<($($T,)+)>,
+                " | ",
+                { $H::TEXT.len() $(+ 3 + $T::TEXT.len())* },
+            >::TEXT;
+        }
+        impl_const_par!($($T),+);
+    };
+}
+
+impl_const_seq!(E0, E1, E2, E3, E4, E5, E6, E7, E8, E9);
+impl_const_par!(B0, B1, B2, B3, B4, B5, B6, B7, B8, B9);
+
+impl ConstDesc for Par<()> {
+    const TEXT: &'static str = "(none)";
+}
+
+impl<S: State> ConstDesc for Then<Par<()>, S>
+where
+    [(); wrap_len("=> ", S::NAME, "")]:,
+{
+    const TEXT: &'static str = EmptyThenBuf::<S, { wrap_len("=> ", S::NAME, "") }>::TEXT;
+}
+
+impl<P, S: State> ConstDesc for Then<Par<P>, S>
+where
+    P: Uncons,
+    Par<P>: ConstDesc,
+    [(); join_len(<Par<P> as ConstDesc>::TEXT, " => ", S::NAME)]:,
+{
+    const TEXT: &'static str = ThenBuf::<Par<P>, S, { join_len(<Par<P> as ConstDesc>::TEXT, " => ", S::NAME) }>::TEXT;
+}

--- a/crates/amaru-pure-stage/src/typestate/describe.rs
+++ b/crates/amaru-pure-stage/src/typestate/describe.rs
@@ -31,6 +31,14 @@ pub trait ConstDesc {
     const TEXT: &'static str;
 }
 
+/// Always panics with [`ConstDesc::TEXT`]. Used by [`reveal_remainder`](crate::reveal_remainder)
+/// to force a compile-time diagnostic that prints the pretty remainder.
+#[doc(hidden)]
+#[allow(clippy::panic)]
+pub const fn remainder_ctfe_panic<Rem: ConstDesc>() -> usize {
+    panic!("{}", Rem::TEXT);
+}
+
 /// ZST whose const parameter is the pretty remainder. Hover a binding of this
 /// type (or ascribe a guess) to read the session at that point.
 pub struct Remainder<const TEXT: &'static str>;
@@ -52,6 +60,8 @@ impl<const TEXT: &'static str> fmt::Display for Remainder<TEXT> {
     }
 }
 
+const MAX: usize = 1024;
+
 const fn write_str(buf: &mut [u8], mut pos: usize, s: &str) -> usize {
     let b = s.as_bytes();
     let mut i = 0;
@@ -63,106 +73,148 @@ const fn write_str(buf: &mut [u8], mut pos: usize, s: &str) -> usize {
     pos
 }
 
-const fn join_len(a: &str, sep: &str, b: &str) -> usize {
-    a.len() + sep.len() + b.len()
+const fn is_ident_start(c: u8) -> bool {
+    c.is_ascii_alphabetic() || c == b'_'
 }
 
-const fn wrap_len(pre: &str, inner: &str, suf: &str) -> usize {
-    pre.len() + inner.len() + suf.len()
+const fn is_ident_continue(c: u8) -> bool {
+    c.is_ascii_alphanumeric() || c == b'_'
 }
 
-const fn angle2_len<R, T>(name: &str) -> usize {
-    name.len() + 1 + type_name::<R>().len() + 2 + type_name::<T>().len() + 1
+const fn skip_ident(b: &[u8], mut i: usize) -> usize {
+    while i < b.len() && is_ident_continue(b[i]) {
+        i += 1;
+    }
+    i
 }
 
-const fn angle1_len<R>(name: &str) -> usize {
-    name.len() + 1 + type_name::<R>().len() + 1
+/// `alloc::string::String` → `String`, `core::option::Option<foo::Bar>` → `Option<Bar>`.
+const fn write_short_name(buf: &mut [u8], mut pos: usize, s: &str) -> usize {
+    let b = s.as_bytes();
+    let mut i = 0;
+    while i < b.len() {
+        if is_ident_start(b[i]) {
+            let mut last;
+            loop {
+                last = i;
+                i = skip_ident(b, i);
+                if i + 1 < b.len() && b[i] == b':' && b[i + 1] == b':' {
+                    i += 2;
+                } else {
+                    break;
+                }
+            }
+            let mut k = last;
+            while k < i {
+                buf[pos] = b[k];
+                pos += 1;
+                k += 1;
+            }
+        } else {
+            buf[pos] = b[i];
+            pos += 1;
+            i += 1;
+        }
+    }
+    pos
 }
 
-const fn str_from_bytes(bytes: &[u8]) -> &str {
+const fn short_name_len(s: &str) -> usize {
+    let mut tmp = [0u8; MAX];
+    write_short_name(&mut tmp, 0, s)
+}
+
+const fn str_from_buf(buf: &'static [u8; MAX], len: usize) -> &'static str {
+    assert!(len <= MAX);
     // Only `write_str` of UTF-8 literals and `type_name` output fills these buffers.
-    unsafe { core::str::from_utf8_unchecked(bytes) }
+    unsafe { core::str::from_utf8_unchecked(core::slice::from_raw_parts(buf.as_ptr(), len)) }
 }
 
-struct Angle2<R, T, const NAME: &'static str, const N: usize>(PhantomData<(R, T)>);
-impl<R, T, const NAME: &'static str, const N: usize> Angle2<R, T, NAME, N> {
-    const BYTES: [u8; N] = {
-        let mut buf = [0u8; N];
+struct Angle2<R, T, const NAME: &'static str>(PhantomData<(R, T)>);
+impl<R, T, const NAME: &'static str> Angle2<R, T, NAME> {
+    const LEN: usize = NAME.len() + 1 + short_name_len(type_name::<R>()) + 2 + short_name_len(type_name::<T>()) + 1;
+    const BUF: [u8; MAX] = {
+        let mut buf = [0u8; MAX];
         let mut pos = 0;
         pos = write_str(&mut buf, pos, NAME);
         pos = write_str(&mut buf, pos, "<");
-        pos = write_str(&mut buf, pos, type_name::<R>());
+        pos = write_short_name(&mut buf, pos, type_name::<R>());
         pos = write_str(&mut buf, pos, ", ");
-        pos = write_str(&mut buf, pos, type_name::<T>());
+        pos = write_short_name(&mut buf, pos, type_name::<T>());
         let _ = write_str(&mut buf, pos, ">");
         buf
     };
-    const TEXT: &'static str = str_from_bytes(&Self::BYTES);
+    const TEXT: &'static str = str_from_buf(&Self::BUF, Self::LEN);
 }
 
-struct Angle1<R, const NAME: &'static str, const N: usize>(PhantomData<R>);
-impl<R, const NAME: &'static str, const N: usize> Angle1<R, NAME, N> {
-    const BYTES: [u8; N] = {
-        let mut buf = [0u8; N];
+struct Angle1<R, const NAME: &'static str>(PhantomData<R>);
+impl<R, const NAME: &'static str> Angle1<R, NAME> {
+    const LEN: usize = NAME.len() + 1 + short_name_len(type_name::<R>()) + 1;
+    const BUF: [u8; MAX] = {
+        let mut buf = [0u8; MAX];
         let mut pos = 0;
         pos = write_str(&mut buf, pos, NAME);
         pos = write_str(&mut buf, pos, "<");
-        pos = write_str(&mut buf, pos, type_name::<R>());
+        pos = write_short_name(&mut buf, pos, type_name::<R>());
         let _ = write_str(&mut buf, pos, ">");
         buf
     };
-    const TEXT: &'static str = str_from_bytes(&Self::BYTES);
+    const TEXT: &'static str = str_from_buf(&Self::BUF, Self::LEN);
 }
 
-struct JoinBuf<A, B, const SEP: &'static str, const N: usize>(PhantomData<(A, B)>);
-impl<A: ConstDesc, B: ConstDesc, const SEP: &'static str, const N: usize> JoinBuf<A, B, SEP, N> {
-    const BYTES: [u8; N] = {
-        let mut buf = [0u8; N];
+struct JoinBuf<A, B, const SEP: &'static str>(PhantomData<(A, B)>);
+impl<A: ConstDesc, B: ConstDesc, const SEP: &'static str> JoinBuf<A, B, SEP> {
+    const LEN: usize = A::TEXT.len() + SEP.len() + B::TEXT.len();
+    const BUF: [u8; MAX] = {
+        let mut buf = [0u8; MAX];
         let mut pos = 0;
         pos = write_str(&mut buf, pos, A::TEXT);
         pos = write_str(&mut buf, pos, SEP);
         let _ = write_str(&mut buf, pos, B::TEXT);
         buf
     };
-    const TEXT: &'static str = str_from_bytes(&Self::BYTES);
+    const TEXT: &'static str = str_from_buf(&Self::BUF, Self::LEN);
 }
 
-struct WrapBuf<T, const PRE: &'static str, const SUF: &'static str, const N: usize>(PhantomData<T>);
-impl<T: ConstDesc, const PRE: &'static str, const SUF: &'static str, const N: usize> WrapBuf<T, PRE, SUF, N> {
-    const BYTES: [u8; N] = {
-        let mut buf = [0u8; N];
+struct WrapBuf<T, const PRE: &'static str, const SUF: &'static str>(PhantomData<T>);
+impl<T: ConstDesc, const PRE: &'static str, const SUF: &'static str> WrapBuf<T, PRE, SUF> {
+    const LEN: usize = PRE.len() + T::TEXT.len() + SUF.len();
+    const BUF: [u8; MAX] = {
+        let mut buf = [0u8; MAX];
         let mut pos = 0;
         pos = write_str(&mut buf, pos, PRE);
         pos = write_str(&mut buf, pos, T::TEXT);
         let _ = write_str(&mut buf, pos, SUF);
         buf
     };
-    const TEXT: &'static str = str_from_bytes(&Self::BYTES);
+    const TEXT: &'static str = str_from_buf(&Self::BUF, Self::LEN);
 }
 
-struct ThenBuf<P, S, const N: usize>(PhantomData<(P, S)>);
-impl<P: ConstDesc, S: State, const N: usize> ThenBuf<P, S, N> {
-    const BYTES: [u8; N] = {
-        let mut buf = [0u8; N];
+struct ThenBuf<P, S>(PhantomData<(P, S)>);
+impl<P: ConstDesc, S: State> ThenBuf<P, S> {
+    const LEN: usize = P::TEXT.len() + 4 + S::NAME.len();
+    const BUF: [u8; MAX] = {
+        let mut buf = [0u8; MAX];
         let mut pos = 0;
         pos = write_str(&mut buf, pos, P::TEXT);
         pos = write_str(&mut buf, pos, " => ");
         let _ = write_str(&mut buf, pos, S::NAME);
         buf
     };
-    const TEXT: &'static str = str_from_bytes(&Self::BYTES);
+    const TEXT: &'static str = str_from_buf(&Self::BUF, Self::LEN);
 }
 
-struct EmptyThenBuf<S: State, const N: usize>(PhantomData<S>);
-impl<S: State, const N: usize> EmptyThenBuf<S, N> {
-    const BYTES: [u8; N] = {
-        let mut buf = [0u8; N];
+struct EmptyThenBuf<S: State>(PhantomData<S>);
+impl<S: State> EmptyThenBuf<S> {
+    const LEN: usize = 3 + S::NAME.len();
+    const BUF: [u8; MAX] = {
+        let mut buf = [0u8; MAX];
         let mut pos = 0;
         pos = write_str(&mut buf, pos, "=> ");
         let _ = write_str(&mut buf, pos, S::NAME);
         buf
     };
-    const TEXT: &'static str = str_from_bytes(&Self::BYTES);
+    const TEXT: &'static str = str_from_buf(&Self::BUF, Self::LEN);
 }
 
 macro_rules! const_lit {
@@ -181,53 +233,32 @@ const_lit!(SetTimeout, "SetTimeout");
 const_lit!(ClearTimeout, "ClearTimeout");
 const_lit!(AddStage, "AddStage");
 
-impl<R, T> ConstDesc for Send<R, T>
-where
-    [(); angle2_len::<R, T>("Send")]:,
-{
-    const TEXT: &'static str = Angle2::<R, T, "Send", { angle2_len::<R, T>("Send") }>::TEXT;
+impl<R, T> ConstDesc for Send<R, T> {
+    const TEXT: &'static str = Angle2::<R, T, "Send">::TEXT;
 }
 
-impl<R, T> ConstDesc for Call<R, T>
-where
-    [(); angle2_len::<R, T>("Call")]:,
-{
-    const TEXT: &'static str = Angle2::<R, T, "Call", { angle2_len::<R, T>("Call") }>::TEXT;
+impl<R, T> ConstDesc for Call<R, T> {
+    const TEXT: &'static str = Angle2::<R, T, "Call">::TEXT;
 }
 
-impl<R> ConstDesc for SendAny<R>
-where
-    [(); angle1_len::<R>("SendAny")]:,
-{
-    const TEXT: &'static str = Angle1::<R, "SendAny", { angle1_len::<R>("SendAny") }>::TEXT;
+impl<R> ConstDesc for SendAny<R> {
+    const TEXT: &'static str = Angle1::<R, "SendAny">::TEXT;
 }
 
-impl<T> ConstDesc for Receive<T>
-where
-    [(); angle1_len::<T>("Receive")]:,
-{
-    const TEXT: &'static str = Angle1::<T, "Receive", { angle1_len::<T>("Receive") }>::TEXT;
+impl<T> ConstDesc for Receive<T> {
+    const TEXT: &'static str = Angle1::<T, "Receive">::TEXT;
 }
 
-impl<T> ConstDesc for Schedule<T>
-where
-    [(); angle1_len::<T>("Schedule")]:,
-{
-    const TEXT: &'static str = Angle1::<T, "Schedule", { angle1_len::<T>("Schedule") }>::TEXT;
+impl<T> ConstDesc for Schedule<T> {
+    const TEXT: &'static str = Angle1::<T, "Schedule">::TEXT;
 }
 
-impl<E: crate::ExternalEffect> ConstDesc for External<E>
-where
-    [(); angle1_len::<E>("External")]:,
-{
-    const TEXT: &'static str = Angle1::<E, "External", { angle1_len::<E>("External") }>::TEXT;
+impl<E: crate::ExternalEffect> ConstDesc for External<E> {
+    const TEXT: &'static str = Angle1::<E, "External">::TEXT;
 }
 
-impl<E: ConstDesc> ConstDesc for Repeat<E>
-where
-    [(); wrap_len("Repeat<", E::TEXT, ">")]:,
-{
-    const TEXT: &'static str = WrapBuf::<E, "Repeat<", ">", { wrap_len("Repeat<", E::TEXT, ">") }>::TEXT;
+impl<E: ConstDesc> ConstDesc for Repeat<E> {
+    const TEXT: &'static str = WrapBuf::<E, "Repeat<", ">">::TEXT;
 }
 
 macro_rules! impl_const_seq {
@@ -240,14 +271,8 @@ macro_rules! impl_const_seq {
         impl<$H: ConstDesc, $($T: ConstDesc),+> ConstDesc for ($H, $($T,)+)
         where
             ($($T,)+): ConstDesc,
-            [(); $H::TEXT.len() $(+ 2 + $T::TEXT.len())*]:,
         {
-            const TEXT: &'static str = JoinBuf::<
-                $H,
-                ($($T,)+),
-                ", ",
-                { $H::TEXT.len() $(+ 2 + $T::TEXT.len())* },
-            >::TEXT;
+            const TEXT: &'static str = JoinBuf::<$H, ($($T,)+), ", ">::TEXT;
         }
         impl_const_seq!($($T),+);
     };
@@ -266,26 +291,14 @@ macro_rules! impl_const_par {
         impl<$H: ConstDesc, $($T: ConstDesc),+> ConstDesc for Par<($H, $($T,)+)>
         where
             Par<($($T,)+)>: ConstDesc,
-            [(); $H::TEXT.len() $(+ 3 + $T::TEXT.len())*]:,
         {
-            const TEXT: &'static str = JoinBuf::<
-                $H,
-                Par<($($T,)+)>,
-                " | ",
-                { $H::TEXT.len() $(+ 3 + $T::TEXT.len())* },
-            >::TEXT;
+            const TEXT: &'static str = JoinBuf::<$H, Par<($($T,)+)>, " | ">::TEXT;
         }
         impl<$H: ConstDesc, $($T: ConstDesc),+> ConstDesc for Choice<($H, $($T,)+)>
         where
             Choice<($($T,)+)>: ConstDesc,
-            [(); $H::TEXT.len() $(+ 3 + $T::TEXT.len())*]:,
         {
-            const TEXT: &'static str = JoinBuf::<
-                $H,
-                Choice<($($T,)+)>,
-                " | ",
-                { $H::TEXT.len() $(+ 3 + $T::TEXT.len())* },
-            >::TEXT;
+            const TEXT: &'static str = JoinBuf::<$H, Choice<($($T,)+)>, " | ">::TEXT;
         }
         impl_const_par!($($T),+);
     };
@@ -298,18 +311,14 @@ impl ConstDesc for Par<()> {
     const TEXT: &'static str = "(none)";
 }
 
-impl<S: State> ConstDesc for Then<Par<()>, S>
-where
-    [(); wrap_len("=> ", S::NAME, "")]:,
-{
-    const TEXT: &'static str = EmptyThenBuf::<S, { wrap_len("=> ", S::NAME, "") }>::TEXT;
+impl<S: State> ConstDesc for Then<Par<()>, S> {
+    const TEXT: &'static str = EmptyThenBuf::<S>::TEXT;
 }
 
 impl<P, S: State> ConstDesc for Then<Par<P>, S>
 where
     P: Uncons,
     Par<P>: ConstDesc,
-    [(); join_len(<Par<P> as ConstDesc>::TEXT, " => ", S::NAME)]:,
 {
-    const TEXT: &'static str = ThenBuf::<Par<P>, S, { join_len(<Par<P> as ConstDesc>::TEXT, " => ", S::NAME) }>::TEXT;
+    const TEXT: &'static str = ThenBuf::<Par<P>, S>::TEXT;
 }

--- a/crates/amaru-pure-stage/src/typestate/effect.rs
+++ b/crates/amaru-pure-stage/src/typestate/effect.rs
@@ -45,7 +45,7 @@ impl<R> Effect for SendAny<R> {
     }
 }
 
-/// Kleene star of a single effect or of a sequence (`Repeat<Cons<A, Cons<B, Nil>>>`).
+/// Kleene star of a single effect or of a sequence (`Repeat<(A, B)>`).
 ///
 /// Selecting the first step unrolls the rest in front of the same `Repeat`.
 /// Selecting the following step discards the star (zero iterations).

--- a/crates/amaru-pure-stage/src/typestate/list.rs
+++ b/crates/amaru-pure-stage/src/typestate/list.rs
@@ -15,7 +15,9 @@
 //! Type-level remainder algebra.
 //!
 //! A remainder is a choice of [`Then<P, S>`] (`A => S | B => T | C => U`).
-//! `P` is a flat [`Cons`] of sequences (parallel, one `S` for the `Then`).
+//! `P` is a right-nested pair list of sequences (parallel, one `S` for the
+//! `Then`). [`Cons`]`<H, T>` is `(H, T)` and [`Nil`] is `()`, so rustc prints
+//! remainders as tuples rather than a named Cons encoding.
 //! [`Select`]`<E, I>` takes the **leftmost** matching head; `I` is inferred
 //! and is unique (later matches are not offered). Exclusive choice drops
 //! every `Then` that was not chosen.
@@ -30,7 +32,7 @@
 //! [`CanFinish`]: strip leading `Repeat` on each parallel branch, drop empties,
 //! succeed iff nothing remains.
 //!
-//! **Limits:** lists are flat, not tree-associative. Sequences are ordered.
+//! **Limits:** lists are right-nested pairs, not tree-associative. Sequences are ordered.
 //! Two choice alternatives with the same head are ambiguous (see [`Select`]
 //! `There` on `Then`). `finish` only strips `Repeat` at a branch prefix.
 //! [`StripRepeat`] knows `Send`, `SendAny`, `Call`, `Wait`, `Terminate`.
@@ -44,8 +46,12 @@ use super::{
     effect::{Repeat, SendAny},
 };
 
-pub struct Nil;
-pub struct Cons<H, T>(PhantomData<(H, T)>);
+/// Empty remainder list. Alias of `()` so rustc prints it as such.
+pub type Nil = ();
+
+/// Right-nested remainder cell. Alias of `(H, T)` so rustc prints
+/// `(Send<Role, T>, (Wait, ()))` instead of `Cons<Send<…>, Cons<Wait, Nil>>`.
+pub type Cons<H, T> = (H, T);
 
 /// Parallel composition `P` of sequences, then next state `S`.
 pub struct Then<P, S>(PhantomData<(P, S)>);
@@ -161,10 +167,16 @@ pub trait IsFalse {}
 impl IsFalse for If<false> {}
 
 /// Select the leftmost head `E`. `I` is inferred and unique.
+#[diagnostic::on_unimplemented(
+    message = "cannot `{E}` from this remainder",
+    label = "not allowed in the remaining session",
+    note = "`{Self}` has no leftmost `{E}`"
+)]
 pub trait Select<E, I> {
     type Rest;
 }
 
+#[diagnostic::do_not_recommend]
 impl<E, Tail, Rest> Select<E, Here> for Cons<Cons<E, Tail>, Rest>
 where
     E: NotRepeat,
@@ -173,6 +185,7 @@ where
 }
 
 /// `Repeat` at the front of a sequence: keep or unroll.
+#[diagnostic::do_not_recommend]
 impl<E, Seq, Tail, Rest> Select<E, Here> for Cons<Cons<Repeat<Seq>, Tail>, Rest>
 where
     Self: TakeRepeat<E, Here>,
@@ -181,6 +194,7 @@ where
 }
 
 /// `Repeat` that does not match `E`: discard it and search what follows.
+#[diagnostic::do_not_recommend]
 impl<E, Seq, Tail, Rest, I> Select<E, Skip<I>> for Cons<Cons<Repeat<Seq>, Tail>, Rest>
 where
     Self: TakeRepeat<E, Skip<I>>,
@@ -189,6 +203,7 @@ where
 }
 
 /// Later parallel sequence. Applies only when this head cannot serve `E`.
+#[diagnostic::do_not_recommend]
 impl<E, Eff, Tail, Rest, I> Select<E, There<I>> for Cons<Cons<Eff, Tail>, Rest>
 where
     Eff: NotRepeat,
@@ -198,6 +213,7 @@ where
     type Rest = Cons<Cons<Eff, Tail>, Rest::Rest>;
 }
 
+#[diagnostic::do_not_recommend]
 impl<E, I, P, S> Select<E, I> for Then<P, S>
 where
     P: Select<E, I>,
@@ -207,6 +223,7 @@ where
 }
 
 /// First choice alternative that can serve `E`. Other `Then`s are dropped.
+#[diagnostic::do_not_recommend]
 impl<E, I, P, S, Rest> Select<E, In<I>> for Cons<Then<P, S>, Rest>
 where
     P: Select<E, I>,
@@ -221,6 +238,7 @@ where
 /// bound here would freeze `T` to the first alternative's payload). Distinct
 /// heads therefore pick a unique `I`; two alternatives with the same head
 /// are ambiguous.
+#[diagnostic::do_not_recommend]
 impl<E, I, P, S, Rest> Select<E, There<I>> for Cons<Then<P, S>, Rest>
 where
     Rest: Select<E, I>,
@@ -254,10 +272,12 @@ pub trait TakeRepeat<E, I> {
     type Rest;
 }
 
+#[diagnostic::do_not_recommend]
 impl<E, Tail, Rest> TakeRepeat<E, Here> for Cons<Cons<Repeat<E>, Tail>, Rest> {
     type Rest = Cons<Cons<Repeat<E>, Tail>, Rest>;
 }
 
+#[diagnostic::do_not_recommend]
 impl<E, T, Tail, Rest> TakeRepeat<E, Here> for Cons<Cons<Repeat<Cons<E, T>>, Tail>, Rest>
 where
     T: Concat<Cons<Repeat<Cons<E, T>>, Tail>>,
@@ -265,6 +285,7 @@ where
     type Rest = Cons<T::Out, Rest>;
 }
 
+#[diagnostic::do_not_recommend]
 impl<E, Seq, Tail, Rest, I> TakeRepeat<E, Skip<I>> for Cons<Cons<Repeat<Seq>, Tail>, Rest>
 where
     Seq: FirstEffect,
@@ -279,10 +300,15 @@ where
 ///
 /// Used by [`Session::discard_repeat`](super::Session::discard_repeat). There is
 /// no impl when the head is not a star, so skipping is a compile error.
+#[diagnostic::on_unimplemented(
+    message = "no leading Repeat to discard in `{Self}`",
+    label = "remainder does not start with Repeat"
+)]
 pub trait DiscardRepeat {
     type Out;
 }
 
+#[diagnostic::do_not_recommend]
 impl<Seq, Tail, Rest> DiscardRepeat for Cons<Cons<Repeat<Seq>, Tail>, Rest>
 where
     Cons<Tail, Rest>: Clean,
@@ -290,10 +316,12 @@ where
     type Out = <Cons<Tail, Rest> as Clean>::Out;
 }
 
+#[diagnostic::do_not_recommend]
 impl<P: DiscardRepeat, S> DiscardRepeat for Then<P, S> {
     type Out = Then<P::Out, S>;
 }
 
+#[diagnostic::do_not_recommend]
 impl<P, S, Rest> DiscardRepeat for Cons<Then<P, S>, Rest>
 where
     Then<P, S>: DiscardRepeat,
@@ -367,13 +395,62 @@ impl<H, T, Rest> ConsIfPresent<Rest> for Cons<H, T> {
 ///
 /// For [`Then<P, S>`], leading [`Repeat`] on each branch of `P` is discarded;
 /// empty branches are dropped; finish is allowed only when no branch remains.
+#[diagnostic::on_unimplemented(
+    message = "cannot finish in `{S}` from remainder `{Self}`",
+    label = "required effects still remain",
+    note = "leading Repeat is stripped automatically; other effects must be performed first"
+)]
 pub trait CanFinish<S, I> {}
 
+#[diagnostic::do_not_recommend]
 impl<P, S: State> CanFinish<S, Here> for Then<P, S> where P: Prune<Out = Nil> {}
 
+#[diagnostic::do_not_recommend]
 impl<P, S: State, Rest> CanFinish<S, Here> for Cons<Then<P, S>, Rest> where Then<P, S>: CanFinish<S, Here> {}
 
+#[diagnostic::do_not_recommend]
 impl<P, S: State, Rest, I> CanFinish<S, There<I>> for Cons<Then<P, S>, Rest> where Rest: CanFinish<S, I> {}
+
+/// [`Select`] plus [`Clean`]. `I` is inferred and unique.
+///
+/// [`Session`](super::Session) methods name this in the **return type**, not a
+/// `where` clause, so a missing effect is E0277 rather than E0599 (“no method”).
+#[diagnostic::on_unimplemented(
+    message = "cannot `{E}` from this remainder",
+    label = "not allowed in the remaining session",
+    note = "`{Self}` has no leftmost `{E}`"
+)]
+pub trait Take<E, I> {
+    type Rest;
+}
+
+#[diagnostic::do_not_recommend]
+impl<R, E, I> Take<E, I> for R
+where
+    R: Select<E, I>,
+    R::Rest: Clean,
+{
+    type Rest = <R::Rest as Clean>::Out;
+}
+
+/// [`CanFinish`] as a projection so [`Session::finish`](super::Session::finish)
+/// does not hide behind E0599.
+#[diagnostic::on_unimplemented(
+    message = "cannot finish in `{S}` from remainder `{Self}`",
+    label = "required effects still remain",
+    note = "leading Repeat is stripped automatically; other effects must be performed first"
+)]
+pub trait FinishIn<S, I> {
+    type Out;
+}
+
+#[diagnostic::do_not_recommend]
+impl<R, S: State, I> FinishIn<S, I> for R
+where
+    R: CanFinish<S, I>,
+{
+    type Out = S;
+}
 
 /// Drop exhausted (`Nil`) sequences after a consume.
 pub trait Clean {

--- a/crates/amaru-pure-stage/src/typestate/list.rs
+++ b/crates/amaru-pure-stage/src/typestate/list.rs
@@ -14,13 +14,13 @@
 
 //! Type-level remainder algebra.
 //!
-//! A remainder is a choice of [`Then<P, S>`] (`A => S | B => T | C => U`).
-//! `P` is a right-nested pair list of sequences (parallel, one `S` for the
-//! `Then`). [`Cons`]`<H, T>` is `(H, T)` and [`Nil`] is `()`, so rustc prints
-//! remainders as tuples rather than a named Cons encoding.
-//! [`Select`]`<E, I>` takes the **leftmost** matching head; `I` is inferred
-//! and is unique (later matches are not offered). Exclusive choice drops
-//! every `Then` that was not chosen.
+//! A remainder is a [`Choice`] of [`Then<Par<P>, S>`] (`A => S | B => T | C => U`).
+//! [`Par`]`<P>` is a tuple of sequences; each sequence is a tuple of effects
+//! (or [`Repeat`](super::Repeat) of a tuple). rustc therefore prints
+//! `Choice<(Then<Par<((Send<Role, T>, Wait),)>, Idle>,)>` rather than a Cons
+//! encoding. [`Select`]`<E, I>` takes the **leftmost** matching head; `I` is
+//! inferred and is unique (later matches are not offered). Exclusive choice
+//! drops every `Then` that was not chosen.
 //!
 //! [`Repeat<Seq>`](super::Repeat) is a Kleene star. Selecting `Seq`'s first
 //! effect **unrolls** the rest in front of the same `Repeat` (or keeps a
@@ -32,12 +32,12 @@
 //! [`CanFinish`]: strip leading `Repeat` on each parallel branch, drop empties,
 //! succeed iff nothing remains.
 //!
-//! **Limits:** lists are right-nested pairs, not tree-associative. Sequences are ordered.
-//! Two choice alternatives with the same head are ambiguous (see [`Select`]
-//! `There` on `Then`). `finish` only strips `Repeat` at a branch prefix.
-//! [`StripRepeat`] knows `Send`, `SendAny`, `Call`, `Wait`, `Terminate`.
-//! [`SetTimeout`](super::SetTimeout) / [`ClearTimeout`](super::ClearTimeout) are
-//! required steps and are not stripped.
+//! **Limits:** sequences, parallel branches, and choice alternatives are tuples
+//! of length at most 10. Sequences are ordered. Two choice alternatives with
+//! the same head are ambiguous (see [`Select`] `There` on [`Choice`]). `finish`
+//! only strips `Repeat` at a branch prefix. [`SetTimeout`](super::SetTimeout) /
+//! [`ClearTimeout`](super::ClearTimeout) are required steps and are not
+//! stripped.
 
 use std::{fmt, marker::PhantomData};
 
@@ -46,12 +46,11 @@ use super::{
     effect::{Repeat, SendAny},
 };
 
-/// Empty remainder list. Alias of `()` so rustc prints it as such.
-pub type Nil = ();
+/// Exclusive choice of [`Then`] alternatives. `C` is a tuple, at most 10 long.
+pub struct Choice<C>(PhantomData<C>);
 
-/// Right-nested remainder cell. Alias of `(H, T)` so rustc prints
-/// `(Send<Role, T>, (Wait, ()))` instead of `Cons<Send<…>, Cons<Wait, Nil>>`.
-pub type Cons<H, T> = (H, T);
+/// Parallel composition of sequences. `P` is a tuple of sequence tuples, at most 10 long.
+pub struct Par<P>(PhantomData<P>);
 
 /// Parallel composition `P` of sequences, then next state `S`.
 pub struct Then<P, S>(PhantomData<(P, S)>);
@@ -65,65 +64,94 @@ pub struct In<I>(PhantomData<I>);
 /// Discard a leading [`Repeat`](super::Repeat) and search what follows with `I`.
 pub struct Skip<I>(PhantomData<I>);
 
-/// First effect of a `Repeat` body (a single tag, or the head of a `Cons`).
-pub trait FirstEffect {
+/// Split a tuple into its first element and the rest.
+///
+/// Implemented for arities 1 through 10. `()` and 11-element tuples have no
+/// impl, so exceeding the remainder limit is a trait-bound error.
+#[diagnostic::on_unimplemented(
+    message = "session remainder tuples support at most 10 elements",
+    note = "`{Self}` is empty or longer than 10 — split the protocol or shorten this list"
+)]
+pub trait Uncons {
     type Head;
+    type Tail;
 }
 
-impl<R, T> FirstEffect for super::effect::Send<R, T> {
-    type Head = super::effect::Send<R, T>;
+/// Prepend `H` to this tuple. Implemented for arities 0 through 9 (result ≤ 10).
+pub trait Prefix<H> {
+    type Out;
 }
 
-impl<R> FirstEffect for SendAny<R> {
-    type Head = SendAny<R>;
+/// Body of a [`Repeat`]: a single [`NotRepeat`] effect, or a tuple of effects.
+pub trait RepeatBody {
+    type Head;
+    type Tail;
 }
 
-impl FirstEffect for super::effect::Wait {
-    type Head = super::effect::Wait;
+/// Concatenate two sequences. Generated per arity so recursion is structural.
+pub trait Concat<Suf> {
+    type Out;
 }
 
-impl FirstEffect for super::effect::Terminate {
-    type Head = super::effect::Terminate;
+/// [`Select`] on a tuple of sequences (the inner type of [`Par`]).
+pub trait SelectTup<E, I> {
+    type Rest;
 }
 
-impl<R, T> FirstEffect for super::effect::Call<R, T> {
-    type Head = super::effect::Call<R, T>;
+/// Strip stars and drop empty sequences from a parallel tuple.
+pub trait PruneTup {
+    type Out;
 }
 
-impl FirstEffect for super::effect::Clock {
-    type Head = super::effect::Clock;
+macro_rules! impl_tuple_ladders {
+    ($H:ident $(, $T:ident)* $(,)?) => {
+        impl<$H $(, $T)*> Uncons for ($H, $($T,)*) {
+            type Head = $H;
+            type Tail = ($($T,)*);
+        }
+        impl<$H $(, $T)*> RepeatBody for ($H, $($T,)*) {
+            type Head = $H;
+            type Tail = ($($T,)*);
+        }
+        impl<$H $(, $T)*, Suf> Concat<Suf> for ($H, $($T,)*)
+        where
+            ($($T,)*): Concat<Suf>,
+            <($($T,)*) as Concat<Suf>>::Out: Prefix<$H>,
+        {
+            type Out = <<($($T,)*) as Concat<Suf>>::Out as Prefix<$H>>::Out;
+        }
+        impl_tuple_ladders!($($T),*);
+    };
+    () => {};
 }
 
-impl<T> FirstEffect for super::effect::Schedule<T> {
-    type Head = super::effect::Schedule<T>;
+macro_rules! impl_prefix {
+    (@from [$($T:ident),*]) => {
+        impl<H $(, $T)*> Prefix<H> for ($($T,)*) {
+            type Out = (H, $($T,)*);
+        }
+    };
+    (@acc [$($done:ident),*] $next:ident $(, $rest:ident)*) => {
+        impl_prefix!(@from [$($done),*]);
+        impl_prefix!(@acc [$($done,)* $next] $($rest),*);
+    };
+    (@acc [$($done:ident),*]) => {
+        impl_prefix!(@from [$($done),*]);
+    };
+    ($($T:ident),*) => {
+        impl_prefix!(@acc [] $($T),*);
+    };
 }
 
-impl FirstEffect for super::effect::CancelSchedule {
-    type Head = super::effect::CancelSchedule;
+impl_tuple_ladders!(T0, T1, T2, T3, T4, T5, T6, T7, T8, T9);
+impl_prefix!(T0, T1, T2, T3, T4, T5, T6, T7, T8);
+
+impl<Suf> Concat<Suf> for () {
+    type Out = Suf;
 }
 
-impl FirstEffect for super::effect::SetTimeout {
-    type Head = super::effect::SetTimeout;
-}
-
-impl FirstEffect for super::effect::ClearTimeout {
-    type Head = super::effect::ClearTimeout;
-}
-
-impl<E: crate::ExternalEffect> FirstEffect for super::effect::External<E> {
-    type Head = super::effect::External<E>;
-}
-
-impl FirstEffect for super::effect::AddStage {
-    type Head = super::effect::AddStage;
-}
-
-impl<T> FirstEffect for super::effect::Receive<T> {
-    type Head = super::effect::Receive<T>;
-}
-
-impl<H, T> FirstEffect for Cons<H, T> {
-    type Head = H;
+impl PruneTup for () {
+    type Out = ();
 }
 
 /// Sequence heads that are not a [`Repeat`] (later parallel branches apply).
@@ -142,6 +170,11 @@ impl NotRepeat for super::effect::ClearTimeout {}
 impl<E: crate::ExternalEffect> NotRepeat for super::effect::External<E> {}
 impl NotRepeat for super::effect::AddStage {}
 impl<T> NotRepeat for super::effect::Receive<T> {}
+
+impl<E: NotRepeat> RepeatBody for E {
+    type Head = E;
+    type Tail = ();
+}
 
 /// Compile-time inequality for `Select` bounds. Names are compared only
 /// within one rustc invocation, so two distinct types never collide.
@@ -176,129 +209,123 @@ pub trait Select<E, I> {
     type Rest;
 }
 
-#[diagnostic::do_not_recommend]
-impl<E, Tail, Rest> Select<E, Here> for Cons<Cons<E, Tail>, Rest>
-where
-    E: NotRepeat,
-{
-    type Rest = Cons<Tail, Rest>;
+/// Dispatch `Select` on the head of the first parallel sequence.
+///
+/// `Self` is that head (`E` or [`Repeat<Body>`]), so the Repeat/effect cases
+/// are disjoint type constructors rather than overlapping `Par<P>` impls.
+pub trait TakeHead<E, I, SeqTail, RestPar> {
+    type Rest;
 }
 
-/// `Repeat` at the front of a sequence: keep or unroll.
 #[diagnostic::do_not_recommend]
-impl<E, Seq, Tail, Rest> Select<E, Here> for Cons<Cons<Repeat<Seq>, Tail>, Rest>
+impl<E: NotRepeat, SeqTail, RestPar> TakeHead<E, Here, SeqTail, RestPar> for E
 where
-    Self: TakeRepeat<E, Here>,
+    SeqTail: ConsIfPresent<RestPar>,
 {
-    type Rest = <Self as TakeRepeat<E, Here>>::Rest;
+    type Rest = SeqTail::Out;
 }
 
-/// `Repeat` that does not match `E`: discard it and search what follows.
 #[diagnostic::do_not_recommend]
-impl<E, Seq, Tail, Rest, I> Select<E, Skip<I>> for Cons<Cons<Repeat<Seq>, Tail>, Rest>
+impl<E, Body, SeqTail, RestPar> TakeHead<E, Here, SeqTail, RestPar> for Repeat<Body>
 where
-    Self: TakeRepeat<E, Skip<I>>,
+    Body: RepeatBody<Head = E>,
+    Repeat<Body>: UnrollRepeat<Body, SeqTail>,
+    <Repeat<Body> as UnrollRepeat<Body, SeqTail>>::Out: ConsIfPresent<RestPar>,
 {
-    type Rest = <Self as TakeRepeat<E, Skip<I>>>::Rest;
+    type Rest = <<Repeat<Body> as UnrollRepeat<Body, SeqTail>>::Out as ConsIfPresent<RestPar>>::Out;
 }
 
-/// Later parallel sequence. Applies only when this head cannot serve `E`.
 #[diagnostic::do_not_recommend]
-impl<E, Eff, Tail, Rest, I> Select<E, There<I>> for Cons<Cons<Eff, Tail>, Rest>
+impl<E, Body, SeqTail, RestPar, I> TakeHead<E, Skip<I>, SeqTail, RestPar> for Repeat<Body>
+where
+    Body: RepeatBody,
+    If<{ types_eq::<Body::Head, E>() }>: IsFalse,
+    SeqTail: ConsIfPresent<RestPar>,
+    SeqTail::Out: SelectTup<E, I>,
+{
+    type Rest = <SeqTail::Out as SelectTup<E, I>>::Rest;
+}
+
+#[diagnostic::do_not_recommend]
+impl<E, Eff, SeqTail, RestPar, I> TakeHead<E, There<I>, SeqTail, RestPar> for Eff
 where
     Eff: NotRepeat,
     If<{ types_eq::<Eff, E>() }>: IsFalse,
-    Rest: Select<E, I>,
+    SeqTail: Prefix<Eff>,
+    RestPar: SelectTup<E, I>,
+    <RestPar as SelectTup<E, I>>::Rest: Prefix<SeqTail::Out>,
 {
-    type Rest = Cons<Cons<Eff, Tail>, Rest::Rest>;
+    type Rest = <<RestPar as SelectTup<E, I>>::Rest as Prefix<SeqTail::Out>>::Out;
 }
 
 #[diagnostic::do_not_recommend]
-impl<E, I, P, S> Select<E, I> for Then<P, S>
+impl<E, I, P> Select<E, I> for Par<P>
 where
-    P: Select<E, I>,
-    P::Rest: Clean,
+    P: SelectTup<E, I>,
 {
-    type Rest = Then<<P::Rest as Clean>::Out, S>;
+    type Rest = Par<P::Rest>;
+}
+
+#[diagnostic::do_not_recommend]
+impl<E, I, P, S> Select<E, I> for Then<Par<P>, S>
+where
+    Par<P>: Select<E, I>,
+    <Par<P> as Select<E, I>>::Rest: Clean,
+{
+    type Rest = Then<<<Par<P> as Select<E, I>>::Rest as Clean>::Out, S>;
 }
 
 /// First choice alternative that can serve `E`. Other `Then`s are dropped.
-#[diagnostic::do_not_recommend]
-impl<E, I, P, S, Rest> Select<E, In<I>> for Cons<Then<P, S>, Rest>
-where
-    P: Select<E, I>,
-    P::Rest: Clean,
-{
-    type Rest = Cons<Then<<P::Rest as Clean>::Out, S>, Nil>;
-}
-
-/// Later choice alternative. This `Then` is dropped.
 ///
 /// `There` stays a candidate even while `E` is still inferred (a `types_eq`
 /// bound here would freeze `T` to the first alternative's payload). Distinct
 /// heads therefore pick a unique `I`; two alternatives with the same head
 /// are ambiguous.
-#[diagnostic::do_not_recommend]
-impl<E, I, P, S, Rest> Select<E, There<I>> for Cons<Then<P, S>, Rest>
-where
-    Rest: Select<E, I>,
-{
-    type Rest = Rest::Rest;
+macro_rules! impl_choice_select {
+    ($H:ident $(, $T:ident)* $(,)?) => {
+        #[diagnostic::do_not_recommend]
+        impl<E, I, $H $(, $T)*> Select<E, In<I>> for Choice<($H, $($T,)*)>
+        where
+            $H: Select<E, I>,
+            <$H as Select<E, I>>::Rest: Clean,
+        {
+            type Rest = Choice<(<<$H as Select<E, I>>::Rest as Clean>::Out,)>;
+        }
+        impl_choice_select!(@there $H $(, $T)*);
+        impl_choice_select!($($T),*);
+    };
+    (@there $H:ident $(, $T:ident)+) => {
+        #[diagnostic::do_not_recommend]
+        impl<E, I, $H, $($T),+> Select<E, There<I>> for Choice<($H, $($T,)+)>
+        where
+            Choice<($($T,)+)>: Select<E, I>,
+        {
+            type Rest = <Choice<($($T,)+)> as Select<E, I>>::Rest;
+        }
+    };
+    (@there $H:ident) => {};
+    () => {};
 }
 
-/// Concatenate two sequences.
-pub trait Concat<Suf> {
+impl_choice_select!(C0, C1, C2, C3, C4, C5, C6, C7, C8, C9);
+
+/// Unroll `Repeat<Body>` in front of `Suffix`: leftover body, then the star, then `Suffix`.
+pub trait UnrollRepeat<Body, Suffix> {
     type Out;
 }
 
-impl<Suf> Concat<Suf> for Nil {
-    type Out = Suf;
-}
-
-impl<H, T: Concat<Suf>, Suf> Concat<Suf> for Cons<H, T> {
-    type Out = Cons<H, T::Out>;
-}
-
-/// How a leading [`Repeat`] serves a selection of `E`.
-///
-/// - [`Here`]: `Repeat<E>` keeps the star; `Repeat<Cons<E, T>>` unrolls `T`
-///   in front of the same `Repeat`.
-/// - [`Skip`]: the star's first step is not `E`, so it is discarded and `E`
-///   is selected from what follows.
-///
-/// [`Here`] unifies `E` with the star body, so [`Session::send`](super::Session::send)
-/// of a later payload cannot skip; use [`Session::discard_repeat`](super::Session::discard_repeat).
-pub trait TakeRepeat<E, I> {
-    type Rest;
-}
-
-#[diagnostic::do_not_recommend]
-impl<E, Tail, Rest> TakeRepeat<E, Here> for Cons<Cons<Repeat<E>, Tail>, Rest> {
-    type Rest = Cons<Cons<Repeat<E>, Tail>, Rest>;
-}
-
-#[diagnostic::do_not_recommend]
-impl<E, T, Tail, Rest> TakeRepeat<E, Here> for Cons<Cons<Repeat<Cons<E, T>>, Tail>, Rest>
+impl<Body, Suffix> UnrollRepeat<Body, Suffix> for Repeat<Body>
 where
-    T: Concat<Cons<Repeat<Cons<E, T>>, Tail>>,
+    Body: RepeatBody,
+    (Repeat<Body>,): Concat<Suffix>,
+    Body::Tail: Concat<<(Repeat<Body>,) as Concat<Suffix>>::Out>,
 {
-    type Rest = Cons<T::Out, Rest>;
-}
-
-#[diagnostic::do_not_recommend]
-impl<E, Seq, Tail, Rest, I> TakeRepeat<E, Skip<I>> for Cons<Cons<Repeat<Seq>, Tail>, Rest>
-where
-    Seq: FirstEffect,
-    If<{ types_eq::<Seq::Head, E>() }>: IsFalse,
-    Cons<Tail, Rest>: Clean,
-    <Cons<Tail, Rest> as Clean>::Out: Select<E, I>,
-{
-    type Rest = <<Cons<Tail, Rest> as Clean>::Out as Select<E, I>>::Rest;
+    type Out = <Body::Tail as Concat<<(Repeat<Body>,) as Concat<Suffix>>::Out>>::Out;
 }
 
 /// Drop a leading [`Repeat`] from the current sequence, leaving the suffix.
 ///
-/// Used by [`Session::discard_repeat`](super::Session::discard_repeat). There is
+/// Used by [`SessionOps::discard_repeat`](super::SessionOps::discard_repeat). There is
 /// no impl when the head is not a star, so skipping is a compile error.
 #[diagnostic::on_unimplemented(
     message = "no leading Repeat to discard in `{Self}`",
@@ -309,24 +336,83 @@ pub trait DiscardRepeat {
 }
 
 #[diagnostic::do_not_recommend]
-impl<Seq, Tail, Rest> DiscardRepeat for Cons<Cons<Repeat<Seq>, Tail>, Rest>
+impl<P, Body> DiscardRepeat for Par<P>
 where
-    Cons<Tail, Rest>: Clean,
+    P: Uncons,
+    P::Head: Uncons<Head = Repeat<Body>>,
+    <P::Head as Uncons>::Tail: ConsIfPresent<P::Tail>,
+    Par<<<P::Head as Uncons>::Tail as ConsIfPresent<P::Tail>>::Out>: Clean,
 {
-    type Out = <Cons<Tail, Rest> as Clean>::Out;
+    type Out = <Par<<<P::Head as Uncons>::Tail as ConsIfPresent<P::Tail>>::Out> as Clean>::Out;
 }
 
 #[diagnostic::do_not_recommend]
-impl<P: DiscardRepeat, S> DiscardRepeat for Then<P, S> {
-    type Out = Then<P::Out, S>;
+impl<P, S> DiscardRepeat for Then<Par<P>, S>
+where
+    Par<P>: DiscardRepeat,
+{
+    type Out = Then<<Par<P> as DiscardRepeat>::Out, S>;
 }
 
 #[diagnostic::do_not_recommend]
-impl<P, S, Rest> DiscardRepeat for Cons<Then<P, S>, Rest>
+impl<C> DiscardRepeat for Choice<C>
 where
-    Then<P, S>: DiscardRepeat,
+    C: Uncons,
+    C::Head: DiscardRepeat,
+    C::Tail: Prefix<<C::Head as DiscardRepeat>::Out>,
 {
-    type Out = Cons<<Then<P, S> as DiscardRepeat>::Out, Rest>;
+    type Out = Choice<<C::Tail as Prefix<<C::Head as DiscardRepeat>::Out>>::Out>;
+}
+
+/// How a leading effect or [`Repeat`] is treated when stripping stars for [`CanFinish`].
+pub trait StripHead<Tail> {
+    type Out;
+}
+
+impl<Seq, Tail: StripRepeat> StripHead<Tail> for Repeat<Seq> {
+    type Out = Tail::Out;
+}
+
+impl<R, T, Tail: Prefix<super::effect::Send<R, T>>> StripHead<Tail> for super::effect::Send<R, T> {
+    type Out = Tail::Out;
+}
+impl<R, Tail: Prefix<SendAny<R>>> StripHead<Tail> for SendAny<R> {
+    type Out = Tail::Out;
+}
+impl<Tail: Prefix<super::effect::Wait>> StripHead<Tail> for super::effect::Wait {
+    type Out = Tail::Out;
+}
+impl<Tail: Prefix<super::effect::Terminate>> StripHead<Tail> for super::effect::Terminate {
+    type Out = Tail::Out;
+}
+impl<R, T, Tail: Prefix<super::effect::Call<R, T>>> StripHead<Tail> for super::effect::Call<R, T> {
+    type Out = Tail::Out;
+}
+impl<Tail: Prefix<super::effect::Clock>> StripHead<Tail> for super::effect::Clock {
+    type Out = Tail::Out;
+}
+impl<T, Tail: Prefix<super::effect::Schedule<T>>> StripHead<Tail> for super::effect::Schedule<T> {
+    type Out = Tail::Out;
+}
+impl<Tail: Prefix<super::effect::CancelSchedule>> StripHead<Tail> for super::effect::CancelSchedule {
+    type Out = Tail::Out;
+}
+impl<Tail: Prefix<super::effect::SetTimeout>> StripHead<Tail> for super::effect::SetTimeout {
+    type Out = Tail::Out;
+}
+impl<Tail: Prefix<super::effect::ClearTimeout>> StripHead<Tail> for super::effect::ClearTimeout {
+    type Out = Tail::Out;
+}
+impl<E: crate::ExternalEffect, Tail: Prefix<super::effect::External<E>>> StripHead<Tail>
+    for super::effect::External<E>
+{
+    type Out = Tail::Out;
+}
+impl<Tail: Prefix<super::effect::AddStage>> StripHead<Tail> for super::effect::AddStage {
+    type Out = Tail::Out;
+}
+impl<T, Tail: Prefix<super::effect::Receive<T>>> StripHead<Tail> for super::effect::Receive<T> {
+    type Out = Tail::Out;
 }
 
 /// Strip leading [`Repeat`] from a sequence.
@@ -334,32 +420,8 @@ pub trait StripRepeat {
     type Out;
 }
 
-impl StripRepeat for Nil {
-    type Out = Nil;
-}
-
-impl<E, T: StripRepeat> StripRepeat for Cons<Repeat<E>, T> {
-    type Out = T::Out;
-}
-
-impl<R, T, Tail> StripRepeat for Cons<super::effect::Send<R, T>, Tail> {
-    type Out = Cons<super::effect::Send<R, T>, Tail>;
-}
-
-impl<R, T, Tail> StripRepeat for Cons<super::effect::Call<R, T>, Tail> {
-    type Out = Cons<super::effect::Call<R, T>, Tail>;
-}
-
-impl<R, Tail> StripRepeat for Cons<SendAny<R>, Tail> {
-    type Out = Cons<SendAny<R>, Tail>;
-}
-
-impl<Tail> StripRepeat for Cons<super::effect::Wait, Tail> {
-    type Out = Cons<super::effect::Wait, Tail>;
-}
-
-impl<Tail> StripRepeat for Cons<super::effect::Terminate, Tail> {
-    type Out = Cons<super::effect::Terminate, Tail>;
+impl StripRepeat for () {
+    type Out = ();
 }
 
 /// After stripping `Repeat` prefixes, drop empty branches.
@@ -367,33 +429,59 @@ pub trait Prune {
     type Out;
 }
 
-impl Prune for Nil {
-    type Out = Nil;
-}
-
-impl<Seq, Rest: Prune> Prune for Cons<Seq, Rest>
-where
-    Seq: StripRepeat,
-    Seq::Out: ConsIfPresent<Rest::Out>,
-{
-    type Out = <Seq::Out as ConsIfPresent<Rest::Out>>::Out;
+impl<P: PruneTup> Prune for Par<P> {
+    type Out = Par<P::Out>;
 }
 
 pub trait ConsIfPresent<Rest> {
     type Out;
 }
 
-impl<Rest> ConsIfPresent<Rest> for Nil {
+impl<Rest> ConsIfPresent<Rest> for () {
     type Out = Rest;
 }
 
-impl<H, T, Rest> ConsIfPresent<Rest> for Cons<H, T> {
-    type Out = Cons<Cons<H, T>, Rest>;
+impl<Seq, Rest> ConsIfPresent<Rest> for Seq
+where
+    Seq: Uncons,
+    Rest: Prefix<Seq>,
+{
+    type Out = Rest::Out;
 }
 
-/// A remainder that may [`Session::finish`](super::Session::finish) in `S`.
+macro_rules! impl_seq_tuples {
+    ($H:ident $(, $T:ident)* $(,)?) => {
+        impl<$H $(, $T)*> StripRepeat for ($H, $($T,)*)
+        where
+            $H: StripHead<($($T,)*)>,
+        {
+            type Out = <$H as StripHead<($($T,)*)>>::Out;
+        }
+        impl<E, I, $H $(, $T)*> SelectTup<E, I> for ($H, $($T,)*)
+        where
+            $H: Uncons,
+            <$H as Uncons>::Head: TakeHead<E, I, <$H as Uncons>::Tail, ($($T,)*)>,
+        {
+            type Rest = <<$H as Uncons>::Head as TakeHead<E, I, <$H as Uncons>::Tail, ($($T,)*)>>::Rest;
+        }
+        impl<$H $(, $T)*> PruneTup for ($H, $($T,)*)
+        where
+            $H: StripRepeat,
+            ($($T,)*): PruneTup,
+            <$H as StripRepeat>::Out: ConsIfPresent<<($($T,)*) as PruneTup>::Out>,
+        {
+            type Out = <<$H as StripRepeat>::Out as ConsIfPresent<<($($T,)*) as PruneTup>::Out>>::Out;
+        }
+        impl_seq_tuples!($($T),*);
+    };
+    () => {};
+}
+
+impl_seq_tuples!(S0, S1, S2, S3, S4, S5, S6, S7, S8, S9);
+
+/// A remainder that may [`SessionOps::finish`](super::SessionOps::finish) in `S`.
 ///
-/// For [`Then<P, S>`], leading [`Repeat`] on each branch of `P` is discarded;
+/// For [`Then<Par<P>, S>`], leading [`Repeat`] on each branch of `P` is discarded;
 /// empty branches are dropped; finish is allowed only when no branch remains.
 #[diagnostic::on_unimplemented(
     message = "cannot finish in `{S}` from remainder `{Self}`",
@@ -403,13 +491,32 @@ impl<H, T, Rest> ConsIfPresent<Rest> for Cons<H, T> {
 pub trait CanFinish<S, I> {}
 
 #[diagnostic::do_not_recommend]
-impl<P, S: State> CanFinish<S, Here> for Then<P, S> where P: Prune<Out = Nil> {}
+impl<P, S: State> CanFinish<S, Here> for Then<Par<P>, S> where Par<P>: Prune<Out = Par<()>> {}
 
-#[diagnostic::do_not_recommend]
-impl<P, S: State, Rest> CanFinish<S, Here> for Cons<Then<P, S>, Rest> where Then<P, S>: CanFinish<S, Here> {}
+macro_rules! impl_choice_finish {
+    ($H:ident $(, $T:ident)* $(,)?) => {
+        #[diagnostic::do_not_recommend]
+        impl<S: State, $H $(, $T)*> CanFinish<S, Here> for Choice<($H, $($T,)*)>
+        where
+            $H: CanFinish<S, Here>,
+        {
+        }
+        impl_choice_finish!(@there $H $(, $T)*);
+        impl_choice_finish!($($T),*);
+    };
+    (@there $H:ident $(, $T:ident)+) => {
+        #[diagnostic::do_not_recommend]
+        impl<S: State, I, $H, $($T),+> CanFinish<S, There<I>> for Choice<($H, $($T,)+)>
+        where
+            Choice<($($T,)+)>: CanFinish<S, I>,
+        {
+        }
+    };
+    (@there $H:ident) => {};
+    () => {};
+}
 
-#[diagnostic::do_not_recommend]
-impl<P, S: State, Rest, I> CanFinish<S, There<I>> for Cons<Then<P, S>, Rest> where Rest: CanFinish<S, I> {}
+impl_choice_finish!(C0, C1, C2, C3, C4, C5, C6, C7, C8, C9);
 
 /// [`Select`] plus [`Clean`]. `I` is inferred and unique.
 ///
@@ -433,7 +540,7 @@ where
     type Rest = <R::Rest as Clean>::Out;
 }
 
-/// [`CanFinish`] as a projection so [`Session::finish`](super::Session::finish)
+/// [`CanFinish`] as a projection so [`SessionOps::finish`](super::SessionOps::finish)
 /// does not hide behind E0599.
 #[diagnostic::on_unimplemented(
     message = "cannot finish in `{S}` from remainder `{Self}`",
@@ -452,32 +559,22 @@ where
     type Out = S;
 }
 
-/// Drop exhausted (`Nil`) sequences after a consume.
+/// Drop exhausted sequences after a consume. Selection already omits empty
+/// branches, so this is identity on [`Par`] / [`Then`] / [`Choice`].
 pub trait Clean {
     type Out;
 }
 
-impl Clean for Nil {
-    type Out = Nil;
+impl<P> Clean for Par<P> {
+    type Out = Par<P>;
 }
 
-impl<T: Clean> Clean for Cons<Nil, T> {
-    type Out = T::Out;
+impl<P, S> Clean for Then<Par<P>, S> {
+    type Out = Then<Par<P>, S>;
 }
 
-impl<H, Tail, T: Clean> Clean for Cons<Cons<H, Tail>, T> {
-    type Out = Cons<Cons<H, Tail>, T::Out>;
-}
-
-impl<P: Clean, S> Clean for Then<P, S> {
-    type Out = Then<P::Out, S>;
-}
-
-impl<P, S, Rest: Clean> Clean for Cons<Then<P, S>, Rest>
-where
-    Then<P, S>: Clean,
-{
-    type Out = Cons<<Then<P, S> as Clean>::Out, Rest::Out>;
+impl<C> Clean for Choice<C> {
+    type Out = Choice<C>;
 }
 
 /// Format a sequence (`Send<A>, Wait`).
@@ -494,77 +591,113 @@ pub trait IsNil {
     const IS_NIL: bool;
 }
 
-impl IsNil for Nil {
+impl IsNil for Par<()> {
     const IS_NIL: bool = true;
 }
 
-impl<H, T> IsNil for Cons<H, T> {
+impl<P: Uncons> IsNil for Par<P> {
     const IS_NIL: bool = false;
 }
 
-impl<H, T> crate::typestate::effect::Effect for Repeat<Cons<H, T>>
-where
-    Cons<H, T>: FmtSeq,
-{
-    fn fmt(f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Repeat<")?;
-        <Cons<H, T> as FmtSeq>::fmt_seq(f)?;
-        write!(f, ">")
+impl FmtSeq for () {
+    fn fmt_seq(_f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
     }
 }
 
-impl<E: Effect> FmtSeq for Cons<E, Nil> {
-    fn fmt_seq(f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        E::fmt(f)
-    }
+macro_rules! impl_fmt_seq {
+    ($H:ident) => {
+        impl<$H: Effect> FmtSeq for ($H,) {
+            fn fmt_seq(f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                $H::fmt(f)
+            }
+        }
+        impl<$H: Effect> crate::typestate::effect::Effect for Repeat<($H,)> {
+            fn fmt(f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "Repeat<")?;
+                $H::fmt(f)?;
+                write!(f, ">")
+            }
+        }
+    };
+    ($H:ident, $($T:ident),+) => {
+        impl<$H: Effect, $($T: Effect),+> FmtSeq for ($H, $($T,)+) {
+            fn fmt_seq(f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                $H::fmt(f)?;
+                write!(f, ", ")?;
+                <($($T,)+) as FmtSeq>::fmt_seq(f)
+            }
+        }
+        impl<$H: Effect, $($T: Effect),+> crate::typestate::effect::Effect for Repeat<($H, $($T,)+)> {
+            fn fmt(f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "Repeat<")?;
+                <($H, $($T,)+) as FmtSeq>::fmt_seq(f)?;
+                write!(f, ">")
+            }
+        }
+        impl_fmt_seq!($($T),+);
+    };
 }
 
-impl<E: Effect, H, T> FmtSeq for Cons<E, Cons<H, T>>
-where
-    Cons<H, T>: FmtSeq,
-{
-    fn fmt_seq(f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        E::fmt(f)?;
-        write!(f, ", ")?;
-        <Cons<H, T> as FmtSeq>::fmt_seq(f)
-    }
+macro_rules! impl_fmt_par {
+    ($H:ident) => {
+        impl<$H: FmtSeq> FmtPar for Par<($H,)> {
+            fn fmt_par(f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                $H::fmt_seq(f)
+            }
+        }
+        impl<$H: FmtPar> FmtPar for Choice<($H,)> {
+            fn fmt_par(f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                $H::fmt_par(f)
+            }
+        }
+    };
+    ($H:ident, $($T:ident),+) => {
+        impl<$H: FmtSeq, $($T: FmtSeq),+> FmtPar for Par<($H, $($T,)+)> {
+            fn fmt_par(f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                $H::fmt_seq(f)?;
+                write!(f, " | ")?;
+                <Par<($($T,)+)> as FmtPar>::fmt_par(f)
+            }
+        }
+        impl<$H: FmtPar, $($T: FmtPar),+> FmtPar for Choice<($H, $($T,)+)> {
+            fn fmt_par(f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                $H::fmt_par(f)?;
+                write!(f, " | ")?;
+                <Choice<($($T,)+)> as FmtPar>::fmt_par(f)
+            }
+        }
+        impl_fmt_par!($($T),+);
+    };
 }
 
-impl FmtPar for Nil {
+impl_fmt_seq!(E0, E1, E2, E3, E4, E5, E6, E7, E8, E9);
+impl_fmt_par!(B0, B1, B2, B3, B4, B5, B6, B7, B8, B9);
+
+impl FmtPar for Par<()> {
     fn fmt_par(f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "(none)")
     }
 }
 
-impl<H: FmtSeq> FmtPar for Cons<H, Nil> {
-    fn fmt_par(f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        H::fmt_seq(f)
-    }
-}
-
-impl<H: FmtSeq, T1, T2> FmtPar for Cons<H, Cons<T1, T2>>
+impl<P, S: State> FmtSeq for Then<Par<P>, S>
 where
-    Cons<T1, T2>: FmtPar,
+    Par<P>: FmtPar + IsNil,
 {
-    fn fmt_par(f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        H::fmt_seq(f)?;
-        write!(f, " | ")?;
-        <Cons<T1, T2> as FmtPar>::fmt_par(f)
-    }
-}
-
-impl<P: FmtPar + IsNil, S: State> FmtSeq for Then<P, S> {
     fn fmt_seq(f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if P::IS_NIL {
+        if <Par<P> as IsNil>::IS_NIL {
             write!(f, "=> {}", S::NAME)
         } else {
-            P::fmt_par(f)?;
+            <Par<P> as FmtPar>::fmt_par(f)?;
             write!(f, " => {}", S::NAME)
         }
     }
 }
 
-impl<P: FmtPar + IsNil, S: State> FmtPar for Then<P, S> {
+impl<P, S: State> FmtPar for Then<Par<P>, S>
+where
+    Par<P>: FmtPar + IsNil,
+{
     fn fmt_par(f: &mut fmt::Formatter<'_>) -> fmt::Result {
         <Self as FmtSeq>::fmt_seq(f)
     }

--- a/crates/amaru-pure-stage/src/typestate/macros.rs
+++ b/crates/amaru-pure-stage/src/typestate/macros.rs
@@ -572,6 +572,31 @@ macro_rules! typestate_tuple {
     };
 }
 
+/// Compile-time dump of a session's pretty remainder.
+///
+/// Infers `Rem` from the value (so it works when that type is unnameable) and
+/// const-evaluates [`ConstDesc::TEXT`](crate::typestate::ConstDesc::TEXT), which
+/// panics. rustc reports that panic as E0080 with the remainder string:
+///
+/// ```ignore
+/// let rem_dump = streaming;
+/// reveal_remainder!(rem_dump);
+/// // error[E0080]: evaluation panicked: Send<ToMux, WantNext> => Streaming
+/// ```
+///
+/// This is the substitute for `const { panic!("{}", <streaming.type>::REMAINDER) }`.
+#[macro_export]
+macro_rules! reveal_remainder {
+    ($s:expr) => {
+        fn reveal<M, Rem: $crate::typestate::ConstDesc>(s: &Session<M, Rem>)
+        where
+            [(); $crate::typestate::remainder_ctfe_panic::<Rem>()]:,
+        {
+        }
+        reveal(&$s);
+    };
+}
+
 /// `Repeat` of a sequence: `star!(Send<A, T>, Send<B, U>)`.
 #[macro_export]
 macro_rules! star {

--- a/crates/amaru-pure-stage/src/typestate/macros.rs
+++ b/crates/amaru-pure-stage/src/typestate/macros.rs
@@ -15,8 +15,10 @@
 //! Surface syntax for states, remainders, roles, and mailboxes.
 //!
 //! `typestate_par!` splits on the first `=> State`: `|` before that is parallel
-//! sequences (one [`Then`](crate::typestate::Then)); `|` after starts another
-//! choice alternative (n-way `Cons` of `Then`). A lone ident is `Then<Nil, S>`.
+//! sequences (one [`Then`](crate::typestate::Then) inside [`Par`](crate::typestate::Par));
+//! `|` after starts another choice alternative (n-way [`Choice`](crate::typestate::Choice)
+//! of `Then`). A lone ident is `Choice<(Then<Par<()>, S>,)>`. Sequences, parallel
+//! branches, and choice alternatives are tuples of length at most 10.
 //! [`star`]`(A, B)` is `Repeat` of that sequence. Grouped [`on_receive`] builds
 //! the input enum and [`ExtractInput`](crate::typestate::ExtractInput).
 //! [`define_messages`](crate::define_messages) generates a struct per variant plus [`From`] /
@@ -465,41 +467,41 @@ macro_rules! typestate_extract {
 #[doc(hidden)]
 macro_rules! typestate_par {
     ($s:ident) => {
-        $crate::typestate::Cons<
-            $crate::typestate::Then<$crate::typestate::Nil, $s>,
-            $crate::typestate::Nil
-        >
+        $crate::typestate::Choice<(
+            $crate::typestate::Then<$crate::typestate::Par<()>, $s>,
+        )>
     };
     ($($rest:tt)*) => {
-        $crate::typestate_choice!(@go [] [] $($rest)*)
+        $crate::typestate_choice!(@go [] [] [] $($rest)*)
     };
 }
 
 #[macro_export]
 #[doc(hidden)]
 macro_rules! typestate_choice {
-    (@go [ $($seqs:tt)* ] [ $($cur:ty),* ] $ty:ty, $($rest:tt)*) => {
-        $crate::typestate_choice!(@go [ $($seqs)* ] [ $($cur,)* $ty ] $($rest)*)
+    (@go [ $($thens:ty),* ] [ $($seqs:tt)* ] [ $($cur:ty),* ] $ty:ty, $($rest:tt)*) => {
+        $crate::typestate_choice!(@go [ $($thens),* ] [ $($seqs)* ] [ $($cur,)* $ty ] $($rest)*)
     };
-    (@go [ $($seqs:tt)* ] [ $($cur:ty),* ] $ty:ty | $($rest:tt)*) => {
-        $crate::typestate_choice!(@go [ $($seqs)* [ $($cur,)* $ty ] ] [] $($rest)*)
+    (@go [ $($thens:ty),* ] [ $($seqs:tt)* ] [ $($cur:ty),* ] $ty:ty | $($rest:tt)*) => {
+        $crate::typestate_choice!(@go [ $($thens),* ] [ $($seqs)* [ $($cur,)* $ty ] ] [] $($rest)*)
     };
-    (@go [ $($seqs:tt)* ] [ $($cur:ty),* ] $ty:ty => $s:ident | $($rest:tt)*) => {
-        $crate::typestate::Cons<
-            $crate::typestate::Then<
-                $crate::typestate_branches!([ $($seqs)* [ $($cur,)* $ty ] ]),
+    (@go [ $($thens:ty),* ] [ $($seqs:tt)* ] [ $($cur:ty),* ] $ty:ty => $s:ident | $($rest:tt)*) => {
+        $crate::typestate_choice!(@go
+            [ $($thens,)* $crate::typestate::Then<
+                $crate::typestate::Par<$crate::typestate_branches!([ $($seqs)* [ $($cur,)* $ty ] ])>,
                 $s
-            >,
-            $crate::typestate_par!($($rest)*)
-        >
+            > ]
+            [] [] $($rest)*)
     };
-    (@go [ $($seqs:tt)* ] [ $($cur:ty),* ] $ty:ty => $s:ident) => {
-        $crate::typestate::Cons<
-            $crate::typestate::Then<
-                $crate::typestate_branches!([ $($seqs)* [ $($cur,)* $ty ] ]),
-                $s
-            >,
-            $crate::typestate::Nil
+    (@go [ $($thens:ty),* ] [ $($seqs:tt)* ] [ $($cur:ty),* ] $ty:ty => $s:ident) => {
+        $crate::typestate::Choice<
+            $crate::typestate_tuple!(
+                $($thens,)*
+                $crate::typestate::Then<
+                    $crate::typestate::Par<$crate::typestate_branches!([ $($seqs)* [ $($cur,)* $ty ] ])>,
+                    $s
+                >
+            )
         >
     };
 }
@@ -507,25 +509,66 @@ macro_rules! typestate_choice {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! typestate_branches {
-    ([]) => {
-        $crate::typestate::Nil
+    (@acc [ $($done:ty),* ]) => {
+        $crate::typestate_tuple!($($done),*)
     };
-    ([ [ $($ty:ty),+ ] $($rest:tt)* ]) => {
-        $crate::typestate::Cons<
-            $crate::typestate_seq!($($ty),+),
-            $crate::typestate_branches!([ $($rest)* ])
-        >
+    (@acc [ $($done:ty),* ] [ $($ty:ty),+ ] $($rest:tt)*) => {
+        $crate::typestate_branches!(@acc
+            [ $($done,)* $crate::typestate_seq!($($ty),+) ]
+            $($rest)*)
+    };
+    ([ $($x:tt)* ]) => {
+        $crate::typestate_branches!(@acc [] $($x)*)
     };
 }
 
 #[macro_export]
 #[doc(hidden)]
 macro_rules! typestate_seq {
-    ($e:ty) => {
-        $crate::typestate::Cons<$e, $crate::typestate::Nil>
+    ($($e:ty),+) => {
+        $crate::typestate_tuple!($($e),+)
     };
-    ($e:ty, $($rest:ty),+) => {
-        $crate::typestate::Cons<$e, $crate::typestate_seq!($($rest),+)>
+}
+
+/// Build a tuple of at most 10 types (`()` if empty, 1-tuples with a trailing comma).
+#[macro_export]
+#[doc(hidden)]
+macro_rules! typestate_tuple {
+    () => {
+        ()
+    };
+    ($t0:ty) => {
+        ($t0,)
+    };
+    ($t0:ty, $t1:ty) => {
+        ($t0, $t1)
+    };
+    ($t0:ty, $t1:ty, $t2:ty) => {
+        ($t0, $t1, $t2)
+    };
+    ($t0:ty, $t1:ty, $t2:ty, $t3:ty) => {
+        ($t0, $t1, $t2, $t3)
+    };
+    ($t0:ty, $t1:ty, $t2:ty, $t3:ty, $t4:ty) => {
+        ($t0, $t1, $t2, $t3, $t4)
+    };
+    ($t0:ty, $t1:ty, $t2:ty, $t3:ty, $t4:ty, $t5:ty) => {
+        ($t0, $t1, $t2, $t3, $t4, $t5)
+    };
+    ($t0:ty, $t1:ty, $t2:ty, $t3:ty, $t4:ty, $t5:ty, $t6:ty) => {
+        ($t0, $t1, $t2, $t3, $t4, $t5, $t6)
+    };
+    ($t0:ty, $t1:ty, $t2:ty, $t3:ty, $t4:ty, $t5:ty, $t6:ty, $t7:ty) => {
+        ($t0, $t1, $t2, $t3, $t4, $t5, $t6, $t7)
+    };
+    ($t0:ty, $t1:ty, $t2:ty, $t3:ty, $t4:ty, $t5:ty, $t6:ty, $t7:ty, $t8:ty) => {
+        ($t0, $t1, $t2, $t3, $t4, $t5, $t6, $t7, $t8)
+    };
+    ($t0:ty, $t1:ty, $t2:ty, $t3:ty, $t4:ty, $t5:ty, $t6:ty, $t7:ty, $t8:ty, $t9:ty) => {
+        ($t0, $t1, $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9)
+    };
+    ($($t:ty),+ $(,)?) => {
+        compile_error!("typestate remainders support at most 10 elements in a sequence, parallel, or choice")
     };
 }
 

--- a/crates/amaru-pure-stage/src/typestate/session.rs
+++ b/crates/amaru-pure-stage/src/typestate/session.rs
@@ -172,19 +172,27 @@ impl<M, Rem: super::ConstDesc> Session<M, Rem> {
 
     /// Pretty remainder (`Send<Role, T> => Idle`).
     ///
-    /// The failing `.send()` popup shows the encoding (`Choice<Then<Par<…>>>`).
-    /// Bind this next to it:
+    /// This is a runtime/`const fn` read of [`REMAINDER`](Self::REMAINDER) and
+    /// needs a value of `self`, so it cannot appear in `const { … }` next to a
+    /// live session. For a compile-time dump of the same string, use
+    /// [`reveal_remainder`](crate::reveal_remainder):
     ///
     /// ```ignore
-    /// let rem = streaming.remainder();
-    /// streaming.send(&mux, WantNext).await;
+    /// reveal_remainder!(streaming);
     /// ```
-    ///
-    /// rust-analyzer may show the string on hover of `rem` or of
-    /// [`REMAINDER`](Self::REMAINDER). If it does not, comment out the bad call
-    /// and `eprintln!("{rem}")` or `assert_eq!(rem, "…")`.
     pub const fn remainder(&self) -> &'static str {
         Self::REMAINDER
+    }
+
+    /// Compile-time dump of [`REMAINDER`](Self::REMAINDER).
+    ///
+    /// Always fails with E0080 whose message is the pretty remainder. Prefer
+    /// [`reveal_remainder`](crate::reveal_remainder) so the span is the call.
+    pub fn reveal(&self)
+    where
+        [(); super::remainder_ctfe_panic::<Rem>()]:,
+    {
+        let _ = self;
     }
 }
 

--- a/crates/amaru-pure-stage/src/typestate/session.rs
+++ b/crates/amaru-pure-stage/src/typestate/session.rs
@@ -166,6 +166,28 @@ pub struct Session<M, Rem> {
     _rem: PhantomData<fn() -> Rem>,
 }
 
+impl<M, Rem: super::ConstDesc> Session<M, Rem> {
+    /// Pretty remainder (`Send<Role, T> => Idle`). Same string as [`Self::remainder`].
+    pub const REMAINDER: &'static str = Rem::TEXT;
+
+    /// Pretty remainder (`Send<Role, T> => Idle`).
+    ///
+    /// The failing `.send()` popup shows the encoding (`Choice<Then<Par<…>>>`).
+    /// Bind this next to it:
+    ///
+    /// ```ignore
+    /// let rem = streaming.remainder();
+    /// streaming.send(&mux, WantNext).await;
+    /// ```
+    ///
+    /// rust-analyzer may show the string on hover of `rem` or of
+    /// [`REMAINDER`](Self::REMAINDER). If it does not, comment out the bad call
+    /// and `eprintln!("{rem}")` or `assert_eq!(rem, "…")`.
+    pub const fn remainder(&self) -> &'static str {
+        Self::REMAINDER
+    }
+}
+
 impl<M, Rem> Session<M, Rem> {
     fn new(effects: Effects<M>) -> Self {
         Self { effects, _rem: PhantomData }

--- a/crates/amaru-pure-stage/src/typestate/session.rs
+++ b/crates/amaru-pure-stage/src/typestate/session.rs
@@ -23,12 +23,17 @@
 //! [`convert_input`](State::convert_input) classifies a mailbox value and does
 //! not consume the state token — [`receive`](State::receive) does.
 
-use std::{fmt, future::Future, marker::PhantomData, time::Duration};
+use std::{
+    fmt,
+    future::{Future, IntoFuture},
+    marker::PhantomData,
+    time::Duration,
+};
 
 use super::{
-    Clean, FmtPar, IntoRoleCall, IntoRoleMail, RoleTag, Select,
+    FmtPar, IntoRoleCall, IntoRoleMail, RoleTag, Take,
     effect::{Call as CallEff, ClearTimeout, Send as SendEff, SendAny, SetTimeout, Terminate, Wait},
-    list::{self, CanFinish},
+    list::{self, FinishIn},
 };
 use crate::{Effects, ExternalEffectAPI, Instant, SendData, StageRef};
 
@@ -124,6 +129,10 @@ pub trait ExtractInput<M>: Sized {
 }
 
 /// The remainder after [`State::receive`] of `In`.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` cannot receive `{In}`",
+    label = "not an admissible input for this state"
+)]
 pub trait OnReceive<In>: State {
     type Then;
 
@@ -148,10 +157,10 @@ pub struct To<S: State>(PhantomData<S>);
 
 /// `Effects` plus the type-level remainder of a receive.
 ///
-/// Protocol [`send`](Self::send), [`send_any`](Self::send_any), [`call`](Self::call),
-/// [`wait`](Self::wait), [`set_timeout`](Self::set_timeout),
-/// [`clear_timeout`](Self::clear_timeout), and [`terminate`](Self::terminate)
-/// consume from `Rem`. Local helpers (`clock`, `external`) do not.
+/// Protocol [`send`](SessionOps::send), [`send_any`](SessionOps::send_any), [`call`](SessionOps::call),
+/// [`wait`](SessionOps::wait), [`set_timeout`](SessionOps::set_timeout),
+/// [`clear_timeout`](SessionOps::clear_timeout), and [`terminate`](SessionOps::terminate)
+/// consume from `Rem` ([`SessionOps`], in the prelude). Local helpers (`clock`, `external`) do not.
 pub struct Session<M, Rem> {
     effects: Effects<M>,
     _rem: PhantomData<fn() -> Rem>,
@@ -185,6 +194,58 @@ impl<M, Rem> Session<M, Rem> {
         self.effects.external(effect)
     }
 
+    /// Send any mailbox message to `target`. Consumes a [`SendAny<Tag>`]
+    /// permission, or uses a [`Repeat<SendAny<Tag>>`](super::Repeat) without
+    /// removing it.
+    pub fn send_any<Tag, T, Dest, I>(self, target: &Dest, msg: T) -> SendAnyOp<M, Rem, Tag, I>
+    where
+        Tag: RoleTag,
+        Dest: IntoRoleMail<Tag, T>,
+    {
+        let mail = target.encode(msg);
+        let send = self.effects.send(target.mailbox(), mail);
+        SendAnyOp { session: self, send, _t: PhantomData }
+    }
+}
+
+/// Returned by [`Session::send_any`]. `.await` requires [`Take`]`<SendAny<Tag>, I>`.
+pub struct SendAnyOp<M, Rem, Tag, I> {
+    session: Session<M, Rem>,
+    send: crate::BoxFuture<'static, ()>,
+    _t: PhantomData<(Tag, I)>,
+}
+
+#[diagnostic::on_unimplemented(
+    message = "cannot send_any `{Tag}` from this remainder",
+    label = "not allowed in the remaining session",
+    note = "the session remainder has no leftmost SendAny<{Tag}>"
+)]
+trait SendAnyAllowed<Tag, I> {}
+
+#[diagnostic::do_not_recommend]
+impl<Rem, Tag, I> SendAnyAllowed<Tag, I> for Rem where Rem: Take<SendAny<Tag>, I> {}
+
+impl<M, Rem, Tag, I> IntoFuture for SendAnyOp<M, Rem, Tag, I>
+where
+    Rem: SendAnyAllowed<Tag, I> + Take<SendAny<Tag>, I>,
+    M: Send + 'static,
+{
+    type Output = Session<M, <Rem as Take<SendAny<Tag>, I>>::Rest>;
+    type IntoFuture = crate::BoxFuture<'static, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let send = self.send;
+        let effects = self.session.effects;
+        Box::pin(async move {
+            send.await;
+            Session::new(effects)
+        })
+    }
+}
+
+/// Protocol steps on [`Session`]. Implemented for every remainder; a missing
+/// effect is [`Take`] / [`FinishIn`] / [`DiscardRepeat`] (E0277), not E0599.
+pub trait SessionOps<M, Rem>: Sized {
     /// Protocol send. Consumes a [`Send<Tag, T>`] allowance.
     ///
     /// `target` wraps a [`StageRef`] claiming `Tag`; its mailbox must implement [`From<T>`].
@@ -256,25 +317,16 @@ impl<M, Rem> Session<M, Rem> {
     ///     let _ = s.send(b, 1u8).await;
     /// }
     /// ```
-    pub fn send<Tag, T, Dest, I>(
+    fn send<Tag, T, Dest, I>(
         self,
         target: &Dest,
         msg: T,
-    ) -> impl Future<Output = Session<M, After<Rem, SendEff<Tag, T>, I>>> + Send
+    ) -> impl Future<Output = Session<M, <Rem as Take<SendEff<Tag, T>, I>>::Rest>> + Send
     where
         Tag: RoleTag,
         Dest: IntoRoleMail<Tag, T>,
-        Rem: Select<SendEff<Tag, T>, I>,
-        Rem::Rest: Clean,
-        M: Send,
-    {
-        let mail = target.encode(msg);
-        let send = self.effects.send(target.mailbox(), mail);
-        async move {
-            send.await;
-            Session::new(self.effects)
-        }
-    }
+        Rem: Take<SendEff<Tag, T>, I>,
+        M: Send;
 
     /// Protocol call. Consumes a [`Call<Tag, T>`](super::Call) allowance.
     ///
@@ -296,64 +348,26 @@ impl<M, Rem> Session<M, Rem> {
     ///     let _ = s.receive(1u8, eff).call(target, 0u32).await;
     /// }
     /// ```
-    pub fn call<Tag, T, Dest, I>(
+    fn call<Tag, T, Dest, I>(
         self,
         target: &Dest,
         msg: T,
-    ) -> impl Future<Output = (Option<Dest::Reply>, Session<M, After<Rem, CallEff<Tag, T>, I>>)> + Send
+    ) -> impl Future<Output = (Option<Dest::Reply>, Session<M, <Rem as Take<CallEff<Tag, T>, I>>::Rest>)> + Send
     where
         Tag: RoleTag,
         Dest: IntoRoleCall<Tag, T> + Clone + Send + 'static,
-        Rem: Select<CallEff<Tag, T>, I>,
-        Rem::Rest: Clean,
+        Rem: Take<CallEff<Tag, T>, I>,
         M: Send,
-        T: Send + 'static,
-    {
-        let dest = target.clone();
-        let mailbox = dest.mailbox().clone();
-        let call = self.effects.call(&mailbox, Dest::TIMEOUT, move |reply| dest.encode(msg, reply));
-        async move {
-            let reply = call.await;
-            (reply, Session::new(self.effects))
-        }
-    }
-
-    /// Send any mailbox message to `target`. Consumes a [`SendAny<Tag>`]
-    /// permission, or uses a [`Repeat<SendAny<Tag>>`](super::Repeat) without
-    /// removing it.
-    pub fn send_any<Tag, T, Dest, I>(
-        self,
-        target: &Dest,
-        msg: T,
-    ) -> impl Future<Output = Session<M, After<Rem, SendAny<Tag>, I>>> + Send
-    where
-        Tag: RoleTag,
-        Dest: IntoRoleMail<Tag, T>,
-        Rem: Select<SendAny<Tag>, I>,
-        Rem::Rest: Clean,
-        M: Send,
-    {
-        let mail = target.encode(msg);
-        let send = self.effects.send(target.mailbox(), mail);
-        async move {
-            send.await;
-            Session::new(self.effects)
-        }
-    }
+        T: Send + 'static;
 
     /// Protocol wait. Consumes a [`Wait`] allowance.
-    pub fn wait<I>(self, delay: Duration) -> impl Future<Output = (Instant, Session<M, After<Rem, Wait, I>>)> + Send
+    fn wait<I>(
+        self,
+        delay: Duration,
+    ) -> impl Future<Output = (Instant, Session<M, <Rem as Take<Wait, I>>::Rest>)> + Send
     where
-        Rem: Select<Wait, I>,
-        Rem::Rest: Clean,
-        M: Send,
-    {
-        let wait = self.effects.wait(delay);
-        async move {
-            let now = wait.await;
-            (now, Session::new(self.effects))
-        }
-    }
+        Rem: Take<Wait, I>,
+        M: Send;
 
     /// Arm a protocol timeout. Consumes a [`SetTimeout`] allowance.
     ///
@@ -371,61 +385,40 @@ impl<M, Rem> Session<M, Rem> {
     ///     s.receive(1u8, eff).finish()
     /// }
     /// ```
-    pub fn set_timeout<I>(
+    fn set_timeout<I>(
         self,
         delay: Duration,
         msg: M,
-    ) -> impl Future<Output = Session<M, After<Rem, SetTimeout, I>>> + Send
+    ) -> impl Future<Output = Session<M, <Rem as Take<SetTimeout, I>>::Rest>> + Send
     where
-        Rem: Select<SetTimeout, I>,
-        Rem::Rest: Clean,
-        M: SendData,
-    {
-        self.set_timeout_at(0, delay, msg)
-    }
+        Rem: Take<SetTimeout, I>,
+        M: SendData;
 
     /// Arm a protocol timeout on `slot`. Consumes a [`SetTimeout`] allowance.
-    pub fn set_timeout_at<I>(
+    fn set_timeout_at<I>(
         self,
         slot: u64,
         delay: Duration,
         msg: M,
-    ) -> impl Future<Output = Session<M, After<Rem, SetTimeout, I>>> + Send
+    ) -> impl Future<Output = Session<M, <Rem as Take<SetTimeout, I>>::Rest>> + Send
     where
-        Rem: Select<SetTimeout, I>,
-        Rem::Rest: Clean,
-        M: SendData,
-    {
-        let set = self.effects.set_timeout_at(slot, delay, msg);
-        async move {
-            set.await;
-            Session::new(self.effects)
-        }
-    }
+        Rem: Take<SetTimeout, I>,
+        M: SendData;
 
     /// Cancel the protocol timeout. Consumes a [`ClearTimeout`] allowance.
-    pub fn clear_timeout<I>(self) -> impl Future<Output = Session<M, After<Rem, ClearTimeout, I>>> + Send
+    fn clear_timeout<I>(self) -> impl Future<Output = Session<M, <Rem as Take<ClearTimeout, I>>::Rest>> + Send
     where
-        Rem: Select<ClearTimeout, I>,
-        Rem::Rest: Clean,
-        M: Send,
-    {
-        self.clear_timeout_at(0)
-    }
+        Rem: Take<ClearTimeout, I>,
+        M: Send;
 
     /// Cancel the protocol timeout on `slot`. Consumes a [`ClearTimeout`] allowance.
-    pub fn clear_timeout_at<I>(self, slot: u64) -> impl Future<Output = Session<M, After<Rem, ClearTimeout, I>>> + Send
+    fn clear_timeout_at<I>(
+        self,
+        slot: u64,
+    ) -> impl Future<Output = Session<M, <Rem as Take<ClearTimeout, I>>::Rest>> + Send
     where
-        Rem: Select<ClearTimeout, I>,
-        Rem::Rest: Clean,
-        M: Send,
-    {
-        let clear = self.effects.clear_timeout_at(slot);
-        async move {
-            clear.await;
-            Session::new(self.effects)
-        }
-    }
+        Rem: Take<ClearTimeout, I>,
+        M: Send;
 
     /// Drop a leading [`Repeat`](super::Repeat) on the current sequence.
     ///
@@ -446,21 +439,15 @@ impl<M, Rem> Session<M, Rem> {
     ///     let _ = s.receive(1u8, eff).discard_repeat();
     /// }
     /// ```
-    pub fn discard_repeat(self) -> Session<M, Rem::Out>
+    fn discard_repeat(self) -> Session<M, <Rem as super::DiscardRepeat>::Out>
     where
-        Rem: super::DiscardRepeat,
-    {
-        Session::new(self.effects)
-    }
+        Rem: super::DiscardRepeat;
 
     /// Protocol terminate. Consumes a [`Terminate`] allowance. Never returns.
-    pub fn terminate<T, I>(self) -> impl Future<Output = T> + Send
+    fn terminate<T, I>(self) -> impl Future<Output = T> + Send
     where
-        Rem: Select<Terminate, I>,
         T: Send,
-    {
-        self.effects.terminate()
-    }
+        Rem: Take<Terminate, I>;
 
     /// End the session when a remainder branch is [`To<S>`].
     ///
@@ -486,9 +473,137 @@ impl<M, Rem> Session<M, Rem> {
     ///     s.receive(1u8, eff).finish()
     /// }
     /// ```
-    pub fn finish<S: State, I>(self) -> S
+    fn finish<S: State, I>(self) -> S
     where
-        Rem: CanFinish<S, I>,
+        Rem: FinishIn<S, I, Out = S>;
+}
+
+impl<M, Rem> SessionOps<M, Rem> for Session<M, Rem> {
+    fn send<Tag, T, Dest, I>(
+        self,
+        target: &Dest,
+        msg: T,
+    ) -> impl Future<Output = Session<M, <Rem as Take<SendEff<Tag, T>, I>>::Rest>> + Send
+    where
+        Tag: RoleTag,
+        Dest: IntoRoleMail<Tag, T>,
+        Rem: Take<SendEff<Tag, T>, I>,
+        M: Send,
+    {
+        let mail = target.encode(msg);
+        let send = self.effects.send(target.mailbox(), mail);
+        async move {
+            send.await;
+            Session::new(self.effects)
+        }
+    }
+
+    fn call<Tag, T, Dest, I>(
+        self,
+        target: &Dest,
+        msg: T,
+    ) -> impl Future<Output = (Option<Dest::Reply>, Session<M, <Rem as Take<CallEff<Tag, T>, I>>::Rest>)> + Send
+    where
+        Tag: RoleTag,
+        Dest: IntoRoleCall<Tag, T> + Clone + Send + 'static,
+        Rem: Take<CallEff<Tag, T>, I>,
+        M: Send,
+        T: Send + 'static,
+    {
+        let dest = target.clone();
+        let mailbox = dest.mailbox().clone();
+        let call = self.effects.call(&mailbox, Dest::TIMEOUT, move |reply| dest.encode(msg, reply));
+        async move {
+            let reply = call.await;
+            (reply, Session::new(self.effects))
+        }
+    }
+
+    fn wait<I>(
+        self,
+        delay: Duration,
+    ) -> impl Future<Output = (Instant, Session<M, <Rem as Take<Wait, I>>::Rest>)> + Send
+    where
+        Rem: Take<Wait, I>,
+        M: Send,
+    {
+        let wait = self.effects.wait(delay);
+        async move {
+            let now = wait.await;
+            (now, Session::new(self.effects))
+        }
+    }
+
+    fn set_timeout<I>(
+        self,
+        delay: Duration,
+        msg: M,
+    ) -> impl Future<Output = Session<M, <Rem as Take<SetTimeout, I>>::Rest>> + Send
+    where
+        Rem: Take<SetTimeout, I>,
+        M: SendData,
+    {
+        self.set_timeout_at(0, delay, msg)
+    }
+
+    fn set_timeout_at<I>(
+        self,
+        slot: u64,
+        delay: Duration,
+        msg: M,
+    ) -> impl Future<Output = Session<M, <Rem as Take<SetTimeout, I>>::Rest>> + Send
+    where
+        Rem: Take<SetTimeout, I>,
+        M: SendData,
+    {
+        let set = self.effects.set_timeout_at(slot, delay, msg);
+        async move {
+            set.await;
+            Session::new(self.effects)
+        }
+    }
+
+    fn clear_timeout<I>(self) -> impl Future<Output = Session<M, <Rem as Take<ClearTimeout, I>>::Rest>> + Send
+    where
+        Rem: Take<ClearTimeout, I>,
+        M: Send,
+    {
+        self.clear_timeout_at(0)
+    }
+
+    fn clear_timeout_at<I>(
+        self,
+        slot: u64,
+    ) -> impl Future<Output = Session<M, <Rem as Take<ClearTimeout, I>>::Rest>> + Send
+    where
+        Rem: Take<ClearTimeout, I>,
+        M: Send,
+    {
+        let clear = self.effects.clear_timeout_at(slot);
+        async move {
+            clear.await;
+            Session::new(self.effects)
+        }
+    }
+
+    fn discard_repeat(self) -> Session<M, <Rem as super::DiscardRepeat>::Out>
+    where
+        Rem: super::DiscardRepeat,
+    {
+        Session::new(self.effects)
+    }
+
+    fn terminate<T, I>(self) -> impl Future<Output = T> + Send
+    where
+        T: Send,
+        Rem: Take<Terminate, I>,
+    {
+        self.effects.terminate()
+    }
+
+    fn finish<S: State, I>(self) -> S
+    where
+        Rem: FinishIn<S, I, Out = S>,
     {
         let _ = self;
         S::make(Marker(Private))
@@ -500,8 +615,6 @@ impl<M, Rem: FmtPar> fmt::Debug for Session<M, Rem> {
         f.debug_struct("Session").field("remaining", &list::describe::<Rem>()).finish_non_exhaustive()
     }
 }
-
-type After<Rem, E, I> = <<Rem as Select<E, I>>::Rest as Clean>::Out;
 
 /// Describe `State + Receive<In> → remainder` without constructing values.
 #[cfg(test)]

--- a/crates/amaru-pure-stage/src/typestate/tests.rs
+++ b/crates/amaru-pure-stage/src/typestate/tests.rs
@@ -142,7 +142,7 @@ fn describe_remainder() {
 fn remainder_const_text_matches_describe() {
     use super::describe::ConstDesc;
     type Rem = <toy::Idle as OnReceive<toy::FindIntersect>>::Then;
-    assert_eq!(describe::<Rem>(), Rem::TEXT);
+    assert_eq!(Rem::TEXT, "Send<Peer, String>, Send<Peer, u8> => Intersect | Wait => Idle");
     const TEXT: &str = Rem::TEXT;
     let _: super::Remainder<{ TEXT }> = super::Remainder;
 }

--- a/crates/amaru-pure-stage/src/typestate/tests.rs
+++ b/crates/amaru-pure-stage/src/typestate/tests.rs
@@ -139,6 +139,19 @@ fn describe_remainder() {
 }
 
 #[test]
+fn remainder_const_text_matches_describe() {
+    use super::describe::ConstDesc;
+    type Rem = <toy::Idle as OnReceive<toy::FindIntersect>>::Then;
+    assert_eq!(describe::<Rem>(), Rem::TEXT);
+    const TEXT: &str = Rem::TEXT;
+    let _: super::Remainder<{ TEXT }> = super::Remainder;
+}
+
+fn _remainder_binding_is_str<M, R: super::describe::ConstDesc>(s: &super::Session<M, R>) {
+    let _: &'static str = s.remainder();
+}
+
+#[test]
 fn set_timeout_is_required_before_finish() {
     type Rem = Choice<(Then<Par<((SetTimeout,),)>, toy::Idle>,)>;
     fn assert_selects<R: Select<SetTimeout, I>, I>() {}

--- a/crates/amaru-pure-stage/src/typestate/tests.rs
+++ b/crates/amaru-pure-stage/src/typestate/tests.rs
@@ -16,9 +16,9 @@
 //! `tests/typestate.rs`.
 
 use super::{
-    Cons, FmtPar, Here, Nil, OnReceive, Select, Then,
+    Choice, FmtPar, Here, OnReceive, Par, Select, Then,
     effect::{Call, ClearTimeout, Repeat, Send, SendAny, SetTimeout},
-    list::{CanFinish, Clean, DiscardRepeat, describe},
+    list::{CanFinish, ConsIfPresent, DiscardRepeat, describe},
     session::describe_receive,
 };
 
@@ -102,24 +102,27 @@ fn receive_constructor_selects_by_input_variant() {
 
 #[test]
 fn select_picks_first_matching_head() {
-    type Left = Then<Cons<Cons<Send<toy::Peer, u8>, Nil>, Nil>, toy::Idle>;
-    type Rem = Cons<Left, Cons<Then<Cons<Cons<Send<toy::Peer, String>, Nil>, Nil>, toy::Done>, Nil>>;
+    type Left = Then<Par<((Send<toy::Peer, u8>,),)>, toy::Idle>;
+    type Rem = Choice<(Left, Then<Par<((Send<toy::Peer, String>,),)>, toy::Done>)>;
 
-    assert_after::<Rem, Send<toy::Peer, u8>, Cons<Then<Nil, toy::Idle>, Nil>, _>();
+    assert_after::<Rem, Send<toy::Peer, u8>, Choice<(Then<Par<()>, toy::Idle>,)>, _>();
 }
 
 #[test]
 fn select_call_is_required_before_finish() {
-    type Rem = Cons<Then<Cons<Cons<Call<toy::Peer, u8>, Nil>, Nil>, toy::Done>, Nil>;
+    type Rem = Choice<(Then<Par<((Call<toy::Peer, u8>,),)>, toy::Done>,)>;
     fn assert_selects<R: Select<Call<toy::Peer, u8>, I>, I>() {}
     assert_selects::<Rem, _>();
     assert_eq!(describe::<Rem>(), format!("Call<{}, u8> => Done", std::any::type_name::<toy::Peer>()));
 }
 
 #[test]
-fn clean_drops_exhausted_sequences() {
-    type Dirty = Cons<Nil, Cons<Then<Nil, toy::Done>, Nil>>;
-    assert_types_eq::<<Dirty as Clean>::Out, Cons<Then<Nil, toy::Done>, Nil>>();
+fn exhausted_sequence_is_dropped_from_parallel() {
+    assert_types_eq::<<() as ConsIfPresent<((Send<toy::Peer, u8>,),)>>::Out, ((Send<toy::Peer, u8>,),)>();
+    assert_types_eq::<
+        <(Send<toy::Peer, u16>,) as ConsIfPresent<((Send<toy::Peer, u8>,),)>>::Out,
+        ((Send<toy::Peer, u16>,), (Send<toy::Peer, u8>,)),
+    >();
 }
 
 #[test]
@@ -137,7 +140,7 @@ fn describe_remainder() {
 
 #[test]
 fn set_timeout_is_required_before_finish() {
-    type Rem = Cons<Then<Cons<Cons<SetTimeout, Nil>, Nil>, toy::Idle>, Nil>;
+    type Rem = Choice<(Then<Par<((SetTimeout,),)>, toy::Idle>,)>;
     fn assert_selects<R: Select<SetTimeout, I>, I>() {}
     assert_selects::<Rem, _>();
     assert_eq!(describe::<Rem>(), "SetTimeout => Idle");
@@ -145,7 +148,7 @@ fn set_timeout_is_required_before_finish() {
 
 #[test]
 fn clear_timeout_is_required_before_finish() {
-    type Rem = Cons<Then<Cons<Cons<ClearTimeout, Nil>, Nil>, toy::Idle>, Nil>;
+    type Rem = Choice<(Then<Par<((ClearTimeout,),)>, toy::Idle>,)>;
     fn assert_selects<R: Select<ClearTimeout, I>, I>() {}
     assert_selects::<Rem, _>();
     assert_eq!(describe::<Rem>(), "ClearTimeout => Idle");
@@ -153,31 +156,27 @@ fn clear_timeout_is_required_before_finish() {
 
 #[test]
 fn unused_star_does_not_block_finish() {
-    type Rem = Cons<Then<Cons<Cons<Repeat<SendAny<toy::Peer>>, Nil>, Nil>, toy::Idle>, Nil>;
+    type Rem = Choice<(Then<Par<((Repeat<SendAny<toy::Peer>>,),)>, toy::Idle>,)>;
     fn assert_finish<R: CanFinish<toy::Idle, Here>>() {}
     assert_finish::<Rem>();
 }
 
 #[test]
 fn star_then_required_send_does_not_finish() {
-    type Rem = Cons<Then<Cons<Cons<Repeat<SendAny<toy::Peer>>, Cons<Send<toy::Peer, u8>, Nil>>, Nil>, toy::Idle>, Nil>;
+    type Rem = Choice<(Then<Par<((Repeat<SendAny<toy::Peer>>, Send<toy::Peer, u8>),)>, toy::Idle>,)>;
     fn assert_selects_send<R: Select<Send<toy::Peer, u8>, I>, I>() {}
     assert_selects_send::<Rem, _>();
 }
 
 #[test]
 fn using_star_keeps_the_star() {
-    type Inner = Then<Cons<Cons<Repeat<SendAny<toy::Peer>>, Nil>, Nil>, toy::Idle>;
-    type Rem = Cons<Inner, Nil>;
+    type Rem = Choice<(Then<Par<((Repeat<SendAny<toy::Peer>>,),)>, toy::Idle>,)>;
     assert_after::<Rem, SendAny<toy::Peer>, Rem, _>();
 }
 
 #[test]
 fn parallel_star_is_usable_beside_a_required_send() {
-    type Rem = Cons<
-        Then<Cons<Cons<Send<toy::Peer, u8>, Nil>, Cons<Cons<Repeat<SendAny<toy::Peer>>, Nil>, Nil>>, toy::Idle>,
-        Nil,
-    >;
+    type Rem = Choice<(Then<Par<((Send<toy::Peer, u8>,), (Repeat<SendAny<toy::Peer>>,))>, toy::Idle>,)>;
     fn assert_send<R: Select<Send<toy::Peer, u8>, I>, I>() {}
     fn assert_any<R: Select<SendAny<toy::Peer>, I>, I>() {}
     assert_send::<Rem, _>();
@@ -186,50 +185,42 @@ fn parallel_star_is_usable_beside_a_required_send() {
 
 #[test]
 fn repeat_sequence_unrolls_then_keeps_the_star() {
-    type Seq = Cons<Send<toy::Peer, u8>, Cons<Send<toy::Peer, u16>, Nil>>;
-    type Rem = Cons<Then<Cons<Cons<Repeat<Seq>, Nil>, Nil>, toy::Idle>, Nil>;
-    type Expect = Cons<Then<Cons<Cons<Send<toy::Peer, u16>, Cons<Repeat<Seq>, Nil>>, Nil>, toy::Idle>, Nil>;
+    type Seq = (Send<toy::Peer, u8>, Send<toy::Peer, u16>);
+    type Rem = Choice<(Then<Par<((Repeat<Seq>,),)>, toy::Idle>,)>;
+    type Expect = Choice<(Then<Par<((Send<toy::Peer, u16>, Repeat<Seq>),)>, toy::Idle>,)>;
     assert_after::<Rem, Send<toy::Peer, u8>, Expect, _>();
 }
 
 #[test]
 fn discard_repeat_leaves_the_suffix() {
-    type Rem =
-        Cons<Then<Cons<Cons<Repeat<Send<toy::Peer, u8>>, Cons<Send<toy::Peer, u16>, Nil>>, Nil>, toy::Idle>, Nil>;
-    type Expect = Cons<Then<Cons<Cons<Send<toy::Peer, u16>, Nil>, Nil>, toy::Idle>, Nil>;
+    type Rem = Choice<(Then<Par<((Repeat<Send<toy::Peer, u8>>, Send<toy::Peer, u16>),)>, toy::Idle>,)>;
+    type Expect = Choice<(Then<Par<((Send<toy::Peer, u16>,),)>, toy::Idle>,)>;
     assert_discard::<Rem, Expect>();
 }
 
 #[test]
 fn repeat_is_discarded_when_the_suffix_matches() {
-    type Rem =
-        Cons<Then<Cons<Cons<Repeat<Send<toy::Peer, u8>>, Cons<Send<toy::Peer, u16>, Nil>>, Nil>, toy::Idle>, Nil>;
-    assert_after::<Rem, Send<toy::Peer, u16>, Cons<Then<Nil, toy::Idle>, Nil>, _>();
+    type Rem = Choice<(Then<Par<((Repeat<Send<toy::Peer, u8>>, Send<toy::Peer, u16>),)>, toy::Idle>,)>;
+    assert_after::<Rem, Send<toy::Peer, u16>, Choice<(Then<Par<()>, toy::Idle>,)>, _>();
 }
 
 #[test]
 fn repeat_of_sequence_is_discarded_when_the_suffix_matches() {
-    type Seq = Cons<Send<toy::Peer, u8>, Cons<Send<toy::Peer, u16>, Nil>>;
-    type Rem = Cons<Then<Cons<Cons<Repeat<Seq>, Cons<Send<toy::Peer, u32>, Nil>>, Nil>, toy::Idle>, Nil>;
-    assert_after::<Rem, Send<toy::Peer, u32>, Cons<Then<Nil, toy::Idle>, Nil>, _>();
+    type Seq = (Send<toy::Peer, u8>, Send<toy::Peer, u16>);
+    type Rem = Choice<(Then<Par<((Repeat<Seq>, Send<toy::Peer, u32>),)>, toy::Idle>,)>;
+    assert_after::<Rem, Send<toy::Peer, u32>, Choice<(Then<Par<()>, toy::Idle>,)>, _>();
 }
 
 #[test]
 fn repeat_wins_over_a_matching_suffix() {
-    type Rem = Cons<Then<Cons<Cons<Repeat<Send<toy::Peer, u8>>, Cons<Send<toy::Peer, u8>, Nil>>, Nil>, toy::Idle>, Nil>;
+    type Rem = Choice<(Then<Par<((Repeat<Send<toy::Peer, u8>>, Send<toy::Peer, u8>),)>, toy::Idle>,)>;
     assert_after::<Rem, Send<toy::Peer, u8>, Rem, _>();
 }
 
 #[test]
 fn leftmost_parallel_head_wins_when_both_match() {
-    type Rem = Cons<
-        Then<
-            Cons<Cons<Send<toy::Peer, u8>, Nil>, Cons<Cons<Send<toy::Peer, u8>, Cons<Send<toy::Peer, u16>, Nil>>, Nil>>,
-            toy::Idle,
-        >,
-        Nil,
-    >;
-    type Expect = Cons<Then<Cons<Cons<Send<toy::Peer, u8>, Cons<Send<toy::Peer, u16>, Nil>>, Nil>, toy::Idle>, Nil>;
+    type Rem = Choice<(Then<Par<((Send<toy::Peer, u8>,), (Send<toy::Peer, u8>, Send<toy::Peer, u16>))>, toy::Idle>,)>;
+    type Expect = Choice<(Then<Par<((Send<toy::Peer, u8>, Send<toy::Peer, u16>),)>, toy::Idle>,)>;
     assert_after::<Rem, Send<toy::Peer, u8>, Expect, _>();
     assert_eq!(
         describe_after::<Rem, Send<toy::Peer, u8>, _>(),
@@ -244,14 +235,9 @@ fn leftmost_parallel_head_wins_when_both_match() {
 #[test]
 fn star_macro_unrolls_the_sequence() {
     use crate::typestate::prelude::*;
-    type Rem = Cons<Then<Cons<Cons<star!(Send<toy::Peer, u8>, Send<toy::Peer, u16>), Nil>, Nil>, toy::Idle>, Nil>;
-    type Expect = Cons<
-        Then<
-            Cons<Cons<Send<toy::Peer, u16>, Cons<star!(Send<toy::Peer, u8>, Send<toy::Peer, u16>), Nil>>, Nil>,
-            toy::Idle,
-        >,
-        Nil,
-    >;
+    type Rem = Choice<(Then<Par<((star!(Send<toy::Peer, u8>, Send<toy::Peer, u16>),),)>, toy::Idle>,)>;
+    type Expect =
+        Choice<(Then<Par<((Send<toy::Peer, u16>, star!(Send<toy::Peer, u8>, Send<toy::Peer, u16>)),)>, toy::Idle>,)>;
     assert_after::<Rem, Send<toy::Peer, u8>, Expect, _>();
 }
 
@@ -284,8 +270,8 @@ mod exclusive_choice {
     });
 
     type Rem = <Idle as OnReceive<Go>>::Then;
-    type AfterAExpect = Cons<Then<Cons<Cons<Send<RoleB, B1>, Nil>, Nil>, StateA>, Nil>;
-    type AfterCExpect = Cons<Then<Cons<Cons<Send<RoleD, D1>, Nil>, Nil>, StateC>, Nil>;
+    type AfterAExpect = Choice<(Then<Par<((Send<RoleB, B1>,),)>, StateA>,)>;
+    type AfterCExpect = Choice<(Then<Par<((Send<RoleD, D1>,),)>, StateC>,)>;
 
     #[test]
     fn after_a_only_b_remains() {
@@ -325,7 +311,7 @@ mod exclusive_choice {
     });
 
     type Rem3 = <Start as OnReceive<Kick>>::Then;
-    type AfterEExpect = Cons<Then<Nil, StateZ>, Nil>;
+    type AfterEExpect = Choice<(Then<Par<()>, StateZ>,)>;
 
     #[test]
     fn three_way_choice_picks_the_last_alternative() {

--- a/crates/amaru-pure-stage/tests/ui.rs
+++ b/crates/amaru-pure-stage/tests/ui.rs
@@ -1,0 +1,281 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Compile-fail snapshots for session typestate diagnostics.
+//!
+//! Snippets in `tests/ui/*.rs` are type-checked with `rustc` against the
+//! `amaru_pure_stage` rlib already built for this test binary (no second Cargo
+//! graph). Expected diagnostics live in the adjacent `*.stderr` file.
+//!
+//! Refresh snapshots with `BLESS=1 cargo test -p amaru-pure-stage --test ui`.
+
+#![allow(clippy::expect_used, clippy::panic)]
+
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+    time::SystemTime,
+};
+
+use serde_json::Value;
+
+#[test]
+fn session_typestate_diagnostics() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let ui_dir = manifest.join("tests/ui");
+    let artifacts = find_artifact_dir();
+    let lib_dirs = collect_lib_dirs(&artifacts);
+    let rlib = crate_artifact(&lib_dirs, "amaru_pure_stage", &["rlib"])
+        .or_else(|| crate_artifact(&lib_dirs, "amaru_pure_stage", &["rmeta"]))
+        .expect("amaru_pure_stage rlib");
+    let rlib = prefer_rmeta(&rlib);
+    let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
+    let out_dir = artifacts.join("amaru-ui-out");
+    fs::create_dir_all(&out_dir).unwrap();
+
+    let mut cases: Vec<PathBuf> = fs::read_dir(&ui_dir)
+        .unwrap()
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|e| e == "rs") && p.file_stem().is_some_and(|s| s != "harness"))
+        .collect();
+    cases.sort();
+    assert!(!cases.is_empty(), "no tests/ui/*.rs snippets");
+
+    let bless = env::var_os("BLESS").is_some() || env::var_os("AMARU_UI_BLESS").is_some();
+    let mut failures = Vec::new();
+
+    for src in &cases {
+        let rel = src.strip_prefix(&manifest).unwrap_or(src);
+        let expected_path = src.with_extension("stderr");
+        let actual = compile_snippet(&rustc, &manifest, rel, &lib_dirs, &rlib, &out_dir);
+        if bless {
+            fs::write(&expected_path, &actual).unwrap();
+            continue;
+        }
+        let expected = fs::read_to_string(&expected_path).unwrap_or_default();
+        if expected != actual {
+            failures.push(format!("{}:\n{}", rel.display(), pretty_assertions::Comparison::new(&expected, &actual)));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "session UI diagnostics mismatch (BLESS=1 to update snapshots):\n\n{}",
+        failures.join("\n\n")
+    );
+}
+
+fn compile_snippet(
+    rustc: &str,
+    manifest: &Path,
+    rel: &Path,
+    lib_dirs: &[PathBuf],
+    rlib: &Path,
+    out_dir: &Path,
+) -> String {
+    let mut cmd = Command::new(rustc);
+    cmd.current_dir(manifest).args([
+        "--edition=2024",
+        "--crate-type=lib",
+        "--emit=metadata",
+        "--error-format=json",
+        "--diagnostic-width=200",
+        "--cap-lints=allow",
+        "-A=unused",
+        "-A=dead_code",
+    ]);
+    cmd.arg("--out-dir").arg(out_dir);
+    for dir in lib_dirs {
+        cmd.arg("-L").arg(format!("dependency={}", dir.display()));
+    }
+    cmd.arg("--extern").arg(format!("amaru_pure_stage={}", rlib.display()));
+    let output = cmd.arg(rel).output().unwrap_or_else(|e| panic!("failed to spawn {rustc}: {e}"));
+
+    if output.status.success() {
+        panic!("{} compiled; expected a session diagnostic", rel.display());
+    }
+
+    format_stderr(&String::from_utf8_lossy(&output.stderr), manifest)
+}
+
+fn format_stderr(stderr: &str, manifest: &Path) -> String {
+    let mut out = String::new();
+    for line in stderr.lines() {
+        let Ok(v) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        let Some(diag) = diagnostic_object(&v) else {
+            continue;
+        };
+        if diag.get("level").and_then(Value::as_str) != Some("error") {
+            continue;
+        }
+        write_diag(&mut out, diag, manifest, 0);
+    }
+    out
+}
+
+fn diagnostic_object(v: &Value) -> Option<&Value> {
+    if v.get("message").is_some() && v.get("level").is_some() {
+        return Some(v);
+    }
+    v.get("message").filter(|m| m.get("level").is_some())
+}
+
+fn write_diag(out: &mut String, diag: &Value, manifest: &Path, indent: usize) {
+    let pad = "  ".repeat(indent);
+    let level = diag.get("level").and_then(Value::as_str).unwrap_or("error");
+    let msg = diag.get("message").and_then(Value::as_str).unwrap_or("");
+    if skip_note(msg) {
+        return;
+    }
+    let code = diag.get("code").and_then(|c| c.get("code")).and_then(Value::as_str);
+    match code {
+        Some(code) if indent == 0 => out.push_str(&format!("{pad}{level}[{code}]: {msg}\n")),
+        _ if indent == 0 => out.push_str(&format!("{pad}{level}: {msg}\n")),
+        Some(code) => out.push_str(&format!("{pad}= {level}[{code}]: {msg}\n")),
+        None => out.push_str(&format!("{pad}= {level}: {msg}\n")),
+    }
+
+    if let Some(span) = diag
+        .get("spans")
+        .and_then(Value::as_array)
+        .and_then(|s| s.iter().find(|s| s.get("is_primary").and_then(Value::as_bool) == Some(true)))
+    {
+        let file = span.get("file_name").and_then(Value::as_str).unwrap_or("");
+        let line = span.get("line_start").and_then(Value::as_u64).unwrap_or(0);
+        let col = span.get("column_start").and_then(Value::as_u64).unwrap_or(0);
+        let file = normalize_path(file, manifest);
+        if indent == 0 || file.starts_with("tests/") {
+            out.push_str(&format!("{pad} --> {file}:{line}:{col}\n"));
+        }
+        if let Some(label) = span.get("label").and_then(Value::as_str).filter(|s| !s.is_empty()) {
+            out.push_str(&format!("{pad}  = {label}\n"));
+        }
+    }
+
+    if let Some(children) = diag.get("children").and_then(Value::as_array) {
+        for child in children {
+            write_diag(out, child, manifest, indent + 1);
+        }
+    }
+}
+
+fn skip_note(msg: &str) -> bool {
+    let m = msg.to_ascii_lowercase();
+    m.contains("full type name has been written")
+        || m.contains("full name for the type has been written")
+        || m.contains("consider using `--verbose`")
+        || m.contains("for more information about this error")
+        || m.contains("long-type-")
+        || m.contains("aborting due to")
+}
+
+fn normalize_path(file: &str, manifest: &Path) -> String {
+    let path = Path::new(file);
+    if let Ok(rel) = path.strip_prefix(manifest) {
+        return rel.display().to_string().replace('\\', "/");
+    }
+    file.replace('\\', "/")
+}
+
+fn find_artifact_dir() -> PathBuf {
+    let exe = env::current_exe().expect("current_exe");
+    let mut dir = exe.parent().unwrap_or(Path::new(".")).to_path_buf();
+    for _ in 0..10 {
+        if dir.join("libamaru_pure_stage.rlib").exists() || newest_hashed(&dir, "amaru_pure_stage", &["rlib"]).is_some()
+        {
+            return dir;
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent.to_path_buf(),
+            None => break,
+        }
+    }
+    panic!("could not find libamaru_pure_stage.rlib (started at {})", exe.display());
+}
+
+fn collect_lib_dirs(artifacts: &Path) -> Vec<PathBuf> {
+    // Hashed `build/<crate>/<hash>/out` artifacts only. `target/debug/lib*.rlib`
+    // copies are metadata stubs under this cargo layout.
+    let mut dirs = Vec::new();
+    let Ok(crates) = fs::read_dir(artifacts.join("build")) else {
+        return dirs;
+    };
+    for crate_dir in crates.flatten() {
+        let Ok(hashes) = fs::read_dir(crate_dir.path()) else {
+            continue;
+        };
+        for hash in hashes.flatten() {
+            let out = hash.path().join("out");
+            if out.is_dir() {
+                dirs.push(out);
+            }
+        }
+    }
+    dirs
+}
+
+fn crate_artifact(dirs: &[PathBuf], crate_name: &str, exts: &[&str]) -> Option<PathBuf> {
+    let mut best: Option<(SystemTime, PathBuf)> = None;
+    for dir in dirs {
+        let Some(path) = newest_hashed(dir, crate_name, exts) else {
+            continue;
+        };
+        let Ok(mtime) = fs::metadata(&path).and_then(|m| m.modified()) else {
+            continue;
+        };
+        if best.as_ref().is_none_or(|(t, _)| mtime >= *t) {
+            best = Some((mtime, path));
+        }
+    }
+    best.map(|(_, p)| p).or_else(|| dirs.iter().find_map(|dir| unhashed(dir, crate_name, exts)))
+}
+
+fn newest_hashed(dir: &Path, crate_name: &str, exts: &[&str]) -> Option<PathBuf> {
+    let prefix = format!("lib{crate_name}-");
+    let mut best: Option<(SystemTime, PathBuf)> = None;
+    for ent in fs::read_dir(dir).ok()?.flatten() {
+        let path = ent.path();
+        let name = path.file_name()?.to_string_lossy();
+        if !name.starts_with(&prefix) {
+            continue;
+        }
+        if !exts.iter().any(|ext| name.ends_with(&format!(".{ext}"))) {
+            continue;
+        }
+        let meta = fs::metadata(&path).ok()?;
+        if meta.len() == 0 {
+            continue;
+        }
+        let mtime = meta.modified().ok()?;
+        if best.as_ref().is_none_or(|(t, _)| mtime >= *t) {
+            best = Some((mtime, path));
+        }
+    }
+    best.map(|(_, p)| p)
+}
+
+fn unhashed(dir: &Path, crate_name: &str, exts: &[&str]) -> Option<PathBuf> {
+    exts.iter().map(|ext| dir.join(format!("lib{crate_name}.{ext}"))).find(|p| p.exists())
+}
+
+fn prefer_rmeta(artifact: &Path) -> PathBuf {
+    let rmeta = artifact.with_extension("rmeta");
+    match fs::metadata(&rmeta) {
+        Ok(meta) if meta.len() > 0 => rmeta,
+        _ => artifact.to_path_buf(),
+    }
+}

--- a/crates/amaru-pure-stage/tests/ui/discard_repeat_without_star.rs
+++ b/crates/amaru-pure-stage/tests/ui/discard_repeat_without_star.rs
@@ -1,0 +1,25 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[path = "harness.rs"]
+mod harness;
+
+use amaru_pure_stage::typestate::prelude::*;
+use harness::{Done, Idle, ToPeer};
+
+on_receive!(Idle, u8 => Send<ToPeer, String> => Done);
+
+fn go<M>(s: Idle, eff: amaru_pure_stage::Effects<M>) {
+    let _ = s.receive(1u8, eff).discard_repeat();
+}

--- a/crates/amaru-pure-stage/tests/ui/discard_repeat_without_star.stderr
+++ b/crates/amaru-pure-stage/tests/ui/discard_repeat_without_star.stderr
@@ -1,3 +1,3 @@
-error[E0599]: no method named `discard_repeat` found for struct `Session<M, (Then<((amaru_pure_stage::typestate::Send<ToPeer, String>, ()), ()), harness::Done>, ())>` in the current scope
+error[E0599]: no method named `discard_repeat` found for struct `Session<M, Choice<(Then<Par<((amaru_pure_stage::typestate::Send<ToPeer, String>,),)>, harness::Done>,)>>` in the current scope
  --> tests/ui/discard_repeat_without_star.rs:24:33
   = method cannot be called due to unsatisfied trait bounds

--- a/crates/amaru-pure-stage/tests/ui/discard_repeat_without_star.stderr
+++ b/crates/amaru-pure-stage/tests/ui/discard_repeat_without_star.stderr
@@ -1,0 +1,3 @@
+error[E0599]: no method named `discard_repeat` found for struct `Session<M, (Then<((amaru_pure_stage::typestate::Send<ToPeer, String>, ()), ()), harness::Done>, ())>` in the current scope
+ --> tests/ui/discard_repeat_without_star.rs:24:33
+  = method cannot be called due to unsatisfied trait bounds

--- a/crates/amaru-pure-stage/tests/ui/finish_required_effect.rs
+++ b/crates/amaru-pure-stage/tests/ui/finish_required_effect.rs
@@ -1,0 +1,25 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[path = "harness.rs"]
+mod harness;
+
+use amaru_pure_stage::typestate::prelude::*;
+use harness::{Done, Idle, ToPeer};
+
+on_receive!(Idle, u8 => Send<ToPeer, String> => Done);
+
+fn go<M>(s: Idle, eff: amaru_pure_stage::Effects<M>) -> Done {
+    s.receive(1u8, eff).finish()
+}

--- a/crates/amaru-pure-stage/tests/ui/finish_required_effect.stderr
+++ b/crates/amaru-pure-stage/tests/ui/finish_required_effect.stderr
@@ -1,6 +1,6 @@
-error[E0277]: cannot finish in `_` from remainder `(Then<((amaru_pure_stage::typestate::Send<ToPeer, String>, ()), ()), harness::Done>, ())`
+error[E0277]: cannot finish in `_` from remainder `Choice<(Then<Par<((amaru_pure_stage::typestate::Send<ToPeer, String>,),)>, harness::Done>,)>`
  --> tests/ui/finish_required_effect.rs:24:25
   = required effects still remain
-  = help: the trait `FinishIn<_, _>` is not implemented for `(Then<((amaru_pure_stage::typestate::Send<ToPeer, String>, ()), ()), harness::Done>, ())`
+  = help: the trait `FinishIn<_, _>` is not implemented for `Choice<(Then<Par<((amaru_pure_stage::typestate::Send<ToPeer, String>,),)>, harness::Done>,)>`
   = note: leading Repeat is stripped automatically; other effects must be performed first
   = note: required by a bound in `amaru_pure_stage::typestate::SessionOps::finish`

--- a/crates/amaru-pure-stage/tests/ui/finish_required_effect.stderr
+++ b/crates/amaru-pure-stage/tests/ui/finish_required_effect.stderr
@@ -1,0 +1,6 @@
+error[E0277]: cannot finish in `_` from remainder `(Then<((amaru_pure_stage::typestate::Send<ToPeer, String>, ()), ()), harness::Done>, ())`
+ --> tests/ui/finish_required_effect.rs:24:25
+  = required effects still remain
+  = help: the trait `FinishIn<_, _>` is not implemented for `(Then<((amaru_pure_stage::typestate::Send<ToPeer, String>, ()), ()), harness::Done>, ())`
+  = note: leading Repeat is stripped automatically; other effects must be performed first
+  = note: required by a bound in `amaru_pure_stage::typestate::SessionOps::finish`

--- a/crates/amaru-pure-stage/tests/ui/harness.rs
+++ b/crates/amaru-pure-stage/tests/ui/harness.rs
@@ -1,0 +1,52 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared protocol types for UI snippets. Avoids `make_states!` / `define_role!`
+//! so rustc does not need `serde` as a crate-level `--extern`.
+
+use amaru_pure_stage::{
+    StageRef,
+    typestate::{InitialState, Marker, NotInitialState, Role, RoleTag, State},
+};
+
+pub struct Idle(Marker);
+impl State for Idle {
+    const NAME: &'static str = "Idle";
+    fn make(marker: Marker) -> Self {
+        Idle(marker)
+    }
+    type Initial = InitialState;
+}
+
+pub struct Done(Marker);
+impl State for Done {
+    const NAME: &'static str = "Done";
+    fn make(marker: Marker) -> Self {
+        Done(marker)
+    }
+    type Initial = NotInitialState;
+}
+
+pub struct ToPeer;
+impl RoleTag for ToPeer {
+    const NAME: &'static str = "ToPeer";
+}
+
+pub struct Peer(StageRef<String>);
+impl Role<ToPeer> for Peer {
+    type Mailbox = String;
+    fn mailbox(&self) -> &StageRef<String> {
+        &self.0
+    }
+}

--- a/crates/amaru-pure-stage/tests/ui/remainder_ascription.rs
+++ b/crates/amaru-pure-stage/tests/ui/remainder_ascription.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
 #[path = "harness.rs"]
 mod harness;
 
@@ -22,6 +25,5 @@ on_receive!(Idle, u8 => Send<ToPeer, String> => Done);
 
 fn go<M>(s: Idle, eff: amaru_pure_stage::Effects<M>) {
     let session = s.receive(1u8, eff);
-    let rem = session.remainder();
-    let _: usize = rem;
+    reveal_remainder!(session);
 }

--- a/crates/amaru-pure-stage/tests/ui/remainder_ascription.rs
+++ b/crates/amaru-pure-stage/tests/ui/remainder_ascription.rs
@@ -1,0 +1,27 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[path = "harness.rs"]
+mod harness;
+
+use amaru_pure_stage::typestate::prelude::*;
+use harness::{Done, Idle, ToPeer};
+
+on_receive!(Idle, u8 => Send<ToPeer, String> => Done);
+
+fn go<M>(s: Idle, eff: amaru_pure_stage::Effects<M>) {
+    let session = s.receive(1u8, eff);
+    let rem = session.remainder();
+    let _: usize = rem;
+}

--- a/crates/amaru-pure-stage/tests/ui/remainder_ascription.stderr
+++ b/crates/amaru-pure-stage/tests/ui/remainder_ascription.stderr
@@ -1,3 +1,4 @@
-error[E0308]: mismatched types
- --> tests/ui/remainder_ascription.rs:26:20
-  = expected `usize`, found `&str`
+error[E0080]: evaluation panicked: Send<ToPeer, String> => Done
+ --> crates/amaru-pure-stage/src/typestate/macros.rs:593:18
+  = evaluation of `go::reveal::<M, amaru_pure_stage::typestate::Choice<(amaru_pure_stage::typestate::Then<amaru_pure_stage::typestate::Par<((amaru_pure_stage::typestate::Send<harness::ToPeer, std::string::String>,),)>, harness::Done>,)>>::{constant#0}` failed inside this call
+  = note: inside `amaru_pure_stage::typestate::remainder_ctfe_panic::<Choice<(Then<Par<((amaru_pure_stage::typestate::Send<ToPeer, String>,),)>, harness::Done>,)>>`

--- a/crates/amaru-pure-stage/tests/ui/remainder_ascription.stderr
+++ b/crates/amaru-pure-stage/tests/ui/remainder_ascription.stderr
@@ -1,0 +1,3 @@
+error[E0308]: mismatched types
+ --> tests/ui/remainder_ascription.rs:26:20
+  = expected `usize`, found `&str`

--- a/crates/amaru-pure-stage/tests/ui/send_any_missing.rs
+++ b/crates/amaru-pure-stage/tests/ui/send_any_missing.rs
@@ -1,0 +1,25 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[path = "harness.rs"]
+mod harness;
+
+use amaru_pure_stage::typestate::prelude::*;
+use harness::{Done, Idle, Peer, ToPeer};
+
+on_receive!(Idle, u8 => Send<ToPeer, String> => Done);
+
+async fn go<M: core::marker::Send>(s: Idle, peer: &Peer, eff: amaru_pure_stage::Effects<M>) {
+    let _ = s.receive(1u8, eff).send_any(peer, String::new()).await;
+}

--- a/crates/amaru-pure-stage/tests/ui/send_any_missing.stderr
+++ b/crates/amaru-pure-stage/tests/ui/send_any_missing.stderr
@@ -1,8 +1,8 @@
-error[E0277]: `SendAnyOp<M, (Then<((amaru_pure_stage::typestate::Send<ToPeer, String>, ()), ()), harness::Done>, ()), ToPeer, _>` is not a future
+error[E0277]: `SendAnyOp<M, Choice<(Then<Par<((amaru_pure_stage::typestate::Send<ToPeer, String>,),)>, harness::Done>,)>, ToPeer, _>` is not a future
  --> tests/ui/send_any_missing.rs:24:63
-  = `SendAnyOp<M, (Then<((amaru_pure_stage::typestate::Send<ToPeer, String>, ()), ()), harness::Done>, ()), ToPeer, _>` is not a future
-  = help: the trait `IntoFuture` is not implemented for `SendAnyOp<M, (Then<((amaru_pure_stage::typestate::Send<ToPeer, String>, ()), ()), harness::Done>, ()), ToPeer, _>`
-  = note: SendAnyOp<M, (Then<((amaru_pure_stage::typestate::Send<ToPeer, String>, ()), ()), harness::Done>, ()), ToPeer, _> must be a future or must implement `IntoFuture` to be awaited
+  = `SendAnyOp<M, Choice<(Then<Par<((amaru_pure_stage::typestate::Send<ToPeer, String>,),)>, harness::Done>,)>, ToPeer, _>` is not a future
+  = help: the trait `IntoFuture` is not implemented for `SendAnyOp<M, Choice<(Then<Par<((amaru_pure_stage::typestate::Send<ToPeer, String>,),)>, harness::Done>,)>, ToPeer, _>`
+  = note: SendAnyOp<M, Choice<(Then<Par<((amaru_pure_stage::typestate::Send<ToPeer, String>,),)>, harness::Done>,)>, ToPeer, _> must be a future or must implement `IntoFuture` to be awaited
   = help: the trait `IntoFuture` is conditionally implemented for `SendAnyOp<M, Rem, Tag, I>`
   = help: remove the `.await`
    --> tests/ui/send_any_missing.rs:24:62

--- a/crates/amaru-pure-stage/tests/ui/send_any_missing.stderr
+++ b/crates/amaru-pure-stage/tests/ui/send_any_missing.stderr
@@ -1,0 +1,8 @@
+error[E0277]: `SendAnyOp<M, (Then<((amaru_pure_stage::typestate::Send<ToPeer, String>, ()), ()), harness::Done>, ()), ToPeer, _>` is not a future
+ --> tests/ui/send_any_missing.rs:24:63
+  = `SendAnyOp<M, (Then<((amaru_pure_stage::typestate::Send<ToPeer, String>, ()), ()), harness::Done>, ()), ToPeer, _>` is not a future
+  = help: the trait `IntoFuture` is not implemented for `SendAnyOp<M, (Then<((amaru_pure_stage::typestate::Send<ToPeer, String>, ()), ()), harness::Done>, ()), ToPeer, _>`
+  = note: SendAnyOp<M, (Then<((amaru_pure_stage::typestate::Send<ToPeer, String>, ()), ()), harness::Done>, ()), ToPeer, _> must be a future or must implement `IntoFuture` to be awaited
+  = help: the trait `IntoFuture` is conditionally implemented for `SendAnyOp<M, Rem, Tag, I>`
+  = help: remove the `.await`
+   --> tests/ui/send_any_missing.rs:24:62

--- a/crates/amaru-pure-stage/tests/ui/send_other_choice.rs
+++ b/crates/amaru-pure-stage/tests/ui/send_other_choice.rs
@@ -1,0 +1,71 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use amaru_pure_stage::{
+    StageRef,
+    typestate::{InitialState, Marker, NotInitialState, Role, RoleTag, State, prelude::*},
+};
+
+struct Idle(Marker);
+impl State for Idle {
+    const NAME: &'static str = "Idle";
+    fn make(marker: Marker) -> Self {
+        Idle(marker)
+    }
+    type Initial = InitialState;
+}
+struct StateA(Marker);
+impl State for StateA {
+    const NAME: &'static str = "StateA";
+    fn make(marker: Marker) -> Self {
+        StateA(marker)
+    }
+    type Initial = NotInitialState;
+}
+struct StateC(Marker);
+impl State for StateC {
+    const NAME: &'static str = "StateC";
+    fn make(marker: Marker) -> Self {
+        StateC(marker)
+    }
+    type Initial = NotInitialState;
+}
+
+macro_rules! tag_role {
+    ($tag:ident, $role:ident) => {
+        struct $tag;
+        impl RoleTag for $tag {
+            const NAME: &'static str = stringify!($tag);
+        }
+        struct $role(StageRef<u8>);
+        impl Role<$tag> for $role {
+            type Mailbox = u8;
+            fn mailbox(&self) -> &StageRef<u8> {
+                &self.0
+            }
+        }
+    };
+}
+tag_role!(RoleA, DestA);
+tag_role!(RoleB, DestB);
+tag_role!(RoleC, DestC);
+tag_role!(RoleD, DestD);
+
+on_receive!(Idle, Go => Send<RoleA, u8>, Send<RoleB, u8> => StateA | Send<RoleC, u8>, Send<RoleD, u8> => StateC);
+struct Go;
+
+async fn go<M: core::marker::Send>(s: Idle, a: &DestA, d: &DestD, eff: amaru_pure_stage::Effects<M>) {
+    let s = s.receive(Go, eff).send(a, 1u8).await;
+    let _ = s.send(d, 1u8).await;
+}

--- a/crates/amaru-pure-stage/tests/ui/send_other_choice.stderr
+++ b/crates/amaru-pure-stage/tests/ui/send_other_choice.stderr
@@ -1,0 +1,21 @@
+error[E0271]: type mismatch resolving `impl Future<Output = Session<M, _>> + Send == impl Future<Output = Session<M, _>> + Send`
+ --> tests/ui/send_other_choice.rs:70:15
+  = types differ
+error[E0277]: the trait bound `DestD: IntoRoleMail<RoleB, u8>` is not satisfied
+ --> tests/ui/send_other_choice.rs:70:20
+  = unsatisfied trait bound
+  = help: the trait `IntoRoleMail<RoleB, u8>` is not implemented for `DestD`
+   --> tests/ui/send_other_choice.rs:51:9
+  = note: required by a bound in `send`
+error[E0277]: the trait bound `DestD: IntoRoleMail<RoleB, u8>` is not satisfied
+ --> tests/ui/send_other_choice.rs:70:13
+  = unsatisfied trait bound
+  = help: the trait `IntoRoleMail<RoleB, u8>` is not implemented for `DestD`
+   --> tests/ui/send_other_choice.rs:51:9
+  = note: required by a bound in `<Session<M, Rem> as amaru_pure_stage::typestate::SessionOps<M, Rem>>::send`
+error[E0277]: the trait bound `DestD: IntoRoleMail<RoleB, u8>` is not satisfied
+ --> tests/ui/send_other_choice.rs:70:28
+  = unsatisfied trait bound
+  = help: the trait `IntoRoleMail<RoleB, u8>` is not implemented for `DestD`
+   --> tests/ui/send_other_choice.rs:51:9
+  = note: required by a bound in `<Session<M, Rem> as amaru_pure_stage::typestate::SessionOps<M, Rem>>::send`

--- a/crates/amaru-pure-stage/tests/ui/send_wrong_payload.rs
+++ b/crates/amaru-pure-stage/tests/ui/send_wrong_payload.rs
@@ -1,0 +1,25 @@
+// Copyright 2026 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[path = "harness.rs"]
+mod harness;
+
+use amaru_pure_stage::typestate::prelude::*;
+use harness::{Done, Idle, Peer, ToPeer};
+
+on_receive!(Idle, u8 => Send<ToPeer, String> => Done);
+
+async fn go<M: core::marker::Send>(s: Idle, peer: &Peer, eff: amaru_pure_stage::Effects<M>) {
+    let _ = s.receive(1u8, eff).send(peer, 0u32).await;
+}

--- a/crates/amaru-pure-stage/tests/ui/send_wrong_payload.stderr
+++ b/crates/amaru-pure-stage/tests/ui/send_wrong_payload.stderr
@@ -1,0 +1,8 @@
+error[E0308]: mismatched types
+ --> tests/ui/send_wrong_payload.rs:24:44
+  = expected `String`, found `u32`
+  = help: the return type of this call is `u32` due to the type of the argument passed
+   --> tests/ui/send_wrong_payload.rs:24:13
+  = note: method defined here
+  = help: try using a conversion method
+   --> tests/ui/send_wrong_payload.rs:24:48


### PR DESCRIPTION
The main problem with typestate is that the compiler diagnostics in case of error are very verbose
and hard to read. This PR makes the types easier to read and adds a `Session::remainder(&self) ->
&str` method for pretty-printing the current typestate.

Future work may require changes to rust-analyzer to introduce a feature that can print a type based
on some trait or attribute — which is more realistic than getting a `typeof` operator accepted into
the Rust language itself (which could then support a const-panic approach for giving a better error
message).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session remainders can be inspected as readable text at runtime or during compilation.
  * Protocol sequences, choices, and parallel branches support tuple-based representations of up to 10 items.
  * Protocol operations are available through a unified session operations API.
  * `send_any` supports flexible message sending, with invalid usage reported by the compiler.

* **Bug Fixes**
  * Improved compiler diagnostics for invalid operations, payloads, and incomplete sessions.

* **Tests**
  * Added coverage for remainder descriptions, choices, payload validation, and required effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->