### PR TITLE
Fix off-by-one epoch check on CC member and action expiry + fix immediate cc resolution post ratification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Other guiding principles:
 
 ## v10.11.20260917 _[unreleased; planned for 2026-09-17]_
 
+### Fixed
+
+- **amaru-ledger**: Off-by-one error in constitutional committee member validity upper-bound check.
+
 ## v10.11.20260910 _[unreleased; planned for 2026-09-10]_
 
 ### Added

--- a/crates/amaru-kernel/src/cardano/constitutional_committee_member_status.rs
+++ b/crates/amaru-kernel/src/cardano/constitutional_committee_member_status.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
+
 use crate::{Credential, cbor, utils::cbor::SerialisedAsArray};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -26,6 +28,15 @@ pub enum ConstitutionalCommitteeMemberStatus {
     // 1. is completely useless to the ledger
     // 2. prevents the type from being `Copy`
     Resigned,
+}
+
+impl fmt::Display for ConstitutionalCommitteeMemberStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DelegatedToHotCredential(hot_credential) => write!(f, "delegated={hot_credential}"),
+            Self::Resigned => write!(f, "resigned"),
+        }
+    }
 }
 
 impl TryFrom<ConstitutionalCommitteeMemberStatus> for Credential {

--- a/crates/amaru-kernel/src/cardano/constitutional_committee_status.rs
+++ b/crates/amaru-kernel/src/cardano/constitutional_committee_status.rs
@@ -12,12 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
+
 use crate::{RationalNumber, cbor};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConstitutionalCommitteeStatus {
     NoConfidence,
     Trusted { threshold: RationalNumber },
+}
+
+impl fmt::Display for ConstitutionalCommitteeStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoConfidence => write!(f, "no-confidence"),
+            Self::Trusted { threshold } => write!(f, "trusted={threshold}"),
+        }
+    }
 }
 
 impl<C> cbor::encode::Encode<C> for ConstitutionalCommitteeStatus {

--- a/crates/amaru-kernel/src/cardano/constitutional_committee_update.rs
+++ b/crates/amaru-kernel/src/cardano/constitutional_committee_update.rs
@@ -19,7 +19,7 @@ use std::{
 
 use crate::{Credential, Epoch, SafeRatio};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConstitutionalCommitteeUpdate {
     NoConfidence,
     ChangeMembers { removed: BTreeSet<Credential>, added: BTreeMap<Credential, Epoch>, threshold: SafeRatio },

--- a/crates/amaru-kernel/src/cardano/governance_action.rs
+++ b/crates/amaru-kernel/src/cardano/governance_action.rs
@@ -23,6 +23,7 @@ pub enum GovernanceAction {
     HardForkInitiation(Option<ProposalId>, ProtocolVersion),
     TreasuryWithdrawals(KeyValuePairs<RewardAccount, Lovelace>, Option<Hash<{ hash::size::SCRIPT }>>),
     NoConfidence(Option<ProposalId>),
+    // TODO: align types with ConstitutionalCommitteeUpdate
     UpdateCommittee(Option<ProposalId>, Vec<Credential>, KeyValuePairs<Credential, Epoch>, RationalNumber),
     NewConstitution(Option<ProposalId>, Constitution),
     Information,

--- a/crates/amaru-ledger/src/epoch_transition/ratification.rs
+++ b/crates/amaru-ledger/src/epoch_transition/ratification.rs
@@ -335,13 +335,13 @@ fn diff_protocol_parameters(old: &ProtocolParameters, new: &ProtocolParameters) 
     } = new;
 
     info!(
-        ledger::protocol_parameters::RATIFY,
-        protocol_version = @opt_field(&old.protocol_version, protocol_version),
+        ledger::protocol_parameters::DUMP,
+        protocol_version = @opt_display(&old.protocol_version, protocol_version),
         max_block_body_size = @opt_field(&old.max_block_body_size, max_block_body_size),
         max_transaction_size = @opt_field(&old.max_transaction_size, max_transaction_size),
         max_block_header_size = @opt_field(&old.max_block_header_size, max_block_header_size),
-        max_tx_ex_units = @opt_field(&old.max_tx_ex_units, max_tx_ex_units),
-        max_block_ex_units = @opt_field(&old.max_block_ex_units, max_block_ex_units),
+        max_tx_ex_units = @opt_display(&old.max_tx_ex_units, max_tx_ex_units),
+        max_block_ex_units = @opt_display(&old.max_block_ex_units, max_block_ex_units),
         max_value_size = @opt_field(&old.max_value_size, max_value_size),
         max_collateral_inputs = @opt_field(&old.max_collateral_inputs, max_collateral_inputs),
         min_fee_a = @opt_field(&old.min_fee_a, min_fee_a),
@@ -349,13 +349,13 @@ fn diff_protocol_parameters(old: &ProtocolParameters, new: &ProtocolParameters) 
         stake_credential_deposit = @opt_field(&old.stake_credential_deposit, stake_credential_deposit),
         stake_pool_deposit = @opt_field(&old.stake_pool_deposit, stake_pool_deposit),
         monetary_expansion_rate =
-            @opt_field(&old.monetary_expansion_rate, monetary_expansion_rate),
+            @opt_display(&old.monetary_expansion_rate, monetary_expansion_rate),
         treasury_expansion_rate =
-            @opt_field(&old.treasury_expansion_rate, treasury_expansion_rate),
+            @opt_display(&old.treasury_expansion_rate, treasury_expansion_rate),
         min_pool_cost = @opt_field(&old.min_pool_cost, min_pool_cost),
         lovelace_per_utxo_byte = @opt_field(&old.lovelace_per_utxo_byte, lovelace_per_utxo_byte),
-        prices = @opt_field(&old.prices, prices),
-        min_fee_ref_script_lovelace_per_byte = @opt_field(
+        prices = @opt_display(&old.prices, prices),
+        min_fee_ref_script_lovelace_per_byte = @opt_display(
             &old.min_fee_ref_script_lovelace_per_byte,
             min_fee_ref_script_lovelace_per_byte,
         ),
@@ -363,15 +363,15 @@ fn diff_protocol_parameters(old: &ProtocolParameters, new: &ProtocolParameters) 
         max_ref_script_size_per_block = @opt_field(&old.max_ref_script_size_per_block, max_ref_script_size_per_block),
         ref_script_cost_stride = @opt_field(&old.ref_script_cost_stride, ref_script_cost_stride),
         ref_script_cost_multiplier =
-            @opt_field(&old.ref_script_cost_multiplier, ref_script_cost_multiplier),
+            @opt_display(&old.ref_script_cost_multiplier, ref_script_cost_multiplier),
         stake_pool_max_retirement_epoch =
             @opt_field(&old.stake_pool_max_retirement_epoch, stake_pool_max_retirement_epoch),
         optimal_stake_pools_count = @opt_field(&old.optimal_stake_pools_count, optimal_stake_pools_count),
-        pledge_influence = @opt_field(&old.pledge_influence, pledge_influence),
+        pledge_influence = @opt_display(&old.pledge_influence, pledge_influence),
         collateral_percentage = @opt_field(&old.collateral_percentage, collateral_percentage),
-        cost_models = @opt_field(&old.cost_models, cost_models),
-        pool_voting_thresholds = @opt_field(&old.pool_voting_thresholds, pool_voting_thresholds),
-        drep_voting_thresholds = @opt_field(&old.drep_voting_thresholds, drep_voting_thresholds),
+        cost_models = @opt_display(&old.cost_models, cost_models),
+        pool_voting_thresholds = @opt_display(&old.pool_voting_thresholds, pool_voting_thresholds),
+        drep_voting_thresholds = @opt_display(&old.drep_voting_thresholds, drep_voting_thresholds),
         min_committee_size = @opt_field(&old.min_committee_size, min_committee_size),
         max_committee_term_length = @opt_field(&old.max_committee_term_length, max_committee_term_length),
         gov_action_lifetime = @opt_field(&old.gov_action_lifetime, gov_action_lifetime),
@@ -381,8 +381,16 @@ fn diff_protocol_parameters(old: &ProtocolParameters, new: &ProtocolParameters) 
     );
 }
 
-fn opt_field<A: Eq + fmt::Display>(old: &A, new: &A) -> Box<dyn tracing::Value> {
-    if old == new { Box::new(tracing::field::Empty) as Box<dyn tracing::Value> } else { Box::new(new.to_string()) }
+fn opt_field<'a, A: Eq + fmt::Display + tracing::Value>(old: &A, new: &'a A) -> Box<dyn tracing::Value + 'a> {
+    if old == new { Box::new(tracing::field::Empty) as Box<dyn tracing::Value> } else { Box::new(new) }
+}
+
+fn opt_display<'a, A: Eq + fmt::Display>(old: &A, new: &'a A) -> Box<dyn tracing::Value + 'a> {
+    if old == new {
+        Box::new(tracing::field::Empty) as Box<dyn tracing::Value>
+    } else {
+        Box::new(tracing::field::display(new))
+    }
 }
 
 fn opt_str(s: String) -> Box<dyn tracing::Value> {

--- a/crates/amaru-ledger/src/epoch_transition/ratification.rs
+++ b/crates/amaru-ledger/src/epoch_transition/ratification.rs
@@ -427,6 +427,7 @@ mod tests {
             dreps_voting_stake: 0,
             pools: BTreeMap::new(),
             dreps: BTreeMap::new(),
+            cc_update: None,
         }
     }
 

--- a/crates/amaru-ledger/src/governance/ratification.rs
+++ b/crates/amaru-ledger/src/governance/ratification.rs
@@ -15,10 +15,9 @@
 use std::{collections::BTreeMap, rc::Rc};
 
 use amaru_kernel::{
-    Ballot, Constitution, ConstitutionalCommitteeStatus, ConstitutionalCommitteeUpdate, Credential, DRep, Epoch,
-    EraHistory, Lovelace, OrphanProposal, PoolId, ProposalEnum, ProposalId, ProposalsRootsRc, ProtocolParameters,
-    RatificationStatus, Vote, Voter,
-    rational_number::{SafeRatio, into_safe_ratio},
+    Ballot, Constitution, ConstitutionalCommitteeUpdate, Credential, DRep, Epoch, EraHistory, Lovelace, OrphanProposal,
+    PoolId, ProposalEnum, ProposalId, ProposalsRootsRc, ProtocolParameters, RatificationStatus, Vote, Voter,
+    rational_number::SafeRatio,
 };
 use amaru_observability::{debug_span, info_span};
 use num::Zero;
@@ -94,21 +93,8 @@ impl<'distr> RatificationContext<'distr> {
         let epoch = snapshot.epoch();
 
         info_span!(ledger::governance::NEW_RATIFICATION_CONTEXT, ratifying_epoch = epoch).in_scope(|| {
-            let constitutional_committee = match snapshot.constitutional_committee()? {
-                ConstitutionalCommitteeStatus::NoConfidence => None,
-                ConstitutionalCommitteeStatus::Trusted { threshold } => {
-                    let members = snapshot
-                        .iter_cc_members()?
-                        .filter_map(|(cold_credential, row)| {
-                            row.valid_until.map(|valid_until| {
-                                (cold_credential, (row.status.and_then(|s| s.try_into().ok()), valid_until))
-                            })
-                        })
-                        .collect();
-
-                    Some(ConstitutionalCommittee::new(into_safe_ratio(&threshold), members))
-                }
-            };
+            let constitutional_committee =
+                ConstitutionalCommittee::resolve(&snapshot, stake_distribution.cc_update.clone())?;
 
             // FIXME: votes entirely stored in-memory
             //

--- a/crates/amaru-ledger/src/governance/ratification/constitutional_committee.rs
+++ b/crates/amaru-ledger/src/governance/ratification/constitutional_committee.rs
@@ -20,11 +20,14 @@ use std::{
 };
 
 use amaru_kernel::{
-    Credential, Epoch, OrphanProposal, ProposalEnum, Vote,
+    ConstitutionalCommitteeStatus, ConstitutionalCommitteeUpdate, Credential, Epoch, OrphanProposal, ProposalEnum,
+    Vote, into_safe_ratio,
     rational_number::{SafeRatio, safe_ratio},
 };
 use amaru_observability::warn;
 use num::Zero;
+
+use crate::store::{ReadStore, StoreError, columns::cc_members};
 
 static ZERO: LazyLock<SafeRatio> = LazyLock::new(SafeRatio::zero);
 
@@ -44,6 +47,95 @@ pub struct ConstitutionalCommittee {
 impl ConstitutionalCommittee {
     pub fn new(threshold: SafeRatio, members: BTreeMap<Credential, (Option<Credential>, Epoch)>) -> Self {
         Self { threshold, members, active_members: RefCell::new(None) }
+    }
+
+    // Restore a constitutional committee from the database.
+    pub fn resolve(
+        db: &impl ReadStore,
+        cc_update: Option<ConstitutionalCommitteeUpdate>,
+    ) -> Result<Option<Self>, StoreError> {
+        match cc_update {
+            Some(ConstitutionalCommitteeUpdate::NoConfidence) => {
+                return Ok(None);
+            }
+            None | Some(ConstitutionalCommitteeUpdate::ChangeMembers { .. }) => {
+                // Handled below; but forcing an exhaustive pattern-match here in case constructors
+                // are ever added.
+            }
+        }
+
+        fn hot_credential_from_row(row: cc_members::Row) -> Option<Credential> {
+            row.status.and_then(|status| Credential::try_from(status).ok())
+        }
+
+        match db.constitutional_committee()? {
+            ConstitutionalCommitteeStatus::NoConfidence => {
+                // Apply an epoch-boundary update if any; the committee is no longer in
+                // no-confidence state.
+                if let Some(ConstitutionalCommitteeUpdate::ChangeMembers { mut added, threshold, .. }) = cc_update {
+                    let mut members: BTreeMap<Credential, (Option<Credential>, Epoch)> = db
+                        .iter_cc_members()?
+                        .filter_map(|(cold_credential, row)| {
+                            if let Some(valid_until) = added.remove(&cold_credential) {
+                                return Some((cold_credential, (hot_credential_from_row(row), valid_until)));
+                            }
+
+                            None
+                        })
+                        .collect();
+
+                    // Remaining members with no hot-delegation.
+                    for (cold_credential, valid_until) in added {
+                        members.insert(cold_credential, (None, valid_until));
+                    }
+
+                    return Ok(Some(Self::new(threshold, members)));
+                }
+
+                Ok(None)
+            }
+
+            ConstitutionalCommitteeStatus::Trusted { threshold } => {
+                // Apply an epoch-boundary update if any; existing members may see their
+                // validity extended, or be removed entirely.
+                if let Some(ConstitutionalCommitteeUpdate::ChangeMembers { removed, mut added, threshold }) = cc_update
+                {
+                    let mut members: BTreeMap<Credential, (Option<Credential>, Epoch)> = db
+                        .iter_cc_members()?
+                        .filter_map(|(cold_credential, row)| {
+                            if let Some(valid_until) = added.remove(&cold_credential) {
+                                return Some((cold_credential, (hot_credential_from_row(row), valid_until)));
+                            }
+
+                            if !removed.contains(&cold_credential) {
+                                return row
+                                    .valid_until
+                                    .map(|valid_until| (cold_credential, (hot_credential_from_row(row), valid_until)));
+                            }
+
+                            None
+                        })
+                        .collect();
+
+                    // Remaining members with no hot-delegation yet.
+                    for (cold_credential, valid_until) in added {
+                        members.insert(cold_credential, (None, valid_until));
+                    }
+
+                    return Ok(Some(Self::new(threshold, members)));
+                }
+
+                let members: BTreeMap<Credential, (Option<Credential>, Epoch)> = db
+                    .iter_cc_members()?
+                    .filter_map(|(cold_credential, row)| {
+                        row.valid_until
+                            .map(|valid_until| (cold_credential, (hot_credential_from_row(row), valid_until)))
+                    })
+                    .collect();
+
+                Ok(Some(Self::new(into_safe_ratio(&threshold), members)))
+            }
+        }
     }
 
     /// View the current threshold for that committee.

--- a/crates/amaru-ledger/src/governance/ratification/constitutional_committee.rs
+++ b/crates/amaru-ledger/src/governance/ratification/constitutional_committee.rs
@@ -277,8 +277,8 @@ mod tests {
     };
 
     use amaru_kernel::{
-        Credential, Epoch, Hash, SafeRatio, VOTE_NO, VOTE_YES, Vote, any_credential, any_rational_number, any_vote_ref,
-        into_safe_ratio, utils::tests::assert_strategy_sometimes_fails,
+        Credential, Epoch, NULL_HASH28, SafeRatio, VOTE_NO, VOTE_YES, Vote, any_credential, any_rational_number,
+        any_vote_ref, into_safe_ratio, utils::tests::assert_strategy_sometimes_fails,
     };
     use num::{One, Zero};
     use proptest::{collection, prelude::*, sample, test_runner::RngSeed};
@@ -288,7 +288,171 @@ mod tests {
     const MIN_ARBITRARY_EPOCH: u64 = 10;
     const MAX_COMMITTEE_SIZE: usize = 10;
 
-    const NULL_HASH: [u8; 28] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    #[cfg(test)]
+    mod constitutional_committee_resolve {
+        use std::collections::BTreeMap;
+
+        use amaru_kernel::{
+            ConstitutionalCommitteeMemberStatus, ConstitutionalCommitteeStatus, ConstitutionalCommitteeUpdate,
+            Credential, Epoch, RationalNumber, SafeRatio, any_credential, rational_number::safe_ratio,
+            utils::tests::run_strategy_with_seed,
+        };
+        use test_case::test_case;
+
+        use super::super::ConstitutionalCommittee;
+        use crate::store::{ReadStore, StoreError, columns::cc_members};
+
+        type Member = (Credential, Option<Credential>, Option<u64>);
+
+        struct Mock {
+            committee: ConstitutionalCommitteeStatus,
+            members: Vec<(Credential, cc_members::Row)>,
+        }
+
+        impl ReadStore for Mock {
+            fn constitutional_committee(&self) -> Result<ConstitutionalCommitteeStatus, StoreError> {
+                Ok(self.committee.clone())
+            }
+
+            fn iter_cc_members(&self) -> Result<impl Iterator<Item = (Credential, cc_members::Row)>, StoreError> {
+                Ok(self.members.iter().copied())
+            }
+        }
+
+        #[derive(Debug, PartialEq, Eq)]
+        enum ExpectedCommittee {
+            None,
+            Committee { threshold: SafeRatio, members: BTreeMap<Credential, (Option<Credential>, Epoch)> },
+        }
+
+        fn credential(seed: u64) -> Credential {
+            run_strategy_with_seed(seed, any_credential())
+        }
+
+        fn no_confidence() -> ConstitutionalCommitteeStatus {
+            ConstitutionalCommitteeStatus::NoConfidence
+        }
+
+        fn trusted(numerator: u64, denominator: u64) -> ConstitutionalCommitteeStatus {
+            ConstitutionalCommitteeStatus::Trusted { threshold: RationalNumber { numerator, denominator } }
+        }
+
+        fn change_members(
+            removed: &[Credential],
+            added: &[(Credential, u64)],
+            threshold: SafeRatio,
+        ) -> ConstitutionalCommitteeUpdate {
+            ConstitutionalCommitteeUpdate::ChangeMembers {
+                removed: removed.iter().copied().collect(),
+                added: added.iter().copied().map(|(cold, epoch)| (cold, Epoch::from(epoch))).collect(),
+                threshold,
+            }
+        }
+
+        fn stored_member((cold, hot, valid_until): Member) -> (Credential, cc_members::Row) {
+            (
+                cold,
+                cc_members::Row {
+                    valid_until: valid_until.map(Epoch::from),
+                    status: hot.map(ConstitutionalCommitteeMemberStatus::from),
+                },
+            )
+        }
+
+        #[test_case(
+            no_confidence(),
+            vec![
+                (credential(1), Some(credential(10)), Some(99)),
+            ],
+            None
+            => ExpectedCommittee::None;
+            "no confidence without an update"
+        )]
+        #[test_case(
+            trusted(2, 3),
+            vec![
+                (credential(1), Some(credential(10)), Some(99)),
+            ],
+            Some(ConstitutionalCommitteeUpdate::NoConfidence)
+            => ExpectedCommittee::None;
+            "no-confidence update overrides a trusted committee"
+        )]
+        #[test_case(
+            no_confidence(),
+            vec![
+                (credential(1), Some(credential(10)),     None),
+                (credential(2), Some(credential(20)), Some(99)),
+                (credential(3),                 None, Some(99)),
+            ],
+            Some(change_members(
+                &[],
+                &[(credential(1), 100), (credential(3), 300), (credential(4), 400)],
+                safe_ratio(2, 3)
+            ))
+            => ExpectedCommittee::Committee {
+                threshold: safe_ratio(2, 3),
+                members: BTreeMap::from([
+                    (credential(1), (Some(credential(10)), Epoch::from(100))),
+                    (credential(3), (                None, Epoch::from(300))),
+                    (credential(4), (                None, Epoch::from(400))),
+                ]),
+            };
+            "an update restores a committee from no confidence"
+        )]
+        #[test_case(
+            trusted(2, 3),
+            vec![
+                (credential(1), Some(credential(10)), Some(99)),
+                (credential(2), Some(credential(20)), Some(99)),
+                (credential(3), Some(credential(30)),     None),
+                (credential(4),                 None, Some(99)),
+            ],
+            None
+            => ExpectedCommittee::Committee {
+                threshold: safe_ratio(2, 3),
+                members: BTreeMap::from([
+                    (credential(1), (Some(credential(10)), Epoch::from(99))),
+                    (credential(2), (Some(credential(20)), Epoch::from(99))),
+                    (credential(4), (                None, Epoch::from(99))),
+                ]),
+            };
+            "trusted committee keeps only seated members"
+        )]
+        #[test_case(
+            trusted(1, 2),
+            vec![
+                (credential(1), Some(credential(10)), Some(99)),
+                (credential(2), Some(credential(20)), Some(99)),
+                (credential(3), Some(credential(30)),     None),
+            ],
+            Some(change_members(
+                &[credential(1), credential(2)],
+                &[(credential(3), 300), (credential(4), 400)],
+                safe_ratio(3, 4)
+            ))
+            => ExpectedCommittee::Committee {
+                threshold: safe_ratio(3, 4),
+                members: BTreeMap::from([
+                    (credential(3), (Some(credential(30)), Epoch::from(300))),
+                    (credential(4), (                None, Epoch::from(400))),
+                ]),
+            };
+            "update removes, re-adds, and introduces committee members"
+        )]
+        fn resolve(
+            committee: ConstitutionalCommitteeStatus,
+            members: Vec<Member>,
+            update: Option<ConstitutionalCommitteeUpdate>,
+        ) -> ExpectedCommittee {
+            let db = Mock { committee, members: members.into_iter().map(stored_member).collect() };
+            match ConstitutionalCommittee::resolve(&db, update).unwrap() {
+                None => ExpectedCommittee::None,
+                Some(committee) => {
+                    ExpectedCommittee::Committee { threshold: committee.threshold, members: committee.members }
+                }
+            }
+        }
+    }
 
     proptest! {
         #[test]
@@ -299,7 +463,7 @@ mod tests {
 
             // If no active members, let's add one.
             if active_members.is_empty() {
-                let cold_credential = Credential::KeyHash(Hash::from(NULL_HASH));
+                let cold_credential = Credential::KeyHash(NULL_HASH28);
                 let hot_credential = cold_credential;
                 committee.update(
                     committee.threshold().clone(),

--- a/crates/amaru-ledger/src/governance/ratification/constitutional_committee.rs
+++ b/crates/amaru-ledger/src/governance/ratification/constitutional_committee.rs
@@ -90,15 +90,15 @@ impl ConstitutionalCommittee {
             return active_members.clone();
         }
 
-        let active_members =
-            Rc::new(
-                self.members
-                    .iter()
-                    .filter_map(|(cold_cred, (hot_cred, valid_until))| {
-                        if valid_until >= &current_epoch { Some((*cold_cred, *hot_cred.as_ref()?)) } else { None }
-                    })
-                    .collect::<BTreeMap<_, _>>(),
-            );
+        let active_members = Rc::new(
+            self.members
+                .iter()
+                .filter_map(|(cold_cred, (hot_cred, valid_until))| {
+                    // tally is always done with an epoch of delay; hence the strict inequality.
+                    if valid_until > &current_epoch { Some((*cold_cred, *hot_cred.as_ref()?)) } else { None }
+                })
+                .collect::<BTreeMap<_, _>>(),
+        );
 
         *self.active_members.borrow_mut() = Some((current_epoch, active_members.clone()));
 
@@ -212,7 +212,7 @@ mod tests {
                 committee.update(
                     committee.threshold().clone(),
                     BTreeMap::from([
-                        (cold_credential, (Some(hot_credential), epoch))
+                        (cold_credential, (Some(hot_credential), epoch + 1))
                     ]),
                     BTreeSet::new(),
 

--- a/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
+++ b/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
@@ -879,29 +879,42 @@ mod tests {
             let mut compass = forest.new_compass();
             let mut cc_update = None;
             while let Some((id, (proposal, _))) = compass.next(&forest, &PROTOCOL_PARAMETERS) {
-                if let ProposalEnum::ConstitutionalCommittee(ConstitutionalCommitteeUpdate::ChangeMembers { added, .. }, _) = proposal {
-                    let min_valid_until = added.values().min();
-                    if min_valid_until >= Some(&Epoch::from(1)) {
-                        cc_update = Some((id, *min_valid_until.unwrap()));
-                    }
+                if let ProposalEnum::ConstitutionalCommittee(ConstitutionalCommitteeUpdate::ChangeMembers { added, .. }, _) = proposal
+                    && let Some(max_valid_until) = added.values().max()
+                    && max_valid_until.as_u64() > 2 {
+                        cc_update = Some((id, *max_valid_until));
                 }
             }
 
-            if let Some((previous_id, min_valid_until)) = cc_update {
-                forest.current_epoch = min_valid_until - 1;
+            let protocol_parameters = ProtocolParameters {
+                max_committee_term_length: 0,
+                ..(*PROTOCOL_PARAMETERS).clone()
+            };
+
+
+            if let Some((target_proposal, max_valid_until)) = cc_update {
+                // Does not yield cc proposals that contains invalid members.
+                forest.current_epoch = max_valid_until - 2;
                 compass = forest.new_compass();
-
-                let protocol_parameters = ProtocolParameters {
-                    max_committee_term_length: 0,
-                    ..(*PROTOCOL_PARAMETERS).clone()
-                };
-
                 while let Some((id, (_, _))) = compass.next(&forest, &protocol_parameters) {
                     prop_assert!(
-                        id != previous_id,
+                        id != target_proposal,
                         "yielded constitutional committee update ({id}) despite now-invalid committee"
                     );
                 }
+
+                // Yield cc proposals that contains barely valid members
+                forest.current_epoch = max_valid_until - 1;
+                compass = forest.new_compass();
+                while let Some((id, (_, _))) = compass.next(&forest, &protocol_parameters) {
+                    if id == target_proposal {
+                        return Ok(());
+                    }
+                }
+                prop_assert!(
+                    false,
+                    "did not yield constitutional committee update ({target_proposal}) with barely-valid committee"
+                );
             } else {
                 prop_assert!(true)
             }

--- a/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
+++ b/crates/amaru-ledger/src/governance/ratification/proposals_forest.rs
@@ -363,7 +363,7 @@ impl ProposalsForestCompass {
             unreachable!("forest's sequence knows of the id {id:?} but it wasn't found in the lookup-table");
         });
 
-        // NOTE(SKIP_PROPOSALS):
+        // NOTE: Skip just-submitted governance proposals
         //
         // Proposals are ratified with an epoch of delay. So
         //
@@ -387,7 +387,7 @@ impl ProposalsForestCompass {
             return None;
         }
 
-        // NOTE(SKIP_PROPOSALS):
+        // NOTE: Skip now-invalid treasury withdrawals
         //
         // On treasury withdrawals, we must ensure there's still enough money in the
         // treasury. This is necessary since there can be an arbitrary number of
@@ -407,14 +407,22 @@ impl ProposalsForestCompass {
             }
         }
 
-        // NOTE(SKIP_PROPOSALS):
+        // NOTE: Skip CC update proposal with invalid members
         //
         // On constitutional committee updates, we should ensure that any term limit is still
         // valid. This can happen if a protocol parameter change that changes the max term limit
         // is ratified *before* a committee update, possibly rendering it invalid.
+        //
+        // Note that we use the *next epoch* (the epoch that just ended) for the validity bound
+        // comparison and not the epoch from which the votes and stake distribution comes from.
+        //
+        // Said differently, during the boundary from e to e+1, we compare the validity of actions
+        // against e, with data coming from e-1.
+        //
+        // This is NOT confusing at all. <insert sobbing emoji>.
         if let ProposalEnum::ConstitutionalCommittee(ChangeMembers { added, .. }, _) = proposal {
             let max_term_length = protocol_parameters.max_committee_term_length;
-            let is_now_invalid = |valid_until| valid_until > &(forest.current_epoch + max_term_length);
+            let is_now_invalid = |valid_until| valid_until > &(forest.current_epoch + 1 + max_term_length);
             if added.values().any(is_now_invalid) {
                 let invalid_members =
                     added.iter().filter(|(_, v)| is_now_invalid(v)).map(|(k, _)| k.as_hash()).collect::<Vec<_>>();
@@ -428,7 +436,7 @@ impl ProposalsForestCompass {
             }
         }
 
-        // NOTE(SKIP_PROPOSALS):
+        // NOTE: Skip proposals with non-matching parent roots.
         //
         // Ensures that the next proposal points to an active root. Not being the case isn't
         // necessarily an issue or a sign that something went wrong.
@@ -953,7 +961,7 @@ mod tests {
                             prop_assert!(
                                 added
                                     .values()
-                                    .all(|valid_until| *valid_until <= forest.current_epoch + PROTOCOL_PARAMETERS.max_committee_term_length)
+                                    .all(|valid_until| *valid_until <= forest.current_epoch + 1 + PROTOCOL_PARAMETERS.max_committee_term_length)
                             );
                         }
                     },

--- a/crates/amaru-ledger/src/governance/ratification/stake_pools.rs
+++ b/crates/amaru-ledger/src/governance/ratification/stake_pools.rs
@@ -360,6 +360,7 @@ mod tests {
                 },
             )]),
             dreps: BTreeMap::new(),
+            cc_update: None,
         }
     }
 }

--- a/crates/amaru-ledger/src/startup.rs
+++ b/crates/amaru-ledger/src/startup.rs
@@ -14,7 +14,7 @@
 
 use std::ops::Deref;
 
-use amaru_kernel::{Epoch, EraHistory, GovernanceAction, ProtocolParameters};
+use amaru_kernel::{Credential, Epoch, EraHistory, GovernanceAction, ProtocolParameters, hash};
 use amaru_observability::{info, info_span};
 use tracing::field;
 
@@ -198,9 +198,48 @@ impl<'a, S: ReadStore> StartupContext<'a, S> {
         Ok(())
     }
 
+    #[expect(clippy::panic)]
     fn emit_constitutional_committee(&self) -> Result<(), StoreError> {
         info_span!(ledger::constitutional_committee::DUMP, status = self.constitutional_committee()?);
+
+        fn is_invalid_cc_member(cold_credential: &Credential) -> bool {
+            false
+                || cold_credential
+                    == &Credential::ScriptHash(hash!("349e55f83e9af24813e6cb368df6a80d38951b2a334dfcdf26815558"))
+                || cold_credential
+                    == &Credential::ScriptHash(hash!("9cc3f387623f45dae6a68b7096b0c2e403d8601a82dc40221ead41e2"))
+                || cold_credential
+                    == &Credential::KeyHash(hash!("dc0d6ef49590eb6880a50a00adde17596e6d76f7159572fa1ff85f2a"))
+        }
+
         for (cold_credential, member) in self.iter_cc_members()? {
+            if self.epoch == Epoch::from(654) && is_invalid_cc_member(&cold_credential) {
+                panic!(
+                    r#"
+    Corrupted ledger state: bootstrap or manual rollback is required.
+
+    Amaru versions prior to v10.11.20260912 contains an off-by-one error which
+    prevented the correct ratification of CC members at the boundary of 653→654.
+
+    Fixing this requires to either:
+
+    - rollback manually if you still have the appropriate ledger states:
+
+      ```
+      amaru node rollback --epoch 654
+      ```
+
+    - re-bootstrap your node:
+
+      ```
+      amaru node rm --wipe-all-dbs
+      amaru node bootstrap
+      ```
+
+    (sorry for the inconvenience :s)"#
+                );
+            }
+
             info!(
                 ledger::constitutional_committee_member::DUMP,
                 cold_credential = cold_credential,

--- a/crates/amaru-ledger/src/startup.rs
+++ b/crates/amaru-ledger/src/startup.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 use amaru_kernel::{Epoch, EraHistory, GovernanceAction, ProtocolParameters};
-use amaru_observability::info;
+use amaru_observability::{info, info_span};
+use tracing::field;
 
 use crate::store::{self, ReadStore, StoreError};
 
@@ -64,6 +65,7 @@ pub fn with_startup_hook<S: ReadStore>(database: &Database<'_, S>) -> Result<(),
     emit_protocol_parameters(database);
     emit_current_pots(database)?;
     emit_active_proposals(database)?;
+    emit_constitutional_committee(database)?;
     Ok(())
 }
 
@@ -137,6 +139,19 @@ fn emit_active_proposals<S: ReadStore>(database: &Database<'_, S>) -> Result<(),
         }
     }
 
+    Ok(())
+}
+
+fn emit_constitutional_committee<S: ReadStore>(database: &Database<'_, S>) -> Result<(), StoreError> {
+    info_span!(ledger::constitutional_committee::LOAD, status = database.stable.constitutional_committee()?);
+    for (cold_credential, member) in database.stable.iter_cc_members()? {
+        info!(
+            ledger::constitutional_committee_member::LOAD,
+            cold_credential = cold_credential,
+            status = @member.status.as_ref().map(field::display),
+            valid_until = @member.valid_until.as_ref().map(|epoch| epoch.as_u64()),
+        );
+    }
     Ok(())
 }
 

--- a/crates/amaru-ledger/src/startup.rs
+++ b/crates/amaru-ledger/src/startup.rs
@@ -12,22 +12,47 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::Deref;
+
 use amaru_kernel::{Epoch, EraHistory, GovernanceAction, ProtocolParameters};
 use amaru_observability::{info, info_span};
 use tracing::field;
 
-use crate::store::{self, ReadStore, StoreError};
+use crate::store::{ReadStore, StoreError};
 
-pub type StartupHook<S> = fn(&Database<'_, S>) -> Result<(), StoreError>;
+// ------------------------------------------------------------------------------------- StartupHook
 
-pub struct Database<'a, S: ReadStore> {
+pub type StartupHook<S> = fn(&StartupContext<'_, S>) -> Result<(), StoreError>;
+
+pub fn no_startup_hook<S: ReadStore>(_: &StartupContext<'_, S>) -> Result<(), StoreError> {
+    Ok(())
+}
+
+pub fn with_startup_hook<'a, S: ReadStore>(ctx: &StartupContext<'a, S>) -> Result<(), StoreError> {
+    ctx.emit_protocol_parameters();
+    ctx.emit_current_pots()?;
+    ctx.emit_active_proposals()?;
+    ctx.emit_constitutional_committee()?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------------- StartupContext
+
+pub struct StartupContext<'a, S: ReadStore> {
     stable: &'a S,
     epoch: Epoch,
     protocol_parameters: &'a ProtocolParameters,
     era_history: &'a EraHistory,
 }
 
-impl<'a, S: ReadStore> Database<'a, S> {
+impl<'a, S: ReadStore> Deref for StartupContext<'a, S> {
+    type Target = S;
+    fn deref(&self) -> &Self::Target {
+        self.stable
+    }
+}
+
+impl<'a, S: ReadStore> StartupContext<'a, S> {
     pub(crate) fn new(
         stable: &'a S,
         epoch: Epoch,
@@ -49,111 +74,145 @@ impl<'a, S: ReadStore> Database<'a, S> {
         self.era_history
     }
 
-    pub fn pots(&self) -> Result<store::columns::pots::Row, StoreError> {
-        self.stable.pots()
-    }
+    fn emit_protocol_parameters(&self) {
+        let ProtocolParameters {
+            protocol_version,
+            max_block_body_size,
+            max_transaction_size,
+            max_block_header_size,
+            max_tx_ex_units,
+            max_block_ex_units,
+            max_value_size,
+            max_collateral_inputs,
+            min_fee_a,
+            min_fee_b,
+            stake_credential_deposit,
+            stake_pool_deposit,
+            monetary_expansion_rate,
+            treasury_expansion_rate,
+            min_pool_cost,
+            lovelace_per_utxo_byte,
+            prices,
+            min_fee_ref_script_lovelace_per_byte,
+            max_ref_script_size_per_tx,
+            max_ref_script_size_per_block,
+            ref_script_cost_stride,
+            ref_script_cost_multiplier,
+            stake_pool_max_retirement_epoch,
+            optimal_stake_pools_count,
+            pledge_influence,
+            collateral_percentage,
+            cost_models: _,
+            pool_voting_thresholds,
+            drep_voting_thresholds,
+            min_committee_size,
+            max_committee_term_length,
+            gov_action_lifetime,
+            gov_action_deposit,
+            drep_deposit,
+            drep_expiry,
+        } = &self.protocol_parameters;
 
-    pub fn iter_proposals(
-        &self,
-    ) -> Result<impl Iterator<Item = (store::columns::proposals::Key, store::columns::proposals::Row)> + '_, StoreError>
-    {
-        self.stable.iter_proposals()
-    }
-}
-
-pub fn with_startup_hook<S: ReadStore>(database: &Database<'_, S>) -> Result<(), StoreError> {
-    emit_protocol_parameters(database);
-    emit_current_pots(database)?;
-    emit_active_proposals(database)?;
-    emit_constitutional_committee(database)?;
-    Ok(())
-}
-
-pub fn no_startup_hook<S: ReadStore>(_: &Database<'_, S>) -> Result<(), StoreError> {
-    Ok(())
-}
-
-fn emit_protocol_parameters<S: ReadStore>(database: &Database<'_, S>) {
-    let protocol_parameters = database.protocol_parameters();
-
-    info!(
-        ledger::protocol_parameters::LOAD,
-        protocol_version = protocol_parameters.protocol_version.to_string(),
-        max_block_body_size = protocol_parameters.max_block_body_size.to_string(),
-        max_transaction_size = protocol_parameters.max_transaction_size.to_string(),
-        max_tx_ex_units = protocol_parameters.max_tx_ex_units.to_string(),
-        max_block_ex_units = protocol_parameters.max_block_ex_units.to_string(),
-        min_fee_a = protocol_parameters.min_fee_a.to_string(),
-        min_fee_b = protocol_parameters.min_fee_b.to_string(),
-        stake_credential_deposit = protocol_parameters.stake_credential_deposit.to_string(),
-        stake_pool_deposit = protocol_parameters.stake_pool_deposit.to_string(),
-        lovelace_per_utxo_byte = protocol_parameters.lovelace_per_utxo_byte.to_string(),
-        collateral_percentage = protocol_parameters.collateral_percentage.to_string(),
-        gov_action_lifetime = protocol_parameters.gov_action_lifetime.to_string(),
-        gov_action_deposit = protocol_parameters.gov_action_deposit.to_string(),
-        drep_deposit = protocol_parameters.drep_deposit.to_string(),
-        drep_expiry = protocol_parameters.drep_expiry.to_string(),
-    );
-}
-
-fn emit_current_pots<S: ReadStore>(database: &Database<'_, S>) -> Result<(), StoreError> {
-    let pots = database.pots()?;
-
-    info!(
-        ledger::pots::LOAD,
-        treasury = pots.treasury,
-        reserves = pots.reserves,
-        fees = pots.fees,
-        donations = pots.donations,
-    );
-
-    Ok(())
-}
-
-fn emit_active_proposals<S: ReadStore>(database: &Database<'_, S>) -> Result<(), StoreError> {
-    for (id, row) in database.iter_proposals()? {
-        let proposal_kind = proposal_kind(&row.proposal.gov_action);
-        let detail = proposal_detail(&row.proposal.gov_action);
-        let proposed_in = database
-            .era_history()
-            .slot_to_epoch_unchecked_horizon(row.proposed_in.transaction.slot)
-            .map_err(|error| StoreError::Internal(Box::new(error)))?;
-
-        if let Some(detail) = detail {
-            info!(
-                ledger::proposal::ACTIVE,
-                id = id.to_string(),
-                proposal_kind,
-                proposed_in,
-                valid_until = row.valid_until,
-                detail,
-            );
-        } else {
-            info!(
-                ledger::proposal::ACTIVE,
-                id = id.to_string(),
-                proposal_kind,
-                proposed_in,
-                valid_until = row.valid_until,
-            );
-        }
-    }
-
-    Ok(())
-}
-
-fn emit_constitutional_committee<S: ReadStore>(database: &Database<'_, S>) -> Result<(), StoreError> {
-    info_span!(ledger::constitutional_committee::LOAD, status = database.stable.constitutional_committee()?);
-    for (cold_credential, member) in database.stable.iter_cc_members()? {
         info!(
-            ledger::constitutional_committee_member::LOAD,
-            cold_credential = cold_credential,
-            status = @member.status.as_ref().map(field::display),
-            valid_until = @member.valid_until.as_ref().map(|epoch| epoch.as_u64()),
+            ledger::protocol_parameters::DUMP,
+            protocol_version,
+            max_block_body_size,
+            max_transaction_size,
+            max_block_header_size,
+            max_tx_ex_units,
+            max_block_ex_units,
+            max_value_size,
+            max_collateral_inputs,
+            min_fee_a,
+            min_fee_b,
+            stake_credential_deposit,
+            stake_pool_deposit,
+            monetary_expansion_rate,
+            treasury_expansion_rate,
+            min_pool_cost,
+            lovelace_per_utxo_byte,
+            prices,
+            min_fee_ref_script_lovelace_per_byte,
+            max_ref_script_size_per_tx,
+            max_ref_script_size_per_block,
+            ref_script_cost_stride,
+            ref_script_cost_multiplier,
+            stake_pool_max_retirement_epoch,
+            optimal_stake_pools_count,
+            pledge_influence,
+            collateral_percentage,
+            pool_voting_thresholds,
+            drep_voting_thresholds,
+            min_committee_size,
+            max_committee_term_length,
+            gov_action_lifetime,
+            gov_action_deposit,
+            drep_deposit,
+            drep_expiry,
         );
     }
-    Ok(())
+
+    fn emit_current_pots(&self) -> Result<(), StoreError> {
+        let pots = self.pots()?;
+
+        info!(
+            ledger::pots::DUMP,
+            treasury = pots.treasury,
+            reserves = pots.reserves,
+            fees = pots.fees,
+            donations = pots.donations,
+        );
+
+        Ok(())
+    }
+
+    fn emit_active_proposals(&self) -> Result<(), StoreError> {
+        for (id, row) in self.iter_proposals()? {
+            let proposal_kind = proposal_kind(&row.proposal.gov_action);
+            let detail = proposal_detail(&row.proposal.gov_action);
+            let proposed_in = self
+                .era_history()
+                .slot_to_epoch_unchecked_horizon(row.proposed_in.transaction.slot)
+                .map_err(|error| StoreError::Internal(Box::new(error)))?;
+
+            if let Some(detail) = detail {
+                info!(
+                    ledger::proposal::ACTIVE,
+                    id = id.to_string(),
+                    proposal_kind,
+                    proposed_in,
+                    valid_until = row.valid_until,
+                    detail = @detail,
+                );
+            } else {
+                info!(
+                    ledger::proposal::ACTIVE,
+                    id = id.to_string(),
+                    proposal_kind,
+                    proposed_in,
+                    valid_until = row.valid_until,
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn emit_constitutional_committee(&self) -> Result<(), StoreError> {
+        info_span!(ledger::constitutional_committee::DUMP, status = self.constitutional_committee()?);
+        for (cold_credential, member) in self.iter_cc_members()? {
+            info!(
+                ledger::constitutional_committee_member::DUMP,
+                cold_credential = cold_credential,
+                status = @member.status.as_ref().map(field::display),
+                valid_until = @member.valid_until.as_ref().map(|epoch| epoch.as_u64()),
+            );
+        }
+        Ok(())
+    }
 }
+
+// ----------------------------------------------------------------------------------------- Helpers
 
 fn proposal_kind(proposal: &GovernanceAction) -> &'static str {
     match proposal {

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -46,7 +46,7 @@ use crate::{
         self,
         block::{BlockValidation, TransactionInvalid},
     },
-    startup::{Database as StartupDatabase, StartupHook},
+    startup::{StartupContext, StartupHook},
     state::volatile::{
         AnchoredVolatileFragment, StoreUpdate, VolatileDB, VolatileFragment, VolatileSequence, VolatileView,
     },
@@ -200,7 +200,7 @@ impl<S: Store, HS: HistoricalStores + Send + 'static> State<S, HS> {
         let epoch = initial_epoch(&stable, &snapshots, &era_history)?;
 
         if let Some(on_startup) = on_startup {
-            on_startup(&StartupDatabase::new(&stable, epoch, &protocol_parameters, &era_history))?;
+            on_startup(&StartupContext::new(&stable, epoch, &protocol_parameters, &era_history))?;
         }
 
         Ok(Self::new_with(

--- a/crates/amaru-ledger/src/state.rs
+++ b/crates/amaru-ledger/src/state.rs
@@ -190,18 +190,18 @@ impl<S: Store, HS: HistoricalStores + Send + 'static> State<S, HS> {
 
         let guardrail_script = stable.constitution()?.guardrail_script;
 
+        let epoch = initial_epoch(&stable, &snapshots, &era_history)?;
+
+        if let Some(on_startup) = on_startup {
+            on_startup(&StartupContext::new(&stable, epoch, &protocol_parameters, &era_history))?;
+        }
+
         let stake_distributions = initial_stake_distributions(
             network,
             &snapshots,
             &era_history,
             emit_initial_stake_distribution_progress_ticks,
         )?;
-
-        let epoch = initial_epoch(&stable, &snapshots, &era_history)?;
-
-        if let Some(on_startup) = on_startup {
-            on_startup(&StartupContext::new(&stable, epoch, &protocol_parameters, &era_history))?;
-        }
 
         Ok(Self::new_with(
             stable,

--- a/crates/amaru-ledger/src/summary/governance.rs
+++ b/crates/amaru-ledger/src/summary/governance.rs
@@ -18,8 +18,8 @@ use std::{
 };
 
 use amaru_kernel::{
-    Anchor, CertificatePointer, Credential, DRep, Epoch, EraHistory, EraHistoryError, Lovelace, ProposalId,
-    RatificationStatus, Slot, TransactionPointer,
+    Anchor, CertificatePointer, ConstitutionalCommitteeUpdate, Credential, DRep, Epoch, EraHistory, EraHistoryError,
+    Lovelace, ProposalId, RatificationStatus, Slot, TransactionPointer, into_safe_ratio,
 };
 
 use crate::{
@@ -32,6 +32,7 @@ pub struct GovernanceSummary {
     pub dreps: BTreeMap<DRep, DRepState>,
     pub dreps_deposits: BTreeMap<Credential, Lovelace>,
     pub pools_deposits: BTreeMap<Credential, Lovelace>,
+    pub cc_update: Option<ConstitutionalCommitteeUpdate>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -75,6 +76,8 @@ impl GovernanceSummary {
 
         let recently_pruned_proposals: BTreeMap<ProposalId, RatificationStatus> =
             db.iter_recently_pruned_proposals()?.collect();
+
+        let mut cc_update = None;
 
         db.iter_proposals()?.try_for_each(|(proposal_id, row)| -> Result<(), Error> {
             let proposed_in = era_history
@@ -133,12 +136,18 @@ impl GovernanceSummary {
                                     .or_insert(*withdrawal);
                             }
                         }
-                        ParameterChange(..)
-                        | HardForkInitiation(..)
-                        | NoConfidence(..)
-                        | UpdateCommittee(..)
-                        | NewConstitution(..)
-                        | Information => (),
+
+                        NoConfidence(..) => cc_update = Some(ConstitutionalCommitteeUpdate::NoConfidence),
+
+                        UpdateCommittee(_, removed, added, threshold) => {
+                            cc_update = Some(ConstitutionalCommitteeUpdate::ChangeMembers {
+                                removed: removed.into_iter().collect(),
+                                added: added.into_iter().collect(),
+                                threshold: into_safe_ratio(&threshold),
+                            })
+                        }
+
+                        ParameterChange(..) | HardForkInitiation(..) | NewConstitution(..) | Information => (),
                     }
                 }
             }
@@ -185,6 +194,6 @@ impl GovernanceSummary {
         dreps.insert(DRep::Abstain, default_protocol_drep());
         dreps.insert(DRep::NoConfidence, default_protocol_drep());
 
-        Ok(GovernanceSummary { dreps, dreps_deposits, pools_deposits })
+        Ok(GovernanceSummary { dreps, dreps_deposits, pools_deposits, cc_update })
     }
 }

--- a/crates/amaru-ledger/src/summary/rewards.rs
+++ b/crates/amaru-ledger/src/summary/rewards.rs
@@ -701,6 +701,7 @@ mod test {
                 dreps_voting_stake: 0,
                 pools: BTreeMap::from([(pool.parameters.id, pool.clone())]),
                 dreps: BTreeMap::new(),
+                cc_update: None,
             },
             accounts: SortedPairs::from(accounts),
         }

--- a/crates/amaru-ledger/src/summary/stake_distribution.rs
+++ b/crates/amaru-ledger/src/summary/stake_distribution.rs
@@ -18,7 +18,10 @@ use std::{
     sync::{OnceLock, atomic, atomic::AtomicUsize},
 };
 
-use amaru_kernel::{Credential, DRep, Epoch, Hash, Lovelace, NetworkName, PoolId, SortedPairs, safe_ratio};
+use amaru_kernel::{
+    ConstitutionalCommitteeUpdate, Credential, DRep, Epoch, Hash, Lovelace, NetworkName, PoolId, SortedPairs,
+    safe_ratio,
+};
 use amaru_observability::info;
 use serde::ser::SerializeStruct;
 
@@ -97,6 +100,10 @@ pub struct StakeDistribution {
 
     /// Mapping of dreps to their relative stake
     pub dreps: BTreeMap<DRep, DRepState>,
+
+    /// Constitutional committee update happening at the boundary; required for building the
+    /// ratification context.
+    pub cc_update: Option<ConstitutionalCommitteeUpdate>,
 }
 
 const PROGRESS_BATCH_SIZE: usize = 1_000;
@@ -107,7 +114,7 @@ impl StakeSummary {
     /// Invariant: The given store is expected to be a snapshot taken at the end of an epoch.
     pub fn new(
         db: &impl Snapshot,
-        GovernanceSummary { mut dreps, pools_deposits, dreps_deposits }: GovernanceSummary,
+        GovernanceSummary { mut dreps, pools_deposits, dreps_deposits, cc_update }: GovernanceSummary,
         network: NetworkName,
         mut notify: impl FnMut(f64),
     ) -> Result<Self, StoreError> {
@@ -267,6 +274,7 @@ impl StakeSummary {
             active_stake,
             pools_voting_stake,
             dreps_voting_stake,
+            cc_update = @cc_update.as_ref().map(tracing::field::display),
         );
 
         Ok(Self {
@@ -279,6 +287,7 @@ impl StakeSummary {
                 dreps_voting_stake,
                 pools,
                 dreps,
+                cc_update,
             },
             accounts,
         })
@@ -422,6 +431,7 @@ pub mod tests {
                 dreps_voting_stake,
                 pools: BTreeMap::new(),
                 pools_voting_stake: 0,
+                cc_update: None,
             }
         }
     }
@@ -480,6 +490,7 @@ pub mod tests {
                 pools_voting_stake,
                 dreps: BTreeMap::new(),
                 dreps_voting_stake: 0,
+                cc_update: None,
             }
         }
     }

--- a/crates/amaru-node/src/tests/configuration.rs
+++ b/crates/amaru-node/src/tests/configuration.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::{
+    collections::{BTreeMap, BTreeSet},
     fmt::{Debug, Formatter},
     num::NonZeroU8,
     path::PathBuf,
@@ -22,9 +23,9 @@ use std::{
 };
 
 use amaru_kernel::{
-    Anchor, Constitution, Epoch, EraHistory, Header, IsHeader, MaxString128, NetworkName, Peer, Point,
-    ProtocolParameters, Transaction, TransactionId, cardano::network_block::make_encoded_chain,
-    cbor::WithOriginalBytes,
+    Anchor, Constitution, ConstitutionalCommitteeStatus, Epoch, EraHistory, Header, IsHeader, MaxString128,
+    NetworkName, Peer, Point, ProtocolParameters, Transaction, TransactionId,
+    cardano::network_block::make_encoded_chain, cbor::WithOriginalBytes,
 };
 use amaru_ledger::{
     epoch_transition::GovernanceActivity,
@@ -415,8 +416,9 @@ impl NodeTestConfig {
                 )?;
                 tx.set_protocol_parameters(pp)?;
                 tx.set_governance_activity(governance_activity)?;
-                // A bootstrapped ledger always has a constitution; these tests never propose one, so
-                // any anchor will do and there is no guardrails script to enforce.
+                // A bootstrapped ledger always has a constitution and a committee status.
+                // These tests never propose a constitution or elect members, so any
+                // constitution anchor will do and the committee starts in no-confidence.
                 tx.set_constitution(&Constitution {
                     anchor: Anchor {
                         url: MaxString128::from_str("https://example.com").map_err(anyhow::Error::msg)?,
@@ -424,6 +426,11 @@ impl NodeTestConfig {
                     },
                     guardrail_script: None,
                 })?;
+                tx.update_constitutional_committee(
+                    &ConstitutionalCommitteeStatus::NoConfidence,
+                    &BTreeMap::new(),
+                    &BTreeSet::new(),
+                )?;
                 tx.commit()?;
                 // initial_stake_distributions needs snapshots at most_recent, most_recent - 1, and
                 // most_recent - 2; take three so that for_epoch(0) and for_epoch(1) both succeed.

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -960,6 +960,18 @@ define_schemas! {
                     required min_committee_size: u16
                     required reason: String
                 }
+                /// Load the current constitutional committee on startup
+                public LOAD {
+                    required status: %amaru_kernel::ConstitutionalCommitteeStatus
+                }
+            }
+            constitutional_committee_member {
+                /// Load the current constitutional committee member on startup
+                public LOAD {
+                    required cold_credential: %amaru_kernel::Credential
+                    optional status: %amaru_kernel::ConstitutionalCommitteeMemberStatus
+                    optional valid_until: amaru_kernel::Epoch
+                }
             }
             governance_activity {
                 /// Update the number of consecutive dormant epochs

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -685,6 +685,7 @@ define_schemas! {
                     required active_stake: amaru_kernel::Lovelace
                     required pools_voting_stake: amaru_kernel::Lovelace
                     required dreps_voting_stake: amaru_kernel::Lovelace
+                    optional cc_update: %amaru_kernel::ConstitutionalCommitteeUpdate
                 }
             }
             rewards {

--- a/crates/amaru-observability/src/schemas.rs
+++ b/crates/amaru-observability/src/schemas.rs
@@ -961,13 +961,13 @@ define_schemas! {
                     required reason: String
                 }
                 /// Load the current constitutional committee on startup
-                public LOAD {
+                public DUMP {
                     required status: %amaru_kernel::ConstitutionalCommitteeStatus
                 }
             }
             constitutional_committee_member {
                 /// Load the current constitutional committee member on startup
-                public LOAD {
+                public DUMP {
                     required cold_credential: %amaru_kernel::Credential
                     optional status: %amaru_kernel::ConstitutionalCommitteeMemberStatus
                     optional valid_until: amaru_kernel::Epoch
@@ -981,7 +981,7 @@ define_schemas! {
             }
             pots {
                 /// Load the current ledger pots
-                public LOAD {
+                public DUMP {
                     required treasury: amaru_kernel::Lovelace
                     required reserves: amaru_kernel::Lovelace
                     required fees: amaru_kernel::Lovelace
@@ -1037,81 +1037,43 @@ define_schemas! {
                 }
             }
             protocol_parameters {
-                /// Load the current protocol parameters
-                public LOAD {
-                    optional protocol_version: String
-                    optional max_block_body_size: String
-                    optional max_transaction_size: String
-                    optional max_block_header_size: String
-                    optional max_tx_ex_units: String
-                    optional max_block_ex_units: String
-                    optional max_value_size: String
-                    optional max_collateral_inputs: String
-                    optional min_fee_a: String
-                    optional min_fee_b: String
-                    optional stake_credential_deposit: String
-                    optional stake_pool_deposit: String
-                    optional monetary_expansion_rate: String
-                    optional treasury_expansion_rate: String
-                    optional min_pool_cost: String
-                    optional lovelace_per_utxo_byte: String
-                    optional prices: String
-                    optional min_fee_ref_script_lovelace_per_byte: String
-                    optional max_ref_script_size_per_tx: String
-                    optional max_ref_script_size_per_block: String
-                    optional ref_script_cost_stride: String
-                    optional ref_script_cost_multiplier: String
-                    optional stake_pool_max_retirement_epoch: String
-                    optional optimal_stake_pools_count: String
-                    optional pledge_influence: String
-                    optional collateral_percentage: String
-                    optional cost_models: String
-                    optional pool_voting_thresholds: String
-                    optional drep_voting_thresholds: String
-                    optional min_committee_size: String
-                    optional max_committee_term_length: String
-                    optional gov_action_lifetime: String
-                    optional gov_action_deposit: String
-                    optional drep_deposit: String
-                    optional drep_expiry: String
-                }
-                /// Ratify a protocol parameters update; only changed parameters are recorded
-                public RATIFY {
-                    optional protocol_version: String
-                    optional max_block_body_size: String
-                    optional max_transaction_size: String
-                    optional max_block_header_size: String
-                    optional max_tx_ex_units: String
-                    optional max_block_ex_units: String
-                    optional max_value_size: String
-                    optional max_collateral_inputs: String
-                    optional min_fee_a: String
-                    optional min_fee_b: String
-                    optional stake_credential_deposit: String
-                    optional stake_pool_deposit: String
-                    optional monetary_expansion_rate: String
-                    optional treasury_expansion_rate: String
-                    optional min_pool_cost: String
-                    optional lovelace_per_utxo_byte: String
-                    optional prices: String
-                    optional min_fee_ref_script_lovelace_per_byte: String
-                    optional max_ref_script_size_per_tx: String
-                    optional max_ref_script_size_per_block: String
-                    optional ref_script_cost_stride: String
-                    optional ref_script_cost_multiplier: String
-                    optional stake_pool_max_retirement_epoch: String
-                    optional optimal_stake_pools_count: String
-                    optional pledge_influence: String
-                    optional collateral_percentage: String
-                    optional cost_models: String
-                    optional pool_voting_thresholds: String
-                    optional drep_voting_thresholds: String
-                    optional min_committee_size: String
-                    optional max_committee_term_length: String
-                    optional gov_action_lifetime: String
-                    optional gov_action_deposit: String
-                    optional drep_deposit: String
-                    optional drep_expiry: String
+                /// Dump the current protocol parameters
+                public DUMP {
+                    optional protocol_version: %amaru_kernel::ProtocolVersion
+                    optional max_block_body_size: u64
+                    optional max_transaction_size: u64
+                    optional max_block_header_size: u16
+                    optional max_tx_ex_units: %amaru_kernel::ExUnits
+                    optional max_block_ex_units: %amaru_kernel::ExUnits
+                    optional max_value_size: u64
+                    optional max_collateral_inputs: u16
+                    optional min_fee_a: amaru_kernel::Lovelace
+                    optional min_fee_b: u64
+                    optional stake_credential_deposit: amaru_kernel::Lovelace
+                    optional stake_pool_deposit: amaru_kernel::Lovelace
+                    optional monetary_expansion_rate: %amaru_kernel::RationalNumber
+                    optional treasury_expansion_rate: %amaru_kernel::RationalNumber
+                    optional min_pool_cost: amaru_kernel::Lovelace
+                    optional lovelace_per_utxo_byte: amaru_kernel::Lovelace
+                    optional prices: %amaru_kernel::ExUnitPrices
+                    optional min_fee_ref_script_lovelace_per_byte: %amaru_kernel::RationalNumber
+                    optional max_ref_script_size_per_tx: u32
+                    optional max_ref_script_size_per_block: u32
+                    optional ref_script_cost_stride: u32
+                    optional ref_script_cost_multiplier: %amaru_kernel::RationalNumber
+                    optional stake_pool_max_retirement_epoch: u64
+                    optional optimal_stake_pools_count: u16
+                    optional pledge_influence: %amaru_kernel::RationalNumber
+                    optional cost_models: %amaru_kernel::CostModels
+                    optional collateral_percentage: u16
+                    optional pool_voting_thresholds: %amaru_kernel::PoolVotingThresholds
+                    optional drep_voting_thresholds: %amaru_kernel::DRepVotingThresholds
+                    optional min_committee_size: u16
+                    optional max_committee_term_length: u64
+                    optional gov_action_lifetime: u64
+                    optional gov_action_deposit: amaru_kernel::Lovelace
+                    optional drep_deposit: amaru_kernel::Lovelace
+                    optional drep_expiry: u64
                 }
             }
             ratification {

--- a/crates/amaru-tui/src/model/telemetry_event.rs
+++ b/crates/amaru-tui/src/model/telemetry_event.rs
@@ -37,12 +37,11 @@ pub enum TelemetryEvent {
     PeerConnected,
     PeerDisconnected,
     PeerResolved,
-    PotsLoad,
+    PotsDump,
     ProposalActive,
     ProposalDrop,
     ProposalSkip,
-    ProtocolParametersLoad,
-    ProtocolParametersRatify,
+    ProtocolParametersDump,
     ProtocolUpgrade,
     RatificationSummarize,
     RewardsSummarize,
@@ -76,8 +75,8 @@ impl TelemetryEvent {
             Some(Self::StakeSnapshot)
         } else if ledger::rewards::SUMMARIZE::matches(&record.target, &record.name) {
             Some(Self::RewardsSummarize)
-        } else if ledger::pots::LOAD::matches(&record.target, &record.name) {
-            Some(Self::PotsLoad)
+        } else if ledger::pots::DUMP::matches(&record.target, &record.name) {
+            Some(Self::PotsDump)
         } else if ledger::state::SWITCH_TO_FORK::matches(&record.target, &record.name) {
             Some(Self::StateSwitchToFork)
         } else if ledger::epoch_transition::COMPUTE::matches(&record.target, &record.name) {
@@ -116,10 +115,8 @@ impl TelemetryEvent {
             Some(Self::ProposalSkip)
         } else if ledger::protocol::UPGRADE::matches(&record.target, &record.name) {
             Some(Self::ProtocolUpgrade)
-        } else if ledger::protocol_parameters::LOAD::matches(&record.target, &record.name) {
-            Some(Self::ProtocolParametersLoad)
-        } else if ledger::protocol_parameters::RATIFY::matches(&record.target, &record.name) {
-            Some(Self::ProtocolParametersRatify)
+        } else if ledger::protocol_parameters::DUMP::matches(&record.target, &record.name) {
+            Some(Self::ProtocolParametersDump)
         } else if ledger::ratification::SUMMARIZE::matches(&record.target, &record.name) {
             Some(Self::RatificationSummarize)
         } else {

--- a/crates/amaru-tui/src/model/telemetry_update.rs
+++ b/crates/amaru-tui/src/model/telemetry_update.rs
@@ -66,7 +66,7 @@ impl Model {
                 self.update_pots(record);
                 self.rewards_ready = true;
             }
-            TelemetryEvent::BootstrapPotsImport | TelemetryEvent::PotsLoad => self.update_pots(record),
+            TelemetryEvent::BootstrapPotsImport | TelemetryEvent::PotsDump => self.update_pots(record),
             TelemetryEvent::EpochTransitionCompute => self.rewards_ready = false,
             TelemetryEvent::EpochTransitionRecord => self.epoch_overlay_exists = true,
             TelemetryEvent::EpochTransitionApply => self.epoch_overlay_exists = false,
@@ -96,12 +96,8 @@ impl Model {
             TelemetryEvent::ProtocolUpgrade => {
                 self.protocol_version = ledger::protocol::UPGRADE::new_version(record).to_string();
             }
-            TelemetryEvent::ProtocolParametersLoad | TelemetryEvent::ProtocolParametersRatify => {
-                let version = if ledger::protocol_parameters::LOAD::matches(&record.target, &record.name) {
-                    ledger::protocol_parameters::LOAD::protocol_version(record)
-                } else {
-                    ledger::protocol_parameters::RATIFY::protocol_version(record)
-                };
+            TelemetryEvent::ProtocolParametersDump => {
+                let version = ledger::protocol_parameters::DUMP::protocol_version(record);
                 if let Some(version) = version.map(ToOwned::to_owned) {
                     self.protocol_version = version;
                 }
@@ -226,11 +222,11 @@ impl Model {
             self.reserves = Some(ledger::rewards::SUMMARIZE::pots_reserves(record));
             self.fees = Some(ledger::rewards::SUMMARIZE::pots_fees(record));
             self.donations = self.donations.or(Some(0));
-        } else if ledger::pots::LOAD::matches(&record.target, &record.name) {
-            self.treasury = Some(ledger::pots::LOAD::treasury(record));
-            self.reserves = Some(ledger::pots::LOAD::reserves(record));
-            self.fees = Some(ledger::pots::LOAD::fees(record));
-            self.donations = Some(ledger::pots::LOAD::donations(record));
+        } else if ledger::pots::DUMP::matches(&record.target, &record.name) {
+            self.treasury = Some(ledger::pots::DUMP::treasury(record));
+            self.reserves = Some(ledger::pots::DUMP::reserves(record));
+            self.fees = Some(ledger::pots::DUMP::fees(record));
+            self.donations = Some(ledger::pots::DUMP::donations(record));
         } else if bootstrap::pots::IMPORT::matches(&record.target, &record.name) {
             self.treasury = Some(bootstrap::pots::IMPORT::treasury(record));
             self.reserves = Some(bootstrap::pots::IMPORT::reserves(record));

--- a/docs/TRACES.md
+++ b/docs/TRACES.md
@@ -1517,7 +1517,16 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
+| `dump` | `TRACE` | public | Load the current constitutional committee on startup | status |  |
 | `ignore` | `TRACE` | public | The constitutional committee votes were ignored during ratification | active_members, min_committee_size, reason |  |
+
+<details><summary>span: `dump`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `status` | `string` | ✓ |
+
+</details>
 
 <details><summary>span: `ignore`</summary>
 
@@ -1526,6 +1535,22 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | `active_members` | `integer` | ✓ |
 | `min_committee_size` | `integer` | ✓ |
 | `reason` | `string` | ✓ |
+
+</details>
+
+## target: `amaru::ledger::constitutional_committee_member`
+
+| name | level | public | description | required fields | optional fields |
+| --- | --- | --- | --- | --- | --- |
+| `dump` | `TRACE` | public | Load the current constitutional committee member on startup | cold_credential | status, valid_until |
+
+<details><summary>span: `dump`</summary>
+
+| field | type | required |
+| --- | --- | --- |
+| `cold_credential` | `string` | ✓ |
+| `status` | `string` |  |
+| `valid_until` | `integer` |  |
 
 </details>
 
@@ -1695,9 +1720,9 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `load` | `TRACE` | public | Load the current ledger pots | treasury, reserves, fees, donations |  |
+| `dump` | `TRACE` | public | Load the current ledger pots | treasury, reserves, fees, donations |  |
 
-<details><summary>span: `load`</summary>
+<details><summary>span: `dump`</summary>
 
 | field | type | required |
 | --- | --- | --- |
@@ -1788,90 +1813,47 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 
 | name | level | public | description | required fields | optional fields |
 | --- | --- | --- | --- | --- | --- |
-| `load` | `TRACE` | public | Load the current protocol parameters |  | protocol_version, max_block_body_size, max_transaction_size, max_block_header_size, max_tx_ex_units, max_block_ex_units, max_value_size, max_collateral_inputs, min_fee_a, min_fee_b, stake_credential_deposit, stake_pool_deposit, monetary_expansion_rate, treasury_expansion_rate, min_pool_cost, lovelace_per_utxo_byte, prices, min_fee_ref_script_lovelace_per_byte, max_ref_script_size_per_tx, max_ref_script_size_per_block, ref_script_cost_stride, ref_script_cost_multiplier, stake_pool_max_retirement_epoch, optimal_stake_pools_count, pledge_influence, collateral_percentage, cost_models, pool_voting_thresholds, drep_voting_thresholds, min_committee_size, max_committee_term_length, gov_action_lifetime, gov_action_deposit, drep_deposit, drep_expiry |
-| `ratify` | `TRACE` | public | Ratify a protocol parameters update; only changed parameters are recorded |  | protocol_version, max_block_body_size, max_transaction_size, max_block_header_size, max_tx_ex_units, max_block_ex_units, max_value_size, max_collateral_inputs, min_fee_a, min_fee_b, stake_credential_deposit, stake_pool_deposit, monetary_expansion_rate, treasury_expansion_rate, min_pool_cost, lovelace_per_utxo_byte, prices, min_fee_ref_script_lovelace_per_byte, max_ref_script_size_per_tx, max_ref_script_size_per_block, ref_script_cost_stride, ref_script_cost_multiplier, stake_pool_max_retirement_epoch, optimal_stake_pools_count, pledge_influence, collateral_percentage, cost_models, pool_voting_thresholds, drep_voting_thresholds, min_committee_size, max_committee_term_length, gov_action_lifetime, gov_action_deposit, drep_deposit, drep_expiry |
+| `dump` | `TRACE` | public | Dump the current protocol parameters |  | protocol_version, max_block_body_size, max_transaction_size, max_block_header_size, max_tx_ex_units, max_block_ex_units, max_value_size, max_collateral_inputs, min_fee_a, min_fee_b, stake_credential_deposit, stake_pool_deposit, monetary_expansion_rate, treasury_expansion_rate, min_pool_cost, lovelace_per_utxo_byte, prices, min_fee_ref_script_lovelace_per_byte, max_ref_script_size_per_tx, max_ref_script_size_per_block, ref_script_cost_stride, ref_script_cost_multiplier, stake_pool_max_retirement_epoch, optimal_stake_pools_count, pledge_influence, cost_models, collateral_percentage, pool_voting_thresholds, drep_voting_thresholds, min_committee_size, max_committee_term_length, gov_action_lifetime, gov_action_deposit, drep_deposit, drep_expiry |
 
-<details><summary>span: `load`</summary>
-
-| field | type | required |
-| --- | --- | --- |
-| `protocol_version` | `string` |  |
-| `max_block_body_size` | `string` |  |
-| `max_transaction_size` | `string` |  |
-| `max_block_header_size` | `string` |  |
-| `max_tx_ex_units` | `string` |  |
-| `max_block_ex_units` | `string` |  |
-| `max_value_size` | `string` |  |
-| `max_collateral_inputs` | `string` |  |
-| `min_fee_a` | `string` |  |
-| `min_fee_b` | `string` |  |
-| `stake_credential_deposit` | `string` |  |
-| `stake_pool_deposit` | `string` |  |
-| `monetary_expansion_rate` | `string` |  |
-| `treasury_expansion_rate` | `string` |  |
-| `min_pool_cost` | `string` |  |
-| `lovelace_per_utxo_byte` | `string` |  |
-| `prices` | `string` |  |
-| `min_fee_ref_script_lovelace_per_byte` | `string` |  |
-| `max_ref_script_size_per_tx` | `string` |  |
-| `max_ref_script_size_per_block` | `string` |  |
-| `ref_script_cost_stride` | `string` |  |
-| `ref_script_cost_multiplier` | `string` |  |
-| `stake_pool_max_retirement_epoch` | `string` |  |
-| `optimal_stake_pools_count` | `string` |  |
-| `pledge_influence` | `string` |  |
-| `collateral_percentage` | `string` |  |
-| `cost_models` | `string` |  |
-| `pool_voting_thresholds` | `string` |  |
-| `drep_voting_thresholds` | `string` |  |
-| `min_committee_size` | `string` |  |
-| `max_committee_term_length` | `string` |  |
-| `gov_action_lifetime` | `string` |  |
-| `gov_action_deposit` | `string` |  |
-| `drep_deposit` | `string` |  |
-| `drep_expiry` | `string` |  |
-
-</details>
-
-<details><summary>span: `ratify`</summary>
+<details><summary>span: `dump`</summary>
 
 | field | type | required |
 | --- | --- | --- |
 | `protocol_version` | `string` |  |
-| `max_block_body_size` | `string` |  |
-| `max_transaction_size` | `string` |  |
-| `max_block_header_size` | `string` |  |
+| `max_block_body_size` | `integer` |  |
+| `max_transaction_size` | `integer` |  |
+| `max_block_header_size` | `integer` |  |
 | `max_tx_ex_units` | `string` |  |
 | `max_block_ex_units` | `string` |  |
-| `max_value_size` | `string` |  |
-| `max_collateral_inputs` | `string` |  |
-| `min_fee_a` | `string` |  |
-| `min_fee_b` | `string` |  |
-| `stake_credential_deposit` | `string` |  |
-| `stake_pool_deposit` | `string` |  |
+| `max_value_size` | `integer` |  |
+| `max_collateral_inputs` | `integer` |  |
+| `min_fee_a` | `integer` |  |
+| `min_fee_b` | `integer` |  |
+| `stake_credential_deposit` | `integer` |  |
+| `stake_pool_deposit` | `integer` |  |
 | `monetary_expansion_rate` | `string` |  |
 | `treasury_expansion_rate` | `string` |  |
-| `min_pool_cost` | `string` |  |
-| `lovelace_per_utxo_byte` | `string` |  |
+| `min_pool_cost` | `integer` |  |
+| `lovelace_per_utxo_byte` | `integer` |  |
 | `prices` | `string` |  |
 | `min_fee_ref_script_lovelace_per_byte` | `string` |  |
-| `max_ref_script_size_per_tx` | `string` |  |
-| `max_ref_script_size_per_block` | `string` |  |
-| `ref_script_cost_stride` | `string` |  |
+| `max_ref_script_size_per_tx` | `integer` |  |
+| `max_ref_script_size_per_block` | `integer` |  |
+| `ref_script_cost_stride` | `integer` |  |
 | `ref_script_cost_multiplier` | `string` |  |
-| `stake_pool_max_retirement_epoch` | `string` |  |
-| `optimal_stake_pools_count` | `string` |  |
+| `stake_pool_max_retirement_epoch` | `integer` |  |
+| `optimal_stake_pools_count` | `integer` |  |
 | `pledge_influence` | `string` |  |
-| `collateral_percentage` | `string` |  |
 | `cost_models` | `string` |  |
+| `collateral_percentage` | `integer` |  |
 | `pool_voting_thresholds` | `string` |  |
 | `drep_voting_thresholds` | `string` |  |
-| `min_committee_size` | `string` |  |
-| `max_committee_term_length` | `string` |  |
-| `gov_action_lifetime` | `string` |  |
-| `gov_action_deposit` | `string` |  |
-| `drep_deposit` | `string` |  |
-| `drep_expiry` | `string` |  |
+| `min_committee_size` | `integer` |  |
+| `max_committee_term_length` | `integer` |  |
+| `gov_action_lifetime` | `integer` |  |
+| `gov_action_deposit` | `integer` |  |
+| `drep_deposit` | `integer` |  |
+| `drep_expiry` | `integer` |  |
 
 </details>
 
@@ -1997,7 +1979,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | `initial_progress` | `TRACE` | public | Report progress for one of the initial stake distributions loaded on startup | epoch, progress |  |
 | `initial_ready` | `TRACE` | public | Finished computing all initial stake distributions loaded on startup | epochs |  |
 | `rotate` | `TRACE` | public | Rotate stake distributions at an epoch boundary | available_stake_distributions |  |
-| `snapshot` | `TRACE` | public | Snapshot of the stake distribution taken at an epoch boundary | accounts, dreps, pools, active_stake, pools_voting_stake, dreps_voting_stake |  |
+| `snapshot` | `TRACE` | public | Snapshot of the stake distribution taken at an epoch boundary | accounts, dreps, pools, active_stake, pools_voting_stake, dreps_voting_stake | cc_update |
 
 <details><summary>span: `compute`</summary>
 
@@ -2050,6 +2032,7 @@ For information on how to use and filter these spans, see [monitoring/README.md]
 | `active_stake` | `integer` | ✓ |
 | `pools_voting_stake` | `integer` | ✓ |
 | `dreps_voting_stake` | `integer` | ✓ |
+| `cc_update` | `string` |  |
 
 </details>
 

--- a/docs/traces-schema.json
+++ b/docs/traces-schema.json
@@ -4343,6 +4343,24 @@
       "description": "Fewer than k blocks were seen within the stability window",
       "public": true
     },
+    "amaru::ledger::constitutional_committee::DUMP": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "status"
+      ],
+      "optional": [],
+      "additionalProperties": false,
+      "name": "dump",
+      "level": "TRACE",
+      "target": "amaru::ledger::constitutional_committee",
+      "description": "Load the current constitutional committee on startup",
+      "public": true
+    },
     "amaru::ledger::constitutional_committee::IGNORE": {
       "type": "object",
       "properties": {
@@ -4367,6 +4385,36 @@
       "level": "TRACE",
       "target": "amaru::ledger::constitutional_committee",
       "description": "The constitutional committee votes were ignored during ratification",
+      "public": true
+    },
+    "amaru::ledger::constitutional_committee_member::DUMP": {
+      "type": "object",
+      "properties": {
+        "cold_credential": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "valid_until": {
+          "title": "uint64",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "required": [
+        "cold_credential"
+      ],
+      "optional": [
+        "status",
+        "valid_until"
+      ],
+      "additionalProperties": false,
+      "name": "dump",
+      "level": "TRACE",
+      "target": "amaru::ledger::constitutional_committee_member",
+      "description": "Load the current constitutional committee member on startup",
       "public": true
     },
     "amaru::ledger::epoch_transition::APPLY": {
@@ -4788,7 +4836,7 @@
       "description": "No pools updates found in the epoch transition overlay",
       "public": true
     },
-    "amaru::ledger::pots::LOAD": {
+    "amaru::ledger::pots::DUMP": {
       "type": "object",
       "properties": {
         "treasury": {
@@ -4824,7 +4872,7 @@
       ],
       "optional": [],
       "additionalProperties": false,
-      "name": "load",
+      "name": "dump",
       "level": "TRACE",
       "target": "amaru::ledger::pots",
       "description": "Load the current ledger pots",
@@ -5004,20 +5052,20 @@
       "description": "Upgrade to a new protocol version",
       "public": true
     },
-    "amaru::ledger::protocol_parameters::LOAD": {
+    "amaru::ledger::protocol_parameters::DUMP": {
       "type": "object",
       "properties": {
         "protocol_version": {
           "type": "string"
         },
         "max_block_body_size": {
-          "type": "string"
+          "type": "integer"
         },
         "max_transaction_size": {
-          "type": "string"
+          "type": "integer"
         },
         "max_block_header_size": {
-          "type": "string"
+          "type": "integer"
         },
         "max_tx_ex_units": {
           "type": "string"
@@ -5026,22 +5074,31 @@
           "type": "string"
         },
         "max_value_size": {
-          "type": "string"
+          "type": "integer"
         },
         "max_collateral_inputs": {
-          "type": "string"
+          "type": "integer"
         },
         "min_fee_a": {
-          "type": "string"
+          "title": "uint64",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         },
         "min_fee_b": {
-          "type": "string"
+          "type": "integer"
         },
         "stake_credential_deposit": {
-          "type": "string"
+          "title": "uint64",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         },
         "stake_pool_deposit": {
-          "type": "string"
+          "title": "uint64",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         },
         "monetary_expansion_rate": {
           "type": "string"
@@ -5050,10 +5107,16 @@
           "type": "string"
         },
         "min_pool_cost": {
-          "type": "string"
+          "title": "uint64",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         },
         "lovelace_per_utxo_byte": {
-          "type": "string"
+          "title": "uint64",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         },
         "prices": {
           "type": "string"
@@ -5062,31 +5125,31 @@
           "type": "string"
         },
         "max_ref_script_size_per_tx": {
-          "type": "string"
+          "type": "integer"
         },
         "max_ref_script_size_per_block": {
-          "type": "string"
+          "type": "integer"
         },
         "ref_script_cost_stride": {
-          "type": "string"
+          "type": "integer"
         },
         "ref_script_cost_multiplier": {
           "type": "string"
         },
         "stake_pool_max_retirement_epoch": {
-          "type": "string"
+          "type": "integer"
         },
         "optimal_stake_pools_count": {
-          "type": "string"
+          "type": "integer"
         },
         "pledge_influence": {
           "type": "string"
         },
-        "collateral_percentage": {
-          "type": "string"
-        },
         "cost_models": {
           "type": "string"
+        },
+        "collateral_percentage": {
+          "type": "integer"
         },
         "pool_voting_thresholds": {
           "type": "string"
@@ -5095,22 +5158,28 @@
           "type": "string"
         },
         "min_committee_size": {
-          "type": "string"
+          "type": "integer"
         },
         "max_committee_term_length": {
-          "type": "string"
+          "type": "integer"
         },
         "gov_action_lifetime": {
-          "type": "string"
+          "type": "integer"
         },
         "gov_action_deposit": {
-          "type": "string"
+          "title": "uint64",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         },
         "drep_deposit": {
-          "type": "string"
+          "title": "uint64",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         },
         "drep_expiry": {
-          "type": "string"
+          "type": "integer"
         }
       },
       "required": [],
@@ -5140,8 +5209,8 @@
         "stake_pool_max_retirement_epoch",
         "optimal_stake_pools_count",
         "pledge_influence",
-        "collateral_percentage",
         "cost_models",
+        "collateral_percentage",
         "pool_voting_thresholds",
         "drep_voting_thresholds",
         "min_committee_size",
@@ -5152,164 +5221,10 @@
         "drep_expiry"
       ],
       "additionalProperties": false,
-      "name": "load",
+      "name": "dump",
       "level": "TRACE",
       "target": "amaru::ledger::protocol_parameters",
-      "description": "Load the current protocol parameters",
-      "public": true
-    },
-    "amaru::ledger::protocol_parameters::RATIFY": {
-      "type": "object",
-      "properties": {
-        "protocol_version": {
-          "type": "string"
-        },
-        "max_block_body_size": {
-          "type": "string"
-        },
-        "max_transaction_size": {
-          "type": "string"
-        },
-        "max_block_header_size": {
-          "type": "string"
-        },
-        "max_tx_ex_units": {
-          "type": "string"
-        },
-        "max_block_ex_units": {
-          "type": "string"
-        },
-        "max_value_size": {
-          "type": "string"
-        },
-        "max_collateral_inputs": {
-          "type": "string"
-        },
-        "min_fee_a": {
-          "type": "string"
-        },
-        "min_fee_b": {
-          "type": "string"
-        },
-        "stake_credential_deposit": {
-          "type": "string"
-        },
-        "stake_pool_deposit": {
-          "type": "string"
-        },
-        "monetary_expansion_rate": {
-          "type": "string"
-        },
-        "treasury_expansion_rate": {
-          "type": "string"
-        },
-        "min_pool_cost": {
-          "type": "string"
-        },
-        "lovelace_per_utxo_byte": {
-          "type": "string"
-        },
-        "prices": {
-          "type": "string"
-        },
-        "min_fee_ref_script_lovelace_per_byte": {
-          "type": "string"
-        },
-        "max_ref_script_size_per_tx": {
-          "type": "string"
-        },
-        "max_ref_script_size_per_block": {
-          "type": "string"
-        },
-        "ref_script_cost_stride": {
-          "type": "string"
-        },
-        "ref_script_cost_multiplier": {
-          "type": "string"
-        },
-        "stake_pool_max_retirement_epoch": {
-          "type": "string"
-        },
-        "optimal_stake_pools_count": {
-          "type": "string"
-        },
-        "pledge_influence": {
-          "type": "string"
-        },
-        "collateral_percentage": {
-          "type": "string"
-        },
-        "cost_models": {
-          "type": "string"
-        },
-        "pool_voting_thresholds": {
-          "type": "string"
-        },
-        "drep_voting_thresholds": {
-          "type": "string"
-        },
-        "min_committee_size": {
-          "type": "string"
-        },
-        "max_committee_term_length": {
-          "type": "string"
-        },
-        "gov_action_lifetime": {
-          "type": "string"
-        },
-        "gov_action_deposit": {
-          "type": "string"
-        },
-        "drep_deposit": {
-          "type": "string"
-        },
-        "drep_expiry": {
-          "type": "string"
-        }
-      },
-      "required": [],
-      "optional": [
-        "protocol_version",
-        "max_block_body_size",
-        "max_transaction_size",
-        "max_block_header_size",
-        "max_tx_ex_units",
-        "max_block_ex_units",
-        "max_value_size",
-        "max_collateral_inputs",
-        "min_fee_a",
-        "min_fee_b",
-        "stake_credential_deposit",
-        "stake_pool_deposit",
-        "monetary_expansion_rate",
-        "treasury_expansion_rate",
-        "min_pool_cost",
-        "lovelace_per_utxo_byte",
-        "prices",
-        "min_fee_ref_script_lovelace_per_byte",
-        "max_ref_script_size_per_tx",
-        "max_ref_script_size_per_block",
-        "ref_script_cost_stride",
-        "ref_script_cost_multiplier",
-        "stake_pool_max_retirement_epoch",
-        "optimal_stake_pools_count",
-        "pledge_influence",
-        "collateral_percentage",
-        "cost_models",
-        "pool_voting_thresholds",
-        "drep_voting_thresholds",
-        "min_committee_size",
-        "max_committee_term_length",
-        "gov_action_lifetime",
-        "gov_action_deposit",
-        "drep_deposit",
-        "drep_expiry"
-      ],
-      "additionalProperties": false,
-      "name": "ratify",
-      "level": "TRACE",
-      "target": "amaru::ledger::protocol_parameters",
-      "description": "Ratify a protocol parameters update; only changed parameters are recorded",
+      "description": "Dump the current protocol parameters",
       "public": true
     },
     "amaru::ledger::ratification::SKIP": {
@@ -5729,6 +5644,9 @@
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
+        },
+        "cc_update": {
+          "type": "string"
         }
       },
       "required": [
@@ -5739,7 +5657,9 @@
         "pools_voting_stake",
         "dreps_voting_stake"
       ],
-      "optional": [],
+      "optional": [
+        "cc_update"
+      ],
       "additionalProperties": false,
       "name": "snapshot",
       "level": "TRACE",


### PR DESCRIPTION
- :round_pushpin: **feat(amaru-ledger): dump the state of the constitutional committee on startup.**  

- :round_pushpin: **fix(amaru-ledger): adjust 'prop_max_cc_term_length_influence_compass_next' to illustrate off-by-one bug.**

- :round_pushpin: **fix(amaru-ledger): off-by-one error regarding constitutional committee expiry check.**
  

- :round_pushpin: **chore: unify and properly type protocol_parameters::{LOAD, RATIFY} events**
  

- :round_pushpin: **chore(amaru-ledger): add warning/panic on start with migration hints when corrupted ledger state is detected.**

- :round_pushpin: **fix(amaru-ledger): use constitutional committee from the ongoing stable state during transition.**
    On the Haskell's side, the DRepPulser is started with the epoch state
  resulting from the beginning of the epoch. This means that it includes
  any ratification outcome (e.g. the election of a new committee).

  So, unlike the stake distribution or votes, we cannot pull the CC from
  the snapshot of the previous epoch. We cannot also simply use the
  state that is currently in the database because it may includes hot
  delegation or resignation that should remain out of context.

  Technically, what we need is the outcome of the previous ratification.

- :round_pushpin: **fix test configuration to add a CC**

- :round_pushpin: **chore(amaru-ledger): cover new ConstitutionalCommittee::resolve with some unit tests.**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pragma-org/codesmith/amaru/pr/1345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791813697&installation_model_id=436488&pr_number=1345&repository=pragma-org%2Famaru&return_to=https%3A%2F%2Fgithub.com%2Fpragma-org%2Famaru%2Fpull%2F1345&signature=e9b51b01b4dedcb9f7be4477d65c7c1727532d627758b61caeb32e4e97630f99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected constitutional committee member validity boundaries at epoch transitions.
  - Improved restoration and application of committee updates, including no-confidence, member changes, removals, additions, and term extensions.
  - Corrected proposal validation around committee term limits.

- **Observability**
  - Added startup reporting for constitutional committee status and members.
  - Expanded protocol parameter and stake distribution diagnostics, including committee updates.
  - Updated telemetry and trace documentation to use consistent data dump events and typed values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->