### PR TITLE
make inbound upstream quantity configurable in peer mix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,17 +39,6 @@ Other guiding principles:
 
 ### Added
 
-- **amaru-protocols**: handshake offers node-to-node protocol version 15 by default, advertising CIP-0155 SRV support. Minimum offered version is still 11. ([#1332](https://github.com/pragma-org/amaru/issues/1332))
-
-### Fixed
-
-- **amaru-bootstrap**: allow cancellation of the bootstrap process.
-
-
-## v10.11.20260910 _[unreleased; planned for 2026-09-10]_
-
-### Added
-
 - **amaru-protocols**: BlockFetch times out after 60s if the peer stalls while serving a range. ([#1303](https://github.com/pragma-org/amaru/pull/1303))
 - **amaru-protocols**: `manager.peer.local_use_applied` is logged when a connection has finished changing local use (for example to Maintenance after an uninteresting demotion).
 
@@ -68,6 +57,8 @@ Other guiding principles:
 - **amaru-consensus**: peer selection prefers promoting a duplex inbound to Using instead of opening a second outbound connection; Using inbounds count toward the upstream target. ([#660](https://github.com/pragma-org/amaru/issues/660))
 - **amaru-protocols**: connection traces include `local_use`, `duplex`, and `stopping`.
 - **amaru-pure-stage**: a stage that stops on purpose is logged at debug. A stage that aborts because of an error still logs that error at info or above before exiting.
+- **amaru**: `--peer-mix` / `AMARU_PEER_MIX` accepts an `inbound` group that shares Using slots with `static` / `shared` / `snapshot` / `ledger`. The default formula includes `inbound~6`. Omitting `inbound` means duplex inbound connections stay downstream-only. ([#1334](https://github.com/pragma-org/amaru/issues/1334))
+- **amaru-protocols**: handshake offers node-to-node protocol version 15 by default, advertising CIP-0155 SRV support. Minimum offered version is still 11. ([#1332](https://github.com/pragma-org/amaru/issues/1332))
 
 ### Fixed
 
@@ -79,6 +70,7 @@ Other guiding principles:
 - **amaru-tui**: `w` or the log `[ WRAP ]` control turns off wrapping so `←`/`→` (and shift-wheel / horizontal wheel) pan long lines; the column offset is kept while scrolling vertically. Pane focus on a tab moved to `Ctrl-←`/`Ctrl-→`.
 - **amaru-tui**: switching the log pane to DEBUG no longer panics when the retained debug stream is larger than ratatui’s `u16` paragraph scroll; the pane renders a visible window around the tail instead of the whole buffer.
 - **amaru-protocols**: the first peer-share request after an outbound handshake is no longer dropped.
+- **amaru-bootstrap**: allow cancellation of the bootstrap process.
 
 ## [v10.11.20260903](https://github.com/pragma-org/amaru/releases/tag/v10.11.20260903)
 

--- a/crates/amaru-consensus/src/performance/effects.rs
+++ b/crates/amaru-consensus/src/performance/effects.rs
@@ -32,9 +32,9 @@ use amaru_pure_stage::{BoxFuture, ExternalEffectAPI, Instant, Resources, SendDat
 use tokio::sync::oneshot;
 
 use super::{
-    ClaimKind, FetchPeerSet, HeaderLifecycleOutcome, HeaderPerformance, HeaderTelemetry, OutboundPick, PeerScores,
-    PeerShareFlags, PeerSnapshot, Performance, PerformanceOp, ResourcePerformance, SelectOutboundParams,
-    SelectPeersParams, SharedIngestResult,
+    ClaimKind, FetchPeerSet, HeaderLifecycleOutcome, HeaderPerformance, HeaderTelemetry, PeerScores, PeerShareFlags,
+    PeerSnapshot, Performance, PerformanceOp, ResourcePerformance, SelectOutboundParams, SelectPeersParams,
+    SelectUsing, SharedIngestResult,
 };
 
 fn require_perf(resources: &Resources) -> ResourcePerformance {
@@ -634,7 +634,7 @@ pub struct SelectOutboundEffect {
 }
 
 impl ExternalEffectAPI for SelectOutboundEffect {
-    type Response = Vec<OutboundPick>;
+    type Response = SelectUsing;
 
     fn run(self: Box<Self>, resources: Resources) -> BoxFuture<'static, Box<dyn SendData>> {
         let perf = require_perf(&resources);

--- a/crates/amaru-consensus/src/performance/mod.rs
+++ b/crates/amaru-consensus/src/performance/mod.rs
@@ -54,8 +54,8 @@ use parking_lot::Mutex;
 pub use peer::{
     ADVERSARIAL_IMPULSE, BlockClaim, CONNECT_FAIL_IMPULSE, ClaimKind, DEFAULT_PEER_MALUS_HALF_LIFE, FetchPeerSet,
     NEVER_CONNECTED_BONUS, OutboundPick, PeerPerformance, PeerScores, PeerShareFlags, PeerSnapshot,
-    SHARE_MALUS_THRESHOLD, SHARE_POLICY_MAX, SelectOutboundParams, SelectPeersParams, SharedIngestResult, SourceCounts,
-    malus_at,
+    SHARE_MALUS_THRESHOLD, SHARE_POLICY_MAX, SelectOutboundParams, SelectPeersParams, SelectUsing, SharedIngestResult,
+    SourceCounts, malus_at,
 };
 pub use peer_mix::{DEFAULT_MALUS_HALF_LIFE, DEFAULT_PEER_MIX, MixEntry, PeerMix, PeerMixParseError, PeerSource};
 use tokio::{
@@ -160,7 +160,7 @@ pub(crate) enum PerformanceOp {
     OkForSharing { effect: OkForSharingEffect, reply: oneshot::Sender<bool> },
     SetLedgerCandidates { effect: SetLedgerCandidatesEffect },
     IngestSharedPeers { effect: IngestSharedPeersEffect, reply: oneshot::Sender<SharedIngestResult> },
-    SelectOutbound { effect: SelectOutboundEffect, reply: oneshot::Sender<Vec<OutboundPick>> },
+    SelectOutbound { effect: SelectOutboundEffect, reply: oneshot::Sender<SelectUsing> },
     SelectSharePeers { effect: SelectSharePeersEffect, reply: oneshot::Sender<Vec<std::net::SocketAddr>> },
     IsStaticPeer { effect: IsStaticPeerEffect, reply: oneshot::Sender<bool> },
     NoteDial { effect: NoteDialEffect },

--- a/crates/amaru-consensus/src/performance/peer.rs
+++ b/crates/amaru-consensus/src/performance/peer.rs
@@ -14,7 +14,8 @@
 
 //! Peer availability claims, quality scores, and outbound peer-source pools.
 //!
-//! Candidate sources (`static` / `shared` / `snapshot` / `ledger`) and the admin [`PeerMix`]
+//! Candidate sources (`static` / `shared` / `snapshot` / `ledger`) plus [`PeerSource::Inbound`]
+//! Using slots, and the admin [`PeerMix`]
 //! live here so connection malus can always evolve with the peer’s source half-life, and so
 //! large peer sets are not copied through pure-stage messages/traces (EDR-031).
 
@@ -135,16 +136,26 @@ pub struct SourceCounts {
     pub ledger_candidates: usize,
 }
 
-/// Parameters for mix + quality outbound selection.
+/// Parameters for mix + quality Using selection (outbound dials and inbound promotions).
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SelectOutboundParams {
-    /// How many new outbound dials to return (typically `target − |outbound| − |pending resolve|`).
+    /// How many new Using slots to fill (typically `target − occupancy`).
     pub open: usize,
     /// Candidates that must not be picked (already outbound, cooling down, or resolving).
     pub excluded: BTreeSet<PeerCandidate>,
+    /// Duplex inbound connections that could be promoted to Using.
+    pub eligible_inbound: usize,
     /// Deterministic RNG seed from peer selection’s random effect.
     pub seed: [u8; 32],
     pub now: Instant,
+}
+
+/// Mix result: inbound Using promotions plus outbound dials.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SelectUsing {
+    /// How many duplex inbound connections to promote to Using.
+    pub inbound: usize,
+    pub outbound: Vec<OutboundPick>,
 }
 
 /// One mix pick: a [`PeerCandidate`] from a named source, not yet resolved to a dial address.
@@ -354,21 +365,26 @@ impl PeerPerformance {
             .unwrap_or(DEFAULT_PEER_MALUS_HALF_LIFE)
     }
 
-    /// Mix allotment + quality-weighted sample of candidates to dial (resolve names afterward).
-    pub fn apply_select_outbound(&self, params: SelectOutboundParams) -> Vec<OutboundPick> {
+    /// Mix allotment: inbound Using promotions plus quality-weighted outbound dials.
+    pub fn apply_select_outbound(&self, params: SelectOutboundParams) -> SelectUsing {
         if params.open == 0 {
-            return Vec::new();
+            return SelectUsing { inbound: 0, outbound: Vec::new() };
         }
         let mut eligible_counts = BTreeMap::new();
         let mut eligible_by_source: BTreeMap<PeerSource, Vec<PeerCandidate>> = BTreeMap::new();
         for entry in self.peer_mix.entries() {
+            if entry.source.is_inbound() {
+                eligible_counts.insert(PeerSource::Inbound, params.eligible_inbound);
+                continue;
+            }
             let list = self.eligible_for_source(entry.source, &params.excluded);
             eligible_counts.insert(entry.source, list.len());
             eligible_by_source.insert(entry.source, list);
         }
         let allotment = self.peer_mix.allot(params.open, &eligible_counts);
+        let inbound = allotment.get(&PeerSource::Inbound).copied().unwrap_or(0);
         if allotment.values().all(|&n| n == 0) {
-            return Vec::new();
+            return SelectUsing { inbound: 0, outbound: Vec::new() };
         }
 
         let mut rng = StdRng::from_seed(params.seed);
@@ -376,6 +392,9 @@ impl PeerPerformance {
         let mut already: BTreeSet<PeerCandidate> = BTreeSet::new();
 
         for entry in self.peer_mix.entries() {
+            if entry.source.is_inbound() {
+                continue;
+            }
             let n = allotment.get(&entry.source).copied().unwrap_or(0);
             if n == 0 {
                 continue;
@@ -392,7 +411,7 @@ impl PeerPerformance {
                 picked.push(OutboundPick { candidate, origin: entry.source });
             }
         }
-        picked
+        SelectUsing { inbound, outbound: picked }
     }
 
     /// Addresses to advertise in a share reply (origin filter + sticky sample + reputation).
@@ -451,6 +470,7 @@ impl PeerPerformance {
             PeerSource::Shared => &self.shared_peers,
             PeerSource::Snapshot => &self.snapshot_candidates,
             PeerSource::Ledger => &self.ledger_candidates,
+            PeerSource::Inbound => return Vec::new(),
         };
         pool.iter().filter(|c| !excluded.contains(*c)).cloned().collect()
     }

--- a/crates/amaru-consensus/src/performance/peer_mix.rs
+++ b/crates/amaru-consensus/src/performance/peer_mix.rs
@@ -14,6 +14,8 @@
 
 //! Admin `peer-mix` formula: floors, proportional weights, per-source malus half-lives.
 //!
+//! `inbound` is a Using-slot group filled by promoting duplex inbound connections.
+//!
 //! A comma-separated token that is only `@duration` (no source name) sets the default
 //! half-life for **following** entries until another naked `@…` appears. Per-entry `@…`
 //! still overrides that default for that source only.
@@ -24,19 +26,22 @@ use std::{collections::BTreeMap, fmt, str::FromStr, time::Duration};
 
 use thiserror::Error;
 
-/// Default formula shipped with the node (static floor, then shared / snapshot / ledger proportions).
-pub const DEFAULT_PEER_MIX: &str = "static!2@15m, shared~6, snapshot~3@1h, ledger~3@24h";
+/// Default formula shipped with the node (static floor, then inbound / shared / snapshot / ledger).
+pub const DEFAULT_PEER_MIX: &str = "static!2@15m, inbound~6, shared~6, snapshot~3@1h, ledger~3@24h";
 
 /// Initial running half-life before any naked `@…` token (and fallback when none is set).
 pub const DEFAULT_MALUS_HALF_LIFE: Duration = Duration::from_secs(6 * 60 * 60);
 
-/// Named outbound candidate source (extensible registry).
+/// Named Using-slot source (extensible registry).
+///
+/// `Inbound` is not a dial pool: it caps how many duplex inbound connections may be Using.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
 pub enum PeerSource {
     Static,
     Shared,
     Snapshot,
     Ledger,
+    Inbound,
 }
 
 impl PeerSource {
@@ -46,7 +51,12 @@ impl PeerSource {
             PeerSource::Shared => "shared",
             PeerSource::Snapshot => "snapshot",
             PeerSource::Ledger => "ledger",
+            PeerSource::Inbound => "inbound",
         }
+    }
+
+    pub fn is_inbound(self) -> bool {
+        matches!(self, PeerSource::Inbound)
     }
 
     fn parse(name: &str) -> Option<Self> {
@@ -55,6 +65,7 @@ impl PeerSource {
             "shared" => Some(PeerSource::Shared),
             "snapshot" => Some(PeerSource::Snapshot),
             "ledger" => Some(PeerSource::Ledger),
+            "inbound" => Some(PeerSource::Inbound),
             _ => None,
         }
     }
@@ -91,6 +102,7 @@ impl Default for PeerMix {
         Self {
             entries: vec![
                 MixEntry { source: PeerSource::Static, floor: 2, weight: 1, half_life: Duration::from_secs(15 * 60) },
+                MixEntry { source: PeerSource::Inbound, floor: 0, weight: 6, half_life: DEFAULT_MALUS_HALF_LIFE },
                 MixEntry { source: PeerSource::Shared, floor: 0, weight: 6, half_life: Duration::from_secs(6 * 3600) },
                 MixEntry { source: PeerSource::Snapshot, floor: 0, weight: 3, half_life: Duration::from_secs(3600) },
                 MixEntry { source: PeerSource::Ledger, floor: 0, weight: 3, half_life: Duration::from_secs(24 * 3600) },
@@ -138,9 +150,11 @@ impl PeerMix {
         Ok(Self { entries })
     }
 
-    /// How many new outbound slots to take from each source for `open` free slots.
+    /// How many new Using slots to take from each source for `open` free slots.
     ///
-    /// `eligible` counts candidates already filtered (not outbound, not cooling, canonical origin).
+    /// `eligible` is remaining capacity per source: filtered outbound candidates (not already
+    /// outbound, not cooling, canonical origin), or promotable duplex inbounds for
+    /// [`PeerSource::Inbound`]. Inbound counts are promotion slots, not dials.
     /// Short buckets **spill** remaining demand to later sources in declaration order.
     pub fn allot(&self, open: usize, eligible: &BTreeMap<PeerSource, usize>) -> BTreeMap<PeerSource, usize> {
         if open == 0 || self.entries.is_empty() {
@@ -421,10 +435,12 @@ mod tests {
     #[test]
     fn default_formula_parses() {
         let m = PeerMix::default();
-        assert_eq!(m.entries().len(), 4);
+        assert_eq!(m.entries().len(), 5);
         assert_eq!(m.entries()[0].source, PeerSource::Static);
         assert_eq!(m.entries()[0].floor, 2);
+        assert_eq!(m.entries()[1].source, PeerSource::Inbound);
         assert_eq!(m.entries()[1].weight, 6);
+        assert_eq!(m.entries()[2].weight, 6);
 
         let def = PeerMix::parse(DEFAULT_PEER_MIX).unwrap();
         assert_eq!(m, def);
@@ -513,5 +529,34 @@ mod tests {
         elig.insert(PeerSource::Ledger, 4);
         let got = m.allot(2, &elig);
         assert_eq!(got.get(&PeerSource::Ledger).copied().unwrap_or(0), 2);
+    }
+
+    #[test]
+    fn parse_inbound() {
+        let m = PeerMix::parse("static~1, inbound~2").unwrap();
+        assert_eq!(m.entries()[1].source, PeerSource::Inbound);
+        assert_eq!(m.entries()[1].weight, 2);
+    }
+
+    #[test]
+    fn inbound_competes_for_open_slots() {
+        let m = PeerMix::parse("inbound~1, static~1").unwrap();
+        let mut elig = BTreeMap::new();
+        elig.insert(PeerSource::Inbound, 10);
+        elig.insert(PeerSource::Static, 10);
+        let got = m.allot(4, &elig);
+        assert_eq!(got.get(&PeerSource::Inbound).copied().unwrap_or(0), 2);
+        assert_eq!(got.get(&PeerSource::Static).copied().unwrap_or(0), 2);
+    }
+
+    #[test]
+    fn omitted_inbound_gets_no_slots() {
+        let m = PeerMix::parse("static~1").unwrap();
+        let mut elig = BTreeMap::new();
+        elig.insert(PeerSource::Inbound, 10);
+        elig.insert(PeerSource::Static, 10);
+        let got = m.allot(4, &elig);
+        assert_eq!(got.get(&PeerSource::Inbound).copied().unwrap_or(0), 0);
+        assert_eq!(got.get(&PeerSource::Static).copied().unwrap_or(0), 4);
     }
 }

--- a/crates/amaru-consensus/src/performance/tests.rs
+++ b/crates/amaru-consensus/src/performance/tests.rs
@@ -336,9 +336,14 @@ fn outbound_selection_prefers_never_connected_over_fresh_failure() {
     let mut good_picks = 0;
     for i in 0..20u8 {
         let seed = [i; 32];
-        let picked =
-            peers.apply_select_outbound(SelectOutboundParams { open: 1, excluded: BTreeSet::new(), seed, now: t(1) });
-        if picked.iter().map(|p| p.candidate.as_peer()).collect::<Vec<_>>() == vec![Some(good)] {
+        let picked = peers.apply_select_outbound(SelectOutboundParams {
+            open: 1,
+            excluded: BTreeSet::new(),
+            eligible_inbound: 0,
+            seed,
+            now: t(1),
+        });
+        if picked.outbound.iter().map(|p| p.candidate.as_peer()).collect::<Vec<_>>() == vec![Some(good)] {
             good_picks += 1;
         }
     }
@@ -363,10 +368,12 @@ fn outbound_selection_picks_unresolved_host() {
     let picked = peers.apply_select_outbound(SelectOutboundParams {
         open: 1,
         excluded: BTreeSet::new(),
+        eligible_inbound: 0,
         seed: [0x42; 32],
         now: t(1),
     });
-    assert_eq!(picked, vec![OutboundPick { candidate: host, origin: PeerSource::Static }]);
+    assert_eq!(picked.inbound, 0);
+    assert_eq!(picked.outbound, vec![OutboundPick { candidate: host, origin: PeerSource::Static }]);
 }
 
 #[test]
@@ -387,10 +394,12 @@ fn outbound_selection_skips_excluded_unresolved_host() {
     let picked = peers.apply_select_outbound(SelectOutboundParams {
         open: 1,
         excluded: BTreeSet::from([host]),
+        eligible_inbound: 0,
         seed: [0x42; 32],
         now: t(1),
     });
-    assert!(picked.is_empty());
+    assert!(picked.outbound.is_empty());
+    assert_eq!(picked.inbound, 0);
 }
 
 #[test]
@@ -414,10 +423,36 @@ fn note_dial_keeps_hostname_in_pool_and_marks_origin() {
     let picked = peers.apply_select_outbound(SelectOutboundParams {
         open: 1,
         excluded: BTreeSet::new(),
+        eligible_inbound: 0,
         seed: [0x42; 32],
         now: t(1),
     });
-    assert_eq!(picked, vec![OutboundPick { candidate: host, origin: PeerSource::Static }]);
+    assert_eq!(picked.outbound, vec![OutboundPick { candidate: host, origin: PeerSource::Static }]);
+}
+
+#[test]
+fn inbound_mix_slots_are_allotted_not_dialed() {
+    use std::collections::BTreeSet;
+
+    use crate::performance::{PeerMix, PeerSource, SelectOutboundParams};
+
+    let static_peer = peer("10.0.0.1:1");
+    let peers = PeerPerformance::with_sources(
+        BTreeSet::from([static_peer]).into_iter().map(amaru_kernel::PeerCandidate::from).collect(),
+        BTreeSet::new(),
+        BTreeSet::new(),
+        PeerMix::parse("inbound~1, static~1").unwrap(),
+    );
+    let picked = peers.apply_select_outbound(SelectOutboundParams {
+        open: 2,
+        excluded: BTreeSet::new(),
+        eligible_inbound: 5,
+        seed: [0x11; 32],
+        now: t(1),
+    });
+    assert_eq!(picked.inbound, 1);
+    assert_eq!(picked.outbound.len(), 1);
+    assert_eq!(picked.outbound[0].origin, PeerSource::Static);
 }
 
 #[test]

--- a/crates/amaru-consensus/src/stages/peer_selection/mod.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/mod.rs
@@ -33,7 +33,7 @@ use amaru_pure_stage::{Effects, Instant, ScheduleId, StageRef};
 pub use crate::performance::{DEFAULT_PEER_MIX, PeerMix, PeerMixParseError};
 use crate::{
     effects::{GenerateRandomSeed, Ledger, LedgerOps, ResolvePeerCandidate, ResolvePeerCandidateResult},
-    performance::{Performance, SelectOutboundParams, SharedIngestResult},
+    performance::{Performance, SelectOutboundParams, SelectUsing, SharedIngestResult},
 };
 
 const STATIC_PEER_BAN_PERIOD: Duration = Duration::from_secs(10);
@@ -210,10 +210,11 @@ fn churn_interval(seed: [u8; 32]) -> Duration {
 /// `regulate_peers` (called from `CheckCooldowns`, outbound non-retry disconnect,
 /// `ConnectFailed`, `Regulate`, churn/uninteresting demotion, and outbound removal
 /// inside `ban_peer` after the ban is recorded)
-/// early-returns if Using occupancy (`Diffusion` outbound + in-flight dials) is at
-/// `target_upstream_peers`. Eligible Maintenance outbound is promoted first. Otherwise it
-/// obtains a seed via `eff.external(GenerateRandomSeed)` and asks Performance to
-/// select [`PeerCandidate`]s (mix + quality-weighted sample within each source;
+/// early-returns if Using occupancy (`Diffusion` outbound + in-flight dials + inbound
+/// Using) is at `target_upstream_peers`. Eligible Maintenance outbound is promoted first.
+/// Otherwise it obtains a seed via `eff.external(GenerateRandomSeed)` and asks Performance
+/// to allot remaining slots across the mix, including `inbound` (duplex inbound promotions)
+/// and outbound [`PeerCandidate`]s (quality-weighted sample within each source;
 /// hard exclude outbound + cool-down + in-flight resolve). Socket candidates are
 /// dialled immediately; Host/SRV candidates are resolved via
 /// [`ResolvePeerCandidate`] and dialled when [`PeerSelectionMsg::Resolved`] arrives.
@@ -647,9 +648,8 @@ impl PeerSelection {
         }
     }
 
-    async fn promote_duplex_inbounds(&mut self, now: Instant, eff: &Effects<PeerSelectionMsg>) {
-        let candidates: Vec<(Peer, ConnectionId)> = self
-            .inbound_peers
+    fn promotable_duplex_inbounds(&self, now: Instant) -> Vec<(Peer, ConnectionId)> {
+        self.inbound_peers
             .iter()
             .filter_map(|(peer, conn)| {
                 if conn.full_duplex
@@ -662,12 +662,24 @@ impl PeerSelection {
                     None
                 }
             })
-            .collect();
+            .collect()
+    }
+
+    async fn promote_duplex_inbounds(&mut self, now: Instant, limit: usize, eff: &Effects<PeerSelectionMsg>) {
+        if limit == 0 {
+            return;
+        }
+        let candidates = self.promotable_duplex_inbounds(now);
+        let mut promoted = 0;
         for (peer, conn_id) in candidates {
-            if self.using_occupancy() >= self.target_upstream_peers {
+            if promoted >= limit || self.using_occupancy() >= self.target_upstream_peers {
                 break;
             }
+            let before = self.using_occupancy();
             self.try_promote(peer, conn_id, now, eff).await;
+            if self.using_occupancy() > before {
+                promoted += 1;
+            }
         }
     }
 
@@ -695,15 +707,14 @@ impl PeerSelection {
 
     async fn regulate_peers(&mut self, eff: &Effects<PeerSelectionMsg>) {
         let now = eff.clock().await;
-        // TODO: this is for testing the feature, should use peer mix quota and metrics ranking
-        self.promote_duplex_inbounds(now, eff).await;
         self.promote_eligible_maintenance(now, eff).await;
         let target_upstream_peers = self.target_upstream_peers;
-        let outbound = self.using_occupancy();
-        if outbound >= target_upstream_peers {
+        let occupancy = self.using_occupancy();
+        if occupancy >= target_upstream_peers {
             return;
         }
-        let open = target_upstream_peers - outbound;
+        let open = target_upstream_peers - occupancy;
+        let eligible_inbound = self.promotable_duplex_inbounds(now).len();
 
         let seed: [u8; 32] = eff.external(GenerateRandomSeed).await;
         let now = eff.clock().await;
@@ -722,9 +733,17 @@ impl PeerSelection {
         excluded.extend(self.bound.keys().cloned());
         self.resolve_backoff.retain(|_, until| *until > now);
         excluded.extend(self.resolve_backoff.keys().cloned());
-        let picked =
-            eff.external(Performance::select_outbound(SelectOutboundParams { open, excluded, seed, now })).await;
-        for pick in picked {
+        let SelectUsing { inbound, outbound } = eff
+            .external(Performance::select_outbound(SelectOutboundParams {
+                open,
+                excluded,
+                eligible_inbound,
+                seed,
+                now,
+            }))
+            .await;
+        self.promote_duplex_inbounds(now, inbound, eff).await;
+        for pick in outbound {
             match pick.candidate.as_peer() {
                 Some(peer) => {
                     if self.outbound_peers.contains_key(&peer) {

--- a/crates/amaru-consensus/src/stages/peer_selection/test_setup.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/test_setup.rs
@@ -164,6 +164,8 @@ pub fn register_guards() -> DeserializerGuards {
         amaru_pure_stage::register_effect_deserializer::<crate::performance::RankPeersForChurnEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::OkForSharingEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::SelectOutboundEffect>().boxed(),
+        amaru_pure_stage::register_data_deserializer::<crate::performance::SelectUsing>().boxed(),
+        amaru_pure_stage::register_data_deserializer::<crate::performance::OutboundPick>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::SelectSharePeersEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::IsStaticPeerEffect>().boxed(),
         amaru_pure_stage::register_effect_deserializer::<crate::performance::NoteDialEffect>().boxed(),

--- a/crates/amaru-consensus/src/stages/peer_selection/tests.rs
+++ b/crates/amaru-consensus/src/stages/peer_selection/tests.rs
@@ -21,16 +21,19 @@ use amaru_pure_stage::{
 };
 
 use super::*;
-use crate::stages::{
-    peer_selection::test_setup::{
-        TestPrep, cooldown_duration, cooldown_instant, first_schedule_id, first_static_schedule_id,
-        peer_selection_stage, second_schedule_id_at, setup, setup_preload, setup_preload_until_sleeping, sim_at,
-        sim_t0, static_cooldown_instant, te_cancel_schedule, te_clear_peer_availability, te_clock, te_clock_suspend,
-        te_is_static_peer, te_peer_adversarial, te_random_seed, te_rank_peers_for_churn, te_record_advertisability,
-        te_record_connection_failure, te_schedule, te_send, test_prep, test_prep_with_snapshot,
-        tm_add_stage_starts_with, with_single_cooldown,
+use crate::{
+    performance::PeerMix,
+    stages::{
+        peer_selection::test_setup::{
+            TestPrep, cooldown_duration, cooldown_instant, first_schedule_id, first_static_schedule_id,
+            peer_selection_stage, second_schedule_id_at, setup, setup_preload, setup_preload_until_sleeping, sim_at,
+            sim_t0, static_cooldown_instant, te_cancel_schedule, te_clear_peer_availability, te_clock,
+            te_clock_suspend, te_is_static_peer, te_peer_adversarial, te_random_seed, te_rank_peers_for_churn,
+            te_record_advertisability, te_record_connection_failure, te_schedule, te_send, test_prep,
+            test_prep_with_snapshot, tm_add_stage_starts_with, with_single_cooldown,
+        },
+        test_utils::{assert_trace, te_input, te_state, tm_state},
     },
-    test_utils::{assert_trace, te_input, te_state, tm_state},
 };
 
 fn conn() -> Connection {
@@ -1571,6 +1574,7 @@ fn test_connected_inbound_duplex_promotes_to_using() {
 #[test]
 fn test_regulate_promotes_duplex_inbound_instead_of_dial() {
     let mut prep = test_prep(&["10.0.0.1:1"]);
+    prep.peer_mix = PeerMix::parse("inbound~1").unwrap();
     prep.state.target_upstream_peers = 1;
     let inbound = TestPrep::peer("8.8.8.8:8");
     prep.state.inbound_peers.insert(inbound, duplex_conn());
@@ -1602,6 +1606,35 @@ fn test_regulate_promotes_duplex_inbound_instead_of_dial() {
         &[tm_send_match::<ManagerMessage>("ps-1", "manager", |m| matches!(m, ManagerMessage::AddPeer(_)))],
     );
     logs.assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
+}
+
+#[test]
+fn test_regulate_does_not_promote_inbound_when_mix_omits_it() {
+    let mut prep = test_prep(&["10.0.0.1:1"]);
+    prep.peer_mix = PeerMix::parse("static~1").unwrap();
+    prep.state.target_upstream_peers = 1;
+    let inbound = TestPrep::peer("8.8.8.8:8");
+    prep.state.inbound_peers.insert(inbound, duplex_conn());
+    let static_p = TestPrep::peer("10.0.0.1:1");
+    let after = {
+        let mut s = prep.state.clone();
+        s.outbound_peers.insert(static_p, PeerState::Connecting);
+        s
+    };
+
+    let (running, _guards, mut logs) = setup(&prep, PeerSelectionMsg::Regulate);
+    assert_trace_contains(
+        &running,
+        &[te_send("ps-1", "manager", ManagerMessage::AddPeer(static_p)).into(), te_state("ps-1", &after).into()],
+    );
+    assert_trace_does_not_contain(
+        &running,
+        &[tm_send_match::<ManagerMessage>("ps-1", "manager", |m| {
+            matches!(m, ManagerMessage::SetLocalUse { local_use: LocalUse::Diffusion, .. })
+        })],
+    );
+    logs.assert_and_remove(Level::INFO, &["peer_selection.peer.added", r#"peer="10.0.0.1:1""#])
+        .assert_no_remaining_at([Level::DEBUG, Level::INFO, Level::WARN, Level::ERROR]);
 }
 
 #[test]

--- a/crates/amaru-node/src/tests/world/generated.rs
+++ b/crates/amaru-node/src/tests/world/generated.rs
@@ -399,7 +399,7 @@ fn test_world_duplex_inbound_upstream_syncs_injector_chain() {
         generated_node(run.seed, 1, listen_b)
             .with_no_upstream_peers()
             .with_target_upstream_peers(1)
-            .with_peer_mix("static~1"),
+            .with_peer_mix("inbound~1"),
         &headers[0],
     );
     let mut world = run.injector_world(

--- a/crates/amaru-node/src/tests/world/real_data.rs
+++ b/crates/amaru-node/src/tests/world/real_data.rs
@@ -144,7 +144,7 @@ fn test_world_disseminates_preprod_fragment() {
             .with_listen_address(listen)
             .with_seed(31 + i as u64)
             .with_target_upstream_peers(3)
-            .with_peer_mix("static!1, shared~6")
+            .with_peer_mix("static!1, inbound~2, shared~6")
             .with_trace_buffer(TraceBuffer::new_shared(50_000, 64_000_000))
             .with_store_dirs(node_tmps[i].path().join("chain"), node_tmps[i].path().join("ledger"))
             .with_global_epoch_offset(offset);

--- a/crates/amaru/src/bin/amaru/cmd/node/run.rs
+++ b/crates/amaru/src/bin/amaru/cmd/node/run.rs
@@ -226,11 +226,13 @@ pub struct Args {
     )]
     peer_removal_cooldown_secs: u64,
 
-    /// Outbound peer source mix formula (floors `!n`, weights `~n`, optional malus half-lives `@Nd`).
+    /// Using-slot mix formula (floors `!n`, weights `~n`, optional malus half-lives `@Nd`).
     ///
-    /// Leaving a source out of the formula disables it, peer slots not used by the formula are filled from the remaining sources in proportion to their weights.
+    /// Sources: `static`, `shared`, `snapshot`, `ledger`, and `inbound` (duplex inbound
+    /// connections promoted to Using). Leaving a source out disables it; unused slots spill
+    /// to remaining sources in declaration order.
     ///
-    /// Example: `@12h, static!2, shared~6, snapshot~8, ledger~4@48h` (naked `@12h` is the default half-life for following sources)
+    /// Example: `@12h, static!2, inbound~6, shared~6, snapshot~8, ledger~4@48h` (naked `@12h` is the default half-life for following sources)
     #[arg(
         long,
         value_name = amaru::value_names::PEER_MIX,

--- a/engineering-decision-records/031-peer-source-mix.md
+++ b/engineering-decision-records/031-peer-source-mix.md
@@ -7,7 +7,7 @@ status: accepted
 
 ## Context
 
-Peer selection maintains four outbound candidate sources: **static**, **shared** (peer-sharing), **snapshot** (big-ledger file), and **ledger** (live registrations).
+Peer selection maintains four outbound candidate sources: **static**, **shared** (peer-sharing), **snapshot** (big-ledger file), and **ledger** (live registrations), plus **inbound** Using slots filled by promoting duplex inbound connections.
 A hard-coded waterfall (static → shared → snapshot → ledger) starves later sources whenever earlier ones can fill `target_upstream_peers` ([#1180](https://github.com/pragma-org/amaru/issues/1180)).
 
 [EDR-030][edr-performance] stores connection `failure_count` and a sticky `adversarial` flag for peer-sharing filters, but `regulate_peers` only skipped cool-downs and already-outbound peers.
@@ -31,7 +31,9 @@ peer-mix = item ("," item)*
 item     = entry | naked_decay
 entry    = name floor? weight? decay?
 naked_decay = "@" duration                        # sets default half-life for *following* entries
-name     = static | shared | snapshot | ledger   # registry; unknown ⇒ config error
+name     = static | shared | snapshot | ledger | inbound   # registry; unknown ⇒ config error
+                                                 # inbound is Using slots filled by promoting
+                                                 # duplex inbound connections, not a dial pool
 floor    = "!" uint                               # minimum slots if eligible peers exist
 weight   = "~" uint                               # proportionality (not numeric equality)
 decay    = "@" duration                           # malus half-life for this source only
@@ -60,7 +62,8 @@ Defaults when a field is omitted:
 
 ### Allotment and spill
 
-For `open = target_upstream_peers − |outbound|` eligible peers:
+For `open = target_upstream_peers − using_occupancy` eligible peers
+(`using_occupancy` is pending Host/SRV resolution plus Using outbound plus Using inbound):
 
 1. Assign **floors** in declaration order, each capped by eligible count and remaining open slots.
 2. Distribute any remainder **proportionally** by `~weight` (largest-remainder), only among sources with weight &gt; 0 and remaining eligible peers.
@@ -151,7 +154,7 @@ After allotting `n` slots to a source:
 ## Default formula
 
 ```text
-static!2@2h, shared~6@6h, snapshot~8@12h, ledger~4@24h
+static!2@15m, inbound~6, shared~6, snapshot~3@1h, ledger~3@24h
 ```
 
 ## Future work


### PR DESCRIPTION
fixes #1334


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for promoting eligible inbound connections to Using slots through the `inbound` peer-mix option.
  - Updated the default peer mix to include inbound connections with a weight of 6.
  - Inbound connections can now compete proportionally with static, shared, snapshot, and ledger sources.
  - Unused inbound slots can spill over to other configured peer sources.

- **Documentation**
  - Updated peer-mix command help and decision records with inbound source configuration and slot-allocation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->