### PR TITLE
Blacksmith runner minor cost saving

### DIFF
--- a/.github/workflows/ci-build-and-test.yml
+++ b/.github/workflows/ci-build-and-test.yml
@@ -38,13 +38,14 @@ jobs:
 
   # To populate the cache on the Blacksmith runners too.
   build-linux-x86_64-blacksmith:
+    if: ${{ github.ref == 'refs/heads/main' }}
     name: Build/Test x86_64/linux
     uses: ./.github/workflows/template-cargo-test.yml
     with:
-      runner: blacksmith-8vcpu-ubuntu-2404
+      runner: blacksmith-2vcpu-ubuntu-2404
       target: x86_64-unknown-linux-gnu
       command: test -p amaru --no-run
-      cache-mode: ${{ github.ref == 'refs/heads/main' && 'WRITE' || 'READ' }}
+      cache-mode: WRITE
 
   build-linux-aarch64:
     name: Build/Test aarch64/linux


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pragma-org/codesmith/amaru/pr/1342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791722669&installation_model_id=436488&pr_number=1342&repository=pragma-org%2Famaru&return_to=https%3A%2F%2Fgithub.com%2Fpragma-org%2Famaru%2Fpull%2F1342&signature=e7b12b087dabaafe3cedacf489187c7b4cc44792087e49cf38433044c5b168ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Linux x86_64 builds now run only for pushes to the main branch.
  * Build caching now consistently uses write mode for these builds.
  * Linux x86_64 builds use a smaller 2-vCPU runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->