### PR TITLE
fix: fetch candidate CC members from volatile and stable proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Other guiding principles:
 
 ### Fixed
 
+- **amaru-ledger**: accept committee hot-key authorizations and resignations from members that a pending `UpdateCommittee` action proposes to seat.
 - **amaru-protocols**: BlockFetch waits for each block to be accepted by TCP before encoding the next, so a slow peer no longer unbounded-buffers. ([#1303](https://github.com/pragma-org/amaru/pull/1303))
 - **amaru-protocols**: BlockFetch keeps the connection up if a new range is requested before the previous batch finishes. ([#1303](https://github.com/pragma-org/amaru/pull/1303))
 - **amaru**: `--tui-log-retention` / `AMARU_TUI_LOG_RETENTION` (default `100MiB`) caps how much log text the TUI keeps. SI suffixes (`kB`, `MB`) are powers of 1000; IEC suffixes (`KiB`, `MiB`) are powers of 1024.

--- a/crates/amaru-ledger/src/context/default/preparation.rs
+++ b/crates/amaru-ledger/src/context/default/preparation.rs
@@ -438,28 +438,34 @@ fn resolve_committee<'block, 'volatile>(
             }
         }
 
+        // NOTE: Scanning stable proposals when resolving committee
+        //
         // A credential neither layer resolves may still be a candidate of a pending `UpdateCommittee`
         // proposal, entitled to authorize a hot key or resign before holding any committee row. Only
         // the proposals vouch for it, discounting those the pending boundary pruned.
+        //
+        // Note that pending `UpdateCommittee` in the volatile are already taken into account by
+        // resolve_cc_members. So here, an unresolved credential can only come from a pending
+        // proposal in the stable store we had no information about.
         let candidates: BTreeSet<&Credential> = cold_credentials_in_certificates
             .into_iter()
             .filter(|cold_credential| !cc_members.contains_key(cold_credential))
             .collect();
 
         if !candidates.is_empty() {
-            let mut proposed = volatile.resolve_committee_candidates();
-
             for (id, row) in db.iter_proposals().map_err(ContextHydratationError::ResolveCommittee)? {
-                if let GovernanceAction::UpdateCommittee(_, _, added, _) = row.proposal.gov_action
-                    && !matches!(volatile.resolve_proposal(&id), Existence::Gone)
-                {
-                    proposed.extend(added.into_iter().map(|(cold_credential, _)| cold_credential));
+                if matches!(volatile.resolve_proposal(&id), Existence::Gone) {
+                    // Discard any proposal that is stable but has been pruned at the not-yet-stable
+                    // epoch boundary.
+                    continue;
                 }
-            }
 
-            for cold_credential in candidates {
-                if proposed.contains(cold_credential) {
-                    cc_members.entry(*cold_credential).or_default();
+                if let GovernanceAction::UpdateCommittee(_, _, added, _) = row.proposal.gov_action {
+                    for (cold_credential, _) in
+                        added.into_iter().filter(|(candidate, _)| candidates.contains(candidate))
+                    {
+                        cc_members.entry(cold_credential).or_default();
+                    }
                 }
             }
         }
@@ -526,16 +532,17 @@ pub fn resolve_proposals(
 mod tests {
     #[cfg(test)]
     mod resolve_committee {
-        use std::collections::{BTreeMap, BTreeSet};
+        use std::collections::BTreeMap;
 
         use amaru_kernel::{
             ConstitutionalCommitteeMemberStatus, Credential, Epoch, GovernanceAction, Proposal, ProposalId,
-            any_credential, any_proposal, any_proposal_id, any_rational_number, utils::tests::run_strategy,
+            any_credential, any_epoch, any_proposal, any_proposal_id, any_proposal_pointer, any_rational_number,
+            utils::tests::run_strategy,
         };
 
         use super::super::resolve_committee;
         use crate::{
-            context::{CCMember, ProposalStateSlim},
+            context::{CCMember, ProposalState, ProposalStateSlim},
             state::volatile::{Bind, CommitteeMemberBind, Empty, Existence, Resettable, VolatileState},
             store::{
                 ReadStore, StoreError,
@@ -547,9 +554,9 @@ mod tests {
         struct Mock {
             volatile_cc_members: Vec<(Credential, Existence<Bind<ConstitutionalCommitteeMemberStatus, Epoch, Empty>>)>,
             stable_cc_members: Vec<(Credential, Option<Epoch>, Option<ConstitutionalCommitteeMemberStatus>)>,
-            proposals: Vec<Proposal>,
-            volatile_candidates: Vec<Credential>,
-            proposals_pruned_at_boundary: bool,
+            volatile_proposals: Vec<(ProposalId, Proposal)>,
+            pruned_proposals: Vec<ProposalId>,
+            stable_proposals: Vec<Proposal>,
         }
 
         impl VolatileState for Mock {
@@ -560,12 +567,23 @@ mod tests {
             type Proposal = Existence<ProposalStateSlim>;
             type CCMembers<'a> = BTreeMap<&'a Credential, Existence<CommitteeMemberBind<'a>>>;
 
-            fn resolve_proposal(&self, _: &ProposalId) -> Self::Proposal {
-                if self.proposals_pruned_at_boundary { Existence::Gone } else { Existence::Unknown }
-            }
+            fn resolve_proposal(&self, proposal_id: &ProposalId) -> Self::Proposal {
+                match self.volatile_proposals.iter().find(|(id, _)| id == proposal_id) {
+                    None => Existence::Unknown,
+                    Some((id, proposal)) => {
+                        if self.pruned_proposals.contains(id) {
+                            return Existence::Gone;
+                        }
 
-            fn resolve_committee_candidates(&self) -> BTreeSet<Credential> {
-                self.volatile_candidates.iter().copied().collect()
+                        let proposal_state = ProposalState {
+                            proposed_in: run_strategy(any_proposal_pointer(u64::MAX)),
+                            valid_until: run_strategy(any_epoch()),
+                            proposal: proposal.clone(),
+                        };
+
+                        Existence::Exists(ProposalStateSlim::from(&proposal_state))
+                    }
+                }
             }
 
             fn resolve_cc_members<'a>(&'a self) -> Self::CCMembers<'a> {
@@ -573,6 +591,17 @@ mod tests {
 
                 for (k, v) in &self.volatile_cc_members {
                     map.insert(k, v.as_refs());
+                }
+
+                for (id, proposal) in &self.volatile_proposals {
+                    if !self.pruned_proposals.contains(id)
+                        && let GovernanceAction::UpdateCommittee(_, removed, added, ..) = &proposal.gov_action
+                    {
+                        assert!(removed.is_empty(), "removed not supported in Mock at the moment");
+                        for (cold_credential, _valid_until) in added.iter() {
+                            map.insert(cold_credential, Existence::Exists(Bind::default()));
+                        }
+                    }
                 }
 
                 map
@@ -587,7 +616,7 @@ mod tests {
             }
 
             fn iter_proposals(&self) -> Result<impl Iterator<Item = (ProposalId, proposals::Row)>, StoreError> {
-                Ok(self.proposals.iter().map(|proposal| {
+                Ok(self.stable_proposals.iter().map(|proposal| {
                     (
                         run_strategy(any_proposal_id()),
                         proposals::Row {
@@ -627,7 +656,7 @@ mod tests {
             let mock = Mock {
                 volatile_cc_members: vec![(cold_credential, Existence::Gone)],
                 stable_cc_members: vec![(cold_credential, Some(Epoch::default()), None)],
-                proposals: vec![any_update_committee_proposal(cold_credential)],
+                stable_proposals: vec![any_update_committee_proposal(cold_credential)],
                 ..Default::default()
             };
 
@@ -640,7 +669,8 @@ mod tests {
         fn candidate_of_a_stable_proposal_with_no_row_is_resolved_for_certificates() {
             let cold_credential: Credential = run_strategy(any_credential());
 
-            let mock = Mock { proposals: vec![any_update_committee_proposal(cold_credential)], ..Default::default() };
+            let mock =
+                Mock { stable_proposals: vec![any_update_committee_proposal(cold_credential)], ..Default::default() };
 
             let context = resolve_committee(&mock, &mock, From::from([&cold_credential]), Default::default()).unwrap();
 
@@ -651,7 +681,10 @@ mod tests {
         fn candidate_of_a_volatile_proposal_with_no_row_is_resolved_for_certificates() {
             let cold_credential: Credential = run_strategy(any_credential());
 
-            let mock = Mock { volatile_candidates: vec![cold_credential], ..Default::default() };
+            let proposal_id = run_strategy(any_proposal_id());
+            let proposal = any_update_committee_proposal(cold_credential);
+
+            let mock = Mock { volatile_proposals: vec![(proposal_id, proposal)], ..Default::default() };
 
             let context = resolve_committee(&mock, &mock, From::from([&cold_credential]), Default::default()).unwrap();
 
@@ -659,18 +692,21 @@ mod tests {
         }
 
         #[test]
-        fn candidate_of_a_proposal_pruned_at_the_pending_boundary_is_not_resolved() {
+        fn candidate_of_a_volatile_proposal_pruned_at_the_pending_boundary_is_not_resolved() {
             let cold_credential: Credential = run_strategy(any_credential());
 
+            let proposal_id = run_strategy(any_proposal_id());
+            let proposal = any_update_committee_proposal(cold_credential);
+
             let mock = Mock {
-                proposals: vec![any_update_committee_proposal(cold_credential)],
-                proposals_pruned_at_boundary: true,
+                volatile_proposals: vec![(proposal_id, proposal)],
+                pruned_proposals: vec![proposal_id],
                 ..Default::default()
             };
 
             let context = resolve_committee(&mock, &mock, From::from([&cold_credential]), Default::default()).unwrap();
 
-            assert!(context.is_empty())
+            assert!(dbg!(context).is_empty())
         }
 
         #[test]
@@ -678,11 +714,11 @@ mod tests {
             let cold_credential: Credential = run_strategy(any_credential());
             let candidate: Credential = run_strategy(any_credential());
 
-            let mock = Mock { proposals: vec![any_update_committee_proposal(candidate)], ..Default::default() };
+            let mock = Mock { stable_proposals: vec![any_update_committee_proposal(candidate)], ..Default::default() };
 
             let context = resolve_committee(&mock, &mock, From::from([&cold_credential]), Default::default()).unwrap();
 
-            assert!(context.is_empty())
+            assert!(dbg!(context).is_empty())
         }
 
         #[test]
@@ -693,13 +729,13 @@ mod tests {
             let mock = Mock {
                 volatile_cc_members: vec![(cold_credential, Existence::Gone)],
                 stable_cc_members: vec![(cold_credential, Some(Epoch::default()), Some(hot_credential.into()))],
-                proposals: vec![any_update_committee_proposal(cold_credential)],
+                stable_proposals: vec![any_update_committee_proposal(cold_credential)],
                 ..Default::default()
             };
 
             let context = resolve_committee(&mock, &mock, Default::default(), From::from([hot_credential])).unwrap();
 
-            assert!(context.is_empty())
+            assert!(dbg!(context).is_empty())
         }
 
         #[test]
@@ -713,7 +749,6 @@ mod tests {
                     Existence::Exists(Bind { left: Resettable::Set(hot_credential.into()), ..Bind::default() }),
                 )],
                 stable_cc_members: vec![(cold_credential, Some(Epoch::default()), None)],
-                proposals: vec![],
                 ..Default::default()
             };
 
@@ -735,8 +770,7 @@ mod tests {
                     cold_credential,
                     Existence::Exists(Bind { left: Resettable::Set(hot_credential.into()), ..Bind::default() }),
                 )],
-                stable_cc_members: vec![],
-                proposals: vec![any_update_committee_proposal(cold_credential)],
+                stable_proposals: vec![any_update_committee_proposal(cold_credential)],
                 ..Default::default()
             };
 
@@ -762,7 +796,7 @@ mod tests {
                     (first_cold_credential, Some(Epoch::default()), None),
                     (second_cold_credential, Some(Epoch::default()), None),
                 ],
-                proposals: vec![any_update_committee_proposal_with_members(vec![
+                stable_proposals: vec![any_update_committee_proposal_with_members(vec![
                     first_cold_credential,
                     second_cold_credential,
                 ])],
@@ -787,9 +821,7 @@ mod tests {
             let hot_credential: Credential = run_strategy(any_credential());
 
             let mock = Mock {
-                volatile_cc_members: vec![],
                 stable_cc_members: vec![(cold_credential, Some(Epoch::default()), Some(hot_credential.into()))],
-                proposals: vec![],
                 ..Default::default()
             };
 

--- a/crates/amaru-ledger/src/context/default/preparation.rs
+++ b/crates/amaru-ledger/src/context/default/preparation.rs
@@ -376,10 +376,14 @@ fn resolve_dreps<'volatile>(
 /// stable store; a `Gone` tombstone skips the stale stable entry.
 ///
 /// A certificate names its member by the store's own key, so `cold_credentials` are resolved
-/// directly. A vote names it by hot credential, which is indexed nowhere, so the whole committee has
-/// to be materialized and matched.
+/// directly, falling back to the pending `UpdateCommittee` proposals for candidates not yet elected.
+/// A vote names it by hot credential, which is indexed nowhere, so the whole committee has to be
+/// materialized and matched.
 fn resolve_committee<'block, 'volatile>(
-    volatile: &'volatile impl VolatileState<CCMembers<'volatile> = <VolatileDB as VolatileState>::CCMembers<'volatile>>,
+    volatile: &'volatile impl VolatileState<
+        CCMembers<'volatile> = <VolatileDB as VolatileState>::CCMembers<'volatile>,
+        Proposal = <VolatileDB as VolatileState>::Proposal,
+    >,
     db: &impl ReadStore,
     cold_credentials_in_certificates: BTreeSet<&'block Credential>,
     hot_credentials_in_votes: BTreeSet<Credential>,
@@ -393,8 +397,6 @@ fn resolve_committee<'block, 'volatile>(
         }
 
         let mut volatile_cc_members = volatile.resolve_cc_members();
-
-        let mut gone_but_requested: BTreeSet<Credential> = BTreeSet::new();
 
         for (cold_credential, row) in db.iter_cc_members().map_err(ContextHydratationError::ResolveCommittee)? {
             let for_certificates = cold_credentials_in_certificates.contains(&cold_credential);
@@ -420,11 +422,7 @@ fn resolve_committee<'block, 'volatile>(
                     }
                 }
 
-                Some(Existence::Gone) => {
-                    if for_certificates {
-                        gone_but_requested.insert(cold_credential);
-                    }
-                }
+                Some(Existence::Gone) => {}
             }
         }
 
@@ -432,45 +430,36 @@ fn resolve_committee<'block, 'volatile>(
         // following an epoch boundary, but not yet available in the stable store. In which case,
         // the volatile contains all the information we know about those members.
         for (cold_credential, existence) in volatile_cc_members.into_iter() {
-            match existence {
-                Existence::Exists(bind) => {
-                    cc_members.insert(
-                        *cold_credential,
-                        CCMember { status: bind.left.to_option(None), valid_until: bind.right.to_option(None) },
-                    );
-                }
-
-                Existence::Gone | Existence::Unknown => {
-                    if cold_credentials_in_certificates.contains(cold_credential) {
-                        gone_but_requested.insert(*cold_credential);
-                    }
-                }
+            if let Existence::Exists(bind) = existence {
+                cc_members.insert(
+                    *cold_credential,
+                    CCMember { status: bind.left.to_option(None), valid_until: bind.right.to_option(None) },
+                );
             }
         }
 
-        // NOTE: Scanning proposals when resolving committee
-        //
-        // In case where the member is requested for certificate but is Gone, we must
-        // still scan the existing governance proposals for any UpdateCommittee action
-        // that would be adding the member. Those are allowed to appear in certificates
-        // for both resignation and hot credential delegation.
-        //
-        // We need not to scan the volatile db here because we correctly record a
-        // default cc member when seeing such a proposal. So the volatile _already_
-        // contains the information and a member that is Gone in the epoch transition,
-        // but reinstated by a recent proposal would show up as `Exists`.
-        //
-        // When the proposal becomes stable, the default binding also gets removed from
-        // the volatile (unless superseded by a more recent one) but the proposal is now
-        // reachable through the stable store.
-        if !gone_but_requested.is_empty() {
-            for (_, row) in db.iter_proposals().map_err(ContextHydratationError::ResolveCommittee)? {
-                if let GovernanceAction::UpdateCommittee(_, _, added, _) = row.proposal.gov_action {
-                    for (cold_credential, _) in
-                        added.into_iter().filter(|(candidate, _)| gone_but_requested.contains(candidate))
-                    {
-                        cc_members.entry(cold_credential).or_default();
-                    }
+        // A credential neither layer resolves may still be a candidate of a pending `UpdateCommittee`
+        // proposal, entitled to authorize a hot key or resign before holding any committee row. Only
+        // the proposals vouch for it, discounting those the pending boundary pruned.
+        let candidates: BTreeSet<&Credential> = cold_credentials_in_certificates
+            .into_iter()
+            .filter(|cold_credential| !cc_members.contains_key(cold_credential))
+            .collect();
+
+        if !candidates.is_empty() {
+            let mut proposed = volatile.resolve_committee_candidates();
+
+            for (id, row) in db.iter_proposals().map_err(ContextHydratationError::ResolveCommittee)? {
+                if let GovernanceAction::UpdateCommittee(_, _, added, _) = row.proposal.gov_action
+                    && !matches!(volatile.resolve_proposal(&id), Existence::Gone)
+                {
+                    proposed.extend(added.into_iter().map(|(cold_credential, _)| cold_credential));
+                }
+            }
+
+            for cold_credential in candidates {
+                if proposed.contains(cold_credential) {
+                    cc_members.entry(*cold_credential).or_default();
                 }
             }
         }
@@ -537,7 +526,7 @@ pub fn resolve_proposals(
 mod tests {
     #[cfg(test)]
     mod resolve_committee {
-        use std::collections::BTreeMap;
+        use std::collections::{BTreeMap, BTreeSet};
 
         use amaru_kernel::{
             ConstitutionalCommitteeMemberStatus, Credential, Epoch, GovernanceAction, Proposal, ProposalId,
@@ -546,7 +535,7 @@ mod tests {
 
         use super::super::resolve_committee;
         use crate::{
-            context::CCMember,
+            context::{CCMember, ProposalStateSlim},
             state::volatile::{Bind, CommitteeMemberBind, Empty, Existence, Resettable, VolatileState},
             store::{
                 ReadStore, StoreError,
@@ -554,10 +543,13 @@ mod tests {
             },
         };
 
+        #[derive(Default)]
         struct Mock {
             volatile_cc_members: Vec<(Credential, Existence<Bind<ConstitutionalCommitteeMemberStatus, Epoch, Empty>>)>,
             stable_cc_members: Vec<(Credential, Option<Epoch>, Option<ConstitutionalCommitteeMemberStatus>)>,
             proposals: Vec<Proposal>,
+            volatile_candidates: Vec<Credential>,
+            proposals_pruned_at_boundary: bool,
         }
 
         impl VolatileState for Mock {
@@ -565,8 +557,16 @@ mod tests {
             type Pool = ();
             type Account<'a> = ();
             type DRep<'a> = ();
-            type Proposal = ();
+            type Proposal = Existence<ProposalStateSlim>;
             type CCMembers<'a> = BTreeMap<&'a Credential, Existence<CommitteeMemberBind<'a>>>;
+
+            fn resolve_proposal(&self, _: &ProposalId) -> Self::Proposal {
+                if self.proposals_pruned_at_boundary { Existence::Gone } else { Existence::Unknown }
+            }
+
+            fn resolve_committee_candidates(&self) -> BTreeSet<Credential> {
+                self.volatile_candidates.iter().copied().collect()
+            }
 
             fn resolve_cc_members<'a>(&'a self) -> Self::CCMembers<'a> {
                 let mut map = BTreeMap::new();
@@ -628,11 +628,61 @@ mod tests {
                 volatile_cc_members: vec![(cold_credential, Existence::Gone)],
                 stable_cc_members: vec![(cold_credential, Some(Epoch::default()), None)],
                 proposals: vec![any_update_committee_proposal(cold_credential)],
+                ..Default::default()
             };
 
             let context = resolve_committee(&mock, &mock, From::from([&cold_credential]), Default::default()).unwrap();
 
             assert_eq!(context.get(&cold_credential), Some(&CCMember::default()))
+        }
+
+        #[test]
+        fn candidate_of_a_stable_proposal_with_no_row_is_resolved_for_certificates() {
+            let cold_credential: Credential = run_strategy(any_credential());
+
+            let mock = Mock { proposals: vec![any_update_committee_proposal(cold_credential)], ..Default::default() };
+
+            let context = resolve_committee(&mock, &mock, From::from([&cold_credential]), Default::default()).unwrap();
+
+            assert_eq!(context.get(&cold_credential), Some(&CCMember::default()))
+        }
+
+        #[test]
+        fn candidate_of_a_volatile_proposal_with_no_row_is_resolved_for_certificates() {
+            let cold_credential: Credential = run_strategy(any_credential());
+
+            let mock = Mock { volatile_candidates: vec![cold_credential], ..Default::default() };
+
+            let context = resolve_committee(&mock, &mock, From::from([&cold_credential]), Default::default()).unwrap();
+
+            assert_eq!(context.get(&cold_credential), Some(&CCMember::default()))
+        }
+
+        #[test]
+        fn candidate_of_a_proposal_pruned_at_the_pending_boundary_is_not_resolved() {
+            let cold_credential: Credential = run_strategy(any_credential());
+
+            let mock = Mock {
+                proposals: vec![any_update_committee_proposal(cold_credential)],
+                proposals_pruned_at_boundary: true,
+                ..Default::default()
+            };
+
+            let context = resolve_committee(&mock, &mock, From::from([&cold_credential]), Default::default()).unwrap();
+
+            assert!(context.is_empty())
+        }
+
+        #[test]
+        fn unknown_credential_is_not_resolved_by_proposals_naming_others() {
+            let cold_credential: Credential = run_strategy(any_credential());
+            let candidate: Credential = run_strategy(any_credential());
+
+            let mock = Mock { proposals: vec![any_update_committee_proposal(candidate)], ..Default::default() };
+
+            let context = resolve_committee(&mock, &mock, From::from([&cold_credential]), Default::default()).unwrap();
+
+            assert!(context.is_empty())
         }
 
         #[test]
@@ -644,6 +694,7 @@ mod tests {
                 volatile_cc_members: vec![(cold_credential, Existence::Gone)],
                 stable_cc_members: vec![(cold_credential, Some(Epoch::default()), Some(hot_credential.into()))],
                 proposals: vec![any_update_committee_proposal(cold_credential)],
+                ..Default::default()
             };
 
             let context = resolve_committee(&mock, &mock, Default::default(), From::from([hot_credential])).unwrap();
@@ -663,6 +714,7 @@ mod tests {
                 )],
                 stable_cc_members: vec![(cold_credential, Some(Epoch::default()), None)],
                 proposals: vec![],
+                ..Default::default()
             };
 
             let context = resolve_committee(&mock, &mock, Default::default(), From::from([hot_credential])).unwrap();
@@ -685,6 +737,7 @@ mod tests {
                 )],
                 stable_cc_members: vec![],
                 proposals: vec![any_update_committee_proposal(cold_credential)],
+                ..Default::default()
             };
 
             let context = resolve_committee(&mock, &mock, Default::default(), From::from([hot_credential])).unwrap();
@@ -713,6 +766,7 @@ mod tests {
                     first_cold_credential,
                     second_cold_credential,
                 ])],
+                ..Default::default()
             };
 
             let context = resolve_committee(
@@ -736,6 +790,7 @@ mod tests {
                 volatile_cc_members: vec![],
                 stable_cc_members: vec![(cold_credential, Some(Epoch::default()), Some(hot_credential.into()))],
                 proposals: vec![],
+                ..Default::default()
             };
 
             let context = resolve_committee(&mock, &mock, Default::default(), From::from([hot_credential])).unwrap();

--- a/crates/amaru-ledger/src/state/volatile.rs
+++ b/crates/amaru-ledger/src/state/volatile.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::VecDeque;
+use std::collections::{BTreeSet, VecDeque};
 
 use amaru_kernel::{
     CertificatePointer, ConstitutionalCommitteeMemberStatus, Credential, DRep, DRepRegistration, Epoch, Lovelace,
@@ -130,6 +130,14 @@ pub trait VolatileState {
     #[expect(clippy::panic)]
     fn resolve_proposal(&self, proposal_id: &ProposalId) -> Self::Proposal {
         panic!("VolatileState.resolve_proposal({proposal_id})")
+    }
+
+    /// Every cold credential an `UpdateCommittee` proposal still in the volatile window proposes to
+    /// seat. Candidates may authorize a hot key or resign ahead of their election while holding no
+    /// committee row, so only the proposals vouch for them, and nothing in the store indexes those.
+    #[expect(clippy::panic)]
+    fn resolve_committee_candidates(&self) -> BTreeSet<Credential> {
+        panic!("VolatileState.resolve_committee_candidates()")
     }
 
     // ---------------------------------------------------------------------------------------- Pots

--- a/crates/amaru-ledger/src/state/volatile.rs
+++ b/crates/amaru-ledger/src/state/volatile.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::VecDeque;
 
 use amaru_kernel::{
     CertificatePointer, ConstitutionalCommitteeMemberStatus, Credential, DRep, DRepRegistration, Epoch, Lovelace,
@@ -130,14 +130,6 @@ pub trait VolatileState {
     #[expect(clippy::panic)]
     fn resolve_proposal(&self, proposal_id: &ProposalId) -> Self::Proposal {
         panic!("VolatileState.resolve_proposal({proposal_id})")
-    }
-
-    /// Every cold credential an `UpdateCommittee` proposal still in the volatile window proposes to
-    /// seat. Candidates may authorize a hot key or resign ahead of their election while holding no
-    /// committee row, so only the proposals vouch for them, and nothing in the store indexes those.
-    #[expect(clippy::panic)]
-    fn resolve_committee_candidates(&self) -> BTreeSet<Credential> {
-        panic!("VolatileState.resolve_committee_candidates()")
     }
 
     // ---------------------------------------------------------------------------------------- Pots

--- a/crates/amaru-ledger/src/state/volatile/aggregate.rs
+++ b/crates/amaru-ledger/src/state/volatile/aggregate.rs
@@ -18,8 +18,8 @@ use std::{
 };
 
 use amaru_kernel::{
-    CertificatePointer, ConstitutionalCommitteeMemberStatus, Credential, DRep, DRepRegistration, Epoch, Lovelace,
-    MemoizedTransactionOutput, PoolId, ProposalId, TransactionInput,
+    CertificatePointer, ConstitutionalCommitteeMemberStatus, Credential, DRep, DRepRegistration, Epoch,
+    GovernanceAction, Lovelace, MemoizedTransactionOutput, PoolId, ProposalId, TransactionInput,
 };
 
 use crate::{
@@ -124,6 +124,21 @@ impl VolatileAggregate {
             Some(state) => Existence::Exists(ProposalStateSlim::from(state.as_ref())),
             None => Existence::Unknown,
         }
+    }
+
+    /// Every cold credential an `UpdateCommittee` proposal folded here proposes to seat, paired with
+    /// the proposal naming it. Candidates may authorize a hot key or resign ahead of their election.
+    pub fn resolve_committee_candidates(&self) -> impl Iterator<Item = (&ProposalId, &Credential)> {
+        self.proposals
+            .iter()
+            .filter_map(|(id, state)| {
+                if let GovernanceAction::UpdateCommittee(_, _, added, _) = &state.proposal.gov_action {
+                    Some(added.iter().map(move |(candidate, _)| (id, candidate)))
+                } else {
+                    None
+                }
+            })
+            .flatten()
     }
 }
 

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::{
-    collections::{BTreeMap, btree_map::Entry},
+    collections::{BTreeMap, BTreeSet, btree_map::Entry},
     mem,
 };
 
@@ -186,6 +186,16 @@ impl VolatileState for VolatileDB {
         } else {
             self.draining.resolve_proposal(id)
         }
+    }
+
+    fn resolve_committee_candidates(&self) -> BTreeSet<Credential> {
+        // Same precedence as `resolve_proposal`: a closing-epoch proposal the pending boundary pruned
+        // no longer vouches for its candidates.
+        self.current
+            .committee_candidates()
+            .chain(self.draining.committee_candidates().filter(|(id, _)| !self.overlay.has_pruned_proposal(id)))
+            .map(|(_, candidate)| *candidate)
+            .collect()
     }
 
     // ---------------------------------------------------------------------------------------- Pots
@@ -543,8 +553,10 @@ mod tests {
     };
 
     use amaru_kernel::{
-        BlockHeight, ConstitutionalCommitteeUpdate, Credential, Epoch, Hash, PREPROD_DEFAULT_PROTOCOL_PARAMETERS,
-        Point, SafeRatio, Slot, SortedPairs, any_modern_output, any_transaction_input, utils::tests::run_strategy,
+        BlockHeight, ConstitutionalCommitteeUpdate, Credential, Epoch, GovernanceAction, Hash,
+        PREPROD_DEFAULT_PROTOCOL_PARAMETERS, Point, Proposal, RatificationStatus, SafeRatio, Slot, SortedPairs,
+        any_modern_output, any_proposal, any_proposal_id, any_rational_number, any_transaction_input,
+        utils::tests::run_strategy,
     };
     use num::Zero;
     use test_case::test_case;
@@ -552,6 +564,7 @@ mod tests {
     use super::*;
     use crate::{
         AccountState,
+        context::ProposalState,
         epoch_transition::{Computed, Effective, GovernanceUpdates, PoolsEpochTransitionUpdates, Rewards},
         state::volatile::{Bind, Resettable},
     };
@@ -1381,6 +1394,26 @@ mod tests {
     }
 
     #[test]
+    fn resolve_committee_candidates_discounts_proposals_pruned_at_the_pending_boundary() {
+        let proposal_id = run_strategy(any_proposal_id());
+
+        let mut db = VolatileDB::default();
+        db.push_back(update_committee_block(10, proposal_id, cred(1)));
+        assert_eq!(db.resolve_committee_candidates(), BTreeSet::from([cred(1)]), "named by a proposal in current");
+
+        db.simple_transition(committee_update(None));
+        assert_eq!(db.resolve_committee_candidates(), BTreeSet::from([cred(1)]), "still named once the block drains");
+
+        let mut db = VolatileDB::default();
+        db.push_back(update_committee_block(10, proposal_id, cred(1)));
+        db.simple_transition(GovernanceUpdates {
+            pruned_proposals: BTreeMap::from([(proposal_id, RatificationStatus::NotRatified)]),
+            ..GovernanceUpdates::default(PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone())
+        });
+        assert!(db.resolve_committee_candidates().is_empty(), "the boundary dropped the proposal");
+    }
+
+    #[test]
     fn resolve_committee_lets_a_resignation_clear_a_hot_key_across_the_boundary() {
         let mut db = VolatileDB::default();
 
@@ -1468,6 +1501,24 @@ mod tests {
             CommitteeAct::Resign => block.fragment.committee.bind_left(cred(1), None),
         }
         .unwrap();
+        block
+    }
+
+    fn update_committee_block(slot: u64, id: ProposalId, candidate: Credential) -> AnchoredVolatileFragment {
+        let mut block = AnchoredVolatileFragment::fixture(slot, slot as u8);
+        let proposal = Proposal {
+            gov_action: GovernanceAction::UpdateCommittee(
+                None,
+                Vec::new(),
+                vec![(candidate, Epoch::from(99))].try_into().unwrap(),
+                run_strategy(any_rational_number()),
+            ),
+            ..run_strategy(any_proposal())
+        };
+        block.fragment.proposals.insert(
+            id,
+            Arc::new(ProposalState { proposed_in: Default::default(), valid_until: Default::default(), proposal }),
+        );
         block
     }
 

--- a/crates/amaru-ledger/src/state/volatile/db.rs
+++ b/crates/amaru-ledger/src/state/volatile/db.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::{
-    collections::{BTreeMap, BTreeSet, btree_map::Entry},
+    collections::{BTreeMap, btree_map::Entry},
     mem,
 };
 
@@ -31,8 +31,8 @@ use crate::{
     state::{
         AnchoredVolatileFragment, StateError,
         volatile::{
-            AccountBind, CommitteeMemberBind, DRepBind, Existence, RollbackGuard, VolatileDBRecovery, VolatileSequence,
-            VolatileSeries, VolatileState, overlay::StateOverlay,
+            AccountBind, Bind, CommitteeMemberBind, DRepBind, Existence, RollbackGuard, VolatileDBRecovery,
+            VolatileSequence, VolatileSeries, VolatileState, overlay::StateOverlay,
         },
     },
     store::{HistoricalStores, Store},
@@ -150,9 +150,21 @@ impl VolatileState for VolatileDB {
     fn resolve_cc_members<'a>(&'a self) -> Self::CCMembers<'a> {
         let mut cc_members: BTreeMap<&'a Credential, Vec<Existence<CommitteeMemberBind<'a>>>> = BTreeMap::new();
 
-        let current = self.current.resolve_cc_members();
+        let current = self.current.resolve_cc_members().chain(
+            self.current.committee_candidates().map(|(_, credential)| (credential, Existence::Exists(Bind::default()))),
+        );
+
         let overlay = self.overlay.cc_members();
-        let drainin = self.draining.resolve_cc_members();
+
+        let drainin = self.draining.resolve_cc_members().chain(self.draining.committee_candidates().filter_map(
+            |(id, credential)| {
+                if self.overlay.has_pruned_proposal(id) {
+                    None
+                } else {
+                    Some((credential, Existence::Exists(Bind::default())))
+                }
+            },
+        ));
 
         // Re-aggregate the binds per cold-credential
         for (cold_credential, cc_member) in current.chain(overlay).chain(drainin) {
@@ -186,16 +198,6 @@ impl VolatileState for VolatileDB {
         } else {
             self.draining.resolve_proposal(id)
         }
-    }
-
-    fn resolve_committee_candidates(&self) -> BTreeSet<Credential> {
-        // Same precedence as `resolve_proposal`: a closing-epoch proposal the pending boundary pruned
-        // no longer vouches for its candidates.
-        self.current
-            .committee_candidates()
-            .chain(self.draining.committee_candidates().filter(|(id, _)| !self.overlay.has_pruned_proposal(id)))
-            .map(|(_, candidate)| *candidate)
-            .collect()
     }
 
     // ---------------------------------------------------------------------------------------- Pots
@@ -1394,23 +1396,41 @@ mod tests {
     }
 
     #[test]
-    fn resolve_committee_candidates_discounts_proposals_pruned_at_the_pending_boundary() {
+    fn resolve_cc_members_yield_committee_candidates() {
+        let mut db = VolatileDB::default();
+
         let proposal_id = run_strategy(any_proposal_id());
 
-        let mut db = VolatileDB::default();
         db.push_back(update_committee_block(10, proposal_id, cred(1)));
-        assert_eq!(db.resolve_committee_candidates(), BTreeSet::from([cred(1)]), "named by a proposal in current");
+        assert_eq!(
+            db.resolve_cc_members().get(&cred(1)),
+            Some(&Existence::Exists(Bind::default())),
+            "named by a proposal in current"
+        );
 
         db.simple_transition(committee_update(None));
-        assert_eq!(db.resolve_committee_candidates(), BTreeSet::from([cred(1)]), "still named once the block drains");
 
+        assert_eq!(
+            db.resolve_cc_members().get(&cred(1)),
+            Some(&Existence::Exists(Bind::default())),
+            "still named once the block drains"
+        );
+    }
+
+    #[test]
+    fn resolve_committee_candidates_discounts_proposals_pruned_at_the_pending_boundary() {
         let mut db = VolatileDB::default();
+
+        let proposal_id = run_strategy(any_proposal_id());
+
         db.push_back(update_committee_block(10, proposal_id, cred(1)));
+
         db.simple_transition(GovernanceUpdates {
             pruned_proposals: BTreeMap::from([(proposal_id, RatificationStatus::NotRatified)]),
             ..GovernanceUpdates::default(PREPROD_DEFAULT_PROTOCOL_PARAMETERS.clone())
         });
-        assert!(db.resolve_committee_candidates().is_empty(), "the boundary dropped the proposal");
+
+        assert!(db.resolve_cc_members().is_empty(), "the boundary dropped the proposal");
     }
 
     #[test]

--- a/crates/amaru-ledger/src/state/volatile/series.rs
+++ b/crates/amaru-ledger/src/state/volatile/series.rs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    collections::{BTreeSet, VecDeque},
-    mem,
-};
+use std::{collections::VecDeque, mem};
 
 use amaru_kernel::{
     Credential, Lovelace, MemoizedTransactionOutput, Point, PoolId, Pots, ProposalId, TransactionInput,
@@ -80,10 +77,6 @@ impl VolatileState for VolatileSeries {
     type Proposal = Existence<ProposalStateSlim>;
     fn resolve_proposal(&self, id: &ProposalId) -> Self::Proposal {
         self.aggregate.resolve_proposal(id)
-    }
-
-    fn resolve_committee_candidates(&self) -> BTreeSet<Credential> {
-        self.committee_candidates().map(|(_, candidate)| *candidate).collect()
     }
 
     // ---------------------------------------------------------------------------------------- Pots

--- a/crates/amaru-ledger/src/state/volatile/series.rs
+++ b/crates/amaru-ledger/src/state/volatile/series.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{collections::VecDeque, mem};
+use std::{
+    collections::{BTreeSet, VecDeque},
+    mem,
+};
 
 use amaru_kernel::{
     Credential, Lovelace, MemoizedTransactionOutput, Point, PoolId, Pots, ProposalId, TransactionInput,
@@ -79,6 +82,10 @@ impl VolatileState for VolatileSeries {
         self.aggregate.resolve_proposal(id)
     }
 
+    fn resolve_committee_candidates(&self) -> BTreeSet<Credential> {
+        self.committee_candidates().map(|(_, candidate)| *candidate).collect()
+    }
+
     // ---------------------------------------------------------------------------------------- Pots
     fn resolve_treasury(&self, pots: &Pots) -> Lovelace {
         pots.treasury
@@ -137,6 +144,12 @@ impl VolatileSequence for VolatileSeries {
 }
 
 impl VolatileSeries {
+    /// The committee candidates named by this series' proposals, paired with the proposal naming
+    /// them so a caller can discount proposals a pending boundary pruned.
+    pub fn committee_candidates(&self) -> impl Iterator<Item = (&ProposalId, &Credential)> {
+        self.aggregate.resolve_committee_candidates()
+    }
+
     /// Rebuild the aggregate from scratch by re-folding the surviving sequence. Only rollback uses
     /// this; stabilization retracts a single fragment off the front exactly and incrementally (see
     /// [`VolatileAggregate::remove_fragment`]).


### PR DESCRIPTION
@arwlf reported an invalid block on mainnet with the following logs:

```
Sep 09 18:41:35 Fast amaru[1265004]: 2026-09-09T16:41:35.364783Z  WARN amaru::consensus: block.invalid failed_tip="[197031688, h'cbb394a0e1ad78f740f210a4e0c9a09d4e4e0f9d14617702635a77ef80cf1be5', 13900703]" parent="[197031676, h'955946a4d2a9fe087be319bbb2c21fd93f58c933bbbe1c0c4e591c16a3e55e9e', 13900702]" error="BlockValidationError: Invalid block: Transaction d0f8573a76cf4dd49ffd3f263a37d820ad9e3bd0094f08de346e33c5233cde51 at index 0 is invalid: transaction failed phase one validation: invalid certificates: invalid cc member hot credential delegation: unknown source entity: ScriptHash(Hash<28>(\"7c34e0240b84029e0932f5e8d81af42a63f55de6da31f16e19b1f5b4\"))" detail="failed to advance the ledger to a new tip"
Sep 09 18:41:35 Fast amaru[1265004]: 2026-09-09T16:41:35.364897Z  WARN amaru::consensus: block.invalid failed_tip="[197031701, h'5f6b23b5b3866a7f9583b11241dc6ab56560d03df4d14b26cf5bdd34a1b09cab', 13900704]" parent="[197031688, h'cbb394a0e1ad78f740f210a4e0c9a09d4e4e0f9d14617702635a77ef80cf1be5', 13900703]" error="the block descends from an invalid block" detail="refusing to validate the descendant of an invalid block"
Sep 09 18:41:35 Fast amaru[1265004]: 2026-09-09T16:41:35.364981Z  INFO amaru::consensus: chain.best_tip_invalidated removed=1
```

This failure was because a candidate CC member was delegating a hot credential before the proposal was enacted to add them to the CC. This *is* an allowed action, however in our block preparation, we were not fetching candidates correctly from proposals. This PR fixes that, and introduces some unit tests to assert the behavior is correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Committee members proposed by a pending committee update can now authorize hot-key actions before the update is finalized.
  - Members who are proposed to join the committee can also submit resignations during this pending period.
  - Improved handling ensures these credentials are recognized consistently while committee changes are awaiting approval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->