### PR TITLE
advertise protocol V15 in consensus handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Other guiding principles:
 
 ## v10.11.20260910 _[unreleased; planned for 2026-09-10]_
 
+### Added
+
+- **amaru-protocols**: handshake offers node-to-node protocol version 15 by default, advertising CIP-0155 SRV support. Minimum offered version is still 11. ([#1332](https://github.com/pragma-org/amaru/issues/1332))
+
 ### Fixed
 
 - **amaru-bootstrap**: allow cancellation of the bootstrap process.

--- a/crates/amaru-protocols/src/connection.rs
+++ b/crates/amaru-protocols/src/connection.rs
@@ -346,7 +346,10 @@ async fn notify_chainsync_terminated(params: &Params, eff: &Effects<ConnectionMe
     .await;
 }
 
-async fn do_initialize(Params { conn_id, role, magic, peer, .. }: &Params, eff: Effects<ConnectionMessage>) -> State {
+async fn do_initialize(
+    Params { conn_id, role, magic, peer, config, .. }: &Params,
+    eff: Effects<ConnectionMessage>,
+) -> State {
     let peer = *peer;
     let muxer = eff.stage("mux", mux::stage).await;
     let muxer = eff.supervise(muxer, ConnectionMessage::ChildDied(ChildId::Mux));
@@ -363,7 +366,7 @@ async fn do_initialize(Params { conn_id, role, magic, peer, .. }: &Params, eff: 
                 handshake::HandshakeInitiator::new(
                     muxer.clone(),
                     handshake_result,
-                    VersionTable::v11_and_above(*magic, false, true),
+                    VersionTable::v11_through(config.max_n2n_version, *magic, false, true),
                 ),
             )
             .await
@@ -378,7 +381,7 @@ async fn do_initialize(Params { conn_id, role, magic, peer, .. }: &Params, eff: 
                     handshake_result,
                     // Use initiator_only_diffusion_mode = false so downstream peers
                     // know we can serve as chainsync/blockfetch server
-                    VersionTable::v11_and_above(*magic, false, true),
+                    VersionTable::v11_through(config.max_n2n_version, *magic, false, true),
                 ),
             )
             .await

--- a/crates/amaru-protocols/src/handshake/mod.rs
+++ b/crates/amaru-protocols/src/handshake/mod.rs
@@ -232,6 +232,28 @@ mod negotiation_tests {
         }
     }
 
+    #[test]
+    fn v15_and_v14_agree_on_v14() {
+        let magic = NetworkMagic::PREPROD;
+        let v15 = VersionTable::v11_and_above(magic, false, true);
+        let v14 = VersionTable::v11_through(VersionNumber::V14, magic, false, true);
+        assert_eq!(
+            compute_negotiation_result(&v15, &v14),
+            HandshakeResult::Accepted(VersionNumber::V14, data(magic, false, true, false))
+        );
+    }
+
+    #[test]
+    fn two_v15_offers_agree_on_v15() {
+        let magic = NetworkMagic::PREPROD;
+        let ours = VersionTable::v11_and_above(magic, false, true);
+        let theirs = VersionTable::v11_and_above(magic, false, true);
+        assert_eq!(
+            compute_negotiation_result(&ours, &theirs),
+            HandshakeResult::Accepted(VersionNumber::V15, data(magic, false, true, false))
+        );
+    }
+
     fn decode_hex(hex: &str) -> Message<VersionData> {
         let bytes = hex::decode(hex).expect(hex);
         cbor::decode(&bytes).unwrap_or_else(|e| panic!("{hex}: {e}"))

--- a/crates/amaru-protocols/src/handshake/tests.rs
+++ b/crates/amaru-protocols/src/handshake/tests.rs
@@ -99,13 +99,14 @@ fn test_against_node() {
     running.run(Run::skip_and_resolve());
     rt.block_on(running.await_external_effect());
     let result = rx.try_next().unwrap();
-    assert_eq!(
-        result,
-        handshake::HandshakeResult::Accepted(
-            VersionNumber::V14,
-            VersionData::new(network_magic, true, PeerSharing::Disabled, false),
-        )
-    );
+    match result {
+        handshake::HandshakeResult::Accepted(version, data) => {
+            assert!(version >= VersionNumber::V14, "{version:?}");
+            assert_eq!(data, VersionData::new(network_magic, true, PeerSharing::Disabled, false));
+        }
+        handshake::HandshakeResult::Refused(reason) => panic!("{reason:?}"),
+        handshake::HandshakeResult::Query(table) => panic!("{table:?}"),
+    }
 }
 
 #[test]
@@ -162,13 +163,14 @@ fn test_against_node_with_tokio() {
     let running = network.run(rt.handle().clone());
 
     let result = rt.block_on(rx.next()).unwrap();
-    assert_eq!(
-        result,
-        handshake::HandshakeResult::Accepted(
-            VersionNumber::V14,
-            VersionData::new(NetworkMagic::MAINNET, true, PeerSharing::Disabled, false),
-        )
-    );
+    match result {
+        handshake::HandshakeResult::Accepted(version, data) => {
+            assert!(version >= VersionNumber::V14, "{version:?}");
+            assert_eq!(data, VersionData::new(NetworkMagic::MAINNET, true, PeerSharing::Disabled, false));
+        }
+        handshake::HandshakeResult::Refused(reason) => panic!("{reason:?}"),
+        handshake::HandshakeResult::Query(table) => panic!("{table:?}"),
+    }
 
     running.abort();
 }

--- a/crates/amaru-protocols/src/manager/mod.rs
+++ b/crates/amaru-protocols/src/manager/mod.rs
@@ -27,6 +27,7 @@ use crate::{
     network_effects::{ConnectError, Network, NetworkOps},
     peer_sharing::{SharePeersReply, ShareResult},
     protocol::Role,
+    protocol_messages::version_number::VersionNumber,
     tx_submission::ResponderParams,
 };
 
@@ -275,6 +276,10 @@ pub struct ManagerConfig {
     pub diffusion_stop_timeout: Duration,
     /// Last-to-finish bound when stopping the maintenance initiator group.
     pub maintenance_stop_timeout: Duration,
+    /// Highest node-to-node protocol version offered in handshake.
+    ///
+    /// Defaults to [`VersionNumber::CURRENT`] (V15). Tests pin V14 to check fallback.
+    pub max_n2n_version: VersionNumber,
 }
 
 impl ManagerConfig {
@@ -307,6 +312,11 @@ impl ManagerConfig {
         self.blockfetch_pipeline_n = n;
         self
     }
+
+    pub fn with_max_n2n_version(mut self, version: VersionNumber) -> Self {
+        self.max_n2n_version = version;
+        self
+    }
 }
 
 impl Default for ManagerConfig {
@@ -320,6 +330,7 @@ impl Default for ManagerConfig {
             blockfetch_pipeline_n: NonZeroU8::MIN,
             diffusion_stop_timeout: Duration::from_secs(300),
             maintenance_stop_timeout: Duration::from_secs(120),
+            max_n2n_version: VersionNumber::CURRENT,
         }
     }
 }

--- a/crates/amaru-protocols/src/protocol_messages/version_number.rs
+++ b/crates/amaru-protocols/src/protocol_messages/version_number.rs
@@ -40,6 +40,14 @@ impl VersionNumber {
     pub const V12: VersionNumber = VersionNumber::new(12);
     pub const V13: VersionNumber = VersionNumber::new(13);
     pub const V14: VersionNumber = VersionNumber::new(14);
+    /// CIP-0155 SRV records may appear in peer-sharing on this version.
+    pub const V15: VersionNumber = VersionNumber::new(15);
+
+    /// Highest node-to-node version offered by default.
+    pub const CURRENT: VersionNumber = Self::V15;
+
+    /// Versions this node can encode, in ascending order.
+    pub const SUPPORTED: [VersionNumber; 5] = [Self::V11, Self::V12, Self::V13, Self::V14, Self::V15];
 
     pub const fn new(value: u64) -> Self {
         Self(value)
@@ -88,6 +96,7 @@ pub(crate) mod tests {
             1 => Just(VersionNumber::V12),
             1 => Just(VersionNumber::V13),
             1 => Just(VersionNumber::V14),
+            1 => Just(VersionNumber::V15),
         ]
     }
 }

--- a/crates/amaru-protocols/src/protocol_messages/version_table.rs
+++ b/crates/amaru-protocols/src/protocol_messages/version_table.rs
@@ -37,33 +37,35 @@ impl VersionTable<VersionData> {
 
     pub fn query(network_magic: NetworkMagic) -> VersionTable<VersionData> {
         let data = VersionData::new(network_magic, false, PeerSharing::Disabled, true);
-        VersionTable {
-            values: vec![
-                (VersionNumber::V11, data.clone()),
-                (VersionNumber::V12, data.clone()),
-                (VersionNumber::V13, data.clone()),
-                (VersionNumber::V14, data),
-            ]
-            .into_iter()
-            .collect::<BTreeMap<VersionNumber, VersionData>>(),
-        }
+        Self::from_v11_through(VersionNumber::CURRENT, data)
     }
 
+    /// Handshake offer from V11 through [`VersionNumber::CURRENT`] (V15).
     pub fn v11_and_above(
         network_magic: NetworkMagic,
         initiator_only_diffusion_mode: bool,
         advertisable: bool,
     ) -> VersionTable<VersionData> {
-        let data = VersionData::new(network_magic, initiator_only_diffusion_mode, advertisable.into(), false);
-        let values = vec![
-            (VersionNumber::V11, data.clone()),
-            (VersionNumber::V12, data.clone()),
-            (VersionNumber::V13, data.clone()),
-            (VersionNumber::V14, data),
-        ]
-        .into_iter()
-        .collect::<BTreeMap<VersionNumber, VersionData>>();
+        Self::v11_through(VersionNumber::CURRENT, network_magic, initiator_only_diffusion_mode, advertisable)
+    }
 
+    /// Handshake offer from V11 up to and including `max` (clamped to [`VersionNumber::CURRENT`]).
+    pub fn v11_through(
+        max: VersionNumber,
+        network_magic: NetworkMagic,
+        initiator_only_diffusion_mode: bool,
+        advertisable: bool,
+    ) -> VersionTable<VersionData> {
+        let data = VersionData::new(network_magic, initiator_only_diffusion_mode, advertisable.into(), false);
+        Self::from_v11_through(max, data)
+    }
+
+    fn from_v11_through(max: VersionNumber, data: VersionData) -> VersionTable<VersionData> {
+        let values = VersionNumber::SUPPORTED
+            .into_iter()
+            .filter(|version| *version <= max)
+            .map(|version| (version, data.clone()))
+            .collect();
         VersionTable { values }
     }
 }
@@ -138,5 +140,19 @@ pub(crate) mod tests {
         pub fn any_version_table()(values in proptest::collection::btree_map(any_version_number(), any_version_data(), 0..3)) -> VersionTable<VersionData> {
             VersionTable { values }
         }
+    }
+
+    #[test]
+    fn v11_and_above_offers_current_version() {
+        let table = VersionTable::v11_and_above(NetworkMagic::PREPROD, true, true);
+        assert_eq!(table.values.keys().copied().collect::<Vec<_>>(), VersionNumber::SUPPORTED.to_vec());
+        assert_eq!(table.values.keys().next_back().copied(), Some(VersionNumber::CURRENT));
+    }
+
+    #[test]
+    fn v11_through_v14_excludes_v15() {
+        let table = VersionTable::v11_through(VersionNumber::V14, NetworkMagic::PREPROD, false, true);
+        assert!(table.values.contains_key(&VersionNumber::V14));
+        assert!(!table.values.contains_key(&VersionNumber::V15));
     }
 }

--- a/crates/amaru-protocols/src/tests/configuration.rs
+++ b/crates/amaru-protocols/src/tests/configuration.rs
@@ -22,7 +22,10 @@ use amaru_mempool::InMemoryMempool;
 use amaru_observability::tracing;
 use amaru_ouroboros_traits::{ChainStore, in_memory_chain_store::InMemoryChainStore};
 
-use crate::tx_submission::{create_transactions, create_transactions_in_mempool};
+use crate::{
+    protocol_messages::version_number::VersionNumber,
+    tx_submission::{create_transactions, create_transactions_in_mempool},
+};
 
 /// Configuration for running 2 test nodes, initiator and responder communicating over TCP:
 ///  - They both have their own chain store and mempool.
@@ -38,6 +41,7 @@ pub(super) struct Configuration {
     pub(super) processing_wait: Option<Duration>,
     pub(super) chain_length: usize,
     pub(super) slow_manager: bool,
+    pub(super) max_n2n_version: VersionNumber,
 }
 
 impl Configuration {
@@ -50,6 +54,7 @@ impl Configuration {
             reconnect_delay: Duration::from_secs(1),
             processing_wait: None,
             slow_manager: false,
+            max_n2n_version: VersionNumber::CURRENT,
         };
         initiator.with_best_chain_of_length(INITIATOR_BLOCKS_NB).with_txs(INITIATOR_TXS_NB)
     }
@@ -63,6 +68,7 @@ impl Configuration {
             reconnect_delay: Duration::from_secs(1),
             processing_wait: None,
             slow_manager: false,
+            max_n2n_version: VersionNumber::CURRENT,
         };
         responder.with_best_chain_of_length(RESPONDER_BLOCKS_NB).with_txs(RESPONDER_TXS_NB)
     }
@@ -95,6 +101,11 @@ impl Configuration {
 
     pub(super) fn with_processing_wait(mut self, wait: Duration) -> Self {
         self.processing_wait = Some(wait);
+        self
+    }
+
+    pub(super) fn with_max_n2n_version(mut self, version: VersionNumber) -> Self {
+        self.max_n2n_version = version;
         self
     }
 }

--- a/crates/amaru-protocols/src/tests/test_cases.rs
+++ b/crates/amaru-protocols/src/tests/test_cases.rs
@@ -28,6 +28,7 @@ use crate::{
     chainsync::ChainSyncInitiatorMsg,
     manager,
     manager::{Manager, ManagerConfig, ManagerMessage},
+    protocol_messages::version_number::VersionNumber,
     tests::{
         accept_stage::{AcceptState, PullAccept, accept_stage},
         assertions::{check_state, wait_for_termination},
@@ -51,6 +52,19 @@ use crate::{
 async fn test_connect_initiator_responder() -> anyhow::Result<()> {
     setup_logging();
     let (responder, addr, responder_done) = start_responder().await?;
+    let (initiator, initiator_done, _) = start_initiator_at(addr).await?;
+
+    wait_for_termination(responder_done, initiator_done).await?;
+    check_state(initiator, responder)?;
+    Ok(())
+}
+
+/// V15 is the default offer; a node that still only speaks V14 must keep working.
+#[tokio::test]
+async fn test_connect_v15_initiator_v14_responder() -> anyhow::Result<()> {
+    setup_logging();
+    let (responder, addr, responder_done) =
+        start_responder_with_configuration(Configuration::responder().with_max_n2n_version(VersionNumber::V14)).await?;
     let (initiator, initiator_done, _) = start_initiator_at(addr).await?;
 
     wait_for_termination(responder_done, initiator_done).await?;
@@ -173,7 +187,10 @@ async fn start_responder_with_configuration(
     } else {
         responder_network.stage("responder", manager::stage)
     };
-    let responder_manager = create_manager(ManagerConfig::default(), StageRef::blackhole());
+    let responder_manager = create_manager(
+        ManagerConfig::default().with_max_n2n_version(configuration.max_n2n_version),
+        StageRef::blackhole(),
+    );
     let responder_stage = responder_network.wire_up(responder_stage, responder_manager);
 
     // Create a connection that notifies the accept stage about new connections
@@ -232,8 +249,10 @@ async fn start_initiator_with_configuration(
         ChainSyncStageState::new(initiator_stage.sender(), fetcher_ref, configuration.processing_wait),
     );
 
-    let manager_config =
-        ManagerConfig::default().with_reconnect_delay(configuration.reconnect_delay).with_connect_retries(10);
+    let manager_config = ManagerConfig::default()
+        .with_reconnect_delay(configuration.reconnect_delay)
+        .with_connect_retries(10)
+        .with_max_n2n_version(configuration.max_n2n_version);
     let initiator_manager = create_manager(manager_config, chainsync_stage.without_state());
     let initiator_stage = initiator_network.wire_up(initiator_stage, initiator_manager);
     let initiator_sender = initiator_network.input(initiator_stage);
@@ -280,7 +299,10 @@ async fn start_responder_with_failing_accept(
     );
     let chainsync_stage = responder_network
         .wire_up(chainsync_stage, ChainSyncStageState::new(responder_stage.sender(), fetcher_ref, None));
-    let responder_manager = create_manager(ManagerConfig::default(), chainsync_stage.without_state());
+    let responder_manager = create_manager(
+        ManagerConfig::default().with_max_n2n_version(configuration.max_n2n_version),
+        chainsync_stage.without_state(),
+    );
 
     // Wire up the manager stage
     let responder_stage = responder_network.wire_up(responder_stage, responder_manager);


### PR DESCRIPTION
fixes #1332


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Node-to-node handshakes now offer protocol version 15 by default.
  - CIP-0155 SRV support is advertised during handshakes.
  - The maximum offered protocol version can be configured, while version 11 remains the minimum.
  - Connection local-use state can now be managed explicitly.
- **Compatibility**
  - Connections between version 15 and older supported peers can negotiate a compatible version, including fallback to version 14.
- **Documentation**
  - Updated the unreleased changelog with the new handshake behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->