### PR TITLE
Update CONTRIBUTING.md - Committers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,7 +216,7 @@ Changes to `main` are proposed via pull requests, and guarded by a [continuous i
 
 Contributors part of the [Amaru committers][] GitHub team shall seek review from one or more other Amaru committers. Yet each member of this team is entrusted with the ability to make judgment on the mergeability of their changes and shall use that power with great care.
 
-Members of the [Amaru committers][] are people [under contract](https://github.com/pragma-org/amaru-treasury/tree/main/journal/2026/contracts) part of the yearly budget set for Amaru.
+Members of the [Amaru committers][] are people [under contract](https://github.com/pragma-org/amaru-treasury/tree/main/journal/2026/contracts) as per the yearly budget set for Amaru.
 
 External contributors must have their contributions approved by at **least two members** of the [Amaru committers][].
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,6 +216,8 @@ Changes to `main` are proposed via pull requests, and guarded by a [continuous i
 
 Contributors part of the [Amaru committers][] GitHub team shall seek review from one or more other Amaru committers. Yet each member of this team is entrusted with the ability to make judgment on the mergeability of their changes and shall use that power with great care.
 
+Members of the [Amaru committers][] are people [under contract](https://github.com/pragma-org/amaru-treasury/tree/main/journal/2026/contracts) part of the yearly budget set for Amaru.
+
 External contributors must have their contributions approved by at **least two members** of the [Amaru committers][].
 
 Occasionally, members of the [Amaru Maintainers Committee](https://github.com/orgs/pragma-org/teams/amaru-maintainers-committee) may request additional reviews or inputs from any contribution.


### PR DESCRIPTION
Added clarification that the Amaru committers group are people under contract

Signed-off-by: Damien <161828179+Dam-CZ@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the Merge / Review Authority guidelines to state that Amaru committers are under contract and accounted for in Amaru’s annual budget.
  * Updated the contributor guidance to provide clearer information about the contractual status and budget treatment of committers involved in merge and review decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->