### PR TITLE
chore: systemd and default environment tweaks for Debian and RPM archives

### DIFF
--- a/.github/debian/amaru-bootstrap.service
+++ b/.github/debian/amaru-bootstrap.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Bootstrap Amaru Cardano node
+Documentation=https://github.com/pragma-org/amaru
+Wants=network-online.target NetworkManager-wait-online.service
+After=network-online.target NetworkManager-wait-online.service
+
+[Service]
+Type=oneshot
+User=amaru
+Group=amaru
+EnvironmentFile=-/etc/default/amaru
+EnvironmentFile=-/etc/sysconfig/amaru
+WorkingDirectory=/var/lib/amaru
+StateDirectory=amaru
+UMask=0027
+ExecStart=/usr/bin/amaru node bootstrap
+TimeoutStartSec=infinity
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+PrivateDevices=yes
+ProtectHome=true
+RestrictSUIDSGID=true
+LockPersonality=true

--- a/.github/debian/amaru.env
+++ b/.github/debian/amaru.env
@@ -1,6 +1,6 @@
 AMARU_NETWORK=mainnet
 AMARU_CHAIN_DIR=/var/lib/amaru/chain.mainnet.db
 AMARU_LEDGER_DIR=/var/lib/amaru/ledger.mainnet.db
-AMARU_PEER_ADDRESS=backbone.mainnet.cardanofoundation.org:3001,backbone.mainnet.emurgornd.com:3001
 AMARU_MIGRATE_CHAIN_DB=true
 AMARU_PID_FILE=/run/amaru/amaru.pid
+AMARU_WITH_JSON_TRACES=true

--- a/.github/debian/amaru.service
+++ b/.github/debian/amaru.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Amaru Cardano node
 Documentation=https://github.com/pragma-org/amaru
-Wants=network-online.target
-After=network-online.target
+Wants=time-sync.target network-online.target NetworkManager-wait-online.service
+After=time-sync.target network-online.target NetworkManager-wait-online.service
 
 [Service]
 Type=simple
@@ -20,10 +20,13 @@ TimeoutStopSec=30
 LimitNOFILE=65536
 NoNewPrivileges=true
 PrivateTmp=true
-ProtectSystem=full
+ProtectSystem=strict
+PrivateDevices=yes
 ProtectHome=true
 RestrictSUIDSGID=true
 LockPersonality=true
+MemoryHigh=1G
+StandardOutput=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,15 @@ Other guiding principles:
   ```
 -->
 
+## v10.11.20260917 _[unreleased; planned for 2026-09-17]_
+
 ## v10.11.20260910 _[unreleased; planned for 2026-09-10]_
 
 ### Added
 
 - **amaru-protocols**: BlockFetch times out after 60s if the peer stalls while serving a range. ([#1303](https://github.com/pragma-org/amaru/pull/1303))
 - **amaru-protocols**: `manager.peer.local_use_applied` is logged when a connection has finished changing local use (for example to Maintenance after an uninteresting demotion).
+- **amaru**: `amaru-bootstrap.service` is now installed alongside amaru for Debian and RPM targets; this is a one-shot systemd service to bootstrap Amaru on first start.
 
 ### Changed
 
@@ -59,6 +62,7 @@ Other guiding principles:
 - **amaru-pure-stage**: a stage that stops on purpose is logged at debug. A stage that aborts because of an error still logs that error at info or above before exiting.
 - **amaru**: `--peer-mix` / `AMARU_PEER_MIX` accepts an `inbound` group that shares Using slots with `static` / `shared` / `snapshot` / `ledger`. The default formula includes `inbound~6`. Omitting `inbound` means duplex inbound connections stay downstream-only. ([#1334](https://github.com/pragma-org/amaru/issues/1334))
 - **amaru-protocols**: handshake offers node-to-node protocol version 15 by default, advertising CIP-0155 SRV support. Minimum offered version is still 11. ([#1332](https://github.com/pragma-org/amaru/issues/1332))
+- **amaru**: the default `/etc/default/amaru` env configuration packages with Debian and RPM no longer define defaults backbone peers and enables JSON traces by default.
 
 ### Fixed
 

--- a/crates/amaru/Cargo.toml
+++ b/crates/amaru/Cargo.toml
@@ -145,6 +145,7 @@ assets = [
   { source = "target/release/amaru", dest = "/usr/bin/amaru", mode = "0755" },
   { source = "../../.github/debian/amaru.env", dest = "/etc/sysconfig/amaru", mode = "0644", config = "noreplace" },
   { source = "../../.github/debian/amaru.service", dest = "/usr/lib/systemd/system/amaru.service", mode = "0644" },
+  { source = "../../.github/debian/amaru-bootstrap.service", dest = "/usr/lib/systemd/system/amaru-bootstrap.service", mode = "0644" },
   { source = "../../dist/share/man/man1/amaru.1", dest = "/usr/share/man/man1/amaru.1", mode = "0644" },
   { source = "../../dist/share/bash-completion/completions/amaru", dest = "/usr/share/bash-completion/completions/amaru", mode = "0644" },
   { source = "../../dist/share/zsh/site-functions/_amaru", dest = "/usr/share/zsh/vendor-completions/_amaru", mode = "0644" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a one-time bootstrap service for Debian and RPM installations, running automatically before the main node service.
  * Enabled JSON traces by default in packaged environment configuration.
  * Added resource and output controls for improved service management.

* **Changed**
  * Packaged defaults no longer include predefined backbone peer addresses.
  * Startup now waits for time synchronization and confirmed network availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->